### PR TITLE
mm docs: Add page-allocator and slab, fix glossary placement

### DIFF
--- a/docs/mm/README.md
+++ b/docs/mm/README.md
@@ -43,10 +43,10 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 
 ### Suggested Reading Order
 
-1. **[Glossary](glossary.md)** - Terminology reference
-2. **[Overview: The Story](overview.md)** - The narrative of how mm/ evolved
-3. **[vmalloc](vmalloc.md)** - Deep dive into one allocator
-4. **[vrealloc](vrealloc.md)** - A recent feature with instructive bugs
+1. **[Overview](overview.md)** - The narrative of how mm/ evolved
+2. **[Page Allocator](page-allocator.md)** - Buddy system fundamentals
+3. **[Slab](slab.md)** - SLUB allocator for small objects
+4. **[vmalloc](vmalloc.md)** - Virtual memory allocation
 
 ### What You'll Learn
 
@@ -74,16 +74,15 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 | Document | What You'll Learn |
 |----------|-------------------|
 | [overview](overview.md) | The 30-year story of Linux memory management |
-| [glossary](glossary.md) | Every term defined for newcomers |
-| [vmalloc](vmalloc.md) | How virtually contiguous allocation works |
-| [vrealloc](vrealloc.md) | Resizing allocations - a case study in kernel development |
+| [page-allocator](page-allocator.md) | Buddy system - physical page management |
+| [slab](slab.md) | SLUB - small object allocation |
+| [vmalloc](vmalloc.md) | Virtually contiguous allocation |
+| [vrealloc](vrealloc.md) | Resizing allocations |
 
 ### Planned
 
 | Document | Status |
 |----------|--------|
-| [page-allocator](page-allocator.md) | Planned - Buddy system deep dive |
-| [slab](slab.md) | Planned - SLUB internals |
 | [page-tables](page-tables.md) | Planned - Virtual memory mapping |
 | [reclaim](reclaim.md) | Planned - What happens under memory pressure |
 | [memcg](memcg.md) | Planned - Container memory limits |
@@ -119,3 +118,9 @@ If you want to read the actual code:
 - Silberschatz, "Operating System Concepts" - Ch. 9-10 (Memory)
 - Tanenbaum, "Modern Operating Systems" - Ch. 3 (Memory Management)
 - Love, "Linux Kernel Development" - Ch. 12 (Memory Management)
+
+---
+
+## Appendix
+
+- **[Glossary](glossary.md)** - Terminology reference

--- a/docs/mm/page-allocator.md
+++ b/docs/mm/page-allocator.md
@@ -1,0 +1,286 @@
+# Page Allocator (Buddy System)
+
+> The foundation of Linux memory management - allocating physical page frames
+
+## What is the Page Allocator?
+
+The page allocator manages physical memory at the page granularity (typically `4KB`). It's the lowest-level allocator in the kernel - every other allocator (SLUB, vmalloc) ultimately gets pages from here.
+
+```c
+struct page *alloc_pages(gfp_t gfp, unsigned int order);
+void free_pages(unsigned long addr, unsigned int order);
+```
+
+## The Buddy System
+
+Linux uses a **buddy allocator**, an algorithm dating back to 1965 (Knowlton). The key insight: manage memory in power-of-2 sized blocks, and when you free memory, merge it with its "buddy" if also free.
+
+### How It Works
+
+```
+Memory divided into blocks of order 0, 1, 2, ... 10
+Order 0 = 1 page (4KB)
+Order 1 = 2 pages (8KB)
+Order 2 = 4 pages (16KB)
+...
+Order 10 = 1024 pages (4MB) - MAX_ORDER default
+
+Free lists per order:
++-------------------------------------------+
+| Order 0: [4KB] [4KB] [4KB] ...            |
+| Order 1: [8KB] [8KB] ...                  |
+| Order 2: [16KB] ...                       |
+| ...                                       |
+| Order 10: [4MB] ...                       |
++-------------------------------------------+
+```
+
+### Allocation Example
+
+Request for 3 pages (needs order 2 = 4 pages):
+
+```
+1. Check order 2 free list
+   - If available: remove block, return it
+   - If empty: go to step 2
+
+2. Check order 3 free list (8 pages)
+   - Split: one 4-page block to satisfy request
+   - Other 4-page block goes to order 2 free list
+
+3. Continue splitting from higher orders if needed
+```
+
+### Free Example (Buddy Merging)
+
+Freeing a 4-page block at address 0x1000:
+
+```
+1. Find buddy address: 0x1000 XOR (4 * PAGE_SIZE) = 0x5000
+
+2. Is buddy free and same order?
+   - Yes: merge into 8-page block, try to merge again
+   - No: add to order 2 free list
+
+Merging continues up to MAX_ORDER or until buddy isn't free
+```
+
+### Why Buddies?
+
+The buddy's address can be computed with a single XOR operation - no searching required. Two adjacent blocks of the same size are buddies only if they came from splitting the same larger block.
+
+## Memory Zones
+
+Physical memory is divided into zones based on hardware constraints:
+
+| Zone | Purpose | Typical Range (x86-64) |
+|------|---------|------------------------|
+| `ZONE_DMA` | Legacy 16-bit DMA devices | 0 - 16MB |
+| `ZONE_DMA32` | 32-bit DMA devices | 0 - 4GB |
+| `ZONE_NORMAL` | Regular allocations | All memory |
+| `ZONE_MOVABLE` | Migratable pages (memory hotplug) | Configurable |
+
+Each zone has its own set of buddy free lists.
+
+## GFP Flags
+
+GFP (Get Free Pages) flags control allocation behavior:
+
+```c
+/* Common combinations */
+GFP_KERNEL    /* Normal allocation, can sleep, can reclaim */
+GFP_ATOMIC    /* Cannot sleep (interrupt context) */
+GFP_USER      /* User-space allocation */
+GFP_DMA       /* Must be in ZONE_DMA */
+GFP_DMA32     /* Must be in ZONE_DMA32 */
+
+/* Modifiers */
+__GFP_ZERO    /* Zero the memory */
+__GFP_NOWARN  /* Suppress allocation failure warnings */
+__GFP_RETRY_MAYFAIL  /* Try hard but may fail */
+```
+
+See [`include/linux/gfp.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/gfp.h) for the full list.
+
+## History & Evolution
+
+### Origins (1991)
+
+The buddy allocator has been in Linux since the beginning. The basic algorithm is from:
+
+> Knowlton, K. C. "A Fast Storage Allocator" Communications of the ACM, 1965
+
+*Note: Pre-LKML era. Early implementation details are in the git history starting from v2.6.12.*
+
+### Per-CPU Page Lists (v2.6)
+
+**Problem**: The zone lock became a bottleneck on SMP systems - every allocation/free needed it.
+
+**Solution**: Per-CPU page lists (`per_cpu_pages`) cache single pages, reducing lock contention.
+
+```
+CPU 0: [page] [page] [page] ...  (hot cache)
+CPU 1: [page] [page] ...
+...
+        |
+        v
+   Zone free lists (locked)
+```
+
+### NUMA Awareness
+
+**Problem**: On NUMA systems, accessing remote memory is slower than local memory.
+
+**Solution**: Per-node zones. Allocations prefer local node memory.
+
+```c
+/* Allocate from specific node */
+alloc_pages_node(node_id, gfp, order);
+```
+
+### Compaction (v2.6.35, 2010)
+
+**Commit**: [748446bb6b5a](https://git.kernel.org/linus/748446bb6b5a)
+
+**Problem**: External fragmentation - free pages scattered, can't satisfy high-order allocations.
+
+**Solution**: Memory compaction - move pages to create contiguous free blocks.
+
+### CMA (Contiguous Memory Allocator, v3.5, 2012)
+
+**Commit**: [c64be2bb1c6e](https://git.kernel.org/linus/c64be2bb1c6e)
+
+**Problem**: Devices need large contiguous buffers but memory fragments over time.
+
+**Solution**: Reserve regions that can be used by movable pages normally, but reclaimed for contiguous allocation when needed.
+
+## Try It Yourself
+
+### View Buddy Allocator State
+
+```bash
+# Free blocks per order, per zone
+cat /proc/buddyinfo
+
+# Example output:
+# Node 0, zone   Normal  1024  512  256  128   64   32   16    8    4    2    1
+#                        ^order 0              ^order 5                    ^order 10
+
+# Each number = count of free blocks at that order
+```
+
+### View Zone Information
+
+```bash
+# Detailed zone stats
+cat /proc/zoneinfo
+
+# Key fields:
+# - min/low/high: watermarks for reclaim
+# - free: current free pages
+# - managed: pages managed by this zone
+```
+
+### Memory Pressure Test
+
+```bash
+# Watch buddy state while allocating memory
+watch -n 1 cat /proc/buddyinfo
+
+# In another terminal, consume memory
+stress --vm 1 --vm-bytes 1G
+```
+
+### Trace Allocations
+
+```bash
+# Enable page allocation tracing (requires debugfs)
+echo 1 > /sys/kernel/debug/tracing/events/kmem/mm_page_alloc/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+
+# Output shows: page address, order, gfp flags, migratetype
+```
+
+## Key Data Structures
+
+### struct zone
+
+```c
+struct zone {
+    unsigned long watermark[NR_WMARK];     /* min/low/high */
+    unsigned long nr_reserved_highatomic;
+    struct per_cpu_pages __percpu *per_cpu_pageset;
+    struct free_area free_area[NR_PAGE_ORDERS];  /* buddy free lists */
+    unsigned long zone_start_pfn;
+    unsigned long managed_pages;
+    unsigned long spanned_pages;
+    unsigned long present_pages;
+    const char *name;
+    /* ... */
+};
+```
+
+### struct free_area
+
+```c
+struct free_area {
+    struct list_head free_list[MIGRATE_TYPES];  /* per-migratetype lists */
+    unsigned long nr_free;
+};
+```
+
+### Migrate Types
+
+Pages are grouped by mobility to reduce fragmentation:
+
+| Type | Description |
+|------|-------------|
+| `MIGRATE_UNMOVABLE` | Kernel allocations that can't move |
+| `MIGRATE_MOVABLE` | User pages, can be migrated/compacted |
+| `MIGRATE_RECLAIMABLE` | Caches that can be freed under pressure |
+
+## Common Issues
+
+### High-Order Allocation Failures
+
+Large contiguous allocations (order > 3) can fail due to fragmentation even with free memory.
+
+**Solutions**:
+- Use `__GFP_RETRY_MAYFAIL` to try harder
+- Use vmalloc instead (virtual contiguity)
+- Enable compaction (`/proc/sys/vm/compact_memory`)
+
+### Zone Imbalance
+
+Memory pressure in one zone while others have free memory.
+
+**Check**: `cat /proc/zoneinfo | grep -E "zone|free|min"`
+
+### OOM Despite Free Pages
+
+Free pages exist but in wrong zone or wrong migratetype.
+
+**Debug**: Check `/proc/buddyinfo` and `/proc/pagetypeinfo`
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/page_alloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) | Core allocator |
+| [`include/linux/gfp.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/gfp.h) | GFP flags |
+| [`include/linux/mmzone.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mmzone.h) | Zone structures |
+
+### Key Commits
+
+| Commit | Kernel | Description |
+|--------|--------|-------------|
+| [748446bb6b5a](https://git.kernel.org/linus/748446bb6b5a) | v2.6.35 | Memory compaction |
+| [c64be2bb1c6e](https://git.kernel.org/linus/c64be2bb1c6e) | v3.5 | CMA introduction |
+
+### Related
+
+- [overview](overview.md) - How page allocator fits with other allocators
+- [slab](slab.md) - SLUB uses pages from buddy allocator
+- [vmalloc](vmalloc.md) - Gets individual pages from buddy

--- a/docs/mm/slab.md
+++ b/docs/mm/slab.md
@@ -1,0 +1,329 @@
+# Slab Allocator (SLUB)
+
+> Efficient allocation of small kernel objects
+
+## What is the Slab Allocator?
+
+The slab allocator sits between the page allocator and kernel code. It carves pages into fixed-size object caches, reducing internal fragmentation and speeding up allocation of commonly-used structures.
+
+```c
+void *kmalloc(size_t size, gfp_t flags);
+void kfree(const void *ptr);
+
+/* Or create a dedicated cache */
+struct kmem_cache *kmem_cache_create(const char *name, size_t size, ...);
+void *kmem_cache_alloc(struct kmem_cache *cache, gfp_t flags);
+void kmem_cache_free(struct kmem_cache *cache, void *ptr);
+```
+
+## Why Not Just Use the Page Allocator?
+
+The page allocator works in `4KB` chunks. But kernel objects are often much smaller:
+
+| Object | Typical Size |
+|--------|--------------|
+| `struct inode` | ~600 bytes |
+| `struct dentry` | ~200 bytes |
+| `struct task_struct` | ~8KB |
+| `struct sk_buff` | ~256 bytes |
+
+Allocating a full page for a 200-byte object wastes 95% of the memory.
+
+## The Slab Concept
+
+Originally from SunOS (Bonwick, 1994), the idea:
+
+1. Pre-allocate pages for specific object types
+2. Carve each page into fixed-size slots
+3. Maintain free lists for fast alloc/free
+4. Reuse memory without returning to page allocator
+
+```
+slab for 256-byte objects (one page):
++-------+-------+-------+-------+-------+-------+...+-------+
+| obj 0 | obj 1 | obj 2 | obj 3 | obj 4 | obj 5 |   |obj 15 |
++-------+-------+-------+-------+-------+-------+...+-------+
+   ^                 ^                       ^
+   |                 |                       |
+ in use            free                    free
+```
+
+## SLUB vs SLAB vs SLOB
+
+Linux has had three slab implementations:
+
+| Allocator | Status | Characteristics |
+|-----------|--------|-----------------|
+| SLAB | Removed (v6.8) | Original, complex, per-CPU queues |
+| SLUB | **Default** | Simpler, lower overhead, no queues |
+| SLOB | Removed (v6.4) | Minimal, for embedded systems |
+
+**SLUB** (the "unqueued slab allocator") won because:
+- Simpler code (easier to maintain, debug)
+- Lower memory overhead
+- Better NUMA awareness
+- Comparable performance
+
+## How SLUB Works
+
+### Per-CPU Slabs
+
+Each CPU has a "current" slab for fast allocation:
+
+```
+CPU 0                    CPU 1
+  |                        |
+  v                        v
++--------+              +--------+
+| slab   |              | slab   |
+| page   |              | page   |
+|--------|              |--------|
+| free   |              | free   |
+| list   |              | list   |
++--------+              +--------+
+
+No locking needed for per-CPU slab!
+```
+
+### Allocation Fast Path
+
+```c
+/* Simplified allocation */
+void *slab_alloc(struct kmem_cache *s) {
+    struct slab *slab = this_cpu_read(s->cpu_slab);
+    void *object = slab->freelist;
+
+    if (likely(object)) {
+        slab->freelist = get_next_free(object);
+        return object;
+    }
+
+    /* Slow path: get new slab */
+    return __slab_alloc(s);
+}
+```
+
+Fast path: load freelist pointer, advance it, return object. No locks.
+
+### Freelist Encoding
+
+SLUB stores the freelist pointer inside free objects themselves:
+
+```
+Free object layout:
++------------------+------------------+
+| next free ptr    | (rest of object) |
++------------------+------------------+
+^
+|-- freelist points here
+
+When allocated, pointer is overwritten by actual data
+```
+
+### Partial Slabs
+
+When a CPU slab fills, SLUB gets a partially-full slab from the node's partial list:
+
+```
+Per-CPU          Per-Node Partial List
++--------+       +--------+  +--------+  +--------+
+| full   | ----> | 75%    |->| 50%    |->| 25%    |
++--------+       +--------+  +--------+  +--------+
+                 (sorted by fullness for efficiency)
+```
+
+## kmalloc Size Classes
+
+`kmalloc()` uses pre-created caches for power-of-2 sizes:
+
+```
+kmalloc-8      (8 bytes)
+kmalloc-16     (16 bytes)
+kmalloc-32     (32 bytes)
+kmalloc-64     (64 bytes)
+kmalloc-96     (96 bytes)    <- not power of 2
+kmalloc-128    (128 bytes)
+...
+kmalloc-8k     (8192 bytes)
+```
+
+Request for 100 bytes -> `kmalloc-128` (28 bytes internal fragmentation)
+
+## Cache Merging
+
+To reduce memory overhead, SLUB merges similar caches:
+
+```
+struct foo { int a, b, c; };      /* 12 bytes */
+struct bar { int x, y, z; };      /* 12 bytes */
+
+/* Both use the same underlying cache! */
+```
+
+Disable with boot option `slub_nomerge` for debugging.
+
+## SLUB Debugging
+
+SLUB has extensive debugging features:
+
+```bash
+# Boot options
+slub_debug=P     # Poisoning - fill with patterns
+slub_debug=F     # Sanity checks on free
+slub_debug=Z     # Red zoning - guard bytes
+slub_debug=U     # User tracking - store alloc/free caller
+slub_debug=T     # Trace - print alloc/free
+
+# Or for specific cache
+slub_debug=PFZ,kmalloc-256
+
+# Check via sysfs
+cat /sys/kernel/slab/kmalloc-256/sanity_checks
+```
+
+### Poison Values
+
+| Pattern | Meaning |
+|---------|---------|
+| `0x5a` | Newly allocated (uninitialized) |
+| `0x6b` | Freed (use-after-free detection) |
+| `0xa5` | Red zone (buffer overflow detection) |
+
+## Try It Yourself
+
+### View All Slab Caches
+
+```bash
+# Summary of all caches
+cat /proc/slabinfo
+
+# Or use slabtop for live monitoring
+slabtop -s c    # Sort by cache size
+```
+
+### Inspect Specific Cache
+
+```bash
+# Via sysfs (SLUB)
+ls /sys/kernel/slab/kmalloc-256/
+
+# Key files:
+# - object_size: actual object size
+# - slab_size: size including metadata
+# - objs_per_slab: objects per slab page
+# - partial: number of partial slabs
+# - cpu_slabs: per-CPU slabs
+```
+
+### Memory Usage by Cache
+
+```bash
+# Top memory consumers
+cat /proc/slabinfo | awk 'NR>2 {print $1, $3*$4}' | sort -k2 -nr | head
+```
+
+### Trace Allocations
+
+```bash
+# Enable kmalloc tracing
+echo 1 > /sys/kernel/debug/tracing/events/kmem/kmalloc/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+## Key Data Structures
+
+### struct kmem_cache
+
+```c
+struct kmem_cache {
+    struct kmem_cache_cpu __percpu *cpu_slab;  /* Per-CPU data */
+    unsigned int size;          /* Object size including metadata */
+    unsigned int object_size;   /* Actual object size */
+    struct kmem_cache_node *node[MAX_NUMNODES];  /* Per-node data */
+    const char *name;
+    /* ... */
+};
+```
+
+### struct kmem_cache_cpu
+
+```c
+struct kmem_cache_cpu {
+    void **freelist;           /* Pointer to next free object */
+    struct slab *slab;         /* Current slab */
+    struct slab *partial;      /* Per-CPU partial list */
+    /* ... */
+};
+```
+
+## History
+
+### SLAB (1996)
+
+Ported from SunOS, based on [Bonwick's 1994 paper](https://www.usenix.org/legacy/publications/library/proceedings/bos94/bonwick.html).
+
+*Note: Predates LKML archives.*
+
+### SLUB Introduction (v2.6.22, 2007)
+
+**Commit**: [81819f0fc828](https://git.kernel.org/linus/81819f0fc828)
+**Author**: Christoph Lameter
+
+*Note: Original LKML thread (Feb 2007) predates reliable archives. See commit message for design rationale.*
+
+### SLAB Deprecation (v6.5, 2023)
+
+**Commit**: [03aecd6e4982](https://git.kernel.org/linus/03aecd6e4982)
+
+SLAB was deprecated, with SLUB as the sole remaining allocator.
+
+### SLAB Removal (v6.8, 2024)
+
+**Commit**: [dade3b5a628d](https://git.kernel.org/linus/dade3b5a628d)
+
+SLAB code removed. SLUB is now the only slab allocator.
+
+## Common Issues
+
+### Slab Fragmentation
+
+Objects allocated but not freed, preventing slab pages from being returned.
+
+**Debug**: Check `/sys/kernel/slab/*/partial`
+
+### Memory Leaks
+
+Allocations without matching frees.
+
+**Debug**: Use `slub_debug=U` to track allocation sites, or use kmemleak.
+
+### Cache Line Bouncing
+
+Per-CPU slab contention on workloads that allocate on one CPU and free on another.
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/slub.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/slub.c) | SLUB implementation |
+| [`include/linux/slab.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/slab.h) | Slab API |
+| [`mm/slab_common.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/slab_common.c) | Common slab code |
+
+### Key Commits
+
+| Commit | Kernel | Description |
+|--------|--------|-------------|
+| [81819f0fc828](https://git.kernel.org/linus/81819f0fc828) | v2.6.22 | SLUB introduction |
+| [03aecd6e4982](https://git.kernel.org/linus/03aecd6e4982) | v6.5 | SLAB deprecation |
+| [dade3b5a628d](https://git.kernel.org/linus/dade3b5a628d) | v6.8 | SLAB removal |
+
+### Further Reading
+
+- [Bonwick, "The Slab Allocator" (1994)](https://www.usenix.org/legacy/publications/library/proceedings/bos94/bonwick.html) - Original design paper
+
+### Related
+
+- [page-allocator](page-allocator.md) - Where SLUB gets its pages
+- [overview](overview.md) - How slab fits in the allocator hierarchy


### PR DESCRIPTION
- Add page-allocator.md (buddy system)
- Add slab.md (SLUB allocator)
- Move glossary to appendix
- Update reading order
- Remove vrealloc from suggested reading