### PR TITLE
docs/mm: Add comprehensive memory subsystem documentation

### DIFF
--- a/docs/mm/README.md
+++ b/docs/mm/README.md
@@ -78,14 +78,16 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 | [slab](slab.md) | SLUB - small object allocation |
 | [vmalloc](vmalloc.md) | Virtually contiguous allocation |
 | [vrealloc](vrealloc.md) | Resizing allocations |
-
-### Planned
-
-| Document | Status |
-|----------|--------|
-| [page-tables](page-tables.md) | Planned - Virtual memory mapping |
-| [reclaim](reclaim.md) | Planned - What happens under memory pressure |
-| [memcg](memcg.md) | Planned - Container memory limits |
+| [page-tables](page-tables.md) | Virtual address translation |
+| [reclaim](reclaim.md) | What happens under memory pressure |
+| [memcg](memcg.md) | Container memory limits |
+| [thp](thp.md) | Transparent Huge Pages - automatic 2MB pages |
+| [numa](numa.md) | NUMA memory policies and balancing |
+| [compaction](compaction.md) | Memory defragmentation for large allocations |
+| [ksm](ksm.md) | Kernel Same-page Merging - memory deduplication |
+| [mmap](mmap.md) | Process address space and VMAs |
+| [page-cache](page-cache.md) | File data caching in memory |
+| [swap](swap.md) | Extending memory to disk |
 
 ---
 
@@ -100,6 +102,13 @@ If you want to read the actual code:
 | [`mm/vmalloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmalloc.c) | vmalloc - virtually contiguous allocation |
 | [`mm/vmscan.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c) | Memory reclaim under pressure |
 | [`mm/memcontrol.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memcontrol.c) | Memory cgroups |
+| [`mm/huge_memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/huge_memory.c) | Transparent Huge Pages |
+| [`mm/mempolicy.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mempolicy.c) | NUMA memory policies |
+| [`mm/compaction.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/compaction.c) | Memory compaction |
+| [`mm/ksm.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/ksm.c) | Kernel Same-page Merging |
+| [`mm/mmap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) | Process address space, VMAs |
+| [`mm/filemap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/filemap.c) | Page cache |
+| [`mm/swapfile.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/swapfile.c) | Swap area management |
 | [`include/linux/gfp.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/gfp.h) | GFP flags definitions |
 
 ---

--- a/docs/mm/compaction.md
+++ b/docs/mm/compaction.md
@@ -1,0 +1,278 @@
+# Memory Compaction
+
+> Defragmenting physical memory for large allocations
+
+## What Is Compaction?
+
+Memory compaction moves pages to create contiguous free regions. Over time, free memory becomes fragmented - scattered in small pieces throughout physical memory. Compaction consolidates these fragments.
+
+```
+Before Compaction:
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│ U │ F │ U │ F │ U │ U │ F │ U │ F │ F │ U │ F │ U │ F │ U │ F │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+  U = Used, F = Free (scattered)
+
+After Compaction:
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│ U │ U │ U │ U │ U │ U │ U │ U │ U │ F │ F │ F │ F │ F │ F │ F │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+  Contiguous free region created
+```
+
+## Why Compaction?
+
+### The Fragmentation Problem
+
+The buddy allocator needs physically contiguous pages for high-order allocations:
+
+| Order | Size | Use Cases |
+|-------|------|-----------|
+| 0 | 4KB | Regular pages |
+| 1 | 8KB | Some kernel allocations |
+| 2 | 16KB | Jumbo frames |
+| 3+ | 32KB+ | Huge pages, DMA buffers |
+
+After running for days/weeks, a system may have plenty of free memory but no contiguous regions for high-order allocations.
+
+### Before Compaction
+
+Prior to compaction, high-order allocation failures were common:
+- THP couldn't allocate 2MB pages
+- DMA buffers failed
+- Network jumbo frames unavailable
+
+The only solutions were rebooting or reserving memory at boot.
+
+## How Compaction Works
+
+### The Algorithm
+
+Compaction uses two scanners moving toward each other:
+
+```
+Zone start                                              Zone end
+    │                                                       │
+    ▼                                                       ▼
+┌───────────────────────────────────────────────────────────────┐
+│                           Zone                                 │
+└───────────────────────────────────────────────────────────────┘
+    │                                                       │
+    ▼ Migration scanner                   Free scanner ▼    │
+    │ (finds movable pages)         (finds free pages)      │
+    │                                                       │
+    └──────────────► ◄──────────────────────────────────────┘
+                     Meet in middle
+```
+
+1. **Free scanner**: Starts at zone end, moves backward, finds free pages
+2. **Migration scanner**: Starts at zone start, moves forward, finds movable pages
+3. **Migration**: Move pages from migration scanner to free scanner locations
+4. **Result**: Free space consolidated at one end
+
+### Page Mobility
+
+Not all pages can be moved:
+
+| Migrate Type | Movable? | Examples |
+|--------------|----------|----------|
+| `MIGRATE_MOVABLE` | Yes | User pages, page cache |
+| `MIGRATE_RECLAIMABLE` | Sometimes | Caches (can be freed instead) |
+| `MIGRATE_UNMOVABLE` | No | Kernel allocations, DMA |
+
+Compaction only works with movable pages. Unmovable pages create permanent fragmentation.
+
+## Compaction Triggers
+
+### 1. Direct Compaction (Synchronous)
+
+When a high-order allocation fails, the allocating process runs compaction:
+
+```
+alloc_pages(order=9)  /* 2MB for THP */
+        │
+        v
+    Allocation fails
+        │
+        v
+    Direct compaction (process blocks)
+        │
+        v
+    Retry allocation
+```
+
+### 2. kcompactd (Asynchronous)
+
+Background kernel thread that compacts proactively:
+
+```bash
+# One kcompactd per NUMA node
+ps aux | grep kcompactd
+# kcompactd0, kcompactd1, ...
+```
+
+Woken when:
+- Watermarks indicate fragmentation
+- High-order allocations are failing
+- Explicitly triggered
+
+### 3. Manual Trigger
+
+```bash
+# Trigger compaction on all nodes
+echo 1 > /proc/sys/vm/compact_memory
+
+# Per-node trigger
+echo 1 > /sys/devices/system/node/node0/compact
+```
+
+## Configuration
+
+### Proactive Compaction (v5.9+)
+
+Compacts in the background before allocations need it:
+
+```bash
+# Enable proactive compaction (0-100, 0=disabled)
+cat /proc/sys/vm/compaction_proactiveness
+echo 20 > /proc/sys/vm/compaction_proactiveness
+
+# Higher = more aggressive background compaction
+# Lower = less CPU usage, more direct compaction
+```
+
+### Compaction Behavior
+
+```bash
+# Fragmentation index threshold for compaction
+# Compaction triggers when fragmentation_index > extfrag_threshold
+# Index 0 = failure due to lack of memory, 1000 = due to fragmentation
+cat /proc/sys/vm/extfrag_threshold
+# 500 (default) - lower = more aggressive (compact at lower fragmentation)
+
+# View fragmentation index per order
+cat /sys/kernel/debug/extfrag/extfrag_index
+```
+
+## Monitoring
+
+### Compaction Statistics
+
+```bash
+cat /proc/vmstat | grep compact
+# compact_migrate_scanned  - Pages scanned for migration
+# compact_free_scanned     - Pages scanned for free space
+# compact_isolated         - Pages isolated for migration
+# compact_stall            - Direct compaction stalls
+# compact_fail             - Compaction failures
+# compact_success          - Successful compactions
+```
+
+### Fragmentation Index
+
+```bash
+# Per-order fragmentation (0.0 = no fragmentation, 1.0 = severe)
+cat /sys/kernel/debug/extfrag/extfrag_index
+
+# Example:
+# Node 0, zone   Normal
+#     order   0   1   2   3   4   5   6   7   8   9  10
+#     index 0.0 0.0 0.0 0.0 0.1 0.2 0.4 0.6 0.8 0.9 1.0
+```
+
+### Tracing
+
+```bash
+# Trace compaction events
+echo 1 > /sys/kernel/debug/tracing/events/compaction/mm_compaction_begin/enable
+echo 1 > /sys/kernel/debug/tracing/events/compaction/mm_compaction_end/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+## Evolution
+
+### Introduction (v2.6.35, 2010)
+
+**Commit**: [748446bb6b5a](https://git.kernel.org/linus/748446bb6b5a) ("mm: compaction: memory compaction core")
+
+**Author**: Mel Gorman
+
+Initial compaction implementation to support THP and reduce high-order allocation failures.
+
+### kcompactd (v4.6, 2016)
+
+**Commit**: [698b1b30642f](https://git.kernel.org/linus/698b1b30642f) ("mm, compaction: introduce kcompactd")
+
+Background compaction daemon, similar to kswapd for reclaim.
+
+### Proactive Compaction (v5.9, 2020)
+
+**Commit**: [facdaa917c4d](https://git.kernel.org/linus/facdaa917c4d) ("mm: proactive compaction")
+
+Compact proactively based on fragmentation levels, reducing direct compaction stalls.
+
+## Compaction vs Reclaim
+
+Both run under memory pressure, but serve different purposes:
+
+| Aspect | Reclaim | Compaction |
+|--------|---------|------------|
+| Goal | Free memory | Create contiguous regions |
+| When | Low free pages | High-order allocation fails |
+| Action | Evict/swap pages | Move pages |
+| Daemon | kswapd | kcompactd |
+
+They often work together: reclaim frees pages, compaction arranges them.
+
+## Common Issues
+
+### Direct Compaction Stalls
+
+Processes blocked waiting for compaction.
+
+**Symptoms**: Latency spikes, high `compact_stall` count
+
+**Solutions**:
+- Enable proactive compaction
+- Tune `compaction_proactiveness`
+- Reduce high-order allocations
+
+### Compaction Failures
+
+Can't create contiguous regions.
+
+**Symptoms**: High `compact_fail`, THP allocation failures
+
+**Causes**:
+- Too many unmovable pages
+- Severe fragmentation
+
+**Solutions**:
+- Reduce kernel memory usage
+- Increase movable zone size
+- Consider memory hotplug for isolation
+
+### High CPU from kcompactd
+
+Background compaction consuming CPU.
+
+**Debug**: `top`, `perf top`
+
+**Solutions**:
+- Reduce `compaction_proactiveness`
+- Accept more direct compaction instead
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/compaction.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/compaction.c) | Compaction implementation |
+| [`mm/page_alloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) | Compaction triggers |
+
+### Related
+
+- [page-allocator](page-allocator.md) - Buddy system, migrate types
+- [thp](thp.md) - Primary consumer of compaction
+- [reclaim](reclaim.md) - Works alongside compaction

--- a/docs/mm/ksm.md
+++ b/docs/mm/ksm.md
@@ -1,0 +1,336 @@
+# Kernel Same-page Merging (KSM)
+
+> Deduplicating identical memory pages
+
+## What Is KSM?
+
+KSM scans memory for pages with identical content and merges them into a single copy-on-write (COW) page. When multiple processes have the same data in memory, KSM saves RAM by keeping only one copy.
+
+```
+Before KSM:
+Process A          Process B          Process C
+┌─────────┐       ┌─────────┐        ┌─────────┐
+│ Page X  │       │ Page X  │        │ Page X  │
+│ (same   │       │ (same   │        │ (same   │
+│ content)│       │ content)│        │ content)│
+└─────────┘       └─────────┘        └─────────┘
+   3 pages = 12KB
+
+After KSM:
+Process A          Process B          Process C
+    │                  │                  │
+    └──────────────────┼──────────────────┘
+                       │
+                       ▼
+                 ┌─────────┐
+                 │ Page X  │  (shared, COW)
+                 │         │
+                 └─────────┘
+   1 page = 4KB (saved 8KB)
+```
+
+## Why KSM?
+
+### The Virtualization Use Case
+
+KSM was designed for virtual machines. Multiple VMs often run identical operating systems:
+
+| Scenario | VMs | Potential Sharing |
+|----------|-----|-------------------|
+| 10 identical Linux VMs | 10 | Kernel, libraries, common data |
+| Development cluster | 50 | Base OS, toolchains |
+| VDI (Virtual Desktop) | 100+ | Windows, Office, browsers |
+
+Without KSM: 10 VMs × 2GB = 20GB RAM
+With KSM: Shared pages reduce to ~8GB (varies by workload)
+
+### Beyond VMs
+
+KSM also helps:
+- Containers with shared base images
+- Multiple instances of the same application
+- Fork-heavy workloads
+
+## How KSM Works
+
+### The ksmd Daemon
+
+A kernel thread (`ksmd`) continuously scans memory:
+
+```
+ksmd loop:
+    │
+    ├── Scan pages marked for merging
+    │
+    ├── Hash page content
+    │
+    ├── Look for matching hash in stable/unstable trees
+    │
+    ├── If match: verify byte-by-byte, merge pages
+    │
+    └── Sleep, repeat
+```
+
+### Two-Tree Structure
+
+KSM uses two red-black trees:
+
+**Stable tree**: Contains merged (shared) pages
+- Pages already deduplicated
+- Searched first for matches
+
+**Unstable tree**: Contains candidate pages
+- Pages seen once, waiting for a match
+- Rebuilt each scan cycle
+
+```
+New page arrives
+      │
+      v
+Search stable tree ──── Match? ──── Yes ──► Merge with stable page
+      │                                           │
+      No                                          │
+      │                                           │
+      v                                           │
+Search unstable tree ── Match? ──── Yes ──► Merge both, add to stable
+      │                                           │
+      No                                          │
+      │                                           │
+      v                                           │
+Add to unstable tree                              │
+      │                                           │
+      └───────────────────────────────────────────┘
+```
+
+### Copy-on-Write
+
+Merged pages are marked COW. If any process writes to the page:
+
+1. Page fault occurs
+2. Kernel copies page for the writer
+3. Writer gets private copy
+4. Other processes keep shared page
+
+## Enabling KSM
+
+### For Applications
+
+Applications must explicitly mark memory for KSM scanning:
+
+```c
+#include <sys/mman.h>
+
+void *ptr = mmap(NULL, size, PROT_READ|PROT_WRITE,
+                 MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+
+/* Enable KSM scanning for this region */
+madvise(ptr, size, MADV_MERGEABLE);
+
+/* Disable KSM scanning */
+madvise(ptr, size, MADV_UNMERGEABLE);
+```
+
+### For QEMU/KVM
+
+QEMU enables KSM for guest memory by default (can be disabled with `-machine mem-merge=off`).
+
+### System-Wide Control
+
+```bash
+# Enable/disable ksmd
+echo 1 > /sys/kernel/mm/ksm/run   # Start scanning
+echo 0 > /sys/kernel/mm/ksm/run   # Stop scanning
+echo 2 > /sys/kernel/mm/ksm/run   # Stop and unmerge all
+
+# Check if running
+cat /sys/kernel/mm/ksm/run
+```
+
+## Configuration
+
+### Scan Rate
+
+```bash
+# Pages to scan per cycle
+cat /sys/kernel/mm/ksm/pages_to_scan
+echo 100 > /sys/kernel/mm/ksm/pages_to_scan  # Default: 100
+
+# Sleep between cycles (milliseconds)
+cat /sys/kernel/mm/ksm/sleep_millisecs
+echo 20 > /sys/kernel/mm/ksm/sleep_millisecs  # Default: 20
+```
+
+Higher `pages_to_scan` + lower `sleep_millisecs` = faster merging but more CPU.
+
+### Merge Behavior
+
+```bash
+# Merge pages across NUMA nodes? (0=no, 1=yes)
+cat /sys/kernel/mm/ksm/merge_across_nodes
+# Default: 1 (merges across nodes)
+# Set to 0 for NUMA-aware workloads
+
+# Maximum merged pages (0=unlimited)
+cat /sys/kernel/mm/ksm/max_page_sharing
+# Limits how many processes share one page
+```
+
+## Monitoring
+
+### KSM Statistics
+
+```bash
+# Pages currently shared (deduplicated)
+cat /sys/kernel/mm/ksm/pages_shared
+
+# Total references to shared pages
+cat /sys/kernel/mm/ksm/pages_sharing
+
+# Memory saved = (pages_sharing - pages_shared) × 4KB
+
+# Unstable tree size
+cat /sys/kernel/mm/ksm/pages_unshared
+
+# Pages that can't be merged (volatile)
+cat /sys/kernel/mm/ksm/pages_volatile
+
+# Full scans completed
+cat /sys/kernel/mm/ksm/full_scans
+```
+
+### Calculating Savings
+
+```bash
+#!/bin/bash
+shared=$(cat /sys/kernel/mm/ksm/pages_shared)
+sharing=$(cat /sys/kernel/mm/ksm/pages_sharing)
+saved=$(( (sharing - shared) * 4 ))  # KB saved
+echo "KSM saving: ${saved} KB"
+```
+
+### Per-Process KSM Usage
+
+```bash
+# Pages merged for a process
+cat /proc/<pid>/ksm_merging_pages
+
+# Memory saved for this process (bytes, v6.1+)
+cat /proc/<pid>/ksm_stat
+```
+
+## Evolution
+
+### Introduction (v2.6.32, 2009)
+
+**Commit**: [f8af4da3b4c1](https://git.kernel.org/linus/f8af4da3b4c1) ("ksm: the mm interface to ksm")
+
+**Authors**: Izik Eidus, Andrea Arcangeli, Chris Wright (Red Hat, VMware)
+
+Originally developed for KVM to reduce memory footprint of virtual machines.
+
+### NUMA Awareness (v3.9, 2013)
+
+**Commit**: [90bd6fd31c80](https://git.kernel.org/linus/90bd6fd31c80) ("ksm: allow trees per NUMA node")
+
+Added `merge_across_nodes` option to prevent cross-node sharing that hurts NUMA locality.
+
+### Per-Process Statistics (v6.1, 2022)
+
+**Commit**: [cb4df4cae4f2](https://git.kernel.org/linus/cb4df4cae4f2) ("ksm: count allocated ksm rmap_items for each process")
+
+Added `/proc/<pid>/ksm_stat` for per-process memory savings tracking.
+
+## Trade-offs
+
+### Benefits
+
+| Benefit | Impact |
+|---------|--------|
+| Memory savings | 10-50% for VM workloads |
+| Higher VM density | More VMs per host |
+| Overcommit | Safely run more than physical RAM |
+
+### Costs
+
+| Cost | Impact |
+|------|--------|
+| CPU overhead | ksmd scanning uses CPU cycles |
+| COW faults | Write to shared page = page fault + copy |
+| Latency | COW adds latency to first write |
+| Security | Side-channel attacks possible (timing) |
+
+### Security Considerations
+
+KSM can leak information through timing:
+- Attacker allocates page with guessed content
+- If merged quickly, content exists elsewhere
+- Timing attack reveals memory contents
+
+For security-sensitive environments, consider disabling KSM or using `merge_across_nodes=0` with process isolation.
+
+## Common Issues
+
+### High CPU Usage
+
+ksmd consuming too much CPU.
+
+**Symptoms**: High CPU in `ksmd` process
+
+**Solutions**:
+- Reduce `pages_to_scan`
+- Increase `sleep_millisecs`
+- Disable if savings are minimal
+
+### Low Merge Rate
+
+Few pages being merged.
+
+**Debug**: Check `pages_shared` vs `pages_unshared`
+
+**Causes**:
+- Workloads with unique data
+- Scan rate too slow
+- Memory not marked `MADV_MERGEABLE`
+
+### NUMA Performance Issues
+
+Cross-node merging hurting performance.
+
+**Symptoms**: Higher memory latency after KSM enabled
+
+**Solution**:
+```bash
+echo 0 > /sys/kernel/mm/ksm/merge_across_nodes
+```
+
+## KSM vs Other Deduplication
+
+| Method | Scope | Overhead | Use Case |
+|--------|-------|----------|----------|
+| KSM | RAM, runtime | CPU for scanning | VMs, containers |
+| zswap | Swap, compressed | CPU for compression | Memory extension |
+| Filesystem dedup | Disk | I/O for scanning | Storage efficiency |
+| COW filesystems | Disk, snapshots | Metadata overhead | Backups, clones |
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/ksm.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/ksm.c) | KSM implementation |
+
+### Kernel Documentation
+
+- [`Documentation/admin-guide/mm/ksm.rst`](https://docs.kernel.org/admin-guide/mm/ksm.html)
+
+### Mailing List Discussions
+
+- [Original KSM patch series](https://lore.kernel.org/lkml/1247851850-4298-8-git-send-email-ieidus@redhat.com/) - Izik Eidus's July 2009 submission
+- [KSM NUMA trees and page migration](https://lore.kernel.org/all/alpine.LNX.2.00.1302111410290.1174@eggly.anvils/T/) - Hugh Dickins's 2013 NUMA awareness patches
+
+### Related
+
+- [reclaim](reclaim.md) - Memory pressure interaction
+- [numa](numa.md) - Cross-node merging considerations
+- [thp](thp.md) - KSM doesn't merge huge pages

--- a/docs/mm/memcg.md
+++ b/docs/mm/memcg.md
@@ -1,0 +1,368 @@
+# Memory Cgroups (memcg)
+
+> Container memory limits and accounting
+
+## What Is memcg?
+
+Memory cgroups (memcg) allow limiting and tracking memory usage for groups of processes. They're the foundation of container memory limits (Docker, Kubernetes, systemd).
+
+```
+Container A (limit: 1GB)      Container B (limit: 2GB)
+┌─────────────────────┐      ┌─────────────────────┐
+│  Process 1          │      │  Process 3          │
+│  Process 2          │      │  Process 4          │
+│  [shared memory]    │      │  [shared memory]    │
+└─────────────────────┘      └─────────────────────┘
+         │                            │
+         └────────────┬───────────────┘
+                      │
+              Memory Controller
+              (tracks & enforces)
+```
+
+## cgroup v1 vs v2
+
+Linux has two cgroup implementations:
+
+| Feature | v1 | v2 |
+|---------|----|----|
+| Hierarchy | Multiple (one per controller) | Single unified |
+| Memory+IO coordination | Difficult | Integrated |
+| Pressure notification | Limited | PSI (Pressure Stall Info) |
+| Default (modern systems) | Legacy | Preferred |
+
+**v2 is recommended** for new deployments. This document focuses on v2.
+
+```bash
+# Check which version is mounted
+mount | grep cgroup
+
+# v1: /sys/fs/cgroup/memory, /sys/fs/cgroup/cpu, etc.
+# v2: /sys/fs/cgroup (unified)
+```
+
+## Basic Operations
+
+### Create a cgroup
+
+```bash
+# Create a new cgroup
+mkdir /sys/fs/cgroup/mygroup
+
+# Move a process into it
+echo $PID > /sys/fs/cgroup/mygroup/cgroup.procs
+
+# Enable memory controller
+echo "+memory" > /sys/fs/cgroup/cgroup.subtree_control
+```
+
+### Set Memory Limit
+
+```bash
+# Set 500MB limit (cgroup v2)
+echo 500M > /sys/fs/cgroup/mygroup/memory.max
+
+# Set soft limit (reclaim target)
+echo 400M > /sys/fs/cgroup/mygroup/memory.high
+```
+
+### View Usage
+
+```bash
+# Current memory usage
+cat /sys/fs/cgroup/mygroup/memory.current
+
+# Detailed statistics
+cat /sys/fs/cgroup/mygroup/memory.stat
+```
+
+## Memory Limits (v2)
+
+| File | Description |
+|------|-------------|
+| `memory.max` | Hard limit. OOM kill if exceeded. |
+| `memory.high` | Soft limit. Throttle and reclaim aggressively. |
+| `memory.low` | Protection. Best-effort preservation under pressure. |
+| `memory.min` | Hard protection. Never reclaim below this. |
+
+```
+                    memory.max
+                        │
+        OOM kill ──────>│
+                        │
+                    memory.high
+                        │
+     Aggressive ───────>│
+      reclaim           │
+                        │
+                    memory.low
+                        │
+    Protected ─────────>│ (best-effort)
+                        │
+                    memory.min
+                        │
+     Cannot ───────────>│ (hard guarantee)
+      reclaim
+```
+
+### Example: Container Limits
+
+```bash
+# Production container setup
+echo 1G > /sys/fs/cgroup/container/memory.max    # Hard limit
+echo 800M > /sys/fs/cgroup/container/memory.high # Start throttling
+echo 200M > /sys/fs/cgroup/container/memory.low  # Protect this much
+```
+
+## What's Accounted
+
+memcg tracks:
+
+| Type | Accounted | Notes |
+|------|-----------|-------|
+| Anonymous pages | Yes | Heap, stack, mmap(MAP_ANONYMOUS) |
+| File cache | Yes | Pages from file reads |
+| Slab (kmem) | Yes (v2) | Kernel objects for this cgroup |
+| Huge pages | Separate | Via `hugetlb` controller |
+| Kernel stacks | Yes (v2) | Per-task kernel stacks |
+
+### Memory Statistics
+
+```bash
+cat /sys/fs/cgroup/mygroup/memory.stat
+
+# Key fields:
+# anon        - Anonymous memory
+# file        - File cache
+# slab        - Kernel slab objects
+# sock        - Network socket buffers
+# pgfault     - Page faults
+# pgmajfault  - Major page faults (disk I/O)
+```
+
+## Per-cgroup Reclaim
+
+When a cgroup approaches its limit, reclaim happens within that cgroup first.
+
+```
+Global memory OK
+        │
+        v
+Cgroup A at memory.high
+        │
+        v
+Reclaim from Cgroup A only
+(other cgroups unaffected)
+```
+
+### memory.reclaim (v5.19+)
+
+Proactively trigger reclaim:
+
+```bash
+# Reclaim 100MB from cgroup
+echo 100M > /sys/fs/cgroup/mygroup/memory.reclaim
+```
+
+Useful for:
+- Pre-warming before load spike
+- Reducing memory before migration
+- Testing reclaim behavior
+
+## OOM Handling
+
+When a cgroup exceeds `memory.max`:
+
+1. Kernel tries reclaim within cgroup
+2. If insufficient, triggers cgroup OOM
+3. OOM killer selects process within cgroup
+4. Selected process is killed
+
+```bash
+# View OOM events
+cat /sys/fs/cgroup/mygroup/memory.events
+
+# Fields:
+# oom        - OOM events count
+# oom_kill   - Processes killed by OOM
+# max        - Times memory.max was hit
+# high       - Times memory.high was hit
+```
+
+### OOM Group Kill (v4.19+)
+
+**Commit**: [3d8b38eb81ca](https://git.kernel.org/linus/3d8b38eb81ca) ("mm, oom: introduce memory.oom.group")
+
+Kill entire cgroup instead of single process:
+
+```bash
+echo 1 > /sys/fs/cgroup/mygroup/memory.oom.group
+```
+
+Useful for containers where killing one process leaves others broken.
+
+## Pressure Stall Information (PSI)
+
+PSI shows how much time tasks spend waiting for memory:
+
+```bash
+cat /sys/fs/cgroup/mygroup/memory.pressure
+
+# avg10=0.00 avg60=0.00 avg300=0.00 total=12345
+# some: percentage of time at least one task was stalled
+# full: percentage of time all tasks were stalled
+```
+
+### Use Cases
+
+- **Autoscaling**: Scale up when pressure increases
+- **Health checks**: Detect memory-constrained containers
+- **Load balancing**: Move workloads from pressured nodes
+
+```bash
+# Monitor system-wide pressure
+cat /proc/pressure/memory
+```
+
+## Hierarchical Limits
+
+Cgroups are hierarchical. Child limits can't exceed parent:
+
+```
+root (limit: 8GB)
+├── container-a (limit: 2GB)
+│   ├── app (limit: 1GB)      <- effective: 1GB
+│   └── sidecar (limit: 3GB)  <- effective: 2GB (parent limit)
+└── container-b (limit: 4GB)
+```
+
+## Swap Control
+
+```bash
+# Limit swap usage (v2)
+echo 0 > /sys/fs/cgroup/mygroup/memory.swap.max    # No swap
+echo 500M > /sys/fs/cgroup/mygroup/memory.swap.max # 500MB swap
+
+# View swap usage
+cat /sys/fs/cgroup/mygroup/memory.swap.current
+```
+
+## History
+
+### Memory Controller Introduction (v2.6.25, 2008)
+
+**Commit**: [8cdea7c05454](https://git.kernel.org/linus/8cdea7c05454) ("Memory controller: cgroups setup")
+
+Initial memory cgroup implementation for cgroup v1.
+
+### Unified Hierarchy (cgroup v2, v4.5, 2016)
+
+The cgroup v2 unified hierarchy was marked non-experimental in v4.5, with the memory controller considered stable for production use. The memory controller was reworked significantly from v1, with cleaner semantics and integrated pressure stall information.
+
+### Kernel Memory Accounting (v4.5+)
+
+Kernel memory (slab, stacks) included in memory.current by default in v2.
+
+### memory.reclaim (v5.19, 2022)
+
+**Commit**: [94968384dde1](https://git.kernel.org/linus/94968384dde1) ("memcg: introduce per-memcg reclaim interface")
+
+Proactive reclaim interface.
+
+## Try It Yourself
+
+### Create a Memory-Limited Shell
+
+```bash
+# Create cgroup
+sudo mkdir /sys/fs/cgroup/test
+
+# Enable memory controller (if needed)
+echo "+memory" | sudo tee /sys/fs/cgroup/cgroup.subtree_control
+
+# Set 100MB limit
+echo 100M | sudo tee /sys/fs/cgroup/test/memory.max
+
+# Move current shell into cgroup
+echo $$ | sudo tee /sys/fs/cgroup/test/cgroup.procs
+
+# Now try to allocate more than 100MB
+python3 -c "x = 'a' * 150_000_000"  # Will be OOM killed
+```
+
+### Monitor a Container
+
+```bash
+# Find container's cgroup
+CGROUP=$(cat /proc/<container-pid>/cgroup | cut -d: -f3)
+
+# Watch memory usage
+watch -n 1 cat /sys/fs/cgroup/$CGROUP/memory.current
+
+# View detailed stats
+cat /sys/fs/cgroup/$CGROUP/memory.stat
+```
+
+### Simulate Memory Pressure
+
+```bash
+# Create cgroup with low limit
+sudo mkdir /sys/fs/cgroup/pressure-test
+echo 50M | sudo tee /sys/fs/cgroup/pressure-test/memory.max
+
+# Run memory-hungry process
+echo $$ | sudo tee /sys/fs/cgroup/pressure-test/cgroup.procs
+stress --vm 1 --vm-bytes 100M
+
+# Watch pressure
+cat /sys/fs/cgroup/pressure-test/memory.pressure
+```
+
+## Common Issues
+
+### Container OOM Despite Free System Memory
+
+Container hit its `memory.max` limit.
+
+**Debug**: Check `memory.events` for `oom` count.
+
+**Solutions**:
+- Increase limit
+- Optimize application memory usage
+- Add swap and `memory.swap.max`
+
+### Slow Container Startup
+
+Memory being reclaimed during startup.
+
+**Debug**: Check `memory.pressure`
+
+**Solutions**:
+- Increase `memory.high`
+- Pre-warm with `memory.reclaim`
+- Check if limit is too low
+
+### Kernel Memory Growing Unbounded (v1)
+
+In cgroup v1, kernel memory wasn't limited by default.
+
+**Solution**: Use cgroup v2, or set `memory.kmem.limit_in_bytes` in v1.
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/memcontrol.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memcontrol.c) | Memory controller implementation |
+| [`include/linux/memcontrol.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/memcontrol.h) | memcg API |
+
+### Kernel Documentation
+
+- [`Documentation/admin-guide/cgroup-v2.rst`](https://docs.kernel.org/admin-guide/cgroup-v2.html) - Authoritative cgroup v2 docs
+
+### Related
+
+- [reclaim](reclaim.md) - How memory is reclaimed
+- [page-allocator](page-allocator.md) - Global memory allocation
+- [glossary](glossary.md) - cgroup, OOM definitions

--- a/docs/mm/mmap.md
+++ b/docs/mm/mmap.md
@@ -1,0 +1,406 @@
+# Process Address Space
+
+> How Linux manages virtual memory for processes
+
+## What Is the Process Address Space?
+
+Each process has its own virtual address space - a private view of memory that the kernel maps to physical memory. This isolation means processes can't access each other's memory (without explicit sharing).
+
+```
+Process A's View              Process B's View
+┌─────────────────┐          ┌─────────────────┐
+│ Stack      ↓    │          │ Stack      ↓    │
+├─────────────────┤          ├─────────────────┤
+│                 │          │                 │
+│   (unmapped)    │          │   (unmapped)    │
+│                 │          │                 │
+├─────────────────┤          ├─────────────────┤
+│ Heap       ↑    │          │ Heap       ↑    │
+├─────────────────┤          ├─────────────────┤
+│ BSS (zero)      │          │ BSS (zero)      │
+├─────────────────┤          ├─────────────────┤
+│ Data            │          │ Data            │
+├─────────────────┤          ├─────────────────┤
+│ Text (code)     │          │ Text (code)     │
+└─────────────────┘          └─────────────────┘
+   0x0                          0x0
+
+Same virtual addresses, different physical memory
+```
+
+## Virtual Memory Areas (VMAs)
+
+The address space is divided into regions called VMAs. Each VMA describes a contiguous range with consistent properties.
+
+### VMA Structure
+
+```c
+struct vm_area_struct {
+    unsigned long vm_start;      /* Start address */
+    unsigned long vm_end;        /* End address (exclusive) */
+    pgprot_t vm_page_prot;       /* Access permissions */
+    unsigned long vm_flags;      /* Flags (VM_READ, VM_WRITE, etc.) */
+    struct file *vm_file;        /* Backing file (or NULL) */
+    unsigned long vm_pgoff;      /* Offset in file */
+    struct mm_struct *vm_mm;     /* Owning mm_struct */
+    /* ... */
+};
+```
+
+### VMA Types
+
+| Type | vm_file | Description |
+|------|---------|-------------|
+| Anonymous | NULL | Heap, stack, mmap(MAP_ANONYMOUS) |
+| File-backed | Set | mmap'd files, executables, libraries |
+| Shared | Set + VM_SHARED | Shared memory regions |
+
+### Viewing VMAs
+
+```bash
+# View process memory map
+cat /proc/<pid>/maps
+
+# Example output:
+# address          perms offset   dev   inode   pathname
+# 00400000-00452000 r-xp 00000000 08:01 1234    /bin/bash
+# 00651000-00652000 r--p 00051000 08:01 1234    /bin/bash
+# 00652000-0065b000 rw-p 00052000 08:01 1234    /bin/bash
+# 0065b000-00660000 rw-p 00000000 00:00 0       [heap]
+# 7f8a0000-7f8a2000 rw-p 00000000 00:00 0
+# 7ffff000-80000000 rw-p 00000000 00:00 0       [stack]
+
+# Detailed view with sizes
+cat /proc/<pid>/smaps
+```
+
+## The mmap() System Call
+
+`mmap()` creates new VMAs - it's how processes request virtual memory.
+
+### Basic Usage
+
+```c
+#include <sys/mman.h>
+
+/* Anonymous mapping (like malloc for large allocations) */
+void *ptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+/* File mapping */
+int fd = open("file.dat", O_RDONLY);
+void *ptr = mmap(NULL, size, PROT_READ,
+                 MAP_PRIVATE, fd, 0);
+
+/* Unmap when done */
+munmap(ptr, size);
+```
+
+### mmap Flags
+
+| Flag | Description |
+|------|-------------|
+| `MAP_PRIVATE` | Copy-on-write, changes not written to file |
+| `MAP_SHARED` | Changes visible to other processes and written to file |
+| `MAP_ANONYMOUS` | Not backed by file, zero-initialized |
+| `MAP_FIXED` | Use exact address (dangerous) |
+| `MAP_POPULATE` | Pre-fault pages (avoid later faults) |
+| `MAP_HUGETLB` | Use huge pages |
+| `MAP_LOCKED` | Lock in RAM (like mlock) |
+
+### Protection Flags
+
+| Flag | Description |
+|------|-------------|
+| `PROT_READ` | Pages can be read |
+| `PROT_WRITE` | Pages can be written |
+| `PROT_EXEC` | Pages can be executed |
+| `PROT_NONE` | Pages cannot be accessed |
+
+## Address Space Layout
+
+### Traditional Layout (32-bit)
+
+```
+┌──────────────────┐ 0xFFFFFFFF (4GB)
+│  Kernel Space    │
+├──────────────────┤ 0xC0000000 (3GB) - TASK_SIZE
+│  Stack     ↓     │
+├──────────────────┤
+│  mmap region ↓   │
+├──────────────────┤
+│                  │
+├──────────────────┤
+│  Heap       ↑    │ brk
+├──────────────────┤
+│  BSS             │
+├──────────────────┤
+│  Data            │
+├──────────────────┤
+│  Text            │
+└──────────────────┘ 0x08048000
+```
+
+### Modern Layout (64-bit with ASLR)
+
+```
+┌──────────────────┐ 0xFFFFFFFFFFFFFFFF
+│  Kernel Space    │
+├──────────────────┤ 0x7FFFFFFFFFFF (128TB user limit)
+│  Stack     ↓     │ (randomized)
+├──────────────────┤
+│                  │
+├──────────────────┤
+│  mmap region     │ (randomized)
+│  (libs, anon)    │
+├──────────────────┤
+│                  │
+├──────────────────┤
+│  Heap       ↑    │ (randomized)
+├──────────────────┤
+│  BSS/Data/Text   │ (randomized)
+└──────────────────┘ 0x0
+```
+
+### ASLR (Address Space Layout Randomization)
+
+ASLR randomizes memory layout to make exploits harder:
+
+```bash
+# Check ASLR setting
+cat /proc/sys/kernel/randomize_va_space
+# 0 = disabled
+# 1 = stack/mmap randomized
+# 2 = + heap randomized (full ASLR)
+```
+
+## Memory Management Structures
+
+### mm_struct
+
+Each address space is described by one `mm_struct` (threads within a process share the same mm_struct via `CLONE_VM`):
+
+```c
+struct mm_struct {
+    struct maple_tree mm_mt;     /* VMA tree (replaced rb_root in v6.1) */
+    unsigned long task_size;     /* Size of user address space */
+    pgd_t *pgd;                  /* Page Global Directory */
+    atomic_t mm_users;           /* Processes sharing this mm */
+    atomic_t mm_count;           /* References to struct */
+    unsigned long start_code, end_code;   /* Text segment */
+    unsigned long start_data, end_data;   /* Data segment */
+    unsigned long start_brk, brk;         /* Heap */
+    unsigned long start_stack;            /* Stack start */
+    unsigned long mmap_base;              /* mmap region base */
+    /* ... */
+};
+```
+
+### VMA Organization
+
+VMAs were stored in a red-black tree until v6.1, then switched to a maple tree for better performance:
+
+```
+Pre-v6.1: Red-Black Tree     v6.1+: Maple Tree
+       [VMA]                    [Maple Node]
+      /     \                   /    |    \
+   [VMA]   [VMA]             [VMA] [VMA] [VMA]
+   /   \                      ...
+[VMA] [VMA]
+```
+
+**Commit**: [d4af56c5c7c6](https://git.kernel.org/linus/d4af56c5c7c6) ("mm: start tracking VMAs with maple tree")
+
+## Demand Paging
+
+Pages aren't allocated until accessed. This is called demand paging or lazy allocation.
+
+```
+mmap() called:
+┌───────────────────────┐
+│ VMA created           │
+│ No physical pages yet │
+└───────────────────────┘
+
+First access:
+┌───────────────────────┐
+│ Page fault            │
+│     ↓                 │
+│ Allocate page         │
+│     ↓                 │
+│ Update page table     │
+│     ↓                 │
+│ Resume execution      │
+└───────────────────────┘
+```
+
+### Fault Types
+
+| Fault | Cause | Resolution |
+|-------|-------|------------|
+| Minor | Page in memory but PTE needs update | Update PTE (includes COW breaks, access/dirty bit updates) |
+| Major | Page not in memory | Read from file/swap |
+| Invalid | Bad access (SIGSEGV) | Kill process |
+
+## Copy-on-Write (COW)
+
+When `fork()` creates a child, pages are shared until written:
+
+```
+After fork():
+Parent          Child
+  │               │
+  └───────┬───────┘
+          │
+          ▼
+    [Shared Page]  (read-only)
+
+After child writes:
+Parent          Child
+  │               │
+  ▼               ▼
+[Original]    [Copy]
+```
+
+This makes `fork()` fast - page tables are duplicated (pointing to the same physical pages, now marked read-only), but the actual data pages are not copied. Only when either process writes does a copy occur.
+
+## Common Operations
+
+### brk/sbrk (Heap)
+
+```c
+/* Expand heap */
+void *old_brk = sbrk(0);
+brk(old_brk + 4096);  /* Add 4KB to heap */
+
+/* malloc typically uses mmap for large allocations */
+```
+
+### mprotect (Change Permissions)
+
+```c
+/* Make region read-only */
+mprotect(ptr, size, PROT_READ);
+
+/* Make region executable (JIT) */
+mprotect(ptr, size, PROT_READ | PROT_EXEC);
+```
+
+### mlock (Pin in RAM)
+
+```c
+/* Prevent page from being swapped */
+mlock(ptr, size);
+
+/* Unlock */
+munlock(ptr, size);
+
+/* Lock all current and future pages */
+mlockall(MCL_CURRENT | MCL_FUTURE);
+```
+
+### mremap (Resize Mapping)
+
+```c
+/* Grow or shrink a mapping */
+void *new_ptr = mremap(ptr, old_size, new_size, MREMAP_MAYMOVE);
+```
+
+## Evolution
+
+### Original Design (1991)
+
+Simple linear list of VMAs. Worked for small address spaces.
+
+### Red-Black Tree (v2.4.10, 2001)
+
+VMA lookup changed from O(n) to O(log n) using rb-tree.
+
+### Maple Tree (v6.1, 2022)
+
+**Commit**: [d4af56c5c7c6](https://git.kernel.org/linus/d4af56c5c7c6)
+
+Replaced rb-tree with maple tree for better cache behavior and RCU-safe lookups.
+
+### Per-VMA Locks (v6.4, 2023)
+
+**Commit**: [5e31275cc997](https://git.kernel.org/linus/5e31275cc997) ("mm: add per-VMA lock and helper functions to control it")
+
+Fine-grained locking per VMA instead of mmap_lock for entire mm, improving scalability for page fault handling.
+
+## Debugging
+
+### /proc Interface
+
+```bash
+# Memory map
+cat /proc/<pid>/maps
+
+# Detailed with RSS, PSS, etc.
+cat /proc/<pid>/smaps
+
+# Summary
+cat /proc/<pid>/smaps_rollup
+
+# Memory stats
+cat /proc/<pid>/status | grep -i vm
+# VmPeak: Peak virtual memory
+# VmSize: Current virtual memory
+# VmRSS:  Resident set size
+# VmData: Data segment
+# VmStk:  Stack
+```
+
+### Tracing
+
+```bash
+# Trace mmap calls
+strace -e mmap,munmap,mprotect ./program
+
+# Trace page faults
+echo 1 > /sys/kernel/debug/tracing/events/exceptions/page_fault_user/enable
+```
+
+## Common Issues
+
+### Virtual Memory Exhaustion
+
+Process hits `TASK_SIZE` limit or `vm.max_map_count`.
+
+```bash
+# View/set max VMAs per process
+cat /proc/sys/vm/max_map_count
+echo 65530 > /proc/sys/vm/max_map_count
+```
+
+### Memory Fragmentation
+
+Many small mappings prevent large allocations.
+
+**Solution**: Use larger mappings, reduce mmap/munmap churn.
+
+### mmap_lock Contention
+
+Multiple threads fighting for mm->mmap_lock.
+
+**Solution**: Upgrade to v6.4+ for per-VMA locks, or reduce mmap operations.
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/mmap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) | mmap implementation |
+| [`mm/memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c) | Page fault handling |
+| [`include/linux/mm_types.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mm_types.h) | mm_struct, vm_area_struct |
+
+### Kernel Documentation
+
+- [`Documentation/mm/process_addrs.rst`](https://docs.kernel.org/mm/process_addrs.html)
+
+### Related
+
+- [page-tables](page-tables.md) - How VMAs are backed by page tables
+- [reclaim](reclaim.md) - Anonymous vs file-backed page handling
+- [thp](thp.md) - Huge pages in VMAs

--- a/docs/mm/numa.md
+++ b/docs/mm/numa.md
@@ -1,0 +1,313 @@
+# NUMA Memory Management
+
+> Managing memory across multiple nodes
+
+## What Is NUMA?
+
+NUMA (Non-Uniform Memory Access) describes systems where memory access time depends on which CPU accesses which memory. Each CPU has "local" memory (fast) and "remote" memory (slower).
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      NUMA System                         │
+│                                                          │
+│   Node 0                          Node 1                 │
+│  ┌──────────────┐                ┌──────────────┐       │
+│  │    CPU 0-7   │                │   CPU 8-15   │       │
+│  └──────┬───────┘                └──────┬───────┘       │
+│         │ fast                          │ fast          │
+│  ┌──────▼───────┐                ┌──────▼───────┐       │
+│  │  Memory 64GB │◄───────────────►  Memory 64GB │       │
+│  └──────────────┘     slow       └──────────────┘       │
+│                    interconnect                          │
+└─────────────────────────────────────────────────────────┘
+
+CPU 0 accessing Node 0 memory: ~80ns
+CPU 0 accessing Node 1 memory: ~150ns (1.9x slower)
+```
+
+## Why NUMA Matters
+
+### The Scalability Problem
+
+As systems grew beyond 4-8 CPUs, a single memory bus became a bottleneck. Every CPU competed for the same memory bandwidth.
+
+### NUMA as Solution
+
+NUMA divides memory into nodes, each with dedicated bandwidth. Local access is fast; remote access crosses an interconnect but the system scales.
+
+| System Type | CPUs | Memory Bandwidth |
+|-------------|------|------------------|
+| UMA (single bus) | 1-8 | Shared, contended |
+| NUMA (2 nodes) | 8-32 | 2x bandwidth |
+| NUMA (8 nodes) | 32-128+ | 8x bandwidth |
+
+## Linux NUMA Support
+
+### Topology Discovery
+
+Linux discovers NUMA topology from firmware (ACPI SRAT/SLIT tables):
+
+```bash
+# View NUMA topology
+numactl --hardware
+
+# Example output:
+# available: 2 nodes (0-1)
+# node 0 cpus: 0 1 2 3 4 5 6 7
+# node 0 size: 65536 MB
+# node distances:
+# node   0   1
+#   0:  10  21
+#   1:  21  10
+```
+
+The distance matrix shows relative access latency (10 = local, higher = remote).
+
+### Default Allocation Policy
+
+By default, Linux allocates memory from the node where the task is running ("local allocation"):
+
+```c
+/* Default: allocate from current node */
+void *ptr = malloc(size);  /* Goes to local node */
+```
+
+## Memory Policies
+
+Linux provides fine-grained control over NUMA placement via memory policies.
+
+### Policy Types
+
+| Policy | Behavior |
+|--------|----------|
+| `MPOL_DEFAULT` | Local allocation (system default) |
+| `MPOL_BIND` | Only allocate from specified nodes |
+| `MPOL_PREFERRED` | Prefer specified node, fall back to others |
+| `MPOL_INTERLEAVE` | Round-robin across specified nodes |
+| `MPOL_LOCAL` | Always allocate from local node |
+
+### Setting Policies
+
+**Process-wide (set_mempolicy)**:
+```c
+#include <numaif.h>
+
+unsigned long nodemask = 0x1;  /* Node 0 */
+set_mempolicy(MPOL_BIND, &nodemask, sizeof(nodemask) * 8);
+/* All future allocations from node 0 only */
+```
+
+**Per-region (mbind)**:
+```c
+#include <numaif.h>
+
+void *ptr = mmap(...);
+unsigned long nodemask = 0x3;  /* Nodes 0 and 1 */
+mbind(ptr, size, MPOL_INTERLEAVE, &nodemask,
+      sizeof(nodemask) * 8, 0);
+/* This region interleaved across nodes 0-1 */
+```
+
+**Command line (numactl)**:
+```bash
+# Run on specific CPUs and memory nodes
+numactl --cpunodebind=0 --membind=0 ./myapp
+
+# Interleave memory across all nodes
+numactl --interleave=all ./myapp
+```
+
+### When to Use Each Policy
+
+| Use Case | Recommended Policy |
+|----------|-------------------|
+| General applications | `MPOL_DEFAULT` (let kernel decide) |
+| Memory-bandwidth bound | `MPOL_INTERLEAVE` |
+| Latency-sensitive | `MPOL_BIND` to local node |
+| Large shared buffers | `MPOL_INTERLEAVE` |
+| Database buffer pools | `MPOL_BIND` or `MPOL_INTERLEAVE` |
+
+## Automatic NUMA Balancing
+
+Since v3.8, Linux can automatically migrate pages to be closer to the CPUs accessing them.
+
+### How It Works
+
+1. Kernel periodically unmaps pages (marks PTEs as "NUMA hint faults")
+2. When accessed, a NUMA hint fault occurs
+3. Kernel records which node accessed the page
+4. If page is frequently accessed from remote node, migrate it
+
+```
+Page on Node 0, accessed by CPU on Node 1
+              │
+              v
+      NUMA hint fault
+              │
+              v
+    Record access from Node 1
+              │
+              v
+    Migrate page to Node 1
+              │
+              v
+    Future accesses are local (fast)
+```
+
+### Configuration
+
+```bash
+# Enable/disable NUMA balancing
+cat /proc/sys/kernel/numa_balancing
+echo 1 > /proc/sys/kernel/numa_balancing
+
+# Scan period bounds (milliseconds between scans)
+cat /proc/sys/kernel/numa_balancing_scan_period_min_ms  # Min time between scans
+cat /proc/sys/kernel/numa_balancing_scan_period_max_ms  # Max time between scans
+# Kernel adjusts scan rate within these bounds based on migration activity
+```
+
+### Trade-offs
+
+**Benefits**:
+- No application changes needed
+- Adapts to changing access patterns
+- Helps poorly-placed workloads
+
+**Costs**:
+- CPU overhead from fault handling
+- Migration overhead
+- Can fight with explicit policies
+
+## Memory Tiering (CXL Era)
+
+Modern systems add new memory tiers via CXL (Compute Express Link):
+
+```
+┌─────────────────────────────────────────────┐
+│              Tiered Memory                   │
+│                                              │
+│  Tier 0: Local DRAM     (~80ns, expensive)  │
+│  Tier 1: CXL Memory     (~200ns, cheaper)   │
+│  Tier 2: Persistent Mem (~300ns, persistent)│
+└─────────────────────────────────────────────┘
+```
+
+Linux treats CXL memory as additional NUMA nodes with higher distances. The kernel can demote cold pages to slower tiers and promote hot pages to faster tiers.
+
+```bash
+# View memory tiers (v6.1+)
+cat /sys/devices/virtual/memory_tiering/memory_tier*/nodelist
+```
+
+## Monitoring
+
+### Per-Node Statistics
+
+```bash
+# Memory per node
+cat /sys/devices/system/node/node*/meminfo
+
+# NUMA hits/misses
+cat /proc/vmstat | grep numa
+# numa_hit        - Allocations satisfied from preferred node
+# numa_miss       - Allocations from non-preferred node
+# numa_foreign    - Pages intended for this node, placed elsewhere
+# numa_interleave - Interleaved allocations
+# numa_local      - Local allocations
+# numa_other      - Non-local allocations
+```
+
+### Per-Process NUMA Map
+
+```bash
+# Show which nodes hold a process's pages
+cat /proc/<pid>/numa_maps
+
+# Example:
+# 7f8a1000 default file=/lib/libc.so anon=1 dirty=1 N0=1
+# 7f8a2000 interleave:0-1 anon=512 N0=256 N1=256
+```
+
+## Evolution
+
+### Early NUMA (v2.5-2.6, 2003-2004)
+
+Basic NUMA support added by SGI, IBM and others for their large systems. Memory policies (`set_mempolicy`, `mbind`) introduced by Andi Kleen. The mempolicy code predates git history (included in initial v2.6.12 import).
+
+### cpusets Integration (v2.6.16, 2005)
+
+**Commit**: [68860ec10bcc](https://git.kernel.org/linus/68860ec10bcc) ("cpusets: automatic numa mempolicy rebinding")
+
+cpusets allowed constraining processes to specific nodes, enabling NUMA-aware container isolation.
+
+### Automatic NUMA Balancing (v3.8, 2013)
+
+**Merge**: [3d59eebc5e13](https://git.kernel.org/linus/3d59eebc5e13) ("Merge tag 'balancenuma-v11'")
+
+Kernel-level automatic page migration based on access patterns. Major work by Mel Gorman, Rik van Riel, and others.
+
+### Memory Tiering (v5.18+, 2022)
+
+**Commit**: [c574bbe91703](https://git.kernel.org/linus/c574bbe91703) ("NUMA balancing: optimize page placement for memory tiering system")
+
+Support for heterogeneous memory (CXL, persistent memory) as additional NUMA tiers with automatic promotion/demotion. Further refined in v6.1 with explicit memory tier framework ([992bf77591cb](https://git.kernel.org/linus/992bf77591cb)).
+
+## Common Issues
+
+### Remote Memory Pressure
+
+Allocations forced to remote nodes due to local exhaustion.
+
+**Symptoms**: High `numa_miss` in `/proc/vmstat`
+
+**Solutions**:
+- Balance workload memory across nodes
+- Use `MPOL_INTERLEAVE` for large allocations
+- Reserve memory on each node
+
+### NUMA Balancing Overhead
+
+Excessive migration and fault handling.
+
+**Symptoms**: High CPU in `task_numa_fault`, many page migrations
+
+**Solutions**:
+- Disable if workload has stable access patterns: `echo 0 > /proc/sys/kernel/numa_balancing`
+- Tune scan rates
+- Use explicit memory policies
+
+### Unbalanced Node Usage
+
+One node exhausted while others have free memory.
+
+**Debug**: Check `/sys/devices/system/node/node*/meminfo`
+
+**Solutions**:
+- Use `MPOL_INTERLEAVE` for large allocations
+- Improve workload distribution
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/mempolicy.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mempolicy.c) | Memory policy implementation |
+| [`kernel/sched/fair.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/sched/fair.c) | NUMA balancing in scheduler |
+| [`mm/migrate.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/migrate.c) | Page migration |
+
+### Kernel Documentation
+
+- [`Documentation/admin-guide/mm/numa_memory_policy.rst`](https://docs.kernel.org/admin-guide/mm/numa_memory_policy.html)
+
+### Mailing List Discussions
+
+- [Automatic NUMA Balancing V3 (RFC)](https://lore.kernel.org/linux-mm/20121116160852.GA4302@gmail.com/t/) - Mel Gorman's 2012 RFC laying out the four-stage design
+- [NUMA balancing sysctls documentation](https://lore.kernel.org/lkml/1373065742-9753-2-git-send-email-mgorman@suse.de/) - July 2013 patch series
+
+### Related
+
+- [page-allocator](page-allocator.md) - Per-node zones
+- [reclaim](reclaim.md) - Per-node reclaim
+- [glossary](glossary.md) - NUMA terminology

--- a/docs/mm/page-cache.md
+++ b/docs/mm/page-cache.md
@@ -1,0 +1,364 @@
+# Page Cache
+
+> Caching file data in memory
+
+## What Is the Page Cache?
+
+The page cache keeps recently accessed file data in RAM. When you read a file, the data stays in memory - subsequent reads come from RAM instead of disk.
+
+```
+First read:
+Application ──► Kernel ──► Storage (slow: ~10ms HDD, ~100μs NVMe)
+                  │
+                  ▼
+             Page Cache (stores copy)
+
+Second read:
+Application ──► Kernel ──► Page Cache (fast, ~100ns)
+                           (storage not touched)
+```
+
+## Why Page Cache?
+
+### The Speed Gap
+
+| Storage | Latency | Bandwidth |
+|---------|---------|-----------|
+| RAM | ~100ns | ~100 GB/s |
+| NVMe SSD | ~100µs | ~7 GB/s |
+| SATA SSD | ~100µs | ~600 MB/s |
+| HDD | ~10ms | ~200 MB/s |
+
+RAM is 1000-100,000x faster than storage. Caching exploits temporal locality - recently accessed data is likely to be accessed again.
+
+### Benefits
+
+- **Read performance**: Hot data served from RAM
+- **Write buffering**: Writes batched, not synchronous
+- **Shared data**: Multiple processes share cached pages
+- **Memory efficiency**: Unused RAM becomes cache
+
+## How It Works
+
+### Reading Files
+
+```
+read(fd, buf, 4096)
+        │
+        v
+Find page in cache? ─── Yes ──► Copy to user buffer
+        │
+        No
+        │
+        v
+Allocate page
+        │
+        v
+Read from disk into page
+        │
+        v
+Add to page cache
+        │
+        v
+Copy to user buffer
+```
+
+### Writing Files
+
+```
+write(fd, buf, 4096)
+        │
+        v
+Find/allocate page in cache
+        │
+        v
+Copy from user buffer to page
+        │
+        v
+Mark page dirty
+        │
+        v
+Return to application (write "complete")
+        │
+        ▼ (later, asynchronously)
+Writeback thread flushes to disk
+```
+
+Writes return immediately - data is in cache, marked dirty. Background writeback handles actual disk I/O.
+
+### The address_space Structure
+
+Each file (inode) has an `address_space` managing its cached pages:
+
+```c
+struct address_space {
+    struct inode *host;           /* Owning inode */
+    struct xarray i_pages;        /* Cached pages */
+    unsigned long nrpages;        /* Number of cached pages */
+    const struct address_space_operations *a_ops;  /* Operations */
+    /* ... */
+};
+```
+
+Pages are indexed by file offset in the XArray, enabling fast lookup.
+
+## Dirty Pages and Writeback
+
+### Dirty Page Lifecycle
+
+```
+Clean page ──► write() ──► Dirty page ──► writeback ──► Clean page
+                               │
+                               ▼
+                     Tracked in dirty lists
+```
+
+### Writeback Triggers
+
+| Trigger | When |
+|---------|------|
+| Periodic | Every `dirty_writeback_centisecs` (default: 5s) |
+| Memory pressure | Reclaim needs to free pages |
+| sync/fsync | Explicit flush request |
+| Dirty threshold | Too many dirty pages system-wide |
+| Dirty age | Page dirty longer than `dirty_expire_centisecs` |
+
+### Dirty Page Limits
+
+```bash
+# Percentage of memory that can be dirty
+cat /proc/sys/vm/dirty_ratio
+# 20 (default) - start blocking writers at 20%
+
+# Background writeback threshold
+cat /proc/sys/vm/dirty_background_ratio
+# 10 (default) - start background writeback at 10%
+
+# Time-based settings (centiseconds)
+cat /proc/sys/vm/dirty_expire_centisecs
+# 3000 (30s) - pages older than this get written
+
+cat /proc/sys/vm/dirty_writeback_centisecs
+# 500 (5s) - writeback thread wakes this often
+```
+
+### Writeback Threads
+
+```bash
+# Per-device writeback threads
+ps aux | grep writeback
+# kworker/u8:0+flush-8:0   (for device 8:0)
+```
+
+## Reading Strategies
+
+### Readahead
+
+The kernel predicts sequential access and reads ahead:
+
+```
+Application reads page 0
+        │
+        v
+Kernel detects sequential pattern
+        │
+        v
+Prefetch pages 1, 2, 3, 4... into cache
+        │
+        v
+When application reads page 1, it's already cached
+```
+
+```bash
+# Default readahead (KB)
+cat /sys/block/sda/queue/read_ahead_kb
+# 128 (default)
+
+# Adjust for workload
+echo 256 > /sys/block/sda/queue/read_ahead_kb
+```
+
+### mmap vs read()
+
+| Method | Mechanism | Best For |
+|--------|-----------|----------|
+| `read()` | Copy from cache to user buffer | Sequential, simple |
+| `mmap()` | Map cache pages into process address space | Random access, large files |
+
+With `mmap()`, page cache pages can be directly mapped into the process address space:
+
+```c
+void *ptr = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+/* ptr directly references page cache pages - true zero-copy */
+
+/* With MAP_PRIVATE, writes trigger COW (copy-on-write) */
+void *ptr = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
+/* Reads are zero-copy, but writes get a private copy */
+```
+
+## Memory Pressure
+
+### Page Cache as "Free" Memory
+
+Linux uses "free" RAM for page cache. When applications need memory:
+
+1. Clean cache pages are dropped immediately
+2. Dirty cache pages are written out, then dropped
+3. Application gets the memory
+
+```bash
+# View memory breakdown
+cat /proc/meminfo | grep -E "MemFree|Cached|Buffers|Available"
+# MemFree:     1234567 kB   (truly free)
+# Cached:      8765432 kB   (page cache)
+# MemAvailable: 9876543 kB  (free + reclaimable cache)
+```
+
+### Drop Caches (Testing Only)
+
+```bash
+# Drop clean caches (for benchmarking)
+sync  # Write dirty pages first
+echo 3 > /proc/sys/vm/drop_caches
+# 1 = page cache
+# 2 = dentries/inodes
+# 3 = both
+```
+
+## Monitoring
+
+### System-Wide Cache Statistics
+
+```bash
+# Disk I/O counters (not direct cache hit/miss - includes readahead, direct I/O)
+cat /proc/vmstat | grep -E "pgpgin|pgpgout"
+# pgpgin   - Pages read from disk (KB)
+# pgpgout  - Pages written to disk (KB)
+
+# Page cache size and state
+cat /proc/meminfo | grep -E "Cached|Buffers|Dirty|Writeback"
+# Cached:      Page cache size (file-backed pages in memory)
+# Buffers:     Block device metadata cache
+# Dirty:       Pages modified, waiting to be written
+# Writeback:   Pages currently being written to disk
+```
+
+Note: Linux doesn't expose a direct "cache hit ratio" counter. High pgpgin with low Cached growth suggests cache pressure.
+
+### Per-File Cache Status
+
+```bash
+# Check if file is cached (using vmtouch or fincore)
+vmtouch -v /path/to/file
+# Files: 1
+# Pages: 1000 (cached: 800)
+
+# Or with fincore (coreutils)
+fincore /path/to/file
+```
+
+### Tracing
+
+```bash
+# Trace page cache events
+echo 1 > /sys/kernel/debug/tracing/events/filemap/mm_filemap_add_to_page_cache/enable
+echo 1 > /sys/kernel/debug/tracing/events/writeback/writeback_dirty_page/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+## Evolution
+
+### Origins (1990s)
+
+Page cache has existed since early Linux. Originally separate from the "buffer cache" (for block devices).
+
+### Unified Page Cache (v2.4, 2001)
+
+Buffer cache merged into page cache. All file I/O goes through one cache.
+
+### Radix Tree (v2.6)
+
+Pages indexed in radix tree for fast lookup by file offset.
+
+### XArray (v4.20, 2018)
+
+**Commit**: [a28334862993](https://git.kernel.org/linus/a28334862993) ("page cache: Finish XArray conversion")
+
+Radix tree replaced with XArray - cleaner API, same performance.
+
+### Folios (v5.16, 2022)
+
+**Commit**: [7b230db3b8d3](https://git.kernel.org/linus/7b230db3b8d3) ("mm: Introduce struct folio")
+
+**Author**: Matthew Wilcox
+
+Folios represent one or more contiguous pages as a single unit. This abstraction reduces overhead for huge pages in the page cache and eliminates confusion about whether a function operates on a head page or any page.
+
+## Direct I/O (Bypassing Cache)
+
+Some applications bypass page cache entirely:
+
+```c
+int fd = open("file", O_RDWR | O_DIRECT);
+/* Reads/writes bypass page cache */
+/* Requires aligned buffers and sizes */
+```
+
+**Use cases**:
+- Databases with their own caching
+- Avoiding double-caching
+- Predictable latency
+
+**Trade-offs**:
+- No readahead benefits
+- No write buffering
+- Application must handle caching
+
+## Common Issues
+
+### Cache Thrashing
+
+Working set larger than available RAM.
+
+**Symptoms**: High `pgpgin`/`pgpgout`, slow I/O
+
+**Solutions**:
+- Add RAM
+- Reduce working set
+- Use O_DIRECT for some workloads
+
+### Dirty Page Buildup
+
+Too many dirty pages causing write stalls.
+
+**Symptoms**: Processes blocked in `balance_dirty_pages`
+
+**Solutions**:
+- Lower `dirty_ratio`
+- Faster storage
+- Reduce write rate
+
+### Readahead Mismatch
+
+Sequential readahead hurts random workloads.
+
+**Solutions**:
+- Use `posix_fadvise(POSIX_FADV_RANDOM)`
+- Reduce `read_ahead_kb`
+- Use `madvise(MADV_RANDOM)` for mmap
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/filemap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/filemap.c) | Page cache core |
+| [`mm/readahead.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/readahead.c) | Readahead logic |
+| [`mm/page-writeback.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page-writeback.c) | Dirty page handling |
+
+### Related
+
+- [reclaim](reclaim.md) - How cache pages are reclaimed
+- [mmap](mmap.md) - Memory-mapped file I/O
+- [swap](swap.md) - When anonymous pages go to disk

--- a/docs/mm/page-tables.md
+++ b/docs/mm/page-tables.md
@@ -1,0 +1,299 @@
+# Page Tables
+
+> Mapping virtual addresses to physical memory
+
+## What Are Page Tables?
+
+Page tables are hierarchical data structures that map virtual addresses (what programs see) to physical addresses (actual RAM locations). The MMU (Memory Management Unit) hardware uses them to translate every memory access.
+
+```
+Virtual Address                Physical Address
+0x7fff12340000   ──────────>   0x1a2b3c000
+       │                              │
+       │    Page Table Walk           │
+       └──────────────────────────────┘
+```
+
+## The Five-Level Hierarchy
+
+Linux uses a five-level page table hierarchy (since v4.14 for x86-64):
+
+```
++-----+
+| PGD |  Page Global Directory
++-----+
+   │
+   v
++-----+
+| P4D |  Page Level 4 Directory (5-level paging only)
++-----+
+   │
+   v
++-----+
+| PUD |  Page Upper Directory
++-----+
+   │
+   v
++-----+
+| PMD |  Page Middle Directory
++-----+
+   │
+   v
++-----+
+| PTE |  Page Table Entry
++-----+
+   │
+   v
+ PAGE    Physical memory page
+```
+
+### Level Details
+
+| Level | Type | Bits (x86-64) | Entries | Maps |
+|-------|------|---------------|---------|------|
+| PGD | `pgd_t` | 47-39 (4-level) or 56-48 (5-level) | 512 | 512GB or 128PB |
+| P4D | `p4d_t` | 47-39 | 512 | 512GB (folded if 4-level) |
+| PUD | `pud_t` | 38-30 | 512 | 1GB |
+| PMD | `pmd_t` | 29-21 | 512 | 2MB |
+| PTE | `pte_t` | 20-12 | 512 | 4KB |
+
+### Address Translation (x86-64, 4-level)
+
+A 48-bit virtual address breaks down as:
+
+```
+ 47      39 38      30 29      21 20      12 11       0
++----------+----------+----------+----------+----------+
+| PGD idx  | PUD idx  | PMD idx  | PTE idx  |  Offset  |
++----------+----------+----------+----------+----------+
+   9 bits     9 bits     9 bits     9 bits    12 bits
+```
+
+## Page Table Folding
+
+Not all architectures need all five levels. Linux handles this through **folding** - unused levels are compile-time optimized away.
+
+| Architecture | Levels | Notes |
+|--------------|--------|-------|
+| x86-64 (LA57) | 5 | 57-bit virtual addresses |
+| x86-64 (standard) | 4 | 48-bit virtual addresses |
+| x86-32 (PAE) | 3 | 36-bit physical addresses |
+| x86-32 | 2 | Original 32-bit |
+| ARM64 | 3-4 | Configurable |
+
+When a level is folded, functions like `p4d_offset()` become no-ops that return the input unchanged.
+
+## Key Data Structures
+
+### Per-Process Page Tables
+
+Each process has its own page tables via `mm_struct`:
+
+```c
+struct mm_struct {
+    pgd_t *pgd;              /* Top-level page table */
+    atomic_t mm_users;       /* Users of this mm */
+    atomic_t mm_count;       /* References to struct */
+    /* ... */
+};
+```
+
+The kernel has a single `swapper_pg_dir` for kernel mappings, shared across all processes.
+
+### Page Table Entry Format (x86-64 specific)
+
+```
+ 63    62    52 51                           12 11  9 8 7 6 5 4 3 2 1 0
++----+--------+-------------------------------+-----+-+-+-+-+-+-+-+-+-+
+| XD | (avail)|        Physical Address       |avail|G|S|D|A|C|W|U|W|P|
++----+--------+-------------------------------+-----+-+-+-+-+-+-+-+-+-+
+  │                        │                          │ │ │ │ │ │ │ │ │
+  │                        │                          │ │ │ │ │ │ │ │ └─ Present
+  │                        │                          │ │ │ │ │ │ │ └─── Writable
+  │                        │                          │ │ │ │ │ │ └───── User accessible
+  │                        │                          │ │ │ │ │ └─────── Write-through
+  │                        │                          │ │ │ │ └───────── Cache disable
+  │                        │                          │ │ │ └─────────── Accessed
+  │                        │                          │ │ └───────────── Dirty
+  │                        │                          │ └─────────────── Page size (huge)
+  │                        │                          └───────────────── Global
+  │                        └──────────────────────────────────────────── PFN
+  └───────────────────────────────────────────────────────────────────── Execute disable
+```
+
+## Page Faults
+
+When the MMU can't translate an address, it triggers a **page fault**. The kernel handles this in `handle_mm_fault()`:
+
+```
+Page Fault
+    │
+    v
+handle_mm_fault()
+    │
+    v
+__handle_mm_fault()
+    │
+    ├── pgd_offset() ─> p4d_alloc()
+    ├── p4d_offset() ─> pud_alloc()
+    ├── pud_offset() ─> pmd_alloc()
+    ├── pmd_offset() ─> pte_alloc()
+    │
+    v
+handle_pte_fault()
+    │
+    ├── do_read_fault()    (file read)
+    ├── do_cow_fault()     (copy-on-write)
+    └── do_shared_fault()  (shared mapping)
+```
+
+### Fault Types
+
+| Type | Cause | Resolution |
+|------|-------|------------|
+| Minor | Page in memory, PTE not set | Update PTE |
+| Major | Page not in memory | Read from disk/swap |
+| Invalid | Bad address or permissions | SIGSEGV |
+
+## TLB (Translation Lookaside Buffer)
+
+The TLB caches recent translations. Without it, every memory access would require multiple page table lookups.
+
+### TLB Flush Operations
+
+```c
+/* Flush single page */
+flush_tlb_page(vma, addr);
+
+/* Flush range */
+flush_tlb_range(vma, start, end);
+
+/* Flush entire mm */
+flush_tlb_mm(mm);
+```
+
+TLB flushes are expensive on SMP - they require IPIs (Inter-Processor Interrupts) to all CPUs running the affected process.
+
+## Huge Pages
+
+Higher-level entries can map large pages directly, skipping lower levels:
+
+| Level | Page Size | Use Case |
+|-------|-----------|----------|
+| PUD | 1GB | Large databases, VMs |
+| PMD | 2MB | General large allocations |
+| PTE | 4KB | Default |
+
+```c
+/* Check if PMD maps a huge page */
+if (pmd_large(*pmd)) {
+    /* 2MB page, no PTE walk needed */
+}
+```
+
+Benefits:
+- Fewer TLB entries needed
+- Reduced page table memory
+- Fewer page faults
+
+Trade-offs:
+- Internal fragmentation
+- Allocation challenges
+
+## History
+
+### Origins (1991-1994)
+
+Early Linux on i386 used two-level page tables (PGD + PTE). The `swapper_pg_dir` was the top-level Page Global Directory, not a single flat table. The i386 hardware dictated this structure.
+
+### Three-Level (v2.3.23, 1999)
+
+Added PMD for PAE (Physical Address Extension) on x86, enabling >4GB physical memory on 32-bit.
+
+### Four-Level (v2.6.11, 2005)
+
+Added PUD for x86-64's 48-bit virtual address space. This predates git history (kernel moved to git at v2.6.12).
+
+### Five-Level (v4.14, 2017)
+
+**Commit**: [77ef56e4f0fb](https://git.kernel.org/linus/77ef56e4f0fb) ("x86: Enable 5-level paging support via CONFIG_X86_5LEVEL=y")
+
+Added P4D for 57-bit virtual addresses (128PB), needed for machines with >64TB physical memory.
+
+## Try It Yourself
+
+### View Process Page Tables
+
+```bash
+# Page table stats for a process
+cat /proc/<pid>/smaps | grep -E "Size|Rss|Pss"
+
+# Detailed page mapping
+cat /proc/<pid>/pagemap  # Binary format
+
+# Parse with tools
+pagemap <pid> <address>
+```
+
+### Check TLB Flushes
+
+```bash
+# TLB flush statistics
+cat /proc/vmstat | grep tlb
+
+# Trace TLB flushes
+echo 1 > /sys/kernel/debug/tracing/events/tlb/tlb_flush/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+### Check Huge Page Usage
+
+```bash
+# System huge page stats
+cat /proc/meminfo | grep -i huge
+
+# Per-process huge pages
+cat /proc/<pid>/smaps | grep -i huge
+```
+
+## Common Issues
+
+### TLB Shootdown Storms
+
+Heavy `mprotect()` or `munmap()` causes excessive IPIs.
+
+**Debug**: Check `/proc/interrupts` for TLB IPI counts.
+
+### Page Table Memory Overhead
+
+Sparse address spaces waste page table memory.
+
+**Debug**: Check `PageTables` in `/proc/meminfo`.
+
+### Huge Page Allocation Failures
+
+Can't allocate huge pages due to fragmentation.
+
+**Solutions**:
+- Reserve at boot: `hugepages=N`
+- Enable THP: `/sys/kernel/mm/transparent_hugepage/enabled`
+- Compact memory: `echo 1 > /proc/sys/vm/compact_memory`
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`include/linux/pgtable.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/pgtable.h) | Generic page table API |
+| [`arch/x86/include/asm/pgtable.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/include/asm/pgtable.h) | x86 page table definitions |
+| [`mm/memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c) | Page fault handling |
+
+### Kernel Documentation
+
+- [`Documentation/mm/page_tables.rst`](https://docs.kernel.org/mm/page_tables.html)
+
+### Related
+
+- [overview](overview.md) - Memory management overview
+- [glossary](glossary.md) - PFN, TLB, MMU definitions

--- a/docs/mm/reclaim.md
+++ b/docs/mm/reclaim.md
@@ -1,0 +1,367 @@
+# Page Reclaim
+
+> What happens when memory runs low
+
+## What Is Page Reclaim?
+
+When the system runs low on free memory, the kernel must reclaim pages from existing users. Page reclaim finds pages that can be freed or written to swap, making room for new allocations.
+
+```
+Memory Pressure
+      │
+      v
+┌─────────────────┐
+│  Page Reclaim   │
+├─────────────────┤
+│ - File pages    │──> Write dirty pages, drop clean
+│ - Anonymous     │──> Swap out
+│ - Slab caches   │──> Shrink caches
+└─────────────────┘
+      │
+      v
+Free Pages Available
+```
+
+## Two Paths to Reclaim
+
+### 1. Background Reclaim (kswapd)
+
+`kswapd` is a per-node kernel thread that reclaims pages in the background when memory falls below the `low` watermark.
+
+```
+Free pages fall below low watermark
+           │
+           v
+    Wake kswapd
+           │
+           v
+    Reclaim pages until high watermark reached
+           │
+           v
+    kswapd sleeps
+```
+
+**Key characteristic**: Processes don't block. kswapd works asynchronously.
+
+### 2. Direct Reclaim
+
+When kswapd can't keep up and free pages fall below the `min` watermark, allocating processes must reclaim pages themselves.
+
+```
+Allocation request
+        │
+        v
+    Free pages < min?
+        │ yes
+        v
+    Direct reclaim (process blocks)
+        │
+        v
+    Retry allocation
+```
+
+**Key characteristic**: The allocating process blocks until pages are freed.
+
+## Watermarks
+
+Each zone has three watermarks controlling reclaim behavior:
+
+```
+             ┌──────────────────┐
+  high ─────>│                  │  Zone healthy, no action
+             ├──────────────────┤
+  low  ─────>│  Wake kswapd     │  Background reclaim starts
+             ├──────────────────┤
+  min  ─────>│  Direct reclaim  │  Allocating process helps
+             ├──────────────────┤
+             │  OOM territory   │  Kill processes
+             └──────────────────┘
+```
+
+Watermarks are derived from `vm.min_free_kbytes`:
+
+```bash
+# View watermarks
+cat /proc/zoneinfo | grep -E "min|low|high"
+
+# Adjust base value (affects all watermarks)
+sysctl vm.min_free_kbytes=65536
+```
+
+## LRU Lists
+
+The kernel tracks page usage with LRU (Least Recently Used) lists. Pages move between lists based on access patterns.
+
+### Classic LRU (Two-List)
+
+```
+              Active                    Inactive
+         ┌─────────────┐           ┌─────────────┐
+  Hot    │   Recent    │           │   Recent    │
+ pages   │   access    │ ────────> │   access    │ ──> Reclaim
+         │             │  demote   │             │
+         └─────────────┘           └─────────────┘
+               ^                          │
+               │        promote           │
+               └──────────────────────────┘
+```
+
+Four lists per node (two types x two states):
+- `LRU_INACTIVE_ANON` - Inactive anonymous pages
+- `LRU_ACTIVE_ANON` - Active anonymous pages
+- `LRU_INACTIVE_FILE` - Inactive file-backed pages
+- `LRU_ACTIVE_FILE` - Active file-backed pages
+
+### Multi-Gen LRU (MGLRU)
+
+Introduced in v6.1, MGLRU replaces the two-list model with multiple generations for better aging accuracy.
+
+```
+Generation 0 (oldest) ──> Generation 1 ──> ... ──> Generation N (youngest)
+      │
+      v
+   Reclaim
+```
+
+**Benefits**:
+- Better detection of hot vs cold pages
+- Reduced CPU overhead from page table scanning
+- Improved performance under memory pressure
+
+```bash
+# Check if MGLRU is enabled (hex bitmask)
+cat /sys/kernel/mm/lru_gen/enabled
+# 0x0007 = fully enabled (0x0001 | 0x0002 | 0x0004)
+
+# Enable all MGLRU features (if built with CONFIG_LRU_GEN)
+echo 0x0007 > /sys/kernel/mm/lru_gen/enabled
+# Bits: 0x0001=base, 0x0002=clear accessed in leaf PTEs, 0x0004=non-leaf PTEs
+```
+
+## What Gets Reclaimed
+
+### File Pages (Page Cache)
+
+Pages backed by files on disk:
+
+| State | Action |
+|-------|--------|
+| Clean | Drop immediately (can re-read from disk) |
+| Dirty | Write to disk first, then drop |
+
+### Anonymous Pages
+
+Pages with no file backing (heap, stack):
+
+| Swap Available | Action |
+|----------------|--------|
+| Yes | Write to swap, then free |
+| No | Cannot reclaim without killing owner (OOM killer) |
+
+### Slab Caches
+
+Kernel object caches can shrink via **shrinkers**:
+
+```c
+/* Shrinkers registered by subsystems */
+register_shrinker(&my_shrinker);
+
+/* Called during reclaim */
+struct shrinker {
+    unsigned long (*count_objects)(struct shrinker *, ...);
+    unsigned long (*scan_objects)(struct shrinker *, ...);
+};
+```
+
+Examples: dentry cache, inode cache, vfs caches.
+
+```bash
+# View shrinker stats
+cat /sys/kernel/debug/shrinker/*
+```
+
+## Swappiness
+
+`vm.swappiness` controls the balance between reclaiming file pages vs anonymous pages:
+
+| Value | Behavior |
+|-------|----------|
+| 0 | Avoid swapping, prefer file cache reclaim |
+| 60 | Default balance |
+| 100 | Aggressively swap anonymous pages |
+
+```bash
+# View current value
+cat /proc/sys/vm/swappiness
+
+# Adjust (persistent in /etc/sysctl.conf)
+sysctl vm.swappiness=10
+```
+
+## OOM Killer
+
+When reclaim fails and memory is exhausted, the OOM (Out of Memory) killer terminates processes to free memory.
+
+### OOM Score
+
+Each process has an OOM score (0-1000). Higher = more likely to be killed.
+
+```bash
+# View OOM score
+cat /proc/<pid>/oom_score
+
+# Adjust OOM priority (-1000 to 1000)
+echo -500 > /proc/<pid>/oom_score_adj  # Less likely to be killed
+echo 1000 > /proc/<pid>/oom_score_adj  # Kill this first
+```
+
+### OOM Selection Criteria
+
+The kernel considers:
+1. Memory usage (primary factor)
+2. `oom_score_adj` adjustments
+3. Whether killing frees memory (children, shared pages)
+4. Root processes get slight protection
+
+```bash
+# Watch OOM events
+dmesg | grep -i "out of memory"
+
+# Or via tracing
+echo 1 > /sys/kernel/debug/tracing/events/oom/oom_score_adj_update/enable
+```
+
+## Reclaim Behavior Tunables
+
+| Sysctl | Description |
+|--------|-------------|
+| `vm.min_free_kbytes` | Base for watermark calculation |
+| `vm.swappiness` | Anon vs file reclaim balance |
+| `vm.vfs_cache_pressure` | Pressure on dentry/inode caches |
+| `vm.dirty_ratio` | Max dirty pages before blocking writes |
+| `vm.dirty_background_ratio` | When background writeback starts |
+
+## History
+
+### Origins
+
+Page reclaim has existed since early Linux. The basic kswapd mechanism predates git history.
+
+### rmap (Reverse Mapping, v2.5)
+
+**Problem**: To reclaim a page, kernel needed to find all PTEs pointing to it. Required scanning all page tables.
+
+**Solution**: Reverse mapping - each page tracks which PTEs map it.
+
+### Split LRU (v2.6.28, 2008)
+
+**Commit**: [4f98a2fee8ac](https://git.kernel.org/linus/4f98a2fee8ac) ("vmscan: split LRU lists into anon & file sets")
+
+Split single LRU into separate anonymous and file lists for better reclaim decisions.
+
+### MGLRU (v6.1, 2022)
+
+**Commit**: [ac35a4902374](https://git.kernel.org/linus/ac35a4902374) ("mm: multi-gen LRU: minimal implementation")
+
+Multi-generational LRU for improved page aging and reduced overhead.
+
+## Try It Yourself
+
+### Monitor Reclaim Activity
+
+```bash
+# Real-time reclaim stats
+watch -n 1 'cat /proc/vmstat | grep -E "pgscan|pgsteal|kswapd"'
+
+# Key metrics:
+# pgscan_kswapd  - Pages scanned by kswapd
+# pgscan_direct  - Pages scanned by direct reclaim
+# pgsteal_*      - Pages successfully reclaimed
+```
+
+### Trigger Memory Pressure
+
+```bash
+# Consume memory to trigger reclaim
+stress --vm 1 --vm-bytes 2G --vm-keep
+
+# Watch kswapd wake up
+watch -n 1 'ps aux | grep kswapd'
+```
+
+### Trace Reclaim Events
+
+```bash
+# Enable reclaim tracing
+echo 1 > /sys/kernel/debug/tracing/events/vmscan/mm_vmscan_direct_reclaim_begin/enable
+echo 1 > /sys/kernel/debug/tracing/events/vmscan/mm_vmscan_direct_reclaim_end/enable
+
+# Watch events
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+### Check Zone Pressure
+
+```bash
+# Detailed zone info including watermarks
+cat /proc/zoneinfo
+
+# Quick check
+cat /proc/buddyinfo
+```
+
+## Common Issues
+
+### Direct Reclaim Stalls
+
+Processes blocked in direct reclaim, causing latency spikes.
+
+**Debug**: Check `allocstall_*` in `/proc/vmstat`
+
+**Solutions**:
+- Increase `vm.min_free_kbytes`
+- Add swap if missing
+- Reduce memory pressure
+
+### kswapd CPU Usage
+
+kswapd consuming excessive CPU.
+
+**Debug**: `top` or `perf top`
+
+**Causes**:
+- Too little free memory
+- Workload constantly dirtying pages
+- Swap thrashing
+
+### OOM Kills Despite Free Memory
+
+Free memory exists but in wrong zone or fragmented.
+
+**Debug**: Check `/proc/buddyinfo` and `/proc/zoneinfo`
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/vmscan.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c) | Core reclaim logic |
+| [`mm/oom_kill.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/oom_kill.c) | OOM killer |
+| [`mm/page_alloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) | Watermark checks |
+
+### Kernel Documentation
+
+- [`Documentation/admin-guide/mm/multigen_lru.rst`](https://docs.kernel.org/admin-guide/mm/multigen_lru.html)
+- [`Documentation/mm/balance.rst`](https://docs.kernel.org/mm/balance.html)
+
+### Mailing List Discussions
+
+- [Multi-Gen LRU Framework v14](https://lore.kernel.org/linux-mm/20220815071332.627393-1-yuzhao@google.com/) - Yu Zhao's August 2022 patch series
+- [MGLRU design doc](https://lore.kernel.org/all/20220815071332.627393-15-yuzhao@google.com/) - Detailed design explaining generations, page table walks, and the PID controller
+
+### Related
+
+- [page-allocator](page-allocator.md) - Watermarks, zones
+- [glossary](glossary.md) - LRU, OOM, swap definitions
+- [memcg](memcg.md) - Per-cgroup memory limits and reclaim

--- a/docs/mm/slab.md
+++ b/docs/mm/slab.md
@@ -191,9 +191,11 @@ cat /sys/kernel/slab/kmalloc-256/sanity_checks
 
 | Pattern | Meaning |
 |---------|---------|
-| `0x5a` | Object in use (`POISON_INUSE`) - detects corruption of live objects |
+| `0x5a` | Uninitialized (`POISON_INUSE`) - detects uninitialized access |
 | `0x6b` | Object freed (`POISON_FREE`) - detects use-after-free |
-| `0xa5` | Red zone padding - detects buffer overflows |
+| `0xa5` | End marker (`POISON_END`) - marks end of poisoned region |
+| `0xbb` | Red zone inactive (`SLUB_RED_INACTIVE`) - detects buffer overflows on free objects |
+| `0xcc` | Red zone active (`SLUB_RED_ACTIVE`) - detects buffer overflows on in-use objects |
 
 ## Security Hardening
 

--- a/docs/mm/swap.md
+++ b/docs/mm/swap.md
@@ -1,0 +1,421 @@
+# Swap
+
+> Extending memory to disk
+
+## What Is Swap?
+
+Swap allows the kernel to move infrequently used pages from RAM to disk, freeing memory for active use. When those pages are needed again, they're read back from swap.
+
+```
+RAM Full, need more memory:
+┌─────────────────────────────────────────┐
+│ RAM: [Active] [Active] [Inactive] [Active] │
+└─────────────────────────────────────────┘
+                    │
+                    ▼ (swap out)
+┌─────────────────────────────────────────┐
+│ RAM: [Active] [Active] [FREE] [Active]    │
+└─────────────────────────────────────────┘
+┌─────────────────────────────────────────┐
+│ Swap: [Inactive page]                     │
+└─────────────────────────────────────────┘
+
+Later, page accessed:
+                    │
+                    ▼ (swap in)
+┌─────────────────────────────────────────┐
+│ RAM: [Active] [Page back] [X] [Active]   │
+└─────────────────────────────────────────┘
+```
+
+## Swap Types
+
+### Swap Partition
+
+Dedicated disk partition for swap:
+
+```bash
+# Create swap partition (during install or with fdisk)
+mkswap /dev/sda2
+swapon /dev/sda2
+
+# View active swap
+swapon --show
+# NAME      TYPE      SIZE USED PRIO
+# /dev/sda2 partition 8G   1.2G -2
+```
+
+### Swap File
+
+Regular file used as swap:
+
+```bash
+# Create a 4GB swap file (modern method)
+fallocate -l 4G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+
+# Make permanent in /etc/fstab:
+# /swapfile none swap sw 0 0
+```
+
+**Note for btrfs (COW filesystems):** The `+C` (no-copy-on-write) attribute must be set before the file has data:
+
+```bash
+# Method 1: Create empty file, set +C, then allocate
+touch /swapfile
+chattr +C /swapfile
+fallocate -l 4G /swapfile
+chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile
+
+# Method 2: Set +C on parent directory (new files inherit it)
+mkdir /swap && chattr +C /swap
+fallocate -l 4G /swap/swapfile
+# ... then mkswap, swapon as usual
+```
+
+### zswap (Compressed Swap Cache)
+
+Compresses pages before writing to disk, often avoiding disk I/O entirely:
+
+```
+Page to swap out
+       │
+       v
+Compress in RAM (zswap pool)
+       │
+       ├── Fits in pool? ──► Store compressed (no disk I/O)
+       │
+       └── Pool full? ──► Write to backing swap device
+```
+
+```bash
+# Enable zswap
+echo 1 > /sys/module/zswap/parameters/enabled
+
+# Configure compressor and pool
+echo lz4 > /sys/module/zswap/parameters/compressor
+echo 20 > /sys/module/zswap/parameters/max_pool_percent
+
+# View statistics
+grep -r . /sys/kernel/debug/zswap/ 2>/dev/null
+```
+
+### zram (Compressed RAM Disk)
+
+RAM-based block device with compression - swap without disk:
+
+```bash
+# Load module
+modprobe zram
+
+# Set size (compression makes effective size larger)
+echo 4G > /sys/block/zram0/disksize
+
+# Use as swap
+mkswap /dev/zram0
+swapon /dev/zram0 -p 100  # Higher priority than disk swap
+```
+
+## Swap Architecture
+
+### Swap Areas
+
+Linux supports multiple swap areas with priorities:
+
+```bash
+# View swap areas
+cat /proc/swaps
+# Filename        Type        Size      Used    Priority
+# /dev/sda2       partition   8388604   1234560 -2
+# /dev/zram0      partition   4194300   567890  100
+```
+
+Higher priority swap is used first. Equal priorities are striped (round-robin).
+
+### Swap Cache
+
+Recently swapped-in pages stay in swap cache briefly:
+
+```
+Swap cache:
+┌─────────────────────────────────────────┐
+│ Page in RAM + still on swap             │
+│ (if process forks, child can share)     │
+└─────────────────────────────────────────┘
+```
+
+If a swapped-in page is swapped out again without modification, no disk write needed.
+
+### Swap Slots
+
+Swap space is divided into slots (one per page):
+
+```c
+/* Each slot tracks one swapped page */
+swap_entry_t entry = swp_entry(type, offset);
+/* type: which swap area */
+/* offset: slot within that area */
+```
+
+## Swapping Mechanics
+
+### Swap Out (Page to Disk)
+
+```
+Memory pressure
+       │
+       v
+Select victim page (from inactive list)
+       │
+       v
+Allocate swap slot
+       │
+       v
+Write page to swap
+       │
+       v
+Update PTE: present=0, swap_entry=slot
+       │
+       v
+Free page frame
+```
+
+### Swap In (Disk to Page)
+
+```
+Process accesses swapped page
+       │
+       v
+Page fault (not present)
+       │
+       v
+Read swap entry from PTE
+       │
+       v
+Allocate page frame
+       │
+       v
+Read from swap into page
+       │
+       v
+Update PTE: present=1, page_frame=new
+       │
+       v
+Resume process
+```
+
+## Configuration
+
+### Swappiness
+
+Controls preference for swapping anonymous pages vs dropping file cache:
+
+```bash
+cat /proc/sys/vm/swappiness
+# 60 (default)
+
+# Lower = prefer dropping cache, avoid swapping
+echo 10 > /proc/sys/vm/swappiness
+
+# Higher = more willing to swap
+echo 80 > /proc/sys/vm/swappiness
+
+# 0 = swap only to avoid OOM (not never)
+```
+
+### Swap Priority
+
+```bash
+# Set priority when enabling
+swapon -p 100 /dev/zram0    # High priority
+swapon -p -2 /dev/sda2      # Low priority (default)
+
+# In /etc/fstab:
+# /dev/zram0 none swap sw,pri=100 0 0
+# /dev/sda2  none swap sw,pri=-2  0 0
+```
+
+### Overcommit
+
+```bash
+# Memory overcommit policy
+cat /proc/sys/vm/overcommit_memory
+# 0 = heuristic (default) - allow reasonable overcommit
+# 1 = always allow - never fail malloc
+# 2 = strict - limit to swap + ratio*RAM
+
+# For mode 2, the ratio:
+cat /proc/sys/vm/overcommit_ratio
+# 50 (default) = swap + 50% of RAM
+```
+
+## Monitoring
+
+### Swap Usage
+
+```bash
+# Quick view
+free -h
+#                total   used   free  shared  buff/cache  available
+# Swap:           8.0G   1.2G   6.8G
+
+# Detailed
+cat /proc/meminfo | grep -i swap
+# SwapCached:    123456 kB  (pages in swap and RAM)
+# SwapTotal:    8388604 kB
+# SwapFree:     7000000 kB
+```
+
+### Swap Activity
+
+```bash
+# Pages swapped in/out
+cat /proc/vmstat | grep -E "pswpin|pswpout"
+# pswpin  - Pages read from swap
+# pswpout - Pages written to swap
+
+# Real-time monitoring
+vmstat 1
+# si = swap in (KB/s)
+# so = swap out (KB/s)
+```
+
+### Per-Process Swap
+
+```bash
+# Swap usage per process
+cat /proc/<pid>/status | grep -i swap
+# VmSwap:     1234 kB
+
+# System-wide total
+awk '/VmSwap/{sum+=$2} END {print sum" kB"}' /proc/*/status 2>/dev/null
+
+# Top swap consumers by process
+grep VmSwap /proc/*/status 2>/dev/null | sort -k2 -n | tail
+```
+
+### zswap Statistics
+
+```bash
+cat /sys/kernel/debug/zswap/pool_total_size     # Compressed size
+cat /sys/kernel/debug/zswap/stored_pages        # Pages in zswap
+cat /sys/kernel/debug/zswap/written_back_pages  # Evicted to disk
+```
+
+## Evolution
+
+### Original Swap (1991)
+
+Basic swap support from the beginning. Single swap area.
+
+### Multiple Swap Areas (v1.3)
+
+Support for multiple swap partitions with priorities.
+
+### Swap Files (v2.6)
+
+Swap files became as efficient as partitions.
+
+### zswap (v3.11, 2013)
+
+**Commit**: [2b2811178e85](https://git.kernel.org/linus/2b2811178e85) ("zswap: add to mm/")
+
+Compressed swap cache to reduce disk I/O.
+
+### zram Swap (v3.14, 2014)
+
+zram became suitable for swap use, enabling diskless swap.
+
+### THP Swap (v4.13, 2017)
+
+**Commit**: [38d8b4e6bdc8](https://git.kernel.org/linus/38d8b4e6bdc8) ("mm, THP, swap: delay splitting THP during swap out")
+
+Transparent Huge Pages can now be swapped without splitting first.
+
+### Swap-over-NFS (Experimental)
+
+Work ongoing to allow swapping to network storage for diskless systems.
+
+## Swap vs No Swap
+
+### Arguments for Swap
+
+| Benefit | Explanation |
+|---------|-------------|
+| OOM prevention | Swap provides buffer before OOM killer |
+| Hibernation | Requires swap for suspend-to-disk |
+| Idle page eviction | Unused pages can be moved out |
+| Overcommit safety | More headroom for memory spikes |
+
+### Arguments Against Swap
+
+| Concern | Explanation |
+|---------|-------------|
+| Latency | Swap is slow, can cause hangs |
+| SSD wear | Frequent swapping wears flash |
+| Thrashing | Heavy swap = system unusable |
+| Memory hiding | Masks memory leaks |
+
+### Recommendation
+
+Most systems benefit from some swap:
+- **Servers**: RAM + zswap, small disk swap for emergencies
+- **Desktops**: RAM/2 to RAM, with zswap
+- **Embedded**: Often none (limited storage, predictable workload)
+
+## Common Issues
+
+### Swap Thrashing
+
+Constant swapping makes system unusable.
+
+**Symptoms**: High `si`/`so` in vmstat, system unresponsive
+
+**Solutions**:
+- Add RAM
+- Reduce workload
+- Lower swappiness
+- Kill memory-hungry processes
+
+### Swap Full
+
+No swap space available.
+
+**Symptoms**: OOM kills despite "free" memory
+
+**Solutions**:
+- Add more swap
+- Enable zswap/zram
+- Investigate memory usage
+
+### SSD Wear
+
+Excessive swap writes wearing SSD.
+
+**Solutions**:
+- Use zswap (reduces writes 2-5x)
+- Reduce swappiness
+- Add RAM
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/swapfile.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/swapfile.c) | Swap area management |
+| [`mm/swap_state.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/swap_state.c) | Swap cache |
+| [`mm/zswap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/zswap.c) | Compressed swap cache |
+| [`drivers/block/zram/`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/block/zram) | zram implementation |
+
+### Kernel Documentation
+
+- [`Documentation/admin-guide/mm/zswap.rst`](https://docs.kernel.org/admin-guide/mm/zswap.html)
+
+### Related
+
+- [reclaim](reclaim.md) - When swap is triggered
+- [page-cache](page-cache.md) - File pages vs anonymous pages
+- [mmap](mmap.md) - Anonymous memory that gets swapped

--- a/docs/mm/thp.md
+++ b/docs/mm/thp.md
@@ -1,0 +1,297 @@
+# Transparent Huge Pages (THP)
+
+> Automatic huge page allocation without application changes
+
+## What Is THP?
+
+Transparent Huge Pages automatically promotes regular 4KB pages to 2MB huge pages when possible. Unlike hugetlbfs, THP requires no application modifications - the kernel handles everything transparently.
+
+```
+Without THP:                    With THP:
+┌─────┬─────┬─────┬─────┐      ┌─────────────────────┐
+│ 4KB │ 4KB │ 4KB │ ... │      │       2MB           │
+│     │     │     │     │      │    (512 x 4KB)      │
+└─────┴─────┴─────┴─────┘      └─────────────────────┘
+   512 TLB entries needed         1 TLB entry needed
+```
+
+## Why THP?
+
+### The TLB Problem
+
+The TLB (Translation Lookaside Buffer) caches page table entries. It's small (typically 64-1536 entries) but critical for performance. With 4KB pages:
+
+| Workload Size | Pages Needed | TLB Pressure |
+|---------------|--------------|--------------|
+| 1MB | 256 | Low |
+| 1GB | 262,144 | High |
+| 100GB | 26,214,400 | Severe |
+
+Large workloads constantly evict TLB entries, causing expensive page table walks.
+
+### Huge Pages as Solution
+
+2MB pages reduce TLB pressure by 512x:
+
+| Page Size | Pages for 1GB | TLB Entries |
+|-----------|---------------|-------------|
+| 4KB | 262,144 | 262,144 |
+| 2MB | 512 | 512 |
+| 1GB | 1 | 1 |
+
+## How THP Works
+
+### Two Allocation Paths
+
+**1. Fault-based (synchronous)**
+
+When a process faults on memory, the kernel tries to allocate a huge page:
+
+```
+Page fault
+    │
+    v
+Can we allocate 2MB?
+    │
+    ├── Yes: Map huge page
+    │
+    └── No: Fall back to 4KB pages
+```
+
+**2. khugepaged (asynchronous)**
+
+A kernel thread scans for regions that can be collapsed into huge pages:
+
+```
+khugepaged thread
+    │
+    v
+Scan process VMAs
+    │
+    v
+Find 512 contiguous 4KB pages?
+    │
+    ├── Yes: Collapse into 2MB huge page
+    │
+    └── No: Skip, try again later
+```
+
+## Configuration
+
+### Global Settings
+
+```bash
+# View current mode
+cat /sys/kernel/mm/transparent_hugepage/enabled
+# [always] madvise never
+
+# Options:
+# always  - THP for all anonymous memory
+# madvise - THP only for MADV_HUGEPAGE regions
+# never   - THP disabled
+echo madvise > /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+### Defrag Settings
+
+```bash
+# When to defragment memory for huge pages
+cat /sys/kernel/mm/transparent_hugepage/defrag
+# [always] defer defer+madvise madvise never
+
+# always        - Sync defrag on fault (can stall)
+# defer         - Async defrag via khugepaged
+# defer+madvise - Defer for most, sync for MADV_HUGEPAGE
+# madvise       - Only defrag for MADV_HUGEPAGE
+# never         - Never defrag for THP
+```
+
+### Per-Process Control
+
+```c
+#include <sys/mman.h>
+
+void *ptr = mmap(NULL, size, PROT_READ|PROT_WRITE,
+                 MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+
+/* Enable THP for this region */
+madvise(ptr, size, MADV_HUGEPAGE);
+
+/* Disable THP for this region */
+madvise(ptr, size, MADV_NOHUGEPAGE);
+```
+
+### khugepaged Tuning
+
+```bash
+# Scan interval (milliseconds)
+cat /sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs
+# 10000 (default)
+
+# Pages to scan per interval
+cat /sys/kernel/mm/transparent_hugepage/khugepaged/pages_to_scan
+# 4096 (default)
+
+# Max unmapped PTEs allowed when collapsing
+cat /sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none
+# 511 (default - collapse even if 511 of 512 PTEs are none/zero)
+```
+
+## THP and Specific Workloads
+
+### Databases
+
+Databases often benefit from THP but can suffer from:
+- Latency spikes during compaction
+- Memory bloat (2MB granularity)
+
+Many databases recommend `madvise` mode with explicit huge page requests.
+
+### Virtual Machines (KVM)
+
+THP was originally designed for KVM:
+
+From commit [71e3aac0724f](https://git.kernel.org/linus/71e3aac0724f):
+> "Lately I've been working to make KVM use hugepages transparently without the usual restrictions of hugetlbfs."
+
+VMs benefit significantly from reduced TLB pressure on nested page tables.
+
+### Redis/Memcached
+
+In-memory stores can see latency spikes from THP defragmentation. Many recommend:
+```bash
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+Or use `madvise` mode with application-level control.
+
+## THP vs hugetlbfs
+
+| Feature | THP | hugetlbfs |
+|---------|-----|-----------|
+| Application changes | None (or MADV_HUGEPAGE for hints) | Required |
+| Page sizes | 2MB (PMD), 16KB-1MB with mTHP (v6.10+) | 2MB, 1GB |
+| Swappable | Yes (since v4.13) | No |
+| Reservation | On-demand | Pre-allocated |
+| Fragmentation risk | Higher | Lower |
+| Overcommit | Yes | No |
+
+## Monitoring
+
+### System-Wide Statistics
+
+```bash
+# THP statistics
+cat /proc/meminfo | grep -i huge
+# AnonHugePages:    2097152 kB  <- THP usage
+# HugePages_Total:       0     <- hugetlbfs
+# HugePages_Free:        0
+
+# Detailed THP stats
+cat /proc/vmstat | grep thp
+# thp_fault_alloc        - Huge pages allocated on fault
+# thp_fault_fallback     - Fell back to 4KB
+# thp_collapse_alloc     - khugepaged collapses
+# thp_split_page         - Huge pages split back to 4KB
+```
+
+### Per-Process
+
+```bash
+# Huge page usage for a process
+cat /proc/<pid>/smaps | grep -i huge
+# AnonHugePages:     2048 kB
+
+# Or summarized
+cat /proc/<pid>/smaps_rollup | grep AnonHugePages
+```
+
+### Tracing
+
+```bash
+# Trace THP events
+echo 1 > /sys/kernel/debug/tracing/events/huge_memory/mm_khugepaged_scan_pmd/enable
+echo 1 > /sys/kernel/debug/tracing/events/huge_memory/mm_collapse_huge_page/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+## History
+
+### THP Introduction (v2.6.38, 2011)
+
+**Commit**: [71e3aac0724f](https://git.kernel.org/linus/71e3aac0724f) ("thp: transparent hugepage core")
+
+**Author**: Andrea Arcangeli (Red Hat)
+
+Initial THP implementation for anonymous memory.
+
+### THP Swap Support (v4.13, 2017)
+
+**Commit**: [38d8b4e6bdc8](https://git.kernel.org/linus/38d8b4e6bdc8) ("mm, THP, swap: delay splitting THP during swap out")
+
+THP pages can now be swapped as a unit without splitting first, improving swap performance.
+
+### Multi-Size THP (v6.10, 2024)
+
+**Commit**: [19eaf44954df](https://git.kernel.org/linus/19eaf44954df) ("mm: thp: support allocation of anonymous multi-size THP")
+
+Enables THP at sizes between 4KB and 2MB (e.g., 16KB, 64KB), providing more flexibility for workloads where 2MB is too large.
+
+## Common Issues
+
+### Latency Spikes
+
+THP defragmentation can cause allocation stalls.
+
+**Symptoms**: Random latency spikes in latency-sensitive applications
+
+**Solutions**:
+- Use `defrag=defer` or `defrag=madvise`
+- Set `enabled=madvise` and control per-region
+- Disable THP for latency-critical apps
+
+### Memory Bloat
+
+Small allocations rounded up to 2MB.
+
+**Symptoms**: Higher than expected memory usage
+
+**Debug**: Compare `AnonHugePages` vs `Anonymous` in `/proc/meminfo`
+
+**Solutions**:
+- Use `madvise` mode
+- Tune application allocation patterns
+
+### khugepaged CPU Usage
+
+khugepaged consuming too much CPU.
+
+**Debug**: `top` or `perf top`
+
+**Solutions**:
+- Increase `scan_sleep_millisecs`
+- Reduce `pages_to_scan`
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/huge_memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/huge_memory.c) | THP core implementation |
+| [`mm/khugepaged.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/khugepaged.c) | Collapse daemon |
+
+### Kernel Documentation
+
+- [`Documentation/admin-guide/mm/transhuge.rst`](https://docs.kernel.org/admin-guide/mm/transhuge.html)
+
+### Mailing List Discussions
+
+- [THP defrag behavior](https://lore.kernel.org/patchwork/patch/745411/) - Discussion on MADV_HUGEPAGE stalling semantics and Mel Gorman's intent for "defer" mode
+- [Node-local hugepage allocations](https://lore.kernel.org/lkml/20181206045917.GG23332@shao2-debian/) - 2018 discussion on THP gfp handling and remote allocations
+
+### Related
+
+- [page-tables](page-tables.md) - PMD-level huge page mapping
+- [compaction](compaction.md) - Memory defragmentation for THP
+- [reclaim](reclaim.md) - THP and memory pressure


### PR DESCRIPTION
Add 10 new documents covering the Linux memory management subsystem:

Core MM infrastructure:
- page-tables.md: Virtual address translation and 5-level hierarchy
- reclaim.md: Memory pressure handling, kswapd, MGLRU
- memcg.md: Memory cgroups v2 for container limits

Advanced topics:
- thp.md: Transparent Huge Pages
- numa.md: NUMA memory policies and balancing
- compaction.md: Memory defragmentation
- ksm.md: Kernel Same-page Merging
- mmap.md: Process address space and VMAs
- page-cache.md: File data caching
- swap.md: Swap subsystem including zswap/zram

All documents include verified kernel commit citations and evolution history.