### PR TITLE
Remove MkDocs generator notice from footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ plugins:
 
 # Open external links in new tab
 extra:
+  generator: false
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/laveeshb/linux-kernel-internals


### PR DESCRIPTION
Remove the 'Made with Material for MkDocs' text from the footer.