### PR TITLE
fix: update site config, nav, and improve documentation links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,12 +21,12 @@ This is a community learning resource, not a definitive reference. The Linux ker
 ### General
 | Document | Description |
 |----------|-------------|
-| [Linux Evolution](docs/linux-evolution.md) | From hobby project to world infrastructure |
+| [Linux Evolution](linux-evolution.md) | From hobby project to world infrastructure |
 
 ### Subsystems
 | Subsystem | Status | Start Here |
 |-----------|--------|------------|
-| [mm/](docs/mm/) | Available | [Overview](docs/mm/overview.md) |
+| [mm/](mm/README.md) | Available | [Getting Started](mm/README.md) |
 | scheduler/ | Planned | |
 | networking/ | Planned | |
 | bpf/ | Planned | |

--- a/docs/mm/README.md
+++ b/docs/mm/README.md
@@ -43,10 +43,31 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 
 ### Suggested Reading Order
 
+**Fundamentals:**
+
 1. **[Overview](overview.md)** - The narrative of how mm/ evolved
 2. **[Page Allocator](page-allocator.md)** - Buddy system fundamentals
 3. **[Slab](slab.md)** - SLUB allocator for small objects
 4. **[vmalloc](vmalloc.md)** - Virtual memory allocation
+
+**Address Translation & Process Memory:**
+
+5. **[Page Tables](page-tables.md)** - Virtual address translation
+6. **[Process Address Space](mmap.md)** - VMAs, mmap, demand paging
+
+**Memory Pressure & Reclaim:**
+
+7. **[Page Reclaim](reclaim.md)** - LRU, kswapd, MGLRU
+8. **[Swap](swap.md)** - Extending memory to disk
+9. **[Page Cache](page-cache.md)** - File data caching
+
+**Advanced Topics:**
+
+10. **[Memory Cgroups](memcg.md)** - Container memory limits
+11. **[NUMA](numa.md)** - Multi-node memory management
+12. **[Transparent Huge Pages](thp.md)** - Automatic huge pages
+13. **[Compaction](compaction.md)** - Memory defragmentation
+14. **[KSM](ksm.md)** - Page deduplication for VMs
 
 ### What You'll Learn
 
@@ -116,17 +137,17 @@ If you want to read the actual code:
 ## Further Reading
 
 ### Free Resources
-- [Bonwick, "The Slab Allocator" (1994)](https://www.usenix.org/legacy/publications/library/proceedings/bos94/bonwick.html) - Original slab paper from USENIX
-- [Gorman, "Understanding the Linux Virtual Memory Manager"](https://www.kernel.org/doc/gorman/) - Free online book
+- Bonwick, [*The Slab Allocator*](https://www.usenix.org/legacy/publications/library/proceedings/bos94/bonwick.html) (1994) - Original slab paper from USENIX
+- Gorman, [*Understanding the Linux Virtual Memory Manager*](https://www.kernel.org/doc/gorman/) - Free online book
 
 ### Kernel Documentation
 - [Documentation/mm/](https://docs.kernel.org/mm/) in the kernel tree
 - [Documentation/admin-guide/mm/](https://docs.kernel.org/admin-guide/mm/) for sysadmin perspective
 
 ### Textbooks
-- Silberschatz, "Operating System Concepts" - Ch. 9-10 (Memory)
-- Tanenbaum, "Modern Operating Systems" - Ch. 3 (Memory Management)
-- Love, "Linux Kernel Development" - Ch. 12 (Memory Management)
+- Silberschatz et al., [*Operating System Concepts*](https://www.os-book.com/) - Ch. 9-10 (Memory)
+- Tanenbaum & Bos, [*Modern Operating Systems*](https://www.pearson.com/en-us/subject-catalog/p/modern-operating-systems/P200000003295) - Ch. 3 (Memory Management)
+- Love, [*Linux Kernel Development*](https://www.oreilly.com/library/view/linux-kernel-development/9780768696974/) - Ch. 12 (Memory Management)
 
 ---
 

--- a/docs/mm/compaction.md
+++ b/docs/mm/compaction.md
@@ -193,7 +193,7 @@ cat /sys/kernel/debug/tracing/trace_pipe
 
 ### Introduction (v2.6.35, 2010)
 
-**Commit**: [748446bb6b5a](https://git.kernel.org/linus/748446bb6b5a) ("mm: compaction: memory compaction core")
+**Commit**: [748446bb6b5a](https://git.kernel.org/linus/748446bb6b5a) ("mm: compaction: memory compaction core") | [LKML](https://lore.kernel.org/lkml/1269347146-7461-1-git-send-email-mel@csn.ul.ie/)
 
 **Author**: Mel Gorman
 

--- a/docs/mm/mmap.md
+++ b/docs/mm/mmap.md
@@ -209,7 +209,7 @@ Pre-v6.1: Red-Black Tree     v6.1+: Maple Tree
 [VMA] [VMA]
 ```
 
-**Commit**: [d4af56c5c7c6](https://git.kernel.org/linus/d4af56c5c7c6) ("mm: start tracking VMAs with maple tree")
+**Commit**: [d4af56c5c7c6](https://git.kernel.org/linus/d4af56c5c7c6) ("mm: start tracking VMAs with maple tree") | [LKML](https://lore.kernel.org/linux-mm/20220822150128.1562046-1-Liam.Howlett@oracle.com/)
 
 ## Demand Paging
 

--- a/docs/mm/overview.md
+++ b/docs/mm/overview.md
@@ -209,6 +209,8 @@ Page tables must be set up. TLB (translation cache) entries are consumed. It's s
 - Fewer TLB entries needed
 - Trade-off: More internal fragmentation
 
+*See [LKML patch series](https://lore.kernel.org/linux-mm/20210317062402.533919-1-npiggin@gmail.com/) by Nicholas Piggin.*
+
 **v6.12 (2024): vrealloc**
 
 **The problem**: You have a vmalloc buffer and want to resize it. Previously, you'd have to allocate new, copy, free old.
@@ -217,6 +219,8 @@ Page tables must be set up. TLB (translation cache) entries are consumed. It's s
 - **Commit**: [3ddc2fefe6f3](https://git.kernel.org/linus/3ddc2fefe6f3)
 - Motivated by Rust's allocator needs (`Vec` resizing)
 - See [vrealloc](vrealloc.md) for the full story and bugs found
+
+*See [LKML patch series](https://lore.kernel.org/all/20240722163111.4766-1-dakr@kernel.org/) by Danilo Krummrich.*
 
 ---
 

--- a/docs/mm/page-cache.md
+++ b/docs/mm/page-cache.md
@@ -288,7 +288,7 @@ Radix tree replaced with XArray - cleaner API, same performance.
 
 ### Folios (v5.16, 2022)
 
-**Commit**: [7b230db3b8d3](https://git.kernel.org/linus/7b230db3b8d3) ("mm: Introduce struct folio")
+**Commit**: [7b230db3b8d3](https://git.kernel.org/linus/7b230db3b8d3) ("mm: Introduce struct folio") | [LKML](https://lore.kernel.org/linux-mm/20210430180740.2707166-1-willy@infradead.org/)
 
 **Author**: Matthew Wilcox
 

--- a/docs/mm/page-tables.md
+++ b/docs/mm/page-tables.md
@@ -216,7 +216,7 @@ Added PUD for x86-64's 48-bit virtual address space. This predates git history (
 
 ### Five-Level (v4.14, 2017)
 
-**Commit**: [77ef56e4f0fb](https://git.kernel.org/linus/77ef56e4f0fb) ("x86: Enable 5-level paging support via CONFIG_X86_5LEVEL=y")
+**Commit**: [77ef56e4f0fb](https://git.kernel.org/linus/77ef56e4f0fb) ("x86: Enable 5-level paging support via CONFIG_X86_5LEVEL=y") | [LKML](https://lore.kernel.org/all/20170313055020.69655-1-kirill.shutemov@linux.intel.com/)
 
 Added P4D for 57-bit virtual addresses (128PB), needed for machines with >64TB physical memory.
 

--- a/docs/mm/swap.md
+++ b/docs/mm/swap.md
@@ -320,7 +320,7 @@ Swap files became as efficient as partitions.
 
 ### zswap (v3.11, 2013)
 
-**Commit**: [2b2811178e85](https://git.kernel.org/linus/2b2811178e85) ("zswap: add to mm/")
+**Commit**: [2b2811178e85](https://git.kernel.org/linus/2b2811178e85) ("zswap: add to mm/") | [LKML](https://lore.kernel.org/lkml/1361397888-14863-1-git-send-email-sjenning@linux.vnet.ibm.com/)
 
 Compressed swap cache to reduce disk I/O.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Linux Kernel Internals
 site_description: Documentation about Linux kernel internals, design decisions, and the journey of contributing
-site_url: https://laveeshb.github.io/linux-kernel-internals/
+site_url: https://kernel-internals.org/
 
 repo_name: laveeshb/linux-kernel-internals
 repo_url: https://github.com/laveeshb/linux-kernel-internals
@@ -55,9 +55,20 @@ nav:
   - Home: index.md
   - Linux Evolution: linux-evolution.md
   - Memory Management:
+    - Getting Started: mm/README.md
     - Overview: mm/overview.md
-    - Glossary: mm/glossary.md
-    - vmalloc: mm/vmalloc.md
-    - vrealloc: mm/vrealloc.md
     - Page Allocator: mm/page-allocator.md
     - SLUB Allocator: mm/slab.md
+    - vmalloc: mm/vmalloc.md
+    - vrealloc: mm/vrealloc.md
+    - Page Tables: mm/page-tables.md
+    - Page Reclaim: mm/reclaim.md
+    - Memory Cgroups: mm/memcg.md
+    - Transparent Huge Pages: mm/thp.md
+    - NUMA: mm/numa.md
+    - Compaction: mm/compaction.md
+    - KSM: mm/ksm.md
+    - Process Address Space: mm/mmap.md
+    - Page Cache: mm/page-cache.md
+    - Swap: mm/swap.md
+    - Glossary: mm/glossary.md


### PR DESCRIPTION
## Summary

- Update site_url to kernel-internals.org
- Fix broken links in index.md (remove `docs/` prefix)
- Add all mm/ docs to mkdocs.yml nav in logical reading order
- Make mm/README.md the entry point for memory management section
- Expand suggested reading order in mm/README.md to cover all 14 docs
- Format book titles in italics and add links to publishers/resources
- Add LKML thread links for major commits across documentation

## LKML Links Added

| File | Feature | Author |
|------|---------|--------|
| overview.md | huge vmalloc | Nicholas Piggin |
| overview.md | vrealloc | Danilo Krummrich |
| compaction.md | memory compaction | Mel Gorman |
| mmap.md | maple tree | Liam Howlett |
| page-tables.md | 5-level paging | Kirill Shutemov |
| page-cache.md | folios | Matthew Wilcox |
| swap.md | zswap | Seth Jennings |

## Test Plan

- [ ] Verify mkdocs builds successfully
- [ ] Check all internal links resolve
- [ ] Verify LKML links are accessible