### PR TITLE
Add mm explainers: overcommit, brk/mmap, memory metrics

### DIFF
--- a/docs/mm/README.md
+++ b/docs/mm/README.md
@@ -76,7 +76,7 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 | "Page tables map virtual to physical" | Multi-level page tables, TLB flushing costs, lazy unmapping |
 | "Memory allocator" | Multiple allocators for different use cases (slab, vmalloc, buddy) |
 | "Fragmentation" | Why physically contiguous memory is hard, vmalloc as a solution |
-| "Memory is finite" | OOM killer, memory cgroups, reclaim |
+| "Memory is finite" | [OOM killer](overcommit.md), memory cgroups, reclaim |
 
 ### What Makes This Different
 
@@ -109,6 +109,16 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 | [mmap](mmap.md) | Process address space and VMAs |
 | [page-cache](page-cache.md) | File data caching in memory |
 | [swap](swap.md) | Extending memory to disk |
+
+### Explainers
+
+Conceptual guides for common memory management questions:
+
+| Document | What You'll Learn |
+|----------|-------------------|
+| [virtual-physical-resident](virtual-physical-resident.md) | VSZ vs RSS vs PSS vs USS - why memory numbers don't add up |
+| [overcommit](overcommit.md) | Why overcommit is the only sane default |
+| [brk-vs-mmap](brk-vs-mmap.md) | Two ways to get memory from the kernel |
 
 ---
 

--- a/docs/mm/brk-vs-mmap.md
+++ b/docs/mm/brk-vs-mmap.md
@@ -1,0 +1,356 @@
+# brk vs mmap: Two Ways to Get Memory
+
+> The kernel provides two mechanisms; userspace allocators choose between them
+
+## Kernel Mechanisms vs Userspace Policy
+
+The kernel provides two system calls for obtaining memory:
+
+1. **`brk()`** - Extend a single contiguous heap region
+2. **`mmap()`** - Create arbitrary memory mappings anywhere
+
+The kernel doesn't care which one you use. It just implements both and lets userspace decide. This document covers both the kernel mechanisms and how glibc uses them - clearly separated.
+
+## The Two Approaches
+
+### brk(): The Heap
+
+`brk()` moves the "program break" - historically called the end of the "data segment," though on modern systems it's just another VMA that grows upward (see `do_brk_flags()` in [mm/vma.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vma.c)):
+
+```
+┌─────────────────┐ High addresses
+│      Stack      │
+│        ↓        │
+│                 │
+│                 │
+│        ↑        │
+│      Heap       │
+├─────────────────┤ ← Program break (brk)
+│   BSS (zeros)   │
+│   Data (init)   │
+│   Text (code)   │
+└─────────────────┘ Low addresses
+```
+
+```c
+// The brk syscall sets the program break
+#include <unistd.h>
+#include <sys/syscall.h>
+
+unsigned long current_brk = syscall(SYS_brk, 0);  // Get current break
+syscall(SYS_brk, current_brk + 4096);             // Extend by 4KB
+// New memory is between old and new break
+
+// Note: sbrk() is the libc wrapper; brk is the actual syscall
+```
+
+**Characteristics:**
+- Single contiguous region
+- Grows upward
+- Cannot release memory in the middle
+- Lower overhead than mmap (but still a syscall - involves VMA updates, security checks, rlimit checks)
+
+### mmap(): Anonymous Mappings
+
+`mmap()` creates a new region anywhere in the address space:
+
+```
+┌─────────────────┐
+│      Stack      │
+│                 │
+│  ┌───────────┐  │
+│  │  mmap #2  │  │  ← Independent regions
+│  └───────────┘  │
+│                 │
+│  ┌───────────┐  │
+│  │  mmap #1  │  │
+│  └───────────┘  │
+│                 │
+│      Heap       │
+├─────────────────┤
+│   Text/Data     │
+└─────────────────┘
+```
+
+```c
+void *p = mmap(NULL, size,
+               PROT_READ | PROT_WRITE,
+               MAP_PRIVATE | MAP_ANONYMOUS,
+               -1, 0);
+```
+
+See [`do_mmap()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) for the kernel implementation.
+
+**Characteristics:**
+- Arbitrary location in address space
+- Each mapping independent
+- Can release (`munmap`) individually
+- More overhead per allocation
+
+## Userspace Policy: How glibc Chooses
+
+This is where userspace makes its own decisions - the kernel isn't involved.
+
+glibc's malloc uses a **dynamic threshold** that adjusts based on allocation patterns:
+
+```
+Allocation size < threshold → brk (main arena heap)
+Allocation size ≥ threshold → mmap
+```
+
+The threshold starts at 128KB and can grow up to 32MB (on 64-bit systems) as the allocator observes large allocations being freed. This dynamic behavior was added to reduce mmap/munmap syscall overhead for programs with consistent large allocation patterns.
+
+**Note:** These thresholds are `glibc`-specific. Other C libraries (`musl`, `bionic`) use different strategies, and some distributions patch `glibc` defaults.
+
+```c
+// Simplified glibc logic
+void *malloc(size_t size) {
+    if (size < mmap_threshold) {
+        return allocate_from_arena();  // Main arena uses brk
+    } else {
+        return mmap(...);              // Direct mmap
+    }
+}
+```
+
+Check or override the threshold:
+```bash
+# Default starts at 128KB (131072 bytes), grows dynamically
+# Can disable dynamic behavior and set fixed threshold:
+$ MALLOC_MMAP_THRESHOLD_=65536 ./myprogram
+
+# Or in code:
+mallopt(M_MMAP_THRESHOLD, 65536);
+```
+
+See [glibc malloc tunables](https://www.gnu.org/software/libc/manual/html_node/Memory-Allocation-Tunables.html) for details.
+
+## Why the Threshold?
+
+### Small allocations → brk (heap)
+
+**Pros:**
+- Lower syscall overhead (glibc extends heap in large chunks, serves many mallocs per brk call)
+- Good locality (allocations are adjacent)
+- Fast allocation from free lists
+
+**Cons:**
+- Memory fragmentation over time
+- Harder to return memory to OS (requires free space at top of heap)
+
+### Large allocations → mmap
+
+**Pros:**
+- Memory returned to OS immediately on free (`munmap()`)
+- No heap fragmentation from large blocks
+- Predictable cleanup
+
+**Cons:**
+- Per-allocation syscall overhead
+- TLB pressure (each mapping needs entries)
+- Potential address space fragmentation
+
+## The Fragmentation Problem
+
+Consider this scenario with brk-only allocation:
+
+```
+Initial heap:
+[  A  ][  B  ][  C  ][  D  ]
+        └─ free B ─┘
+
+After free(B):
+[  A  ][hole][  C  ][  D  ]
+       └─ Can't return to OS!
+
+Even if C and D are freed:
+[  A  ][          free           ]
+       └─ Still can't shrink brk past A
+```
+
+With mmap for large allocations:
+```
+Heap: [  A  ][ B ][ C ]   (small allocations)
+
+mmap regions:
+[ Large D ]   ← munmap() returns directly to OS
+[ Large E ]   ← Independent of heap
+```
+
+## Real-World Example
+
+```c
+#include <stdlib.h>
+#include <stdio.h>
+
+int main() {
+    // Small allocation - goes to heap (brk)
+    void *small = malloc(1024);
+    printf("Small (1KB): %p\n", small);
+
+    // Large allocation - uses mmap
+    void *large = malloc(256 * 1024);
+    printf("Large (256KB): %p\n", large);
+
+    // Notice the address difference
+    // small: near heap (lower address)
+    // large: mmap region (higher, separate)
+
+    free(large);  // glibc calls munmap() → returns to OS
+    free(small);  // Goes to malloc's free list (no syscall)
+
+    return 0;
+}
+```
+
+Trace the syscalls:
+```bash
+$ strace -e brk,mmap,munmap ./test
+brk(NULL)                               = 0x55a8b8c49000
+brk(0x55a8b8c6a000)                     = 0x55a8b8c6a000  # Heap setup
+mmap(NULL, 266240, ..., MAP_ANONYMOUS)  = 0x7f8b12345000  # Large alloc
+munmap(0x7f8b12345000, 266240)          = 0              # Large free
+```
+
+## When glibc Returns Memory
+
+### Heap (brk) memory:
+
+- Freed blocks go to malloc's free list for reuse
+- `glibc` automatically trims the heap when free space at the top exceeds `M_TRIM_THRESHOLD` (default 128KB)
+- `malloc_trim()` can force trimming, but only releases memory at the top of the heap
+- Memory in the middle of the heap cannot be returned to the OS
+
+### mmap memory:
+
+- `munmap()` on free → immediate return to OS
+- RSS decreases visibly
+- Clean release regardless of allocation order
+
+```c
+// Force heap trimming (only affects top of heap)
+#include <malloc.h>
+malloc_trim(0);  // Returns free memory at heap top to OS
+
+// Alternatively, use MADV_DONTNEED on specific ranges
+madvise(addr, len, MADV_DONTNEED);  // Release pages, keep mapping
+```
+
+## Tuning the Threshold
+
+```c
+#include <malloc.h>
+
+// Increase threshold: fewer mmaps, bigger heap
+mallopt(M_MMAP_THRESHOLD, 512 * 1024);  // 512KB
+
+// Decrease threshold: more mmaps, smaller heap
+mallopt(M_MMAP_THRESHOLD, 64 * 1024);   // 64KB
+```
+
+Or via environment:
+```bash
+# All allocations ≥64KB use mmap
+export MALLOC_MMAP_THRESHOLD_=65536
+./myprogram
+```
+
+## Trade-offs Summary
+
+| Factor | brk (heap) | mmap |
+|--------|------------|------|
+| Syscall overhead | Low | Per-allocation |
+| Memory return to OS | Difficult | Immediate |
+| Fragmentation | Can accumulate | Per-region only |
+| Locality | Good | Scattered |
+| TLB pressure | Low | Higher |
+| Best for | Many small allocs | Large allocs |
+
+## Historical Context
+
+These two system calls come from different eras and were designed for different purposes.
+
+### brk(): The Original (1979)
+
+`brk()` appeared in **Version 7 AT&T Unix (1979)** - one of the earliest Unix system calls. In the 1970s, address spaces were tiny (often 64KB total). The "program break" literally divided the program's code from its data, and you grew the heap by moving this boundary upward.
+
+For over a decade, `brk()` was the **only** way for applications to acquire heap memory. Every `malloc()` implementation used it.
+
+The call is now considered a historical artifact:
+- Marked **LEGACY** in Single UNIX Specification v2
+- **Removed** from POSIX.1-2001
+- Linux keeps it for compatibility, but modern allocators use it less
+
+### mmap(): File Mapping First (1983-1988)
+
+`mmap()` was designed for a completely different purpose: **memory-mapped files**.
+
+Timeline:
+- **1983 (4.2BSD)**: API designed and documented, but not implemented
+- **~1988 (SunOS 4.0)**: First working implementation by Sun Microsystems
+- **4.3BSD-Reno**: BSD implementation (based on Mach VM, after Sun refused to share their code)
+- **4.4BSD**: Official BSD release with mmap
+
+The original use case was mapping file contents directly into memory - read a file by accessing memory addresses instead of calling `read()`. This had nothing to do with heap allocation.
+
+### MAP_ANONYMOUS: The Game Changer
+
+The feature that made `mmap()` useful for heap allocation: **`MAP_ANONYMOUS`** (or `MAP_ANON`).
+
+- Allows memory mappings **not backed by any file**
+- Before this existed, the workaround was `mmap("/dev/zero", ...)`
+- **`MAP_ANONYMOUS` with `MAP_PRIVATE`**: Available in early Linux (inherited from BSD)
+
+#### The "Monstrosity" That Took Years
+
+**`MAP_ANONYMOUS` with `MAP_SHARED`** has a contentious history:
+
+**July 1996**: A.N. Kuznetsov [discovered](https://lkml.iu.edu/hypermail/linux/kernel/9607.3/0055.html) Linux 2.0 lacked this feature:
+> *"Unpleasant discovery, 2.0 has no shared anonymous mmap ??? I do not believe to my eyes..."*
+
+**Linus Torvalds [replied](https://lkml.iu.edu/hypermail/linux/kernel/9607.3/0107.html)** dismissively:
+> *"a monstrosity (even the name is a oxymoron [sic]), and it's hard to implement to boot"*
+> *"definitely 2.1, if even that"*
+
+He recommended SysV shared memory instead and wanted to "avoid shared anonymous mmap altogether."
+
+**2000-2001**: **Christoph Rohland** (SAP AG) finally implemented the solution in the 2.3/2.4 development cycle by creating the **`shmem`/`tmpfs`** filesystem. The clever trick: Linux creates an "artificial file-backing for anonymous pages using a RAM-based filesystem." Shared anonymous mappings aren't truly anonymous - they're backed by an invisible `tmpfs` file.
+
+*Note: Linux 2.4 predates git (kernel switched to git in April 2005 with 2.6.12). No commit IDs exist for pre-git history.*
+
+Once `MAP_ANONYMOUS` existed, allocators could use `mmap()` for large allocations with a key advantage: `munmap()` returns memory to the OS immediately, unlike `brk()` where you can only shrink the heap from the top.
+
+### Why Both Survive
+
+Today we have two mechanisms because they evolved for different purposes:
+
+| Era | Mechanism | Purpose |
+|-----|-----------|---------|
+| 1979 | `brk()` | Grow a single heap (the only option) |
+| 1983-88 | `mmap()` | Map files into memory |
+| 1990s+ | `mmap()` + `MAP_ANONYMOUS` | Alternative to `brk()` for heap |
+
+Modern allocators like `glibc`'s `malloc` use **both**: `brk()` for the main arena (small allocations benefit from locality), `mmap()` for large allocations (clean release back to OS). This isn't elegant design - it's historical accident turned pragmatic engineering.
+
+## Try It Yourself
+
+```bash
+# Watch brk vs mmap in action
+strace -e brk,mmap,munmap ./myprogram
+
+# See heap size
+cat /proc/<pid>/maps | grep heap
+
+# See all anonymous mappings
+cat /proc/<pid>/maps | grep anon
+
+# Compare RSS before/after large allocation free
+watch -n 0.5 "grep -E 'VmRSS|VmData' /proc/<pid>/status"
+```
+
+## Further Reading
+
+- [glibc malloc internals](https://sourceware.org/glibc/wiki/MallocInternals) - How glibc manages memory
+- [mallopt(3) man page](https://man7.org/linux/man-pages/man3/mallopt.3.html) - Tuning options
+- [brk(2) man page](https://man7.org/linux/man-pages/man2/brk.2.html) - System call documentation
+- [LWN: malloc() tutorial](https://lwn.net/Articles/250967/) - Historical context

--- a/docs/mm/overcommit.md
+++ b/docs/mm/overcommit.md
@@ -1,0 +1,309 @@
+# Memory Overcommit: Why It's the Only Sane Default
+
+> The real question isn't "why overcommit" - it's "why would you NOT overcommit"
+
+## The Real Question
+
+You have 8GB of RAM. A program calls `malloc(16GB)`. Should the kernel refuse?
+
+On most Linux systems (with default settings), this allocation is allowed. But the question isn't "why does Linux do this crazy thing?" The question is: **what's the alternative?**
+
+## Without Overcommit, fork() Breaks
+
+The answer starts with `fork()` and [copy-on-write](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c) (COW).
+
+When you `fork()`, the child gets a copy of the parent's address space - but no pages are actually copied until one process writes to them (see `copy_present_pte()`). This is COW, and it's essential for Unix.
+
+But here's the problem: without overcommit, the kernel must **reserve** physical memory for all those potential copies at fork time. A 3GB process on a 4GB system couldn't fork - even if the child immediately calls `exec()` and discards everything.
+
+That would be insane. So overcommit exists.
+
+Once you accept overcommit for fork(), extending it to general allocations is a small step:
+1. Sparse arrays work (map 1GB, touch 10MB)
+2. Memory-mapped files don't require RAM for unread pages
+3. Programs that reserve-then-use (like JVMs) don't waste memory
+
+## The fork() Example
+
+Consider `fork()`:
+
+```c
+// Parent process using 4GB of RAM
+pid_t pid = fork();
+// Child is created with a copy of 4GB address space
+if (pid == 0) {
+    char *args[] = {"/bin/ls", NULL};
+    execve("/bin/ls", args, NULL);  // Immediately replaces address space
+}
+```
+
+Without overcommit, `fork()` would need 8GB total (4GB parent + 4GB child) even though the child immediately calls `exec()` and discards its copy.
+
+With copy-on-write and overcommit:
+- Child shares parent's pages (no copy yet)
+- `exec()` replaces address space before any copy happens
+- Actual memory needed: ~4GB (not 8GB)
+
+## How Overcommit Works
+
+When a process requests memory via `mmap()` or `brk()` (the actual syscalls - `malloc()` is a userspace wrapper that calls these), the kernel:
+
+1. **Creates a VMA** - A `vm_area_struct` describing the region (defined in [include/linux/mm_types.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mm_types.h), operations in [mm/vma.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vma.c))
+2. **Doesn't allocate physical RAM** - No pages assigned yet
+3. **Returns success** - The process can use the addresses
+
+Note: Page tables are **not** populated at mmap time. They're created on-demand when pages are first accessed (page fault).
+
+Physical RAM is allocated later, on first access (demand paging):
+
+```
+mmap(1GB)            First write to page
+     │                      │
+     ▼                      ▼
+┌─────────┐           ┌─────────┐
+│ VMA     │           │ Page    │
+│ created │    ───►   │ fault   │
+│ (no RAM)│           │ handler │
+└─────────┘           └─────────┘
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │ Allocate    │
+                    │ physical    │
+                    │ page now    │
+                    └─────────────┘
+```
+
+## Overcommit Modes
+
+Linux provides three modes via `/proc/sys/vm/overcommit_memory`:
+
+### Mode 0: Heuristic (Default)
+
+```bash
+$ cat /proc/sys/vm/overcommit_memory
+0
+```
+
+**Behavior:** Linux uses heuristics to decide if an allocation is "reasonable."
+
+- Rejects obviously excessive allocations
+- Allows moderate overcommit
+- Considers available RAM, swap, and current usage
+
+The heuristic is implemented in `__vm_enough_memory()` ([mm/util.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/util.c)). It considers total RAM, swap, hugetlb reservations, admin/user reserves, and existing commitments. The simplified rule: reject if obviously excessive, allow if plausibly satisfiable.
+
+### Mode 1: Always Overcommit
+
+```bash
+$ echo 1 > /proc/sys/vm/overcommit_memory
+```
+
+**Behavior:** Never refuse an allocation based on memory availability.
+
+- A 1TB `mmap()` succeeds on a 16GB system
+- Useful for sparse arrays, memory-mapped files
+- Dangerous if programs actually touch what they allocate
+
+### Mode 2: Strict Accounting
+
+```bash
+$ echo 2 > /proc/sys/vm/overcommit_memory
+```
+
+**Behavior:** Track commit charge, refuse if over limit.
+
+Commit limit is calculated in [mm/util.c:vm_commit_limit()](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/util.c):
+
+```
+If overcommit_kbytes is set:
+    Commit limit = overcommit_kbytes + Swap
+
+Otherwise:
+    Commit limit = ((RAM - HugePages) * overcommit_ratio/100) + Swap
+```
+
+```bash
+$ cat /proc/sys/vm/overcommit_ratio
+50  # Default: 50%
+
+# Alternatively, set an absolute limit ([added in kernel 3.14](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=49f0ce5f9232)):
+$ echo 8388608 > /proc/sys/vm/overcommit_kbytes  # 8GB
+
+# On an 8GB RAM + 2GB swap system with default ratio:
+# Commit limit = (8GB * 0.5) + 2GB = 6GB
+```
+
+Check current status:
+```bash
+$ cat /proc/meminfo | grep Commit
+CommitLimit:    6291456 kB
+Committed_AS:   2145678 kB
+```
+
+## When Overcommit Fails: The OOM Killer
+
+If programs actually use more memory than available, someone must die:
+
+```
+Physical RAM exhausted
+        │
+        ▼
+┌───────────────────┐
+│    OOM Killer     │
+│                   │
+│ Scores processes: │
+│ - RSS + swap      │
+│ - Page tables     │
+│ - oom_score_adj   │
+│                   │
+│ Kills highest     │
+│ scoring process   │
+└───────────────────┘
+```
+
+The OOM killer selects a victim based on ([mm/oom_kill.c:oom_badness()](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/oom_kill.c)):
+
+- **`RSS`** - Resident memory usage
+- **Swap entries** - Memory swapped out
+- **Page tables** - Memory used for page tables
+- **oom_score_adj** - User-tunable adjustment (-1000 to 1000)
+
+Earlier kernels considered process age and child processes, but these heuristics were [removed in 2019](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=bbbe48029720) as unreliable. See the [LKML discussion](https://lore.kernel.org/lkml/20190225065854.30027-1-shakeelb@google.com/) for the rationale.
+
+```bash
+# View OOM score for a process
+$ cat /proc/<pid>/oom_score
+150
+
+# Protect a critical process
+$ echo -500 > /proc/<pid>/oom_score_adj
+```
+
+## Why Not Just Disable Overcommit?
+
+Strict mode (mode 2) sounds safer. Why isn't it default?
+
+**Problem 1: `fork()` becomes expensive**
+
+Without overcommit, every `fork()` must reserve memory for potential COW copies, even if `exec()` follows immediately.
+
+**Problem 2: Sparse data structures fail**
+
+```c
+// Sparse array: reserve 1GB address space, use 10MB
+void *sparse = mmap(NULL, 1UL << 30,  // 1GB
+                    PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+// Only pages actually written consume physical RAM
+// Without overcommit: allocation might fail or reserve 1GB
+// With overcommit: works fine, RSS reflects actual usage
+```
+
+**Problem 3: Memory-mapped files**
+
+```c
+// Map 10GB file, read 100 bytes
+void *p = mmap(NULL, 10UL*1024*1024*1024,
+               PROT_READ, MAP_PRIVATE, fd, 0);
+// Without overcommit: might fail
+// With overcommit: only accessed pages loaded
+```
+
+**Problem 4: JVM and similar runtimes**
+
+```bash
+# JVM reserves max heap at startup
+java -Xmx8g -jar app.jar
+# Actual usage might be 500MB
+```
+
+## The Trade-off
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Overcommit (default) | More programs run, `fork()` works, sparse structures | OOM killer may strike |
+| Strict (mode 2) | Predictable failures | Wastes memory, `fork()` heavy, breaks sparse usage |
+
+## Historical Context
+
+### Before Linux: Traditional Unix
+
+Early Unix systems (1970s-80s) typically used **strict memory accounting**. When you called `malloc()`, the system checked if physical memory (or swap) was available. This was simpler but wasteful - memory reserved but unused by one process couldn't be used by others.
+
+### Linux's Aggressive Approach (1990s)
+
+Linux chose a different path from the start. Linus Torvalds favored **optimistic allocation** - let programs allocate freely, deal with shortages when they actually occur. This matched how programs really behave: they often allocate more than they use.
+
+Why this made sense:
+1. **Memory was expensive** - Maximize utilization of scarce RAM
+2. **`fork()`/`exec()` pattern** - The dominant Unix pattern, benefits enormously from COW + overcommit
+3. **Sparse usage is common** - Real programs don't touch all allocated memory
+
+### The OOM Killer (1998)
+
+The inevitable consequence of optimistic allocation: sometimes the bet fails. [Rik van Riel](https://github.com/torvalds/linux/blob/master/mm/oom_kill.c) created the OOM killer in **August 1998** (Linux 2.1.x development series) to handle this:
+
+> *"Copyright (C) 1998,2000 Rik van Riel"*
+> *"Thanks go out to Claus Fischer for some serious inspiration and for goading me into coding this file."*
+
+The OOM killer was controversial from day one. But the alternatives are worse:
+- **(a)** Return `ENOMEM` and have programs crash anyway
+- **(b)** Never overcommit and waste enormous amounts of memory
+- **(c)** Kill something and let the system recover
+
+Option (c) is the least bad. That's engineering reality.
+
+### Evolution of Overcommit Controls
+
+- **Linux 2.4**: Formalized `vm.overcommit_memory` sysctl (modes 0, 1, 2)
+- **Linux 2.6**: Added `vm.overcommit_ratio` for strict mode tuning
+- **Linux 3.14**: Added `vm.overcommit_kbytes` as alternative to ratio ([commit 49f0ce5f](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=49f0ce5f9232))
+- **2010**: OOM killer [rewritten by David Rientjes](https://lwn.net/Articles/391222/) (Google)
+- **Linux 4.6 (2016)**: OOM reaper introduced ([commit aac4536355](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=aac453635549)) - reclaims memory from OOM victims faster
+- **Linux 4.19 (2018)**: `cgroup`-aware OOM killer ([commit 3d8b38eb81](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3d8b38eb81ca)) - can kill entire `cgroup` as a unit
+
+## Recommendations
+
+**For most workloads:** Keep default (mode 0)
+
+**For databases/critical services:**
+```bash
+# Protect from OOM killer
+echo -1000 > /proc/<pid>/oom_score_adj
+```
+
+**For containers:**
+- Use memory cgroups to limit and isolate
+- Let container runtime handle OOM
+
+**For strict environments:**
+```bash
+# Mode 2 with careful ratio
+echo 2 > /proc/sys/vm/overcommit_memory
+echo 80 > /proc/sys/vm/overcommit_ratio
+```
+
+## Try It Yourself
+
+```bash
+# Check current mode
+cat /proc/sys/vm/overcommit_memory
+
+# See commit limit and usage
+grep -i commit /proc/meminfo
+
+# View OOM scores
+for pid in /proc/[0-9]*; do
+    echo "$(cat $pid/oom_score 2>/dev/null) $(cat $pid/comm 2>/dev/null)"
+done | sort -rn | head -10
+
+# Watch for OOM events
+dmesg -w | grep -i oom
+```
+
+## Further Reading
+
+- [overcommit-accounting.rst](https://www.kernel.org/doc/Documentation/mm/overcommit-accounting.rst) - Official documentation
+- [LWN: The OOM killer](https://lwn.net/Articles/317814/) - OOM killer deep dive
+- [vm_overcommit_memory sysctl](https://docs.kernel.org/admin-guide/sysctl/vm.html#overcommit-memory) - Sysctl documentation

--- a/docs/mm/overview.md
+++ b/docs/mm/overview.md
@@ -345,7 +345,7 @@ virtme-ng --kdir . --append 'test_vmalloc.run_test_mask=0xFFFF'
 | SLUB allocator | [`mm/slub.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/slub.c) | `kmem_cache_alloc()`, `kmalloc()` |
 | vmalloc | [`mm/vmalloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmalloc.c) | `vmalloc()`, `vfree()` |
 | Memory reclaim | [`mm/vmscan.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c) | `shrink_node()`, `kswapd()` |
-| OOM killer | [`mm/oom_kill.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/oom_kill.c) | `out_of_memory()`, `oom_badness()` |
+| OOM killer | [`mm/oom_kill.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/oom_kill.c) | `out_of_memory()`, `oom_badness()` - see [overcommit](overcommit.md) |
 
 ---
 
@@ -372,3 +372,9 @@ virtme-ng --kdir . --append 'test_vmalloc.run_test_mask=0xFFFF'
 - [page-allocator](page-allocator.md) - Buddy system details
 - [slab](slab.md) - SLUB internals
 - [glossary](glossary.md) - Terminology reference
+
+### Explainers
+
+- [virtual-physical-resident](virtual-physical-resident.md) - VSZ vs RSS vs PSS explained
+- [overcommit](overcommit.md) - Why overcommit is the only sane default
+- [brk-vs-mmap](brk-vs-mmap.md) - Two ways to get memory from the kernel

--- a/docs/mm/virtual-physical-resident.md
+++ b/docs/mm/virtual-physical-resident.md
@@ -1,0 +1,310 @@
+# Virtual vs Physical vs Resident Memory
+
+> Understanding `VSZ`, `RSS`, and why memory numbers don't add up
+
+## The Confusion
+
+You run `ps aux` and see a process using 500MB of virtual memory (`VSZ`). But `free` shows plenty of memory available. Or you add up all the `RSS` values and get more than your total RAM. What's going on?
+
+The answer lies in understanding three different ways of measuring memory.
+
+## The Three Memory Types
+
+### Virtual Memory (VSZ/VIRT)
+
+**What it is:** The total address space a process has mapped.
+
+**What it includes:**
+- Code (text segment)
+- Data (heap, stack, globals)
+- Shared libraries
+- Memory-mapped files
+- Allocations that haven't been touched yet
+
+Virtual memory is just *address space*. It doesn't mean physical RAM is being used.
+
+**`VSZ` is almost always meaningless for understanding memory usage.** Don't use it to answer "how much memory is this process using?" - use `RSS`, `PSS`, or `USS` instead. `VSZ` is only useful for debugging address space layout issues.
+
+```bash
+# A process with 500MB virtual doesn't use 500MB of RAM
+$ ps -o pid,vsz,rss,comm -p $$
+  PID    VSZ   RSS COMMAND
+ 1234 502400 12340 bash
+```
+
+In this example, `bash` has 500MB of virtual address space but only ~12MB resident in RAM. The `VSZ` number is essentially meaningless for capacity planning.
+
+### Physical Memory
+
+**What it is:** Actual RAM chips in your system.
+
+**What uses it:**
+- Kernel code and data structures
+- Process pages that are resident (`RSS`)
+- Page cache (file data cached in memory, including block buffers)
+- Slab caches (kernel object caches)
+
+Physical memory is shared, cached, and reused. The kernel manages it as a scarce resource.
+
+```bash
+$ free -h
+              total        used        free      shared  buff/cache   available
+Mem:           15Gi       4.2Gi       1.1Gi       890Mi       10Gi        10Gi
+```
+
+Here, 10GB is "used" by cache but available if needed.
+
+### Resident Memory (RSS/RES)
+
+**What it is:** The portion of virtual memory currently in physical RAM.
+
+**What it includes:**
+- Private pages actually in RAM
+- Shared pages (libraries, shared memory)
+
+**What it excludes:**
+- Swapped out pages
+- Pages never touched (demand paging)
+- Memory-mapped files not currently loaded
+
+`RSS` can be misleading for shared memory - here's why.
+
+## Why `RSS` Doesn't Add Up
+
+Consider two processes using the same shared library:
+
+```
+Process A: RSS = 100MB (includes 40MB libc)
+Process B: RSS = 80MB (includes 40MB libc)
+Total RSS = 180MB
+```
+
+But `libc` only exists once in physical RAM. The actual memory used is closer to 140MB.
+
+This is why `RSS` totals often exceed physical RAM - shared pages are counted multiple times.
+
+### `PSS`: Proportional Set Size
+
+To solve the double-counting problem, Linux provides `PSS`:
+
+```
+Shared memory contribution = (shared size) / (number of sharers)
+```
+
+For the example above:
+```
+Process A: PSS = 60MB + (40MB / 2) = 80MB
+Process B: PSS = 40MB + (40MB / 2) = 60MB
+Total PSS = 140MB (accurate!)
+```
+
+```bash
+# Works on any kernel since 2.6.25 (2008)
+$ awk '/^Pss:/ {sum += $2} END {print sum " kB"}' /proc/<pid>/smaps
+
+# Faster on kernel 4.14+ (no parsing needed)
+$ grep ^Pss: /proc/<pid>/smaps_rollup
+Pss:               98765 kB
+```
+
+Note: `PSS` has been available since kernel 2.6.25 via `/proc/<pid>/smaps`. The pre-aggregated `/proc/<pid>/smaps_rollup` was [added in kernel 4.14](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=493b0e9d945f) (2017) to avoid parsing overhead.
+
+## Virtual Memory Can Be Huge
+
+A process can map far more virtual memory than physical RAM exists:
+
+```c
+// This succeeds even on a 16GB system
+void *p = mmap(NULL, 1UL << 40,  // 1 TB
+               PROT_READ | PROT_WRITE,
+               MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
+               -1, 0);
+// MAP_NORESERVE: don't reserve swap space for this mapping.
+// Without it, strict overcommit (mode 2) might reject the allocation.
+```
+
+Why? Because:
+1. **Demand paging**: Pages aren't allocated until touched
+2. **Overcommit**: Linux allows allocations exceeding physical RAM
+3. **Sparse mappings**: Most of the space may never be used
+
+## The Memory Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Virtual Address Space                │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐   │
+│  │  Mapped  │ │  Mapped  │ │  Mapped  │ │  Mapped  │   │
+│  │ (unused) │ │ (in RAM) │ │ (swapped)│ │ (file)   │   │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘   │
+└─────────────────────────────────────────────────────────┘
+        │              │             │            │
+        │              ▼             │            │
+        │       ┌──────────┐         │            │
+        │       │ Physical │         │            │
+        │       │   RAM    │◄────────┘            │
+        │       └──────────┘   (swap in)          │
+        │              │                          │
+        │              ▼                          ▼
+        │       ┌──────────┐              ┌──────────┐
+        │       │   Swap   │              │   Disk   │
+        │       │  Device  │              │  (file)  │
+        │       └──────────┘              └──────────┘
+        │
+        ▼
+   Page fault on
+   first access
+   (demand paging)
+```
+
+## Practical Examples
+
+### Example 1: JVM Heap
+
+```bash
+$ java -Xmx4g -jar myapp.jar &
+$ ps -o vsz,rss,comm -p $!
+   VSZ    RSS COMMAND
+5242880 512000 java
+```
+
+Virtual: ~5GB (includes max heap reservation)
+Resident: ~500MB (actual heap usage)
+
+The JVM reserves virtual space for the max heap but only uses physical RAM as needed.
+
+### Example 2: Memory-Mapped File
+
+```bash
+$ ls -l bigfile.dat
+-rw-r--r-- 1 user user 10737418240 Jan 1 00:00 bigfile.dat  # 10GB file
+
+# Process maps entire file
+$ cat /proc/<pid>/maps | grep bigfile
+7f0000000000-7f0280000000 r--s ... bigfile.dat
+
+$ ps -o vsz,rss -p <pid>
+    VSZ    RSS
+10500000  50000   # 10GB virtual, 50MB resident
+```
+
+The file is mapped but only accessed pages are in RAM.
+
+### Example 3: Shared Libraries
+
+```bash
+$ pmap -x <pid> | grep libc
+00007f1234000000   2048K r-x-- libc.so.6    # Code (shared)
+00007f1234200000     64K r---- libc.so.6    # Read-only data
+00007f1234210000     16K rw--- libc.so.6    # Private data (COW)
+```
+
+Most of `libc` is shared across all processes using it.
+
+### `USS`: Unique Set Size
+
+**`USS`** (Unique Set Size) measures only the private memory used by a process - memory that would be freed if this process alone were killed. It excludes all shared memory.
+
+```bash
+# USS = Private_Clean + Private_Dirty (both matched by "Private")
+$ grep ^Private /proc/<pid>/smaps | awk '{sum += $2} END {print sum " kB"}'
+```
+
+`USS` is useful for understanding the true per-process memory cost, especially when analyzing container density or kill impact.
+
+## Historical Context
+
+Memory metrics evolved as systems became more complex and the question "how much memory is this process using?" became harder to answer.
+
+### Early Unix: Simple Metrics
+
+In early Unix systems, memory accounting was straightforward:
+- **Virtual size**: How much address space is mapped
+- **Resident size**: How much is in physical RAM
+
+This was sufficient when processes rarely shared memory and systems had megabytes, not gigabytes.
+
+### The Shared Library Problem (1990s-2000s)
+
+As shared libraries became universal, `RSS` became misleading. If 100 processes share `libc`, each reports `libc`'s size in its `RSS` - summing them gives a wildly inflated total.
+
+The `/proc` filesystem (present since early Linux development, well before 1.0) provided basic memory stats, but detailed per-mapping information came later.
+
+### Linux Adds Detailed Accounting
+
+| Version | Year | Addition |
+|---------|------|----------|
+| **2.6.14** | Oct 2005 | `/proc/pid/smaps` - [commit e070ad49](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e070ad49f31155d872d8e96cab2142840993e3c0) by Mauricio Lin |
+| **2.6.25** | Apr 2008 | **`PSS` added** - [LKML patch](https://lkml.iu.edu/hypermail/linux/kernel/0710.3/1565.html) by Fengguang Wu, concept by Matt Mackall |
+| **4.14** | Nov 2017 | `/proc/pid/smaps_rollup` - [commit 493b0e9d](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=493b0e9d945f) for faster aggregate stats |
+
+### The `PSS` Innovation (2007-2008)
+
+Matt Mackall proposed `PSS` at the [Embedded Linux Conference](https://lwn.net/Articles/230975/) to answer: *"How much memory are applications really using?"*
+
+The insight was simple: if 4 processes share a 40MB library, charge each 10MB (40/4) instead of 40MB. This makes `PSS` values actually sum to physical memory usage.
+
+The [original LKML patch](https://lkml.iu.edu/hypermail/linux/kernel/0708.1/3420.html) (August 2007) was submitted by Fengguang Wu implementing Matt Mackall's concept. It was merged as part of the "maps4" series in kernel 2.6.25.
+
+### Finer-Grained PSS Breakdown
+
+Modern kernels (4.14+) provide PSS broken down by type in `smaps_rollup`:
+
+```bash
+$ grep Pss /proc/<pid>/smaps_rollup
+Pss:               98765 kB
+Pss_Anon:          41000 kB   # Anonymous (heap, stack)
+Pss_File:          54000 kB   # File-backed mappings
+Pss_Shmem:          3765 kB   # Shared memory (41000 + 54000 + 3765 = 98765)
+```
+
+For quick RSS checks without parsing smaps, use `/proc/<pid>/status`:
+
+```bash
+$ grep -E '^(VmRSS|RssAnon|RssFile|RssShmem)' /proc/<pid>/status
+VmRSS:      123456 kB
+RssAnon:     45000 kB
+RssFile:     75000 kB
+RssShmem:     3456 kB
+```
+
+### Modern Challenges
+
+Today's complexity continues to grow:
+- **`cgroups`**: Memory limits across process groups
+- **`KSM`**: Identical pages merged across processes
+- **Transparent Huge Pages**: 2MB/1GB pages complicate accounting
+- **Memory tiering**: Fast vs slow memory (DRAM vs PMEM)
+
+The basic `VSZ`/`RSS`/`PSS` model still works, but tools like `cgroup` memory stats and `/proc/meminfo` provide the fuller picture.
+
+## Summary
+
+| Metric | What It Measures | Shared Memory | Use For |
+|--------|------------------|---------------|---------|
+| `VSZ`/`VIRT` | Address space | Counts fully | Seeing address layout |
+| `RSS`/`RES` | Pages in RAM | Counts per-process | Quick memory check |
+| `PSS` | Proportional RAM | Divides fairly | Accurate accounting |
+| `USS` | Private only | Excludes | Per-process impact |
+
+## Try It Yourself
+
+```bash
+# Compare VSZ vs RSS
+ps aux --sort=-%mem | head -10
+
+# See detailed memory breakdown
+cat /proc/self/smaps_rollup
+
+# Watch memory changes
+watch -n 1 'cat /proc/meminfo | head -10'
+
+# See shared vs private
+pmap -x <pid>
+```
+
+## Further Reading
+
+- [proc(5) man page](https://man7.org/linux/man-pages/man5/proc.5.html) - `/proc` filesystem documentation
+- [ELC: How much memory are applications really using?](https://lwn.net/Articles/230975/) - Matt Mackall's `PSS` introduction
+- [smaps_rollup LKML discussion](https://lore.kernel.org/lkml/20170806225154.18820-1-dancol@google.com/) - Original patch series

--- a/docs/site-index.md
+++ b/docs/site-index.md
@@ -56,6 +56,14 @@ A complete listing of all documentation, organized by topic.
 | [KSM](mm/ksm.md) | Page deduplication for VMs |
 | [vrealloc](mm/vrealloc.md) | Resizing vmalloc allocations |
 
+### Explainers
+
+| Page | Description |
+|------|-------------|
+| [Virtual vs Physical vs Resident](mm/virtual-physical-resident.md) | Understanding VSZ, RSS, PSS, and USS |
+| [Memory Overcommit](mm/overcommit.md) | Why it's the only sane default |
+| [brk vs mmap](mm/brk-vs-mmap.md) | Two ways to get memory from the kernel |
+
 ### Reference
 
 | Page | Description |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,5 +92,9 @@ nav:
       - Compaction: mm/compaction.md
       - KSM: mm/ksm.md
       - vrealloc: mm/vrealloc.md
+    - Explainers:
+      - Virtual vs Physical vs Resident: mm/virtual-physical-resident.md
+      - Memory Overcommit: mm/overcommit.md
+      - brk vs mmap: mm/brk-vs-mmap.md
     - Reference:
       - Glossary: mm/glossary.md


### PR DESCRIPTION
## Summary

Adds three explainer documents for mm/:

1. **Virtual vs Physical vs Resident Memory**
   - Why VSZ is almost always meaningless
   - RSS, PSS, USS explained
   - Why memory numbers don't add up

2. **Memory Overcommit: Why It's the Only Sane Default**
   - fork() would break without overcommit
   - OOM killer: universally disliked, alternatives are worse
   - Three overcommit modes

3. **brk vs mmap: Two Ways to Get Memory**
   - Kernel provides mechanisms, userspace makes policy
   - glibc threshold behavior (clearly marked as userspace policy)

### Key Points

- Clear separation of kernel mechanisms vs userspace policy
- Reframed overcommit from "why does Linux do this" to "why would you NOT"
- VSZ explicitly called out as meaningless for capacity planning
- LKML links and commit IDs for all claims

## Closes
- Closes #76
- Closes #77
- Closes #79