### PR TITLE
Add custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+kernel-internals.org


### PR DESCRIPTION
Configure kernel-internals.org as the custom domain for GitHub Pages.