### PR TITLE
Add mm lifecycle documentation

### DIFF
--- a/docs/mm/README.md
+++ b/docs/mm/README.md
@@ -6,6 +6,8 @@
 
 This documentation explains how Linux manages memory - not just the theory, but the actual implementation decisions, trade-offs, and lessons learned over 30+ years of development.
 
+> **Browsing on GitHub?** See the [full site index](../site-index.md) for a complete listing of all documentation.
+
 ### Prerequisites
 
 This documentation assumes familiarity with:
@@ -69,14 +71,29 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 13. **[Compaction](compaction.md)** - Memory defragmentation
 14. **[KSM](ksm.md)** - Page deduplication for VMs
 
+**End-to-End Walkthroughs:**
+
+After the fundamentals, these trace operations through the entire stack:
+
+15. **[Life of a malloc](life-of-malloc.md)** - From userspace to physical page
+16. **[Life of a page](life-of-page.md)** - Allocation through reclaim
+17. **[What happens when you fork](fork.md)** - COW mechanics
+18. **[Running out of memory](oom.md)** - The path to OOM kill
+19. **[Life of a file read](life-of-read.md)** - Page cache in action
+20. **[What happens during swapping](swapping.md)** - Swap-out and swap-in
+
 ### What You'll Learn
 
 | Textbook Concept | Linux Reality |
 |------------------|---------------|
-| "Page tables map virtual to physical" | Multi-level page tables, TLB flushing costs, lazy unmapping |
+| "malloc allocates memory" | [No - it reserves address space](life-of-malloc.md). Physical pages come later via demand paging |
+| "fork copies process memory" | [Copy-on-write](fork.md) means pages are shared until written |
+| "Page tables map virtual to physical" | Multi-level page tables, TLB flushing costs, [lazy creation](life-of-malloc.md) |
 | "Memory allocator" | Multiple allocators for different use cases (slab, vmalloc, buddy) |
 | "Fragmentation" | Why physically contiguous memory is hard, vmalloc as a solution |
-| "Memory is finite" | [OOM killer](overcommit.md), memory cgroups, reclaim |
+| "Memory is finite" | [Watermarks, kswapd, direct reclaim, OOM killer](oom.md) - a progression, not a cliff |
+| "Reading files hits disk" | [Page cache](life-of-read.md) means most reads are from memory |
+| "Swap is slow" | [Swap mechanics](swapping.md) - understand when and why it hurts |
 
 ### What Makes This Different
 
@@ -110,6 +127,19 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 | [page-cache](page-cache.md) | File data caching in memory |
 | [swap](swap.md) | Extending memory to disk |
 
+### Lifecycle
+
+Narrative walkthroughs following memory operations end-to-end:
+
+| Document | What You'll Learn |
+|----------|-------------------|
+| [life-of-malloc](life-of-malloc.md) | Tracing malloc() from userspace to physical pages |
+| [life-of-page](life-of-page.md) | A physical page's journey through allocation, use, and reclaim |
+| [fork](fork.md) | COW setup, page table copying, and COW fault handling |
+| [oom](oom.md) | Watermarks, kswapd, direct reclaim, and OOM killer |
+| [life-of-read](life-of-read.md) | How read() flows through the page cache |
+| [swapping](swapping.md) | Swap-out and swap-in mechanics in detail |
+
 ### Explainers
 
 Conceptual guides for common memory management questions:
@@ -121,6 +151,17 @@ Conceptual guides for common memory management questions:
 | [brk-vs-mmap](brk-vs-mmap.md) | Two ways to get memory from the kernel |
 | [contiguous-memory](contiguous-memory.md) | Why large allocations fail despite free memory |
 | [cow](cow.md) | Copy-on-write edge cases and when it breaks |
+
+### Kernel Bugs & CVEs
+
+Analysis of notable Linux kernel vulnerabilities, data corruption bugs, and edge cases:
+
+| Document | What You'll Learn |
+|----------|-------------------|
+| [Bug Index](bugs/README.md) | Catalog of all mm bugs by severity, year, and subsystem |
+| [SLUB Bugs](slab.md#notorious-bugs-and-edge-cases) | Heap exploitation (CVE-2021-22555, CVE-2022-29582) |
+| [THP Bugs](thp.md#notorious-bugs-and-edge-cases) | khugepaged races, COW issues (CVE-2020-29368) |
+| [Page Table Bugs](page-tables.md#notorious-bugs-and-edge-cases) | Meltdown, Spectre, TLB flush races |
 
 ---
 
@@ -142,6 +183,8 @@ If you want to read the actual code:
 | [`mm/mmap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) | Process address space, VMAs |
 | [`mm/filemap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/filemap.c) | Page cache |
 | [`mm/swapfile.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/swapfile.c) | Swap area management |
+| [`mm/oom_kill.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/oom_kill.c) | OOM killer, victim selection |
+| [`kernel/fork.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/fork.c) | Process creation, dup_mm() |
 | [`include/linux/gfp.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/gfp.h) | GFP flags definitions |
 
 ---

--- a/docs/mm/bugs/README.md
+++ b/docs/mm/bugs/README.md
@@ -1,0 +1,194 @@
+# Memory Management Bugs (Kernel)
+
+> A catalog of notable Linux kernel memory management bugs, vulnerabilities, and edge cases
+
+This index covers bugs in the Linux kernel's mm/ subsystem - security vulnerabilities, data corruption, performance regressions, and stability issues. These are real kernel bugs we analyze for educational purposes.
+
+## Quick Reference
+
+### By Severity
+
+| Severity | Count | Examples |
+|----------|-------|----------|
+| **Critical (CVE, exploit)** | 15+ | Dirty COW, Meltdown, SLUB exploits |
+| **Data corruption** | 5+ | Large folio data loss, swap ABA |
+| **Deadlock/hang** | 5+ | mmap_sem deadlock, OOM livelock |
+| **Performance** | 5+ | Thrashing, readahead traps |
+
+### By Year
+
+| Year | Notable Bugs |
+|------|--------------|
+| 2024 | Swap slot ABA (CVE-2024-26759) |
+| 2023 | StackRot (CVE-2023-3269), Large folio data loss, glibc heap overflow (CVE-2023-6246) |
+| 2022 | io_uring UAF (CVE-2022-29582), systemd cgroup massacre |
+| 2021 | Netfilter heap OOB (CVE-2021-22555) |
+| 2020 | THP COW race (CVE-2020-29368) |
+| 2018 | mremap TLB race (CVE-2018-18281), Spectre variants |
+| 2017 | Meltdown (CVE-2017-5754), Spectre (CVE-2017-5753/5715), Stack Clash |
+| 2016 | Dirty COW (CVE-2016-5195) |
+
+---
+
+## Detailed Bug Documentation
+
+### Subsystem Bug Sections
+
+Detailed analysis of bugs in specific subsystems (located within each topic's documentation):
+
+| Document | Subsystem | Key Bugs |
+|----------|-----------|----------|
+| [SLUB Allocator Bugs](../slab.md#notorious-bugs-and-edge-cases) | mm/slub.c | CVE-2021-22555, CVE-2022-29582, heap exploitation |
+| [THP Bugs](../thp.md#notorious-bugs-and-edge-cases) | mm/huge_memory.c | CVE-2020-29368, khugepaged races, collapse bugs |
+| [Page Table Bugs](../page-tables.md#notorious-bugs-and-edge-cases) | arch/*/mm/ | Meltdown, Spectre, TLB flush races |
+
+### Lifecycle Document Bug Sections
+
+The lifecycle docs contain narrative bug coverage as part of their end-to-end walkthroughs:
+
+| Document | Section | Key Bugs |
+|----------|---------|----------|
+| [fork.md](../fork.md#notorious-bugs-and-edge-cases) | COW & fork bugs | Dirty COW (CVE-2016-5195), StackRot (CVE-2023-3269), mremap (CVE-2004-0077) |
+| [oom.md](../oom.md#notorious-bugs-and-edge-cases) | OOM killer bugs | mmap_sem deadlock, thrashing livelock, CVE-2012-4398 |
+| [life-of-malloc.md](../life-of-malloc.md#notorious-bugs-and-edge-cases) | Heap & allocation bugs | glibc CVE-2023-6246, Stack Clash, mmap_min_addr bypass |
+| [life-of-page.md](../life-of-page.md#notorious-bugs-and-edge-cases) | Page lifecycle bugs | Refcount overflow, large folio data loss, LRU corruption |
+| [life-of-read.md](../life-of-read.md#notorious-bugs-and-edge-cases) | Page cache bugs | filemap_fault races, 9p corruption, readahead issues |
+| [swapping.md](../swapping.md#notorious-bugs-and-edge-cases) | Swap bugs | Swap slot ABA (CVE-2024-26759), zswap races |
+
+---
+
+## Bug Categories
+
+### Security Vulnerabilities (CVEs)
+
+Bugs with assigned CVEs, typically exploitable for privilege escalation or information disclosure.
+
+| CVE | Name | Subsystem | Type | Details |
+|-----|------|-----------|------|---------|
+| CVE-2024-26759 | Swap slot ABA | swap | Race/corruption | [swapping.md](../swapping.md#case-1-the-swap-slot-aba-problem-cve-2024-26759) |
+| CVE-2023-3269 | StackRot | maple tree | UAF | [fork.md](../fork.md#case-2-stackrot-cve-2023-3269) |
+| CVE-2023-6246 | glibc syslog | glibc heap | Overflow | [life-of-malloc.md](../life-of-malloc.md#case-1-glibc-heap-overflow-cve-2023-6246) |
+| CVE-2022-29582 | io_uring UAF | io_uring/slub | UAF | [slab.md](slab.md#case-2-io_uring-use-after-free-cve-2022-29582) |
+| CVE-2021-22555 | Netfilter heap OOB | netfilter/slub | Heap OOB | [slab.md](slab.md#case-1-netfilter-heap-out-of-bounds-cve-2021-22555) |
+| CVE-2020-29368 | THP COW race | thp | Race | [thp.md](thp.md#case-1-thp-cow-race-cve-2020-29368) |
+| CVE-2018-18281 | mremap TLB race | mremap | TLB race | [fork.md](../fork.md#case-4-tlb-flush-races-in-mremap-cve-2018-18281) |
+| CVE-2017-5754 | Meltdown | CPU/page tables | Side channel | [page-tables.md](page-tables.md#case-1-meltdown-cve-2017-5754) |
+| CVE-2017-5753 | Spectre v1 | CPU | Side channel | [page-tables.md](page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
+| CVE-2017-5715 | Spectre v2 | CPU | Side channel | [page-tables.md](page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
+| CVE-2016-5195 | Dirty COW | COW | Race | [fork.md](../fork.md#case-1-dirty-cow-cve-2016-5195) |
+| CVE-2012-4398 | OOM deadlock | OOM | Deadlock | [oom.md](../oom.md#case-5-cve-2012-4398---oom-deadlock-denial-of-service) |
+| CVE-2009-2695 | mmap_min_addr bypass | mmap | Logic | [life-of-malloc.md](../life-of-malloc.md#case-3-mmap_min_addr-bypass-cve-2009-2695) |
+| CVE-2004-0077 | mremap disaster | mremap | Logic | [fork.md](../fork.md#case-3-the-mremap-disaster-cve-2004-0077) |
+
+### Data Corruption Bugs
+
+Bugs causing silent data loss or corruption without security implications.
+
+| Bug | Year | Subsystem | Details |
+|-----|------|-----------|---------|
+| Large folio data loss | 2023 | writeback/folio | [life-of-page.md](../life-of-page.md#case-2-large-folio-data-loss-2023) |
+| Swap slot ABA | 2024 | swap | [swapping.md](../swapping.md#case-1-the-swap-slot-aba-problem-cve-2024-26759) |
+| 9p read corruption | 2025 | 9p/netfs | [life-of-read.md](../life-of-read.md#case-2-9p-read-corruption-2025) |
+| zswap races | Ongoing | zswap | [swapping.md](../swapping.md#case-2-zswap-race-conditions) |
+
+### Deadlock & Hang Bugs
+
+Bugs causing system hangs or unrecoverable states.
+
+| Bug | Year | Subsystem | Details |
+|-----|------|-----------|---------|
+| mmap_sem deadlock | 2010-2016 | OOM | [oom.md](../oom.md#case-2-the-mmap_sem-deadlock-2010-2016) |
+| Swap-over-NFS deadlock | Historical | swap/NFS | [swapping.md](../swapping.md#case-3-swap-over-nfs-instability) |
+
+### Performance Bugs
+
+Bugs causing severe performance degradation.
+
+| Bug | Year | Subsystem | Details |
+|-----|------|-----------|---------|
+| Thrashing livelock | 2010+ | reclaim | [oom.md](../oom.md#case-3-the-thrashing-livelock-2010-mitigated-2018) |
+| Readahead trap | Ongoing | readahead | [swapping.md](../swapping.md#case-5-the-swap-readahead-trap) |
+| khugepaged CPU | Ongoing | thp | [thp.md](thp.md#case-3-khugepaged-cpu-storms) |
+
+---
+
+## Exploitation Techniques
+
+Common techniques used to exploit mm bugs:
+
+### Heap Exploitation (SLUB)
+
+| Technique | Description | Used In |
+|-----------|-------------|---------|
+| **Heap spray** | Fill heap with controlled objects | CVE-2021-22555 |
+| **Cross-cache attack** | Exploit objects across different caches | CVE-2022-29582 |
+| **Freelist corruption** | Overwrite SLUB freelist pointers | Many heap overflows |
+| **msg_msg abuse** | Use msgsnd() for heap layout control | CVE-2021-22555 |
+
+### Race Conditions
+
+| Technique | Description | Used In |
+|-----------|-------------|---------|
+| **userfaultfd** | Pause kernel at precise moments | Dirty COW variants |
+| **FUSE** | Control page fault timing via filesystem | Various exploits |
+| **CPU pinning** | Control which CPU runs exploit code | Race window expansion |
+
+### Side Channels
+
+| Technique | Description | Used In |
+|-----------|-------------|---------|
+| **Flush+Reload** | Measure cache timing | Meltdown, Spectre |
+| **Prime+Probe** | Fill cache, measure evictions | Spectre variants |
+
+---
+
+## Hardening & Mitigations
+
+### Kernel Config Options
+
+| Option | Protects Against | Performance Impact |
+|--------|------------------|-------------------|
+| `CONFIG_SLAB_FREELIST_RANDOM` | Heap layout prediction | Minimal |
+| `CONFIG_SLAB_FREELIST_HARDENED` | Freelist pointer corruption | Minimal |
+| `CONFIG_INIT_ON_ALLOC_DEFAULT_ON` | Info leaks via uninitialized memory | Low |
+| `CONFIG_INIT_ON_FREE_DEFAULT_ON` | UAF info leaks | Low |
+| `CONFIG_PAGE_TABLE_ISOLATION` | Meltdown | 1-5% |
+| `CONFIG_RETPOLINE` | Spectre v2 | Variable |
+
+### Runtime Tunables
+
+```bash
+# Restrict userfaultfd (reduces race exploit surface)
+echo 0 > /proc/sys/vm/unprivileged_userfaultfd
+
+# Restrict kernel pointer exposure
+echo 2 > /proc/sys/kernel/kptr_restrict
+
+# Enable KFENCE sampling
+echo 100 > /sys/module/kfence/parameters/sample_interval
+```
+
+---
+
+## External Resources
+
+### Research & Write-ups
+
+- [Google Project Zero](https://googleprojectzero.blogspot.com/) - Kernel vulnerability research
+- [xairy/linux-kernel-exploitation](https://github.com/xairy/linux-kernel-exploitation) - Comprehensive link collection
+- [how2heap](https://github.com/shellphish/how2heap) - Heap exploitation techniques
+
+### Disclosure Lists
+
+- [oss-security](https://www.openwall.com/lists/oss-security/) - Public vulnerability disclosures
+- [LKML security](https://lore.kernel.org/linux-security-module/) - Kernel security discussions
+
+---
+
+## Contributing
+
+Found a bug not listed here? Contributions welcome:
+
+1. Add to the appropriate subsystem file in `bugs/`
+2. Include: CVE (if assigned), fix commit, root cause analysis
+3. Link from this index

--- a/docs/mm/fork.md
+++ b/docs/mm/fork.md
@@ -1,0 +1,881 @@
+# What happens when you fork
+
+> The memory mechanics of process creation
+
+## fork() in 30 seconds
+
+When a process calls `fork()`, the kernel creates a child process that's almost an exact copy of the parent. But copying gigabytes of memory would be slow and wasteful. Instead, Linux uses **copy-on-write (COW)**: parent and child share the same physical pages until one of them writes.
+
+```mermaid
+flowchart TB
+    subgraph before["Parent Process (before fork)"]
+        VAS["Virtual Address Space<br/>[stack] [heap] [data] [code] [libs]"]
+        PP["Physical pages (owned exclusively)"]
+        VAS --> PP
+    end
+
+    subgraph after["After fork()"]
+        subgraph Parent1["Parent"]
+            PS1["[stack]"]
+        end
+        subgraph Child1["Child"]
+            CS1["[stack]"]
+        end
+        SP["Shared physical pages (read-only)"]
+        PS1 --> SP
+        CS1 --> SP
+    end
+
+    subgraph cow["After child writes to stack"]
+        subgraph Parent2["Parent"]
+            PS2["[stack]"]
+            OP["[Original]"]
+            PS2 --> OP
+        end
+        subgraph Child2["Child"]
+            CS2["[stack]"]
+            CP["[Copy] (new page)"]
+            CS2 --> CP
+        end
+    end
+
+    before --> after
+    after --> cow
+```
+
+This makes fork() fast - `O(page tables)` rather than `O(memory used)`.
+
+## Before fork: The parent's memory
+
+A typical process has multiple memory regions, each backed differently:
+
+```mermaid
+flowchart TB
+    subgraph addr["Parent Process Address Space"]
+        direction TB
+        HIGH["High addresses"]
+        STACK["[Stack]<br/>Anonymous, private, grows down"]
+        MMAP["[Memory-mapped files]<br/>File-backed, may be shared"]
+        LIBS["[Shared libraries]<br/>File-backed, shared across processes<br/>(libc.so, etc.)"]
+        HEAP["[Heap]<br/>Anonymous, private, grows up"]
+        BSS["[BSS]<br/>Anonymous (zero-initialized global variables)"]
+        DATA["[Data]<br/>File-backed (initialized global variables)"]
+        TEXT["[Text/Code]<br/>File-backed, read-only, executable"]
+        LOW["Low addresses"]
+
+        HIGH --- STACK
+        STACK --- MMAP
+        MMAP --- LIBS
+        LIBS --- HEAP
+        HEAP --- BSS
+        BSS --- DATA
+        DATA --- TEXT
+        TEXT --- LOW
+    end
+```
+
+Each region is represented by a VMA ([Virtual Memory Area](mmap.md)). The kernel must handle each VMA appropriately during fork.
+
+## The fork system call
+
+Fork is implemented via the `clone()` system call internally:
+
+```c
+// User calls fork()
+pid_t child = fork();
+
+// glibc translates to:
+clone(SIGCHLD, 0, NULL, NULL, 0);
+
+// Kernel entry point: kernel/fork.c
+SYSCALL_DEFINE0(fork)
+{
+    struct kernel_clone_args args = {
+        .exit_signal = SIGCHLD,
+    };
+    return kernel_clone(&args);
+}
+```
+
+### What gets copied
+
+Fork creates copies of many process structures:
+
+| Structure | What Happens |
+|-----------|--------------|
+| `task_struct` | New copy for child |
+| `mm_struct` | New copy (address space descriptor) |
+| VMAs | Duplicated (but reference same pages) |
+| Page tables | Duplicated (pointing to same physical pages) |
+| Physical pages | **Shared** (COW setup) |
+| File descriptors | Duplicated (reference same files) |
+| Signal handlers | Copied |
+
+The critical insight: **page tables are copied, physical pages are not**.
+
+## Inside dup_mm(): Copying the address space
+
+The memory copying happens in [`dup_mm()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/fork.c):
+
+```c
+// kernel/fork.c (simplified)
+static struct mm_struct *dup_mm(struct task_struct *tsk,
+                                struct mm_struct *oldmm)
+{
+    struct mm_struct *mm;
+
+    // 1. Allocate new mm_struct
+    mm = allocate_mm();
+
+    // 2. Copy mm_struct fields
+    memcpy(mm, oldmm, sizeof(*mm));
+
+    // 3. Allocate new page tables (PGD)
+    mm->pgd = pgd_alloc(mm);
+
+    // 4. Copy VMAs and page tables
+    dup_mmap(mm, oldmm);
+
+    return mm;
+}
+```
+
+### VMA duplication
+
+Each VMA is duplicated, but the handling depends on its type:
+
+```c
+// kernel/fork.c dup_mmap() (simplified)
+static int dup_mmap(struct mm_struct *mm, struct mm_struct *oldmm)
+{
+    struct vm_area_struct *mpnt, *tmp;
+
+    for_each_vma(oldmm, mpnt) {
+        // Skip regions marked DONTFORK
+        if (mpnt->vm_flags & VM_DONTFORK)
+            continue;
+
+        // Create new VMA for child
+        tmp = vm_area_dup(mpnt);
+
+        // Handle special cases
+        if (mpnt->vm_flags & VM_WIPEONFORK) {
+            // Child sees zeros (security feature)
+            tmp->anon_vma = NULL;
+        }
+
+        // Copy page tables for this VMA
+        copy_page_range(mm, oldmm, tmp, mpnt);
+
+        // Add VMA to child's address space
+        insert_vm_struct(mm, tmp);
+    }
+}
+```
+
+### Page table copying and COW setup
+
+The key function is [`copy_page_range()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c), which walks the parent's page tables and creates corresponding entries in the child:
+
+```c
+// mm/memory.c (simplified)
+int copy_page_range(struct mm_struct *dst_mm, struct mm_struct *src_mm,
+                    struct vm_area_struct *dst_vma,
+                    struct vm_area_struct *src_vma)
+{
+    // Walk page table levels: PGD → PUD → PMD → PTE
+    // For each valid PTE...
+
+    // If it's a private writable mapping:
+    if (is_cow_mapping(src_vma->vm_flags)) {
+        // Make BOTH parent and child PTEs read-only
+        ptep_set_wrprotect(src_mm, addr, src_pte);
+        pte = pte_wrprotect(pte);
+    }
+
+    // Copy the PTE to child (pointing to same physical page)
+    set_pte_at(dst_mm, addr, dst_pte, pte);
+
+    // Increment page reference count
+    page_dup_rmap(page);
+}
+```
+
+**Critical detail**: Both parent AND child are made read-only for private writable mappings. This ensures the first writer (whichever process) triggers the COW fault.
+
+### The COW setup in detail
+
+```mermaid
+flowchart TB
+    subgraph before["Before fork"]
+        PPTE1["Parent PTE<br/>[RW, present]<br/>refcount=1"]
+        PAGE1["Physical Page"]
+        PPTE1 --> PAGE1
+    end
+
+    subgraph after["After fork (COW setup)"]
+        PPTE2["Parent PTE<br/>[RO, present]"]
+        PAGE2["Physical Page<br/>refcount=2"]
+        CPTE["Child PTE<br/>[RO, present]"]
+        PPTE2 --> PAGE2
+        CPTE --> PAGE2
+    end
+
+    before --> after
+```
+
+Both PTEs point to the same physical page. Both are marked read-only. The page's reference count increments to 2.
+
+## COW fault handling
+
+When either process writes to a COW page, a page fault occurs:
+
+```c
+// User code (in parent or child)
+buffer[0] = 'x';  // Write to shared page
+
+// CPU: "PTE says read-only, but this is a write!"
+// → Page fault → Kernel handles it
+```
+
+The kernel handles this in [`do_wp_page()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c):
+
+```c
+// mm/memory.c (simplified)
+static vm_fault_t do_wp_page(struct vm_fault *vmf)
+{
+    struct folio *old_folio = page_folio(vmf->page);
+
+    // Check if we're the only user of this page
+    if (folio_reuse_one_vma(old_folio, vmf->vma)) {
+        // We're the only mapper - just make it writable
+        wp_page_reuse(vmf, old_folio);
+        return 0;
+    }
+
+    // Multiple mappers - need to copy
+    return wp_page_copy(vmf);
+}
+
+static vm_fault_t wp_page_copy(struct vm_fault *vmf)
+{
+    struct folio *old_folio = page_folio(vmf->page);
+    struct folio *new_folio;
+
+    // 1. Allocate new page
+    new_folio = vma_alloc_folio(GFP_HIGHUSER_MOVABLE, ...);
+
+    // 2. Copy content (the actual "copy" in copy-on-write)
+    copy_user_highpage(&new_folio->page, &old_folio->page, ...);
+
+    // 3. Update page table to point to new page (with write permission)
+    set_pte_at(vma->vm_mm, vmf->address, vmf->pte,
+               mk_pte(&new_folio->page, vma->vm_page_prot));
+
+    // 4. Decrement old page refcount
+    folio_put(old_folio);
+
+    return 0;
+}
+```
+
+### After COW fault
+
+```mermaid
+flowchart LR
+    subgraph parent["Parent (still read-only)"]
+        PPTE["Parent PTE<br/>[RO, present]"]
+        ORIG["Original Page<br/>refcount=1"]
+        PPTE --> ORIG
+    end
+
+    subgraph child["Child (has its own copy)"]
+        CPTE["Child PTE<br/>[RW, present]"]
+        COPY["New Page (copy)<br/>refcount=1"]
+        CPTE --> COPY
+    end
+```
+
+**Important**: The parent's PTE stays read-only even though it's now the exclusive owner. If the parent writes later, `do_wp_page()` sees refcount=1, calls `wp_page_reuse()`, and simply makes the PTE writable - no copy needed. This lazy approach avoids modifying PTEs that might never be written to.
+
+## TLB considerations
+
+After modifying page tables, stale TLB entries must be invalidated.
+
+### During fork
+
+When making PTEs read-only for COW:
+
+```c
+// The parent's PTE changes from RW to RO
+// TLB might have cached the old RW entry
+
+ptep_set_wrprotect(src_mm, addr, src_pte);
+// This implies a TLB flush for that address
+```
+
+On x86, modifying a PTE from writable to read-only requires flushing the TLB entry. Otherwise, the CPU might use a cached writable entry and skip the COW fault.
+
+### During COW fault
+
+After updating the faulting process's PTE:
+
+```c
+// Old entry (RO) → New entry (RW, different physical page)
+// Flush the old TLB entry
+
+flush_tlb_page(vma, address);
+```
+
+### Multi-threaded processes
+
+If the forking process is multi-threaded, all threads share the same `mm_struct`. During fork:
+
+- The forking thread holds `mmap_lock` for write
+- Other threads are prevented from faulting during the page table copy
+- TLB shootdowns may be needed across CPUs running sibling threads
+
+This is one reason `fork()` in heavily multi-threaded processes can be slow.
+
+## Memory accounting after fork
+
+After fork, memory metrics can be confusing:
+
+```bash
+# Parent and child both show:
+ps -o pid,vsz,rss,comm -p $PARENT_PID,$CHILD_PID
+
+# VSZ: Same (same virtual address space layout)
+# RSS: Initially same, diverges as COW happens
+```
+
+### RSS (Resident Set Size)
+
+RSS counts physical pages mapped to a process. After fork:
+
+- Both processes count the shared pages in their RSS
+- The sum of parent + child RSS > actual physical memory used
+- This is expected! RSS is per-process, not system-wide
+
+```mermaid
+flowchart LR
+    subgraph reality["Reality after fork"]
+        PHYS["Physical memory: 100MB (shared)"]
+        subgraph reported["Reported (misleading)"]
+            PRSS["Parent RSS: 100MB"]
+            CRSS["Child RSS: 100MB"]
+            TRSS["Total RSS: 200MB"]
+        end
+        ACTUAL["Actual physical: 100MB"]
+    end
+```
+
+### PSS (Proportional Set Size)
+
+PSS divides shared pages among sharing processes:
+
+```mermaid
+flowchart LR
+    subgraph pss["With PSS"]
+        PHYS["Physical memory: 100MB<br/>(shared between 2 processes)"]
+        subgraph accurate["Accurate accounting"]
+            PPSS["Parent PSS: 50MB"]
+            CPSS["Child PSS: 50MB"]
+            TPSS["Total PSS: 100MB"]
+        end
+    end
+```
+
+```bash
+# View PSS
+cat /proc/$PID/smaps_rollup | grep Pss
+```
+
+### Shared vs Private
+
+The `smaps` file distinguishes:
+
+```bash
+cat /proc/$PID/smaps | grep -E "^(Shared|Private)"
+
+# Shared_Clean:  Shared, unmodified pages
+# Shared_Dirty:  Shared, modified pages (rare after fork)
+# Private_Clean: Private pages, not written
+# Private_Dirty: Private pages, written (COW completed)
+```
+
+After fork, most pages are `Shared_Clean`. As COW happens, they become `Private_Dirty` in the writing process.
+
+## exec() and COW cleanup
+
+The common pattern `fork() + exec()` is highly optimized:
+
+```c
+pid_t pid = fork();
+if (pid == 0) {
+    // Child process
+    exec("/bin/ls", ...);  // Replace address space entirely
+}
+```
+
+When `exec()` runs:
+
+1. **Entire address space is discarded**
+2. COW pages are never copied (refcount decremented instead)
+3. New program's pages are mapped fresh
+
+```mermaid
+flowchart LR
+    FORK["fork()"]
+    COW["Shared COW pages"]
+    EXEC["exec()<br/>Discards all!"]
+    RESULT["No copies made!<br/>Just refcount up, then down."]
+
+    FORK --> COW --> EXEC
+    COW --> RESULT
+```
+
+This is why shells (which fork+exec constantly) are efficient despite creating many child processes.
+
+### vfork() optimization
+
+`vfork()` goes further - it doesn't even copy page tables:
+
+```c
+pid_t pid = vfork();
+if (pid == 0) {
+    // Child SHARES parent's address space entirely
+    // Parent is BLOCKED until child exits or execs
+    exec("/bin/ls", ...);
+}
+```
+
+**Warning**: With `vfork()`, any memory modification in the child corrupts the parent. Only use if you `exec()` or `_exit()` immediately.
+
+## Special cases
+
+### VM_DONTFORK
+
+Some VMAs shouldn't be inherited:
+
+```c
+// After mmap, mark the region as don't-fork
+void *buf = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+madvise(buf, size, MADV_DONTFORK);
+```
+
+The child simply won't have this mapping. Use for DMA buffers or security-sensitive regions.
+
+### VM_WIPEONFORK
+
+The mapping exists in the child but content is zeroed:
+
+```c
+madvise(addr, len, MADV_WIPEONFORK);
+```
+
+Added in kernel 4.14 ([commit d2cd9ede6e19](https://git.kernel.org/linus/d2cd9ede6e19) | [LKML](https://lore.kernel.org/lkml/20170811212829.29186-3-riel@redhat.com/)) for security-sensitive data (encryption keys, random state) that shouldn't leak to children.
+
+### Huge pages and fork
+
+Transparent Huge Pages (THP) have special COW handling:
+
+- **Old behavior**: Copy entire 2MB on first write (expensive!)
+- **Modern behavior (v4.5+)**: Split THP into 4KB pages, COW only the written page
+
+See the [THP documentation](thp.md) and [COW explainer](cow.md) for details.
+
+## Performance considerations
+
+### Fork latency
+
+Fork time scales with:
+
+1. **Number of VMAs**: Each VMA is duplicated
+2. **Page table size**: All page table levels are copied
+3. **TLB flush overhead**: Especially on multi-CPU processes
+
+For a process with 1GB of mapped memory (256K pages), fork must walk and copy page table entries for all of them.
+
+### Reducing fork overhead
+
+1. **Use `posix_spawn()` when possible**: Combines fork+exec more efficiently
+2. **Avoid huge address spaces before fork**: Unmapping reduces page table copying
+3. **Consider `vfork()` for fork+exec**: No page table copy, but dangerous
+
+### Measuring fork impact
+
+```bash
+# Time fork() operations
+perf stat -e 'syscalls:sys_enter_clone' ./your_program
+
+# Trace fork latency
+perf trace -e clone ./your_program
+
+# Watch COW faults after fork
+perf stat -e page-faults ./your_program
+```
+
+## Try it yourself
+
+### Watch COW in action
+
+```bash
+cat > /tmp/cow_demo.c << 'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+int main() {
+    // Allocate and touch memory
+    size_t size = 100 * 1024 * 1024;  // 100MB
+    char *buf = malloc(size);
+    memset(buf, 'A', size);  // Fault in all pages
+
+    printf("Before fork - check RSS:\n");
+    printf("  Parent PID: %d\n", getpid());
+    char cmd[64];
+    snprintf(cmd, sizeof(cmd), "ps -o pid,rss -p %d", getpid());
+    system(cmd);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+        // Child
+        printf("\nAfter fork - child PID: %d\n", getpid());
+        sleep(1);  // Let parent print first
+
+        printf("\nChild writing to all pages (triggering COW)...\n");
+        memset(buf, 'B', size);
+
+        printf("\nAfter COW - check both processes:\n");
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "ps -o pid,rss -p %d,%d", getppid(), getpid());
+        system(cmd);
+
+        exit(0);
+    } else {
+        // Parent
+        sleep(2);  // Let child do its work
+        wait(NULL);
+    }
+
+    return 0;
+}
+EOF
+gcc -o /tmp/cow_demo /tmp/cow_demo.c
+/tmp/cow_demo
+```
+
+### Monitor page sharing
+
+```bash
+# View shared vs private memory
+cat /proc/$PID/smaps_rollup
+
+# Before fork (in parent):
+# Shared_Clean + Shared_Dirty ≈ 0 (no sharing)
+# Private_Clean + Private_Dirty ≈ RSS
+
+# After fork (before COW):
+# Shared_Clean ≈ most memory (COW shared)
+# Private_* ≈ small
+
+# After COW:
+# Private_Dirty increases (copies made)
+```
+
+### Trace fork system call
+
+```bash
+# Trace fork with timing
+strace -f -T -e clone,execve ./your_program
+
+# -f: follow forks
+# -T: show time spent in syscall
+```
+
+### Count page table pages
+
+```bash
+# Page table memory is in /proc/PID/status
+grep -E "VmPTE|VmPMD" /proc/$PID/status
+
+# VmPTE: PTE-level page table memory
+# VmPMD: PMD-level page table memory
+```
+
+## Key source files
+
+| File | What It Does |
+|------|--------------|
+| [`kernel/fork.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/fork.c) | fork/clone implementation, dup_mm() |
+| [`mm/memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c) | copy_page_range(), COW fault handling |
+| [`mm/mmap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) | VMA duplication |
+| [`include/linux/mm_types.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mm_types.h) | mm_struct, vm_area_struct |
+
+## History
+
+### Early COW
+
+Copy-on-write in Unix predates Linux. Linux inherited the technique from Unix tradition when Linus Torvalds wrote the initial implementation in 1991.
+
+### Per-VMA locks (v6.4, 2023)
+
+**Commit**: [5e31275cc997](https://git.kernel.org/linus/5e31275cc997) ("mm: add per-VMA lock and helper functions to control it") | [LKML](https://lore.kernel.org/all/20230109205336.3665937-1-surenb@google.com/)
+
+**Author**: Suren Baghdasaryan
+
+COW page faults can now be handled with per-VMA locks instead of the global `mmap_lock`, significantly improving scalability for multi-threaded processes after fork.
+
+### COW under VMA lock (v6.4+, 2023)
+
+**Commit**: [164b06f238b9](https://git.kernel.org/linus/164b06f238b9) ("mm: call wp_page_copy() under the VMA lock") | [LKML](https://lkml.kernel.org/r/20231006195318.4087158-3-willy@infradead.org)
+
+**Author**: Matthew Wilcox (Oracle)
+
+Part of ongoing work to handle COW faults without taking `mmap_lock`, improving concurrent page fault handling.
+
+## Notorious bugs and edge cases
+
+Fork and COW involve subtle race conditions between memory mapping, page table manipulation, and signal handling. These bugs have led to some of the most impactful Linux kernel vulnerabilities.
+
+---
+
+### Case 1: Dirty COW (CVE-2016-5195)
+
+#### What happened
+
+In October 2016, Phil Oester discovered a race condition in the kernel's COW handling that had existed since kernel 2.6.22 (September 2007) - **nine years** undetected.
+
+The vulnerability allowed an unprivileged local user to gain write access to read-only memory mappings, enabling privilege escalation to root.
+
+#### The bug
+
+The [official Dirty COW page](https://dirtycow.ninja/) explains the race condition occurs between two operations:
+
+1. **Thread A**: Writing to a COW memory mapping (triggers COW fault)
+2. **Thread B**: Calling `madvise(MADV_DONTNEED)` to discard the page
+
+When these race repeatedly, the kernel can be confused into writing data directly to the original read-only page instead of creating a private copy first.
+
+```mermaid
+sequenceDiagram
+    participant T1 as Thread 1 (write)
+    participant K as Kernel
+    participant T2 as Thread 2 (madvise)
+
+    T1->>K: Write to COW page
+    K->>K: Start COW fault handling
+    T2->>K: madvise(MADV_DONTNEED)
+    K->>K: Discard the COW copy
+    K->>K: Race! Write goes to original page
+    Note over K: Read-only page now modified!
+```
+
+#### Real-world implications
+
+The vulnerability was [actively exploited in the wild](https://www.redhat.com/en/blog/understanding-and-mitigating-dirty-cow-vulnerability). Attack scenarios included:
+
+- Overwriting `/etc/passwd` to gain root access
+- Modifying setuid binaries
+- Rooting Android devices before version 7 (Nougat)
+
+[Red Hat's analysis](https://access.redhat.com/security/vulnerabilities/DirtyCow): *"Although it is a local privilege escalation, remote attackers can use it in conjunction with other exploits that allow remote execution of non-privileged code to achieve remote root access."*
+
+#### The fix
+
+**Commit**: [19be0eaffa3a](https://git.kernel.org/linus/19be0eaffa3a) ("mm: remove gup_flags FOLL_WRITE games from __get_user_pages()") | [LKML](https://lkml.org/lkml/2016/10/19/860)
+
+**Author**: Linus Torvalds
+
+Linus wrote: *"This is an ancient bug that was actually attempted to be fixed once (badly) by me eleven years ago... It was then undone due to problems on s390."*
+
+The fix removed the `FOLL_WRITE` flag manipulation that created the race window.
+
+#### Why it went undetected
+
+The bug was subtle:
+- Required precise timing between two threads
+- Only affected private mappings of read-only files
+- Normal testing wouldn't trigger the race
+
+#### Legacy
+
+Dirty COW spawned research into similar races. The name comes from "Dirty" (the write operation) + "COW" (Copy-On-Write). It earned its own logo, website, and became a textbook example of race condition vulnerabilities.
+
+---
+
+### Case 2: StackRot (CVE-2023-3269)
+
+#### What happened
+
+In June 2023, Ruihan Li (Peking University) discovered a use-after-free vulnerability in the maple tree - the new data structure that replaced red-black trees for VMA management in kernel 6.1.
+
+#### The bug
+
+The [StackRot disclosure](https://github.com/lrh2000/StackRot) explains:
+
+When the stack grows (via `MAP_GROWSDOWN`), the kernel adjusts the VMA's start address. This adjustment modifies the maple tree **without holding the MM write lock**.
+
+Because maple trees are RCU-safe, node modifications create new nodes and schedule old ones for deletion via RCU callbacks. But VMA access only requires the MM read lock - it doesn't enter RCU critical sections.
+
+```mermaid
+flowchart TD
+    A["Stack grows<br/>(page fault below stack)"] --> B["Kernel adjusts VMA start"]
+    B --> C["Maple tree node replaced"]
+    C --> D["Old node scheduled for RCU free"]
+    D --> E["Other thread holds MM read lock<br/>Still has pointer to old node"]
+    E --> F["RCU callback frees old node"]
+    F --> G["USE-AFTER-FREE!"]
+```
+
+#### Real-world implications
+
+From the [oss-security disclosure](https://www.openwall.com/lists/oss-security/2023/07/05/1):
+
+> *"An unprivileged local user could use this flaw to compromise the kernel and escalate their privileges."*
+
+The vulnerability affected kernels 6.1 through 6.4 - any system using maple trees for VMA management.
+
+#### The fix
+
+Linus merged the fix on June 28, 2023 during the 6.5 merge window, with backports to 6.1.37, 6.3.11, and 6.4.1.
+
+Linus provided [a detailed merge message](https://github.com/lrh2000/StackRot) explaining the technical approach: ensuring proper locking when modifying maple tree nodes that might be accessed under RCU.
+
+#### Why this matters for fork
+
+Fork duplicates VMAs and their maple tree representation. The maple tree's complexity (compared to the simpler red-black tree it replaced) introduced this subtle race. It's a reminder that data structure changes in MM code require extremely careful concurrency analysis.
+
+---
+
+### Case 3: The mremap() disaster (CVE-2004-0077)
+
+#### What happened
+
+In February 2004, Paul Starzetz discovered a critical vulnerability in `mremap()` - the system call that moves or resizes memory mappings.
+
+#### The bug
+
+From the [ISEC advisory](https://isec.pl/en/vulnerabilities/isec-0014-mremap-unmap.txt):
+
+> *"A critical security vulnerability was found in the Linux kernel memory management code in the mremap(2) system call due to incorrect bound checks."*
+
+The kernel failed to properly validate arguments to `mremap()`. By crafting specific arguments, an attacker could:
+
+1. Overflow page table counters
+2. Hijack another process's virtual memory segment
+3. If that segment ran with elevated privileges, gain those privileges
+
+#### Real-world implications
+
+Any local user could escalate to root. The vulnerability was trivially exploitable with public proof-of-concept code.
+
+From the advisory: *"No special privileges are required to use the mremap(2) system call, thus any process may misuse its unexpected behavior to disrupt the kernel memory management subsystem."*
+
+#### The fix
+
+Multiple patches were required across kernel versions 2.4.x and 2.6.x. The fix added proper bounds checking in the mremap path.
+
+#### Legacy
+
+This bug highlighted the danger of complex MM system calls. It led to increased scrutiny of mmap/mremap/mprotect code paths and inspired research into MM syscall fuzzing.
+
+---
+
+### Case 4: TLB flush races in mremap (CVE-2018-18281)
+
+#### What happened
+
+In 2018, Jann Horn (Google Project Zero) found a TLB (Translation Lookaside Buffer) race in `mremap()`.
+
+#### The bug
+
+From Horn's research ["Taking a page from the kernel's book"](https://research.checkpoint.com/2018/mmap-vulnerabilities-linux-kernel/):
+
+When `mremap()` moves a mapping, it must:
+1. Update page tables
+2. Flush TLBs on all CPUs that might have cached the old translation
+
+If the TLB flush is incomplete or races with concurrent access, a CPU might use stale translations, accessing the wrong physical page.
+
+#### Real-world implications
+
+An attacker could potentially read or write memory belonging to other processes, bypassing isolation.
+
+#### The fix
+
+**Commit**: [eb66ae030829](https://git.kernel.org/linus/eb66ae030829) ("mremap: properly flush TLB before releasing the page")
+
+**Author**: Will Deacon
+
+The fix ensures TLB flushes happen before releasing both source and destination page table locks, preventing stale TLB entries from accessing reallocated pages.
+
+---
+
+### Case 5: fork() and userfaultfd races
+
+#### The pattern
+
+`userfaultfd` allows userspace to handle page faults. This is extremely useful for:
+- Live migration of VMs
+- Garbage collectors
+- Custom memory management
+
+But it's also a powerful primitive for exploiting race conditions. By handling page faults in userspace, an attacker can **pause kernel execution** at precise moments.
+
+#### Exploitation technique
+
+From [CVE-2019-18683 analysis](https://a13xp0p0v.github.io/2020/02/15/CVE-2019-18683.html):
+
+1. Attacker maps memory with userfaultfd
+2. Triggers a kernel code path that accesses that memory
+3. Kernel blocks waiting for userspace to handle the fault
+4. Attacker manipulates other kernel state while kernel is paused
+5. Attacker releases the fault
+6. Kernel continues with corrupted state
+
+This technique has been used in many kernel exploits, including Dirty COW variants.
+
+#### Mitigation
+
+Since kernel 5.2, `/proc/sys/vm/unprivileged_userfaultfd` can restrict userfaultfd to privileged users:
+
+```bash
+# Disable unprivileged userfaultfd (reduces kernel attack surface)
+echo 0 > /proc/sys/vm/unprivileged_userfaultfd
+```
+
+Many distributions now default to `0`.
+
+---
+
+### Summary: Lessons learned
+
+| Bug | Year | Root Cause | Impact | Prevention |
+|-----|------|------------|--------|------------|
+| **Dirty COW** | 2016 | Race in COW + madvise | Root access | Kernel update, lived 9 years undetected |
+| **StackRot** | 2023 | RCU vs MM lock mismatch | Root access | Careful data structure concurrency review |
+| **mremap bounds** | 2004 | Missing bounds checks | Root access | Syscall argument validation |
+| **TLB flush race** | 2018 | Incomplete TLB flush | Memory disclosure | Proper flush ordering |
+| **userfaultfd races** | Ongoing | Kernel pause primitive | Various | Restrict unprivileged userfaultfd |
+
+The common thread: **fork and COW involve complex state shared between processes**. Any race condition in this code has severe security implications because it can break process isolation.
+
+## Further reading
+
+### Related docs
+
+- [Copy-on-Write](cow.md) - Deep dive into COW mechanics and edge cases
+- [Process address space](mmap.md) - VMA structure and management
+- [Virtual vs Physical vs Resident](virtual-physical-resident.md) - Understanding memory metrics
+
+### External resources
+
+- [LWN: The price of fork()](https://lwn.net/Articles/820258/) (2020) - Performance analysis of fork in modern systems
+- [Dirty COW vulnerability page](https://dirtycow.ninja/) - Original disclosure and technical details
+- [StackRot disclosure](https://github.com/lrh2000/StackRot) - CVE-2023-3269 details and exploit

--- a/docs/mm/life-of-malloc.md
+++ b/docs/mm/life-of-malloc.md
@@ -1,0 +1,703 @@
+# Life of a malloc
+
+> Tracing a userspace memory allocation from `malloc()` to physical pages
+
+## What happens when you call malloc?
+
+When a program calls `malloc(1024)`, what actually happens? The answer involves multiple layers of software, each optimizing for different goals:
+
+```mermaid
+flowchart TD
+    A["malloc(1024)"] --> B
+
+    subgraph B["glibc (ptmalloc2)"]
+        B1["Check thread-local free lists"]
+        B2["Try arena allocation"]
+        B3["Maybe call brk() or mmap()"]
+    end
+
+    B -->|"only if needed"| C
+
+    subgraph C["Kernel: System Call"]
+        C1["brk(): extend heap"]
+        C2["mmap(): create new mapping"]
+    end
+
+    C --> D
+
+    subgraph D["Kernel: VMA Creation"]
+        D1["Create/extend vm_area_struct"]
+        D2["No physical memory yet!"]
+    end
+
+    D -->|"later, on first access"| E
+
+    subgraph E["Kernel: Page Fault"]
+        E1["Process touches the memory"]
+        E2["Trap into kernel"]
+        E3["Allocate physical page"]
+        E4["Update page tables"]
+    end
+
+    E --> F
+
+    subgraph F["Physical Memory"]
+        F1["Page from buddy allocator"]
+        F2["Mapped into process address space"]
+    end
+```
+
+The key insight: **malloc doesn't allocate physical memory**. It reserves virtual address space. Physical pages are allocated later, on first access, through demand paging.
+
+## Stage 1: Userspace (glibc)
+
+### The allocator's job
+
+`malloc()` is a library function, not a system call. glibc implements it using ptmalloc2 (derived from dlmalloc). The allocator has one goal: satisfy memory requests without calling into the kernel more than necessary.
+
+```c
+void *malloc(size_t size);
+```
+
+For each allocation, ptmalloc2 checks:
+
+1. **Thread-local cache**: Each thread has a tcache with small, recently-freed chunks. Fastest path - no locking.
+
+2. **Fastbins**: Per-arena lists of small freed chunks (up to ~160 bytes default). Quick LIFO access.
+
+3. **Small/large bins**: Sorted lists of freed chunks. Searched for best fit.
+
+4. **Top chunk**: The "wilderness" - unused space at the end of the heap. Can be carved up.
+
+5. **System call**: Only when all else fails does glibc ask the kernel for more memory.
+
+### When glibc calls the kernel
+
+glibc uses two system calls to get memory from the kernel:
+
+| Method | When Used | Typical Threshold |
+|--------|-----------|-------------------|
+| `brk()` | Small allocations, heap growth | < 128KB (tunable via `M_MMAP_THRESHOLD`) |
+| `mmap()` | Large allocations | >= 128KB |
+
+The threshold is adaptive - glibc adjusts it based on allocation patterns. You can override with `mallopt(M_MMAP_THRESHOLD, bytes)`.
+
+**Why two methods?**
+
+- `brk()` extends the heap contiguously. Simple, but freed memory can't return to the kernel until everything above it is also freed.
+- `mmap()` creates independent mappings. Can be returned to the kernel immediately with `munmap()`, but has more overhead.
+
+See [brk vs mmap](brk-vs-mmap.md) for the full trade-off analysis.
+
+## Stage 2: Kernel entry
+
+### The brk() path
+
+When glibc calls `brk()`, it's asking the kernel to move the program break - the end of the heap:
+
+```c
+// Userspace (glibc)
+void *new_mem = sbrk(4096);  // Wrapper around brk()
+```
+
+The kernel handles this in [`mm/mmap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c):
+
+```c
+// Pseudocode - actual implementation has more validation
+SYSCALL_DEFINE1(brk, unsigned long, brk)
+{
+    struct mm_struct *mm = current->mm;
+
+    // Validate: not decreasing into existing mappings,
+    // not exceeding RLIMIT_DATA, etc.
+
+    // Extend or shrink the heap VMA
+    if (brk > mm->brk)
+        do_brk_flags(...);  // Creates/extends VMA
+
+    mm->brk = brk;
+    return brk;
+}
+```
+
+The kernel updates the process's `mm_struct` to extend the heap VMA. No physical memory is allocated yet - just the virtual address range is reserved.
+
+### The mmap() path
+
+For larger allocations, glibc uses `mmap()` with `MAP_ANONYMOUS`:
+
+```c
+// Userspace (glibc simplified)
+void *ptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+// Kernel: mm/mmap.c
+SYSCALL_DEFINE6(mmap, ...)
+{
+    // Find free virtual address range
+    // Create new VMA
+    // Return address to userspace
+}
+```
+
+Again, no physical memory yet. The kernel creates a VMA describing the mapping and returns. No page table entries exist yet - they'll be created lazily on first access.
+
+## Stage 3: VMA creation
+
+Both `brk()` and `mmap()` result in VMA (Virtual Memory Area) creation or modification.
+
+```c
+// From include/linux/mm_types.h
+struct vm_area_struct {
+    unsigned long vm_start;     // Start address
+    unsigned long vm_end;       // End address (exclusive)
+    struct mm_struct *vm_mm;    // Owning address space
+    pgprot_t vm_page_prot;      // Access permissions
+    unsigned long vm_flags;     // VM_READ, VM_WRITE, etc.
+    struct file *vm_file;       // NULL for anonymous memory
+    // ...
+};
+```
+
+For a `malloc()` that triggers `mmap()`:
+
+```mermaid
+flowchart LR
+    subgraph before["Before mmap()"]
+        direction LR
+        A1[stack] --- A2[libs] --- A3[heap] --- A4[text]
+    end
+
+    before -->|"mmap()"| after
+
+    subgraph after["After mmap()"]
+        direction LR
+        B1[stack] --- B2["<b>NEW VMA</b><br/>vm_file = NULL<br/>vm_flags = VM_READ|WRITE"] --- B3[libs] --- B4[heap]
+    end
+```
+
+The new VMA is added to the process's maple tree (or red-black tree in kernels before v6.1). See [process address space](mmap.md) for details on VMA organization.
+
+**Key point**: When `malloc()` returns, you have a valid pointer, but no physical memory backs it. The page table entries for this region don't exist yet - they're created on first access when the CPU faults.
+
+## Stage 4: Page fault
+
+Physical memory is allocated on first access. When the program reads or writes the malloc'd memory:
+
+```c
+char *ptr = malloc(4096);
+ptr[0] = 'x';  // First access - triggers page fault
+```
+
+The CPU finds no valid page table entry and triggers a page fault exception. The kernel handles it:
+
+```c
+// Simplified from mm/memory.c
+static vm_fault_t handle_pte_fault(struct vm_fault *vmf)
+{
+    // PTE is empty - this is a new page
+    if (pte_none(vmf->orig_pte)) {
+        if (vma_is_anonymous(vmf->vma))
+            return do_anonymous_page(vmf);  // Our path
+        else
+            return do_fault(vmf);  // File-backed
+    }
+    // ... other cases (COW, swap, etc.)
+}
+```
+
+### Anonymous page allocation
+
+For anonymous memory (heap, stack), [`do_anonymous_page()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c) runs:
+
+```c
+// Simplified from mm/memory.c
+static vm_fault_t do_anonymous_page(struct vm_fault *vmf)
+{
+    struct folio *folio;
+
+    // 1. Allocate a physical page (folio)
+    //    A folio is the modern replacement for struct page - it represents
+    //    one or more contiguous pages as a single unit. For most anonymous
+    //    allocations, this is a single 4KB page.
+    folio = vma_alloc_zeroed_movable_folio(vmf->vma, vmf->address);
+
+    // 2. Prepare page table entry
+    entry = mk_pte(&folio->page, vma->vm_page_prot);
+    if (vma->vm_flags & VM_WRITE)
+        entry = pte_mkwrite(pte_mkdirty(entry), vma);
+
+    // 3. Install in page table
+    set_pte_at(vma->vm_mm, vmf->address, vmf->pte, entry);
+
+    // 4. Add to reverse mapping (for reclaim)
+    folio_add_new_anon_rmap(folio, vma, vmf->address);
+
+    return 0;
+}
+```
+
+This is where physical memory finally gets allocated.
+
+## Stage 5: Page allocator
+
+The `vma_alloc_zeroed_movable_folio()` call ultimately reaches the buddy allocator:
+
+```c
+// The chain of calls (simplified):
+vma_alloc_zeroed_movable_folio()
+  → folio_alloc()
+    → __folio_alloc()
+      → __alloc_pages()  // The core buddy allocator entry point
+```
+
+[`__alloc_pages()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) is the heart of Linux memory allocation:
+
+```c
+// mm/page_alloc.c (heavily simplified)
+struct page *__alloc_pages(gfp_t gfp, unsigned int order, int nid, nodemask_t *nodemask)
+{
+    // 1. Fast path: try per-CPU lists
+    page = get_page_from_freelist(gfp, order, ...);
+    if (page)
+        return page;
+
+    // 2. Slow path: wake kswapd, try harder
+    page = __alloc_pages_slowpath(gfp, order, ...);
+    return page;
+}
+```
+
+### Fast path
+
+Most allocations succeed immediately from per-CPU page lists or zone free lists:
+
+```mermaid
+flowchart TD
+    subgraph pcplists["Per-CPU lists (pcplists) - No locking needed"]
+        CPU0["CPU 0: [page][page][page]..."]
+        CPU1["CPU 1: [page][page]..."]
+        CPU2["CPU 2: [page][page][page][page]..."]
+    end
+
+    pcplists -->|"refill when empty"| buddy
+
+    subgraph buddy["Zone free lists (buddy allocator)"]
+        O0["Order 0: [4KB][4KB][4KB]..."]
+        O1["Order 1: [8KB][8KB]..."]
+        O2["..."]
+    end
+```
+
+For a single-page allocation (typical for page faults), the kernel checks the per-CPU list first. This requires no locking and is very fast.
+
+### Slow path
+
+If free pages are low:
+
+1. **Wake kswapd**: Background reclaim daemon
+2. **Direct reclaim**: The allocating process frees some pages itself
+3. **Compaction**: Defragment memory for high-order allocations
+4. **OOM killer**: Last resort - kill a process to free memory
+
+See [page reclaim](reclaim.md) for details on memory pressure handling.
+
+## Stage 6: Return to userspace
+
+After the page fault handler succeeds:
+
+1. **Page table updated**: The PTE now points to the physical page
+2. **TLB entry created**: CPU caches the virtual→physical mapping
+3. **Execution resumes**: The faulting instruction is retried
+
+```mermaid
+flowchart LR
+    subgraph before["Before page fault"]
+        VA1["Virtual Address<br/>0x7f1234"] -.-x|"✗"| NP["No physical<br/>page"]
+    end
+
+    subgraph after["After page fault"]
+        VA2["Virtual Address<br/>0x7f1234"] --> PP["Physical Page<br/>0x3a5000"]
+        PP --> ZM["Zeroed memory<br/>(4096 bytes)"]
+    end
+```
+
+The program continues, unaware that a complex dance just occurred. From its perspective, `ptr[0] = 'x'` just worked.
+
+## Why demand paging?
+
+This lazy allocation strategy has major benefits:
+
+### 1. Fast malloc
+
+`malloc()` returns immediately. The kernel work is deferred until actually needed.
+
+### 2. Sparse allocations are cheap
+
+A program can allocate 1GB but only use 4KB. It pays only for what it touches:
+
+```c
+// "Allocate" 1GB
+char *huge = malloc(1024 * 1024 * 1024);
+
+// Only use 4KB - only one physical page allocated
+huge[0] = 'a';
+```
+
+### 3. Overcommit works
+
+The kernel can promise more memory than physically exists. Most programs don't use all they request. See [memory overcommit](overcommit.md).
+
+### 4. fork() is fast
+
+Child processes share pages with parents via [copy-on-write](cow.md). Physical copies only happen when either process writes.
+
+## Try it yourself
+
+### Watch malloc in action
+
+```bash
+# Trace system calls from a simple allocation
+strace -e brk,mmap,munmap -f sh -c 'head -c 1M /dev/zero > /dev/null'
+
+# See page faults
+perf stat -e page-faults,minor-faults,major-faults ./your_program
+```
+
+### Observe demand paging
+
+```bash
+# Create a program that allocates but doesn't touch memory
+cat > /tmp/lazy.c << 'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main() {
+    printf("PID: %d\n", getpid());
+    printf("Before malloc...\n");
+    getchar();
+
+    char *p = malloc(100 * 1024 * 1024);  // 100MB
+    printf("After malloc, before touch...\n");
+    getchar();
+
+    for (int i = 0; i < 100 * 1024 * 1024; i += 4096)
+        p[i] = 'x';  // Touch each page
+    printf("After touching all pages...\n");
+    getchar();
+
+    return 0;
+}
+EOF
+gcc -o /tmp/lazy /tmp/lazy.c
+/tmp/lazy
+
+# In another terminal, watch RSS grow:
+watch -n 1 'ps -o pid,vsz,rss,comm -p $(pgrep lazy)'
+# VSZ jumps after malloc, RSS jumps only after touching
+```
+
+### Examine the malloc threshold
+
+```bash
+# See glibc's mmap threshold behavior
+cat > /tmp/mmap_test.c << 'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    // Small allocation - likely uses brk()
+    void *small = malloc(1024);
+    printf("Small (1KB): %p\n", small);
+
+    // Large allocation - likely uses mmap()
+    void *large = malloc(256 * 1024);
+    printf("Large (256KB): %p\n", large);
+
+    // Notice the address ranges are very different
+    return 0;
+}
+EOF
+gcc -o /tmp/mmap_test /tmp/mmap_test.c
+strace -e brk,mmap /tmp/mmap_test
+```
+
+### Trace page faults in the kernel
+
+```bash
+# Enable page fault tracing (requires root, debugfs mounted)
+echo 1 > /sys/kernel/debug/tracing/events/exceptions/page_fault_user/enable
+cat /sys/kernel/debug/tracing/trace_pipe &
+
+# Run a program - see faults in real time
+./your_program
+
+# Disable when done
+echo 0 > /sys/kernel/debug/tracing/events/exceptions/page_fault_user/enable
+```
+
+## Common misconceptions
+
+### "malloc allocates memory"
+
+Not really. It reserves address space. Physical pages come later via page faults.
+
+### "My program uses 1GB because malloc(1GB) succeeded"
+
+Check RSS (Resident Set Size), not VSZ (Virtual Size). VSZ includes all reserved address space; RSS is physical memory actually used.
+
+```bash
+ps -o pid,vsz,rss,comm -p <pid>
+```
+
+### "Page faults are bad"
+
+Minor faults (demand paging) are normal and expected. Major faults (reading from disk) are expensive. The kernel optimizes for minor faults to be fast.
+
+## Key source files
+
+| File | What It Does |
+|------|--------------|
+| [`mm/mmap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) | brk(), mmap() implementation |
+| [`mm/memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c) | Page fault handling, do_anonymous_page() |
+| [`mm/page_alloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) | Buddy allocator, __alloc_pages() |
+| [`include/linux/mm_types.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mm_types.h) | vm_area_struct, mm_struct definitions |
+
+## History
+
+### Demand paging origins
+
+Demand paging has been part of Linux since the beginning. The basic mechanism - mapping virtual addresses without backing physical memory until access - is fundamental to Unix-like systems.
+
+### VMA management evolution
+
+In **Stage 3** above, when `mmap()` creates a new VMA, it must be inserted into the process's VMA collection for later lookup (e.g., during page faults). The data structure for this has evolved:
+
+**Red-black tree (early Linux)**: VMAs were organized in an rb-tree for `O(log n)` lookup. Simple but required careful locking.
+
+**Maple tree (v6.1, 2022)**: VMAs moved to a maple tree - a B-tree variant optimized for cache locality and RCU-safe operations. This allows concurrent VMA lookups without holding `mmap_lock`, improving page fault scalability.
+
+**Commit**: [d4af56c5c7c6](https://git.kernel.org/linus/d4af56c5c7c6) ("mm: start tracking VMAs with maple tree") | [LKML](https://lore.kernel.org/linux-mm/20220906194824.2110408-9-Liam.Howlett@oracle.com/)
+
+**Author**: Liam Howlett (Oracle)
+
+### Folio conversion (v5.16+)
+
+In **Stage 4** above, `do_anonymous_page()` allocates a `struct folio` rather than a raw `struct page`. A folio is the modern abstraction for memory:
+
+- **What it is**: A folio represents one or more physically contiguous pages managed as a unit
+- **Why it exists**: The old `struct page` API was ambiguous - functions didn't know if they received a head page, tail page, or single page. Folios make the semantics explicit.
+- **In our flow**: `vma_alloc_zeroed_movable_folio()` allocates a folio, which for anonymous faults is typically a single 4KB page (or a 2MB transparent huge page if enabled)
+
+**Commit**: [7b230db3b8d3](https://git.kernel.org/linus/7b230db3b8d3) ("mm: Introduce struct folio") | [LKML](https://lore.kernel.org/linux-mm/20210622121551.3398730-3-willy@infradead.org/)
+
+**Author**: Matthew Wilcox (Oracle)
+
+## Notorious bugs and edge cases
+
+The malloc path spans userspace (glibc) and kernel (brk/mmap, page fault). Bugs at either level can lead to memory corruption or privilege escalation.
+
+---
+
+### Case 1: glibc heap overflow (CVE-2023-6246)
+
+#### What happened
+
+In January 2024, Qualys discovered a heap buffer overflow in glibc's `__vsyslog_internal()` function that could be exploited for local privilege escalation.
+
+#### The bug
+
+From the [Qualys disclosure](https://medium.com/@elpepinillo/heap-heap-hooray-unveiling-glibc-heap-overflow-vulnerability-cve-2023-6246-0c6412423069):
+
+The `__vsyslog_internal()` function in glibc could overflow a heap buffer when processing specially crafted input. The heap (managed by ptmalloc2 in glibc) stores the buffer, and overflowing it corrupts adjacent heap metadata.
+
+#### Real-world implications
+
+An attacker with local access could escalate to root by exploiting programs that use `syslog()`.
+
+#### Why this matters for malloc
+
+When you call `malloc()`, glibc's ptmalloc2 manages the heap internally. Heap corruption vulnerabilities like this one abuse:
+
+1. **Chunk metadata**: ptmalloc stores size/flags adjacent to user data
+2. **Free list pointers**: Corrupting these leads to arbitrary write primitives
+3. **Tcache/fastbin**: Modern glibc mitigations complicate exploitation but don't eliminate it
+
+#### The fix
+
+**Commit**: [6bd0e4efcc78](https://sourceware.org/git/?p=glibc.git;a=commit;h=6bd0e4efcc78f3c0115e5ea9739a1642807450da) (glibc)
+
+Fixed in glibc 2.39. The vulnerability was introduced in glibc 2.37 by commit `52a5be0df411`.
+
+#### Mitigations
+
+Modern glibc includes:
+- **Safe-linking**: Pointer mangling in fastbins/tcache
+- **Chunk size validation**: Detect corrupted size fields
+- **Top chunk integrity checks**: Prevent wilderness corruption
+
+---
+
+### Case 2: The Stack Clash (2017)
+
+#### What happened
+
+Qualys discovered that the gap between stack and heap could be jumped, allowing stack-to-heap or heap-to-stack corruption.
+
+#### The bug
+
+The kernel maintains a "stack guard page" - an unmapped page between the stack and other mappings. The assumption: any access to this page triggers a segfault.
+
+But large allocations (via `alloca()` or VLAs) can jump over the guard page:
+
+```c
+void vulnerable() {
+    char buf[HUGE_SIZE];  // If HUGE_SIZE > guard gap...
+    buf[0] = 'A';         // ...we land in heap/mmap region
+}
+```
+
+#### Real-world implications
+
+Local privilege escalation on many Linux distributions. The vulnerability affected:
+- Linux (CVE-2017-1000364)
+- FreeBSD, OpenBSD, NetBSD, Solaris
+- Programs using large stack allocations
+
+#### The fix
+
+**Commit**: [1be7107fbe18](https://git.kernel.org/linus/1be7107fbe18) ("mm: larger stack guard gap, between vmas")
+
+The kernel increased the stack guard gap from 1 page (4KB) to 1MB by default:
+
+```bash
+# Check current guard gap
+cat /proc/sys/vm/stack_guard_gap
+# Default: 256 (pages) = 1MB on 4KB page systems
+```
+
+#### Why this matters for malloc
+
+The heap (via `brk()`) and stack grow toward each other. This bug showed that the boundary between them must be carefully protected.
+
+---
+
+### Case 3: mmap_min_addr bypass (CVE-2009-2695)
+
+#### What happened
+
+NULL pointer dereference bugs in the kernel could be exploited by mapping memory at address 0.
+
+#### The bug
+
+Many kernel bugs involve dereferencing a NULL pointer. Normally this would crash. But if an attacker can map memory at address 0 and control its contents, they can turn a NULL dereference into code execution.
+
+The kernel added `mmap_min_addr` to prevent low-address mappings. But SELinux's `unconfined_t` domain bypassed this restriction.
+
+From [Red Hat's advisory](https://access.redhat.com/articles/17995):
+
+> *"A system with SELinux enforced was found to be more permissive in allowing local users in the unconfined_t domain to map low memory areas even if the mmap_min_addr restriction is enabled."*
+
+#### The fix
+
+Multiple commits fixed the SELinux policy and strengthened `mmap_min_addr` enforcement:
+- [9c0d9010](https://git.kernel.org/linus/9c0d9010)
+- [8cf948e7](https://git.kernel.org/linus/8cf948e7)
+
+```bash
+# Check current minimum mmap address
+cat /proc/sys/vm/mmap_min_addr
+# Default: 65536 (64KB) on most distributions
+```
+
+#### Why this matters for malloc
+
+When `malloc()` uses `mmap()` for large allocations, the kernel chooses the address. `mmap_min_addr` ensures the kernel never maps at dangerously low addresses.
+
+---
+
+### Case 4: ptmalloc thread arena exhaustion
+
+#### What happened
+
+Under heavy concurrent allocation, glibc's ptmalloc could create excessive arenas, wasting memory.
+
+#### The bug
+
+ptmalloc creates per-thread arenas to reduce lock contention. But the default limit (`8 * num_cpus`) can lead to:
+
+1. Many threads each get their own arena
+2. Each arena has its own heap segment
+3. Fragmentation and memory waste explode
+
+#### Real-world implications
+
+Applications with many threads (e.g., Java apps, web servers) could use 2-3x more memory than expected due to arena overhead.
+
+#### Mitigation
+
+```bash
+# Limit arenas (set before running program)
+export MALLOC_ARENA_MAX=2
+
+# Or use alternative allocators
+# jemalloc, tcmalloc have better multi-threaded behavior
+```
+
+---
+
+### Case 5: brk randomization weaknesses
+
+#### What happened
+
+ASLR (Address Space Layout Randomization) randomizes mmap but historically left brk predictable.
+
+#### The bug
+
+If `brk()` always returns the same address, heap exploitation becomes easier - attackers know where heap data lives.
+
+Early ASLR implementations randomized:
+- Stack location ✓
+- mmap base ✓
+- brk/heap location - **partially or not at all**
+
+#### Modern status
+
+Modern kernels randomize brk with `CONFIG_COMPAT_BRK=n`:
+
+```bash
+# Check if brk randomization is enabled
+cat /proc/sys/kernel/randomize_va_space
+# 2 = full ASLR including brk
+```
+
+---
+
+### Summary: Lessons learned
+
+| Bug | Year | Layer | Impact | Prevention |
+|-----|------|-------|--------|------------|
+| **glibc heap overflow** | 2024 | Userspace | Root access | Update glibc |
+| **Stack Clash** | 2017 | Kernel | Root access | Larger guard gap |
+| **mmap_min_addr bypass** | 2009 | Kernel/SELinux | Root access | Fixed in kernel |
+| **Arena exhaustion** | Ongoing | Userspace | Memory waste | `MALLOC_ARENA_MAX` |
+| **brk predictability** | Historical | Kernel | Easier exploitation | Full ASLR |
+
+The common thread: **malloc is the foundation of memory safety**. Bugs in heap management (glibc) or virtual memory setup (kernel) have severe security implications.
+
+## Further reading
+
+### Related docs
+
+- [Process address space](mmap.md) - VMAs, mmap details
+- [Page allocator](page-allocator.md) - Buddy system internals
+- [Memory overcommit](overcommit.md) - Why demand paging enables overcommit
+- [brk vs mmap](brk-vs-mmap.md) - When glibc uses each method
+- [Page reclaim](reclaim.md) - What happens when memory runs low
+
+### External resources
+
+- [glibc malloc internals](https://sourceware.org/glibc/wiki/MallocInternals) - Official glibc documentation
+- [The Stack Clash](https://blog.qualys.com/vulnerabilities-threat-research/2017/06/19/the-stack-clash) - Qualys research paper
+- [Heap exploitation techniques](https://github.com/shellphish/how2heap) - Educational heap exploitation examples

--- a/docs/mm/life-of-page.md
+++ b/docs/mm/life-of-page.md
@@ -1,0 +1,750 @@
+# Life of a page
+
+> Following a physical page from allocation through reclaim and reuse
+
+## The journey of a page
+
+A physical page in Linux leads an eventful life. It's born in the buddy allocator, assigned to serve a process or cache, tracked for activity, and eventually reclaimed when memory runs low. This document follows that journey.
+
+```mermaid
+flowchart TD
+    subgraph lifecycle["Page Lifecycle"]
+        FREE["Free Pool<br/>(Buddy Allocator)"]
+        ACTIVE["Active Use"]
+        INACTIVE["Inactive LRU"]
+        RECLAIM["Reclaim Decision"]
+        SWAP["Swap Out"]
+        SWAPSPACE["Swap Space"]
+
+        FREE -->|"alloc_pages()"| ACTIVE
+        ACTIVE --> INACTIVE
+        INACTIVE --> RECLAIM
+        RECLAIM -->|"free_pages()"| FREE
+        ACTIVE -->|"anonymous page"| SWAP
+        RECLAIM --> SWAP
+        SWAP --> SWAPSPACE
+    end
+```
+
+## Birth: Page allocation
+
+Every page's life begins in the buddy allocator's free lists. When the kernel needs a page - for a process, page cache, or kernel data structure - it calls [`alloc_pages()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c):
+
+```c
+struct page *alloc_pages(gfp_t gfp, unsigned int order);
+```
+
+### From free list to assigned
+
+```mermaid
+flowchart TD
+    subgraph buddy["Buddy Allocator Free Lists"]
+        O0["Order 0: [page][page][page]..."]
+        O1["Order 1: [    ][    ]..."]
+        O2["..."]
+    end
+
+    buddy -->|"alloc_pages(GFP_USER, 0)"| page
+
+    subgraph page["struct page (Fresh)"]
+        P1["flags = 0"]
+        P2["_refcount = 1"]
+        P3["_mapcount = -1 (unmapped)"]
+        P4["mapping = NULL"]
+        P5["index = 0"]
+    end
+```
+
+The page starts with a clean slate: refcount of 1 (the allocator holds it), no mappings, no flags indicating special state.
+
+### Page initialization
+
+Depending on use, the page gets initialized differently:
+
+| Use Case | Initialization |
+|----------|----------------|
+| Anonymous (heap/stack) | Zeroed, added to anon rmap |
+| Page cache | Linked to file's address_space |
+| Slab object | Added to slab cache's freelist |
+| Kernel buffer | May or may not be zeroed |
+
+For anonymous pages (the most common case from [malloc](life-of-malloc.md)), the kernel zeros the page and sets up reverse mappings:
+
+```c
+// From mm/memory.c do_anonymous_page()
+folio = vma_alloc_zeroed_movable_folio(vma, addr);
+folio_add_new_anon_rmap(folio, vma, addr);
+folio_add_lru(folio);  // Add to LRU for tracking
+```
+
+## The page structure
+
+Every physical page frame is represented by a `struct page` (or `struct folio` for compound pages):
+
+```c
+// Simplified from include/linux/mm_types.h
+struct page {
+    unsigned long flags;        // Page state flags (PG_locked, PG_dirty, etc.)
+    atomic_t _refcount;         // Reference count
+    atomic_t _mapcount;         // How many page tables map this page
+    struct address_space *mapping;  // Owner (file or anon_vma)
+    pgoff_t index;              // Offset within mapping
+    struct list_head lru;       // LRU list linkage
+    // ... many more fields via unions
+};
+```
+
+### Key page flags
+
+Flags track the page's state through its lifecycle:
+
+| Flag | Meaning |
+|------|---------|
+| `PG_locked` | Page is locked for I/O or other exclusive operation |
+| `PG_referenced` | Page was recently accessed |
+| `PG_uptodate` | Page content is valid |
+| `PG_dirty` | Page modified, needs writeback |
+| `PG_lru` | Page is on an LRU list |
+| `PG_active` | Page is on active LRU list |
+| `PG_swapbacked` | Page can be swapped (anonymous) |
+| `PG_swapcache` | Page is in swap cache |
+| `PG_writeback` | Page is being written to disk |
+| `PG_reclaim` | Page is being reclaimed |
+
+View a page's flags in debugfs:
+
+```bash
+# For a specific PFN (page frame number)
+cat /sys/kernel/debug/page_owner  # If CONFIG_PAGE_OWNER enabled
+```
+
+### Reference counting
+
+The page's `_refcount` tracks how many users hold the page:
+
+```mermaid
+flowchart LR
+    subgraph refcount["_refcount transitions"]
+        R0["0: Free in buddy allocator"]
+        R1["1: Allocated, single owner"]
+        R2["2+: Multiple references"]
+    end
+
+    R0 -->|"alloc_pages()"| R1
+    R1 -->|"get_page()"| R2
+    R2 -->|"put_page()"| R1
+    R1 -->|"put_page()"| R0
+```
+
+The `_mapcount` tracks page table mappings specifically:
+- `-1`: Not mapped in any page table
+- `0`: Mapped in exactly one page table
+- `N`: Mapped in N+1 page tables (shared)
+
+## Active use: Working set
+
+Once allocated and mapped, the page enters the working set. The kernel tracks access patterns to make reclaim decisions later.
+
+### LRU lists
+
+Pages are organized into LRU (Least Recently Used) lists per memory node:
+
+```mermaid
+flowchart TD
+    subgraph node0["Node 0 LRU Lists"]
+        subgraph anon["Anonymous Pages"]
+            AA["Active Anonymous<br/>[page]─[page]─[page]─[page]"]
+            IA["Inactive Anonymous<br/>[page]─[page]─[page]─[page]"]
+            IA -->|"promote"| AA
+            IA -->|"reclaim"| R1["Reclaim"]
+        end
+        subgraph file["File Pages"]
+            AF["Active File<br/>[page]─[page]─[page]"]
+            IF["Inactive File<br/>[page]─[page]─[page]─[page]"]
+            IF -->|"promote"| AF
+            IF -->|"reclaim"| R2["Reclaim"]
+        end
+    end
+```
+
+Pages move between lists based on access:
+
+1. **New pages**: Start on inactive list
+2. **Accessed on inactive**: Get `PG_referenced` flag set
+3. **Accessed again**: Promoted to active list
+4. **Active but not accessed**: Demoted to inactive
+5. **Inactive and not accessed**: Candidates for reclaim
+
+### The referenced flag dance
+
+The `PG_referenced` flag implements a second-chance algorithm:
+
+```mermaid
+flowchart LR
+    subgraph first["First access"]
+        A1["PG_referenced=0"] -->|"access"| A2["PG_referenced=1"]
+    end
+
+    subgraph second["Second access while referenced"]
+        B1["PG_referenced=1"] -->|"access"| B2["Move to Active"]
+    end
+
+    subgraph scan["Reclaim scan"]
+        C1["PG_referenced=1"] -->|"scan"| C2["PG_referenced=0<br/>(gets second chance)"]
+    end
+```
+
+This prevents single accesses from keeping cold pages in memory while still protecting genuinely hot pages.
+
+### Multi-Gen LRU (MGLRU)
+
+Kernel v6.1 introduced MGLRU as an alternative to the classic two-list model:
+
+```mermaid
+flowchart LR
+    subgraph classic["Classic LRU"]
+        CA["Active"] --> CI["Inactive"] --> CR["Reclaim"]
+    end
+
+    subgraph mglru["MGLRU"]
+        G3["Gen 3<br/>(newest)"] --> G2["Gen 2"] --> G1["Gen 1"] --> G0["Gen 0<br/>(oldest)"]
+        G0 --> MR["Reclaim"]
+    end
+```
+
+MGLRU uses multiple generations instead of two lists, providing finer-grained aging and better performance under memory pressure.
+
+```bash
+# Check if MGLRU is enabled
+cat /sys/kernel/mm/lru_gen/enabled
+# 0x0007 = fully enabled
+```
+
+See [page reclaim](reclaim.md) for details on MGLRU.
+
+## Reclaim: The page's twilight
+
+When memory runs low, the kernel must reclaim pages. A page's fate depends on its type and state.
+
+### The reclaim decision tree
+
+```mermaid
+flowchart TD
+    START["Is page reclaimable?"] --> LOCKED{"Page locked?"}
+    LOCKED -->|"yes"| SKIP["Skip (in use)"]
+    LOCKED -->|"no"| DIRTY{"Page dirty?"}
+    DIRTY -->|"yes"| WRITEBACK["Writeback first"]
+    DIRTY -->|"no"| MAPPED{"Page mapped?"}
+    MAPPED -->|"yes"| UNMAP["Unmap from page tables"]
+    MAPPED -->|"no"| ANON{"Anonymous page?"}
+    ANON -->|"yes"| SWAPOUT["Swap out (if swap available)"]
+    ANON -->|"no (file page)"| FREE["Free the page"]
+```
+
+### File-backed pages: Easy reclaim
+
+File pages (page cache) are relatively easy to reclaim:
+
+```mermaid
+flowchart LR
+    subgraph clean["Clean file page"]
+        C1["Page cache<br/>(clean)"] -->|"reclaim"| C2["Free to<br/>buddy"]
+    end
+
+    subgraph dirty["Dirty file page"]
+        D1["Page cache<br/>(dirty)"] -->|"writeback"| D2["Wait for<br/>I/O"] -->|"complete"| D3["Free to<br/>buddy"]
+    end
+```
+
+*Can re-read from disk if needed later*
+
+The page can always be re-read from the backing file if needed again.
+
+### Anonymous pages: Swap or die
+
+Anonymous pages (heap, stack) have no backing file. Without swap, they can't be reclaimed:
+
+```mermaid
+flowchart LR
+    subgraph withswap["With swap available"]
+        A1["Anonymous<br/>page"] -->|"write to swap"| A2["Swap cache"] -->|"complete"| A3["Free to<br/>buddy"]
+    end
+
+    subgraph noswap["Without swap"]
+        B1["Anonymous<br/>page"] -->|"❌"| B2["Cannot reclaim<br/>without killing owner"]
+    end
+```
+
+*Page content preserved in swap space*
+
+This is why running without swap can lead to OOM kills even with "free" file cache pages.
+
+### The swap-out process
+
+When an anonymous page is chosen for swap-out:
+
+```c
+// Simplified from mm/vmscan.c shrink_folio_list()
+static unsigned int shrink_folio_list(struct list_head *folio_list, ...)
+{
+    // For each folio on the list...
+
+    // 1. Try to unmap from all page tables
+    try_to_unmap(folio, ...);
+
+    // 2. If anonymous and unmapped, add to swap
+    if (folio_test_anon(folio) && !folio_mapped(folio)) {
+        if (!add_to_swap(folio))
+            goto activate_locked;  // Failed, keep the page
+
+        // 3. Write to swap device
+        pageout(folio, ...);
+    }
+
+    // 4. If writeback complete, free the page
+    if (!folio_test_writeback(folio))
+        free_unref_folios(...);
+}
+```
+
+The page table entry is replaced with a swap entry:
+
+```mermaid
+flowchart LR
+    subgraph before["Before swap-out"]
+        PTE1["Page Table Entry<br/>[present=1]"] --> PP["Physical Page<br/>(data here)"]
+    end
+
+    subgraph after["After swap-out"]
+        SE["Swap Entry<br/>[present=0]<br/>[swap type+offset]"] --> SS["Swap Space<br/>(data here)"]
+    end
+
+    before -->|"swap-out"| after
+    PP -->|"returned to"| BUDDY["Buddy Allocator"]
+```
+
+## Resurrection: Swap-in
+
+When a process accesses a swapped page, a page fault brings it back:
+
+```mermaid
+flowchart TD
+    A["Process accesses swapped address"] --> B["Page fault: PTE has swap entry"]
+    B --> C["do_swap_page()"]
+
+    subgraph C["do_swap_page()"]
+        C1["1. Allocate new physical page"]
+        C2["2. Read from swap device"]
+        C3["3. Add to swap cache"]
+        C4["4. Update page table"]
+        C5["5. Add to LRU"]
+    end
+
+    C --> D["Page restored, process continues"]
+```
+
+### Swap cache
+
+The swap cache avoids redundant I/O when multiple processes share a swapped page:
+
+```mermaid
+flowchart LR
+    subgraph without["Without swap cache"]
+        WA["Process A faults"] --> WR1["Read from swap"] --> WM1["Page in memory"]
+        WB["Process B faults"] --> WR2["Read from swap"] --> WM2["Another copy!"]
+    end
+
+    subgraph with["With swap cache"]
+        XA["Process A faults"] --> XR["Read from swap"] --> XC["Page in swap cache + memory"]
+        XB["Process B faults"] --> XF["Find in swap cache"] --> XC
+    end
+```
+
+The page stays in swap cache until:
+- All processes have private copies (after COW)
+- Or the swap slot is needed
+
+## Death and rebirth
+
+Eventually, a page's content is no longer needed. The page returns to the buddy allocator:
+
+```c
+// Final path
+put_page(page);  // Decrement refcount
+  → folio_put()
+    → if (refcount == 0)
+        → free_unref_page()
+          → Return to per-CPU freelist or buddy
+```
+
+### Page reuse
+
+The freed page doesn't stay free for long:
+
+```mermaid
+flowchart TD
+    FREE["Page freed"] --> PCPU["Per-CPU freelist: [page]<br/>(Hot cache)"]
+    PCPU -->|"Next allocation (same CPU)"| GRAB["Grab from per-CPU list (fast!)"]
+    PCPU -->|"Eventually"| BUDDY["Return to buddy, merge with buddies"]
+```
+
+Per-CPU lists keep recently-freed pages hot in cache for immediate reuse.
+
+## The complete lifecycle
+
+Putting it all together for a typical anonymous page:
+
+```mermaid
+flowchart LR
+    A["malloc()<br/>VMA create"] --> B["first access<br/>Page fault alloc"]
+    B --> C["used actively<br/>Active LRU"]
+    C --> D["memory pressure<br/>Inactive LRU"]
+    D --> E["swap out<br/>Swap space"]
+    E --> F["access again<br/>Swap in"]
+
+    style A fill:#e1f5fe
+    style B fill:#b3e5fc
+    style C fill:#81d4fa
+    style D fill:#4fc3f7
+    style E fill:#29b6f6
+    style F fill:#03a9f4
+```
+
+**State transitions:**
+
+| Stage | refcount | mapcount |
+|-------|----------|----------|
+| Page fault alloc | 1→2 | -1→0 |
+| Active/Inactive LRU | 2 | 0 |
+| Swap out | 0 | -1 |
+| Swap in | 1→2 | -1→0 |
+
+## Try it yourself
+
+### Watch page state changes
+
+```bash
+# View system-wide page statistics
+cat /proc/vmstat | grep -E "^pg|^ps"
+
+# Key metrics:
+# pgalloc_*     - Pages allocated
+# pgfree        - Pages freed
+# pgactivate    - Pages moved to active list
+# pgdeactivate  - Pages moved to inactive list
+# pswpin/pswpout - Swap activity
+```
+
+### Monitor LRU activity
+
+```bash
+# Watch LRU list sizes
+watch -n 1 'cat /proc/meminfo | grep -E "Active|Inactive"'
+
+# Per-node LRU stats
+cat /sys/devices/system/node/node0/meminfo
+```
+
+### Trace page lifecycle events
+
+```bash
+# Enable page allocation tracing
+echo 1 > /sys/kernel/debug/tracing/events/kmem/mm_page_alloc/enable
+echo 1 > /sys/kernel/debug/tracing/events/kmem/mm_page_free/enable
+
+# Watch allocations and frees
+cat /sys/kernel/debug/tracing/trace_pipe
+
+# Disable when done
+echo 0 > /sys/kernel/debug/tracing/events/kmem/mm_page_alloc/enable
+echo 0 > /sys/kernel/debug/tracing/events/kmem/mm_page_free/enable
+```
+
+### Observe swap behavior
+
+```bash
+# Watch swap activity in real-time
+vmstat 1
+
+# Columns si/so show swap in/out per second
+
+# Detailed swap info
+cat /proc/swaps
+swapon --show
+
+# Per-process swap usage
+for pid in /proc/[0-9]*; do
+    name=$(cat $pid/comm 2>/dev/null)
+    swap=$(grep VmSwap $pid/status 2>/dev/null | awk '{print $2}')
+    [ -n "$swap" ] && [ "$swap" != "0" ] && echo "$name: ${swap}kB"
+done | sort -t: -k2 -n -r | head
+```
+
+### Force reclaim to observe page lifecycle
+
+```bash
+# Drop clean caches (doesn't affect anonymous pages)
+echo 1 > /proc/sys/vm/drop_caches  # Page cache
+echo 2 > /proc/sys/vm/drop_caches  # Dentries and inodes
+echo 3 > /proc/sys/vm/drop_caches  # Both
+
+# Force memory pressure (careful on production!)
+stress --vm 1 --vm-bytes 90% --vm-keep &
+watch -n 1 'cat /proc/meminfo | grep -E "MemFree|SwapUsed|Active|Inactive"'
+```
+
+## Key source files
+
+| File | What It Does |
+|------|--------------|
+| [`include/linux/mm_types.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mm_types.h) | struct page, struct folio definitions |
+| [`include/linux/page-flags.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/page-flags.h) | PG_* flag definitions |
+| [`mm/page_alloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) | Buddy allocator, page allocation |
+| [`mm/vmscan.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c) | Page reclaim, LRU management |
+| [`mm/swap_state.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/swap_state.c) | Swap cache |
+| [`mm/rmap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/rmap.c) | Reverse mapping, finding page table entries |
+
+## History
+
+### struct page evolution
+
+The `struct page` has grown and changed significantly over the years:
+
+**Early Linux**: Simple structure tracking basic page state.
+
+**v2.5/2.6**: Added reverse mapping (rmap) support - the ability to find all page table entries pointing to a page. Essential for reclaim.
+
+**v4.x-5.x**: Increasing use of compound pages (multi-page allocations treated as one unit).
+
+**v5.16 (2022)**: Introduction of `struct folio` to formalize compound page handling:
+
+**Commit**: [7b230db3b8d3](https://git.kernel.org/linus/7b230db3b8d3) ("mm: Introduce struct folio") | [LKML](https://lore.kernel.org/linux-mm/20210622121551.3398730-3-willy@infradead.org/)
+
+**Author**: Matthew Wilcox (Oracle)
+
+Throughout the lifecycle above, you see `folio` instead of `page` in modern code:
+- **Stage 1**: `vma_alloc_zeroed_movable_folio()` allocates a folio
+- **Stage 4**: `shrink_folio_list()` processes folios during reclaim
+- **Why it matters**: A folio explicitly represents one or more contiguous pages as a unit, eliminating ambiguity about whether a function receives a head page, tail page, or single page
+
+### LRU evolution
+
+The LRU system described in Stage 2 (page tracking) has evolved significantly:
+
+**Classic LRU (pre-v2.6.28)**: Single active/inactive list for all pages.
+
+**Split LRU (v2.6.28, 2008)**: Separate lists for anonymous and file pages, as shown in the diagrams above.
+
+**MGLRU (v6.1, 2022)**: Multi-generational LRU (covered in the MGLRU section above) replaces two lists with multiple generations for finer-grained aging.
+
+**Commit**: [ac35a4902374](https://git.kernel.org/linus/ac35a4902374) ("mm: multi-gen LRU: minimal implementation") | [LKML](https://lore.kernel.org/linux-mm/20220815071332.627393-1-yuzhao@google.com/)
+
+**Author**: Yu Zhao (Google)
+
+MGLRU significantly improves performance under memory pressure by avoiding the "refault" problem where useful pages get evicted too aggressively.
+
+## Notorious bugs and edge cases
+
+Page lifecycle management involves reference counting, LRU tracking, and writeback coordination. Bugs here cause use-after-free, data corruption, or system crashes.
+
+---
+
+### Case 1: Page refcount underflow/overflow
+
+#### What happened
+
+Page reference counting bugs are a perennial source of kernel vulnerabilities. A refcount going negative (underflow) or wrapping around (overflow) leads to use-after-free.
+
+#### The bug
+
+From [Project Zero research](https://projectzero.google/2021/10/how-simple-linux-kernel-memory.html):
+
+> *"A bug allowing probabilistic skewing of the refcount of a struct pid down was documented, where colliding TIOCSPGRP calls from two threads repeatedly could mess up the refcount."*
+
+The pattern:
+1. Bug causes refcount to decrement one extra time
+2. Refcount hits 0 prematurely
+3. Page is freed while still in use
+4. Another allocation reuses the page
+5. Original user writes to "freed" page → **memory corruption**
+
+#### Real-world implications
+
+[Research from Fudan University](https://yuanxzhang.github.io/paper/cid-security21.pdf) found:
+
+> *"UAF vulnerabilities from refcount bugs can be exploited for local privilege escalation... such vulnerabilities can be stealthy - hiding in the kernel for about 4 years until discovered, affecting tens of millions of Linux PCs/servers including 66% of Android devices."*
+
+#### Mitigations
+
+- **`refcount_t` type**: Saturates on overflow/underflow instead of wrapping
+- **KASAN**: Detects use-after-free in debug builds
+- **Page poisoning**: Fills freed pages with patterns to detect misuse
+
+---
+
+### Case 2: Large folio data loss (2023)
+
+#### What happened
+
+The large folio feature (kernel 6.1+) introduced a bug causing silent data loss on XFS and other filesystems.
+
+#### The bug
+
+From the [LKML report](https://lore.kernel.org/linux-mm/CAHk-=wjty_0NfiZn2HVzT0Ye-RR09+Rqbd1azwJLOTJrX+V5MQ@mail.gmail.com/T/):
+
+> *"At least 16 instances of data loss in a fleet of 1.5k VMs... happens mostly on nodes running database or storage-oriented workloads, including PostgreSQL, MySQL, RocksDB."*
+
+Large folios changed how pages are tracked through the writeback path. The bug caused pages to be marked clean when they were actually dirty.
+
+```mermaid
+flowchart LR
+    A["Page modified"] --> B["Marked dirty"]
+    B --> C["Large folio writeback bug"]
+    C --> D["Page marked clean<br/>WITHOUT writing!"]
+    D --> E["DATA LOSS"]
+```
+
+#### Real-world implications
+
+Meta disabled large folios in their kernels. Jens Axboe noted: *"Meta ran into this issue and have been reverting it since our 5.19 release."*
+
+#### The fix
+
+**Commit**: [a48d5bdc877b](https://git.kernel.org/linus/a48d5bdc877b) ("mm: fix for negative counter: nr_file_hugepages")
+
+**Author**: Stefan Roesch
+
+---
+
+### Case 3: LRU list corruption
+
+#### What happened
+
+Pages must be properly added to and removed from LRU lists. Bugs in this code cause list corruption, leading to crashes or infinite loops in reclaim.
+
+#### The bug class
+
+Common patterns:
+- Adding a page to LRU twice
+- Removing a page not on LRU
+- Racing between LRU add/remove and page free
+
+From a [Red Hat bug report](https://access.redhat.com/solutions/5773601):
+
+> *"kernel BUG at mm/filemap.c:240!"* - triggered by corrupted page cache state.
+
+#### Why it's hard
+
+LRU operations happen from multiple contexts:
+- Page allocation (add to LRU)
+- Page reclaim (remove from LRU)
+- Page migration (move between LRUs)
+- Memory cgroup changes (reparent LRU)
+
+All must coordinate correctly, often under memory pressure when the system is already stressed.
+
+#### Mitigations
+
+- **LRU lock**: Per-node locking protects LRU lists
+- **Page flags**: `PG_lru` flag tracks LRU membership
+- **Debug checks**: `CONFIG_DEBUG_VM` enables assertions
+
+---
+
+### Case 4: Reverse mapping (rmap) bugs
+
+#### What happened
+
+Reverse mapping tracks which page table entries point to a page. Bugs here cause missed unmaps or corrupted page tables.
+
+#### The bug
+
+When reclaiming a page, the kernel must:
+1. Find all PTEs pointing to the page (via rmap)
+2. Unmap each PTE
+3. Only then free the page
+
+If rmap is corrupted or incomplete:
+- PTEs point to freed pages → **use-after-free**
+- Pages can't be reclaimed → **memory leak**
+
+#### Historical example
+
+Early rmap implementations had scalability issues. A page mapped by 1000 processes required walking 1000 entries. This led to:
+- Long reclaim latencies
+- Lock contention
+- Livelock under pressure
+
+#### Modern solutions
+
+- **Anonymous VMA (anon_vma)**: Chain structure for efficient anonymous page tracking
+- **Object-based reverse mapping**: File pages tracked via address_space
+- **Batched operations**: Process multiple pages together
+
+---
+
+### Case 5: hwpoison and page refcount
+
+#### What happened
+
+Memory hardware errors (hwpoison) require special handling. A page with an uncorrectable error must be isolated without corrupting other data.
+
+#### The bug
+
+From a kernel fix for `mm/hwpoison`:
+
+> *"After trying to drain pages from pagevec/pageset, the reference count of the page was not reduced if the page was still not on the LRU list."*
+
+Hwpoison must handle pages in various states:
+- On LRU, can be isolated normally
+- In pagevec (batched, not yet on LRU)
+- Being migrated
+- Mapped by userspace
+
+Each case requires different handling, and missing any leads to refcount leaks or premature frees.
+
+#### The fix
+
+**Commit**: [4f32be677b12](https://git.kernel.org/linus/4f32be677b12) ("mm/hwpoison: fix page refcount of unknown non LRU page")
+
+**Author**: Wanpeng Li
+
+The fix adds `put_page()` to drop the page reference from `__get_any_page()` when the page is still not on the LRU list after draining.
+
+#### Why this matters
+
+Hardware errors are rare but when they occur:
+- Page must be isolated immediately
+- Processes mapping the page need `SIGBUS`
+- Page must never be reallocated
+
+Getting this wrong means either data corruption (reusing bad memory) or memory leaks (good memory marked bad forever).
+
+---
+
+### Summary: Lessons learned
+
+| Bug | Root Cause | Impact | Prevention |
+|-----|------------|--------|------------|
+| **Refcount bugs** | Inc/dec mismatch | Use-after-free | `refcount_t`, KASAN |
+| **Large folio writeback** | Dirty tracking error | Data loss | Kernel update, disable large folios |
+| **LRU corruption** | Race conditions | Crash, memory leak | Proper locking, debug checks |
+| **rmap corruption** | Incomplete tracking | Use-after-free | Careful audit |
+| **hwpoison handling** | Edge case mishandling | Data corruption | Comprehensive testing |
+
+The common thread: **pages pass through many states and subsystems**. Every transition is a potential bug site.
+
+## Further reading
+
+### Related docs
+
+- [Page allocator](page-allocator.md) - Buddy system details
+- [Page reclaim](reclaim.md) - Reclaim mechanisms in depth
+- [Swap](swap.md) - Swap subsystem details
+- [Life of a malloc](life-of-malloc.md) - How pages get allocated for userspace
+
+### LWN articles
+
+- [The folio pull request](https://lwn.net/Articles/849538/) (2021) - Why folios were introduced
+- [Multi-generational LRU: the basics](https://lwn.net/Articles/851184/) (2021) - MGLRU design
+- [A deep dive into CMA](https://lwn.net/Articles/486301/) (2012) - Contiguous memory and page migration

--- a/docs/mm/life-of-read.md
+++ b/docs/mm/life-of-read.md
@@ -1,0 +1,841 @@
+# Life of a file read
+
+> Tracing a read() syscall through the page cache
+
+## What happens when you read a file?
+
+When a program reads a file, the data rarely comes directly from disk. The kernel maintains a **page cache** - a cache of file data in memory. Most reads are satisfied from this cache without touching the disk at all.
+
+```mermaid
+flowchart TD
+    A["read(fd, buf, 4096)"] --> B
+
+    B["<b>VFS Layer</b><br/>- Find file from fd<br/>- Check permissions<br/>- Call file system's read method"]
+    B --> C
+
+    C["<b>Page Cache Lookup</b><br/>- Search file's address_space for page at offset<br/>- Using xarray (radix tree)"]
+    C --> D{Cache Result}
+
+    D -->|Cache HIT| E["Return cached<br/>data immediately<br/>(no disk I/O!)"]
+    D -->|Cache MISS| F["Allocate page<br/>Submit I/O to disk<br/>Wait for completion<br/>Add page to cache<br/>Return data"]
+
+    E --> G
+    F --> G
+
+    G["<b>Copy to User Buffer</b><br/>copy_to_user(buf, page_address + offset, count)"]
+    G --> H["read() returns bytes read"]
+```
+
+The key insight: **the page cache makes most reads fast**. Sequential file reads typically hit cache 99%+ of the time due to readahead.
+
+## The page cache
+
+The page cache is the kernel's cache of file contents. Every file read goes through it.
+
+### Why cache file data?
+
+| Operation | Latency |
+|-----------|---------|
+| Memory access | ~100 nanoseconds |
+| SSD read | ~100 microseconds (1000x slower) |
+| HDD read | ~10 milliseconds (100,000x slower) |
+
+Even with fast SSDs, memory is orders of magnitude faster. The page cache exploits temporal locality - data read once is likely to be read again soon.
+
+### Page cache organization
+
+Each open file has an `address_space` that manages its cached pages:
+
+```c
+// From include/linux/fs.h
+struct address_space {
+    struct inode *host;           // Owning inode
+    struct xarray i_pages;        // Cached pages (xarray/radix tree)
+    atomic_t i_mmap_writable;     // Writable mappings
+    struct rb_root_cached i_mmap; // Tree of private/shared mappings
+    unsigned long nrpages;        // Number of cached pages
+    const struct address_space_operations *a_ops;  // Operations
+    // ...
+};
+```
+
+Pages are indexed by file offset:
+
+```mermaid
+flowchart LR
+    subgraph file["File (offset in pages)"]
+        direction LR
+        P0["[0]"]
+        P1["[1]"]
+        P2["[2]"]
+        P3["[3]"]
+        P4["[4]"]
+        P5["[5]"]
+        P6["[6]"]
+        P7["..."]
+    end
+
+    subgraph xarray["address_space xarray"]
+        direction LR
+        O0["offset 0"] --> PG0["page_0"]
+        O1["offset 1"] --> PG1["page_1"]
+        O2["offset 2"] --> EMPTY["(empty - not cached)"]
+        O3["offset 3"] --> PG3["page_3"]
+        O4["..."]
+    end
+```
+
+## Stage 1: System call entry
+
+A user program calls `read()`:
+
+```c
+// User space
+ssize_t n = read(fd, buffer, 4096);
+
+// Kernel entry: fs/read_write.c
+SYSCALL_DEFINE3(read, unsigned int, fd, char __user *, buf, size_t, count)
+{
+    struct fd f = fdget_pos(fd);
+
+    // ... permission checks ...
+
+    ret = vfs_read(f.file, buf, count, &pos);
+
+    fdput_pos(f);
+    return ret;
+}
+```
+
+### From fd to file
+
+The kernel translates the file descriptor to a `struct file`:
+
+```mermaid
+flowchart LR
+    subgraph fdtable["Process File Descriptor Table"]
+        direction LR
+        FD0["fd 0"] --> STDIN["stdin"]
+        FD1["fd 1"] --> STDOUT["stdout"]
+        FD2["fd 2"] --> STDERR["stderr"]
+        FD3["fd 3"] --> FILE["/home/user/data.txt<br/>(Our file)"]
+        FD4["..."]
+    end
+```
+
+```c
+struct file {
+    struct path f_path;           // Dentry and mount
+    struct inode *f_inode;        // Inode (file metadata)
+    const struct file_operations *f_op;  // read/write operations
+    loff_t f_pos;                 // Current file position
+    struct address_space *f_mapping;  // Page cache
+    // ...
+};
+```
+
+## Stage 2: VFS read dispatch
+
+`vfs_read()` calls the file system's read implementation:
+
+```c
+// fs/read_write.c
+ssize_t vfs_read(struct file *file, char __user *buf,
+                 size_t count, loff_t *pos)
+{
+    // Check we can read
+    if (!(file->f_mode & FMODE_READ))
+        return -EBADF;
+
+    // Check buffer is valid user memory
+    if (!access_ok(buf, count))
+        return -EFAULT;
+
+    // Call file system's read method
+    if (file->f_op->read)
+        ret = file->f_op->read(file, buf, count, pos);
+    else if (file->f_op->read_iter)
+        ret = new_sync_read(file, buf, count, pos);
+
+    return ret;
+}
+```
+
+Most file systems use the generic `read_iter` path, which goes through `generic_file_read_iter()`:
+
+```c
+// mm/filemap.c
+ssize_t generic_file_read_iter(struct kiocb *iocb, struct iov_iter *iter)
+{
+    if (iocb->ki_flags & IOCB_DIRECT)
+        return mapping_direct_IO(...);  // Bypass cache
+
+    return filemap_read(iocb, iter, 0);  // Normal path
+}
+```
+
+## Stage 3: Page cache lookup
+
+The core of file reading is [`filemap_read()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/filemap.c):
+
+```c
+// mm/filemap.c (simplified)
+ssize_t filemap_read(struct kiocb *iocb, struct iov_iter *iter,
+                     ssize_t already_read)
+{
+    struct file *file = iocb->ki_filp;
+    struct address_space *mapping = file->f_mapping;
+    pgoff_t index = iocb->ki_pos >> PAGE_SHIFT;  // Page index from offset
+
+    for (;;) {
+        // 1. Try to find page in cache
+        folio = filemap_get_folio(mapping, index);
+
+        if (IS_ERR(folio)) {
+            // Cache miss - need to read from disk
+            folio = page_cache_sync_readahead(...);
+        }
+
+        // 2. Wait for page to be up-to-date
+        folio_wait_locked(folio);
+        if (!folio_test_uptodate(folio))
+            goto error;
+
+        // 3. Copy data to user buffer
+        copied = copy_folio_to_iter(folio, offset, bytes, iter);
+
+        folio_put(folio);
+        index++;
+    }
+}
+```
+
+### The xarray lookup
+
+Finding a page in the cache uses the xarray (evolved from radix tree):
+
+```c
+// Finding page at index
+struct folio *filemap_get_folio(struct address_space *mapping,
+                                 pgoff_t index)
+{
+    return __filemap_get_folio(mapping, index, FGP_ENTRY, 0);
+}
+
+struct folio *__filemap_get_folio(struct address_space *mapping,
+                                   pgoff_t index, fgf_t fgp_flags,
+                                   gfp_t gfp)
+{
+    struct folio *folio;
+
+    // Lock-free lookup in xarray
+    folio = xa_load(&mapping->i_pages, index);
+
+    if (!folio || xa_is_value(folio))
+        return ERR_PTR(-ENOENT);  // Not in cache
+
+    // Found - increment reference
+    folio_get(folio);
+    return folio;
+}
+```
+
+The lookup is effectively `O(1)` for practical file sizes - `xarray` is a radix tree with bounded height, not a balanced tree, so performance doesn't degrade with more pages.
+
+## Stage 4: Cache hit (fast path)
+
+When the page is in cache and up-to-date, reading is fast:
+
+```mermaid
+flowchart TD
+    subgraph cachehit["Cache Hit"]
+        direction TB
+        S1["1. xa_load() finds page in xarray<br/>~50-100ns"]
+        S1 --> S2["2. Check page is uptodate (PG_uptodate set)<br/>~10ns"]
+        S2 --> S3["3. copy_to_user() copies data<br/>~1-10us<br/>(depends on size, may need multiple pages)"]
+        S3 --> S4["<b>Total: ~1-10 microseconds for typical read</b>"]
+    end
+```
+
+No disk I/O, no waiting, just memory copies.
+
+### The copy to userspace
+
+```c
+// Copy from kernel page to user buffer
+size_t copy_folio_to_iter(struct folio *folio, size_t offset,
+                          size_t bytes, struct iov_iter *i)
+{
+    // Map the page temporarily
+    // Copy bytes to user buffer
+    // Handle partial pages (offset within page)
+}
+```
+
+This is the primary cost of cached reads - copying data from kernel memory to user memory.
+
+## Stage 5: Cache miss (slow path)
+
+When the page isn't in cache, the kernel must read from disk:
+
+```c
+// Page not in cache - allocate and read
+static struct folio *page_cache_sync_readahead(...)
+{
+    // 1. Allocate a new folio
+    folio = filemap_alloc_folio(gfp, 0);
+
+    // 2. Add to page cache
+    error = filemap_add_folio(mapping, folio, index, gfp);
+
+    // 3. Submit I/O to read from disk
+    folio_mark_uptodate(folio);  // After I/O completes
+
+    return folio;
+}
+```
+
+### I/O submission
+
+The actual disk read goes through the file system and block layer:
+
+```mermaid
+flowchart TD
+    subgraph cachemiss["Cache Miss Path"]
+        direction TB
+        A["filemap_read()"] --> B["page_cache_sync_readahead()"]
+        B --> C["Address space operations<br/>(a_ops->readahead)"]
+        C --> D["File system:<br/>ext4_readahead() / xfs_vm_readahead() / etc."]
+        D --> E["Block layer:<br/>submit_bio()"]
+        E --> F["Device driver:<br/>NVMe / SATA / etc."]
+        F --> G["Physical disk I/O"]
+    end
+```
+
+The process blocks until I/O completes (unless using async I/O).
+
+### Waiting for I/O
+
+```c
+// Block until page is ready
+folio_wait_locked(folio);
+
+// Check it completed successfully
+if (!folio_test_uptodate(folio)) {
+    folio_put(folio);
+    return -EIO;
+}
+```
+
+## Stage 6: Readahead
+
+The kernel doesn't just read the requested page - it reads ahead, predicting you'll want subsequent pages:
+
+```mermaid
+flowchart TD
+    subgraph request["Read request for page 5"]
+        direction TB
+        subgraph without["Without readahead"]
+            direction LR
+            W1["Read: [5]"]
+            W2["Cache: [5]"]
+        end
+        subgraph with["With readahead (window = 8)"]
+            direction LR
+            R1["Read: [5][6][7][8][9][10][11][12]"]
+            R2["Cache: [5][6][7][8][9][10][11][12]"]
+        end
+        subgraph next["Next read for page 6"]
+            N1["Cache hit! No disk I/O needed."]
+        end
+    end
+```
+
+### Readahead algorithm
+
+The kernel uses an adaptive readahead algorithm:
+
+```c
+// mm/readahead.c (simplified)
+void page_cache_sync_readahead(struct address_space *mapping,
+                                struct file_ra_state *ra,
+                                struct file *file,
+                                pgoff_t index,
+                                unsigned long req_count)
+{
+    // Check if sequential access pattern
+    if (index == ra->prev_pos + 1) {
+        // Sequential - expand readahead window
+        ra->size = min(ra->size * 2, ra->ra_pages);
+    } else {
+        // Random - shrink window
+        ra->size = 4;  // Start small
+    }
+
+    // Submit readahead I/O
+    do_page_cache_ra(ractl, ra->size, ra->async_size);
+}
+```
+
+### Readahead state
+
+Each file has readahead state tracking its access pattern:
+
+```c
+struct file_ra_state {
+    pgoff_t start;          // Where readahead started
+    unsigned int size;      // Current window size
+    unsigned int async_size;// Async portion (trigger next readahead)
+    unsigned int ra_pages;  // Maximum window
+    unsigned int mmap_miss; // Cache miss in mmap
+    loff_t prev_pos;        // Previous read position
+};
+```
+
+### Tuning readahead
+
+```bash
+# View default readahead size (in 512-byte sectors)
+cat /sys/block/sda/queue/read_ahead_kb
+
+# Adjust (e.g., for sequential workloads)
+echo 256 > /sys/block/sda/queue/read_ahead_kb
+
+# Per-file readahead via posix_fadvise
+posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);  // Hint: sequential
+posix_fadvise(fd, 0, 0, POSIX_FADV_RANDOM);      // Hint: random
+```
+
+## mmap vs read
+
+There's another way to read files - memory-mapping with `mmap()`:
+
+```c
+// read() approach
+char buf[4096];
+read(fd, buf, 4096);
+
+// mmap() approach
+char *ptr = mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
+// Access ptr directly - page faults load data
+```
+
+Both use the same page cache:
+
+```mermaid
+flowchart BT
+    subgraph pagecache["Page Cache<br/>(single cache for file, regardless of access method)"]
+    end
+
+    subgraph readmethod["read()"]
+        R1["Explicit<br/>copy to<br/>user buf"]
+    end
+
+    subgraph mmapmethod["mmap()"]
+        M1["On-demand<br/>via page<br/>faults"]
+    end
+
+    readmethod --> pagecache
+    mmapmethod --> pagecache
+```
+
+**read()**: Explicit copy from page cache to user buffer.
+**mmap()**: Map page cache pages directly into process address space; no copy needed.
+
+See [page cache](page-cache.md) and [process address space](mmap.md) for details.
+
+## Direct I/O
+
+Sometimes you want to bypass the page cache entirely:
+
+```c
+// Open with O_DIRECT
+int fd = open("file.dat", O_RDONLY | O_DIRECT);
+
+// Read bypasses page cache - goes directly to/from user buffer
+read(fd, aligned_buffer, size);
+```
+
+**When to use direct I/O**:
+- Database engines (they have their own caching)
+- Very large sequential reads (cache would be wasteful)
+- When you need predictable I/O timing
+
+**Requirements**:
+- Buffer must be aligned (typically 512 bytes or 4KB)
+- Offset and size often must be aligned too
+
+## The complete picture
+
+Here's the full flow for a `read()` call:
+
+```mermaid
+flowchart TD
+    A["read(fd, buf, 4096)"] --> B["fdget_pos(fd)<br/><i>Get struct file from fd table</i>"]
+    B --> C["vfs_read()<br/><i>Permission checks, dispatch</i>"]
+    C --> D["generic_file_read_iter()<br/><i>Most file systems</i>"]
+    D --> E["filemap_read()<br/><i>Page cache logic</i>"]
+    E --> F{Page in cache?}
+
+    F -->|YES| G["Page in cache"]
+    F -->|NO| H["Not in cache"]
+
+    H --> I["<b>Readahead:</b><br/>- Allocate pages<br/>- Submit I/O<br/>- Wait for I/O<br/>- Add to cache"]
+
+    G --> J["folio_wait_locked()<br/><i>ensure page is ready</i>"]
+    I --> J
+
+    J --> K["copy_folio_to_iter()<br/><i>copy to user buffer</i>"]
+    K --> L["return bytes_read"]
+```
+
+## Try it yourself
+
+### Watch cache hit ratio
+
+```bash
+# Clear the page cache (requires root)
+echo 3 > /proc/sys/vm/drop_caches
+
+# Read a file
+cat /path/to/large/file > /dev/null
+
+# Check cache stats
+cat /proc/vmstat | grep -E "pgpg|pgfault"
+# pgpgin  - pages read from disk
+# pgpgout - pages written to disk
+```
+
+### Compare cached vs uncached reads
+
+```bash
+# First read (cold cache)
+time cat /path/to/large/file > /dev/null
+
+# Second read (warm cache)
+time cat /path/to/large/file > /dev/null
+
+# The second read should be much faster
+```
+
+### Monitor readahead
+
+```bash
+# Watch readahead activity
+cat /proc/vmstat | grep -E "pgread|pgalloc"
+
+# Trace readahead events
+echo 1 > /sys/kernel/debug/tracing/events/filemap/mm_filemap_add_to_page_cache/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+### View cache contents for a file
+
+```bash
+# Using fincore (part of util-linux)
+fincore /path/to/file
+
+# Shows which pages of the file are in cache
+
+# Using vmtouch (third-party tool)
+vmtouch -v /path/to/file
+```
+
+### Test direct I/O
+
+```bash
+# Read with direct I/O (bypasses cache)
+dd if=/path/to/file of=/dev/null bs=4096 iflag=direct
+
+# Compare with buffered I/O
+dd if=/path/to/file of=/dev/null bs=4096
+
+# Direct I/O timing is more consistent but potentially slower
+# for cached data
+```
+
+### Observe page cache size
+
+```bash
+# Current cache usage
+cat /proc/meminfo | grep -E "Cached|Buffers"
+
+# Watch it grow as you read files
+watch -n 1 'cat /proc/meminfo | grep -E "Cached|Buffers"'
+
+# Read a large file in another terminal
+cat /path/to/large/file > /dev/null
+```
+
+## Key source files
+
+| File | What It Does |
+|------|--------------|
+| [`mm/filemap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/filemap.c) | Page cache operations, filemap_read() |
+| [`mm/readahead.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/readahead.c) | Readahead algorithm |
+| [`fs/read_write.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/read_write.c) | VFS read/write entry points |
+| [`include/linux/fs.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/fs.h) | struct address_space, file operations |
+| [`include/linux/pagemap.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/pagemap.h) | Page cache APIs |
+
+## History
+
+### Page cache evolution
+
+**Early Linux**: Simple page cache with manual readahead.
+
+**v2.4**: Unified buffer cache and page cache.
+
+**v2.6**: Radix tree for page cache lookup, adaptive readahead.
+
+**v4.20 (2018)**: XArray replaced radix tree for page cache indexing.
+
+**Commit**: [4c7472c0df2f](https://git.kernel.org/linus/4c7472c0df2f) ("page cache: Convert find_get_entry to XArray") | [LKML](https://lore.kernel.org/linux-mm/20181205145239.17953-1-willy@infradead.org/)
+
+**Author**: Matthew Wilcox
+
+In the flow above, `filemap_get_folio()` uses the `xarray` to look up cached pages by file offset. The `xarray` provides better cache utilization than the radix tree it replaced, speeding up the cache hit path.
+
+### Folio conversion (v5.16+)
+
+In the flow above, functions like `filemap_get_folio()` and `filemap_read()` work with `struct folio` rather than raw `struct page`:
+
+**Commit**: [7b230db3b8d3](https://git.kernel.org/linus/7b230db3b8d3) ("mm: Introduce struct folio") | [LKML](https://lore.kernel.org/linux-mm/20210622121551.3398730-3-willy@infradead.org/)
+
+**Author**: Matthew Wilcox
+
+- **What it enables**: The page cache can now store large folios (e.g., 64KB or larger) for files, reducing metadata overhead and improving I/O efficiency for large sequential reads
+- **In our flow**: When `read()` triggers a cache miss, `filemap_alloc_folio()` may allocate a large folio, and readahead fills it with multiple pages worth of file data in a single I/O operation
+
+## Notorious bugs and edge cases
+
+The page cache and read path involve complex interactions between filesystems, memory management, and I/O. Bugs here cause data corruption, stale reads, or crashes.
+
+---
+
+### Case 1: filemap_fault() race conditions
+
+#### What happened
+
+The `filemap_fault()` function handles page faults for memory-mapped files. Race conditions between invalidation and fault handling have caused multiple bugs.
+
+#### The bug
+
+From [kernel discussions](https://linux.kernel.narkive.com/8lKSc68j/potential-fix-to-filemap-fault):
+
+A race can occur between:
+1. **Thread A**: Handling a page fault, reading file data into page cache
+2. **Thread B**: Invalidating/truncating the file
+
+If Thread B truncates the file while Thread A is faulting in a page, Thread A might install a page beyond the new file end, or see stale data.
+
+> *"We see a blank page from time to time, when we should be seeing valid data."*
+
+#### Real-world implications
+
+Applications using mmap'd files (databases, VMs, etc.) could see:
+- Stale data after truncation
+- Blank pages
+- Crashes on invalid access
+
+#### Mitigations
+
+- Proper page lock ordering between fault and truncate paths
+- `page_mkwrite()` coordination for writable mappings
+- Filesystem-specific locking (e.g., i_rwsem)
+
+---
+
+### Case 2: 9p read corruption (2025)
+
+#### What happened
+
+[Recent LKML discussion](https://lkml.org/lkml/2025/12/19/689) documented read corruption with 9p filesystem and mmapped content.
+
+#### The bug
+
+The 9p filesystem's splice implementation had a bug where page pinning during data transfer could race with page cache operations, causing:
+
+- Incorrect data being read
+- Data appearing in wrong file positions
+- Silent corruption without errors
+
+#### Why this matters
+
+Any filesystem implementing custom I/O paths (splice, direct I/O, io_uring) must coordinate carefully with the page cache. Bugs in this coordination are difficult to detect because:
+
+1. They require specific timing
+2. Corruption is silent
+3. Standard I/O testing doesn't trigger them
+
+---
+
+### Case 3: Poisoned page cache data loss
+
+#### What happened
+
+When a hardware memory error (hwpoison) affects a page cache page, the kernel must handle it carefully to avoid silent data loss.
+
+#### The bug
+
+From [kernel patch discussion](https://www.spinics.net/lists/linux-fsdevel/msg204546.html):
+
+> *"Solve silent data loss caused by poisoned page cache (shmem/tmpfs)"*
+
+If a page in the page cache gets a hardware error:
+1. The page is marked poisoned
+2. But readers might still see cached (potentially corrupted) data
+3. Writes might silently fail
+
+For tmpfs/shmem, there's no backing store to recover from - the data is simply lost.
+
+#### Real-world implications
+
+Hardware errors in RAM used for page cache could cause:
+- Database corruption
+- Lost user data
+- Inconsistent filesystem state
+
+#### Mitigation
+
+The patches ensure:
+- Poisoned pages are immediately evicted from cache
+- Subsequent reads go to disk (if file-backed)
+- Errors are properly propagated to userspace
+
+---
+
+### Case 4: Readahead window explosion
+
+#### What happened
+
+The adaptive readahead algorithm tries to predict access patterns. Bugs in the heuristics can cause excessive I/O.
+
+#### The bug
+
+If readahead incorrectly predicts sequential access:
+1. Kernel reads many pages ahead
+2. Application doesn't use them
+3. Useful pages get evicted to make room
+4. Application triggers more I/O for the evicted pages
+5. System thrashes despite available memory
+
+#### Historical examples
+
+- **Random access on large files**: Readahead assumes sequential, wastes bandwidth
+- **Multiple streams**: Readahead doesn't track per-reader state well (improved in recent kernels)
+- **SSD vs HDD**: Optimal readahead differs; default often wrong
+
+#### Tuning
+
+```bash
+# Check default readahead (KB)
+blockdev --getra /dev/sda
+# Typical: 256 (KB)
+
+# Reduce for random workloads
+blockdev --setra 64 /dev/sda
+
+# Per-file hint in application
+posix_fadvise(fd, 0, 0, POSIX_FADV_RANDOM);
+```
+
+---
+
+### Case 5: Page cache coherency with direct I/O
+
+#### What happened
+
+Applications mixing buffered I/O (page cache) and direct I/O can see stale data.
+
+#### The bug
+
+```c
+// Thread A: buffered write
+write(fd, "AAAA", 4);
+
+// Thread B: direct read (bypasses page cache)
+char buf[4];
+pread(fd_dio, buf, 4, 0);  // Might see old data!
+
+// Why: Page cache is dirty but not yet written to disk
+// Direct I/O reads from disk, sees old data
+```
+
+#### Real-world implications
+
+Databases often use:
+- Direct I/O for data files (predictable latency)
+- Buffered I/O for logs (better small-write performance)
+
+If not carefully coordinated, one subsystem sees stale data from the other.
+
+#### Mitigation
+
+```c
+// Before direct read, flush buffered writes
+fsync(fd);  // Ensure page cache written to disk
+
+// Or use O_DSYNC for writes
+int fd = open(path, O_WRONLY | O_DSYNC);
+
+// Or invalidate cache before direct read
+posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+```
+
+---
+
+### Case 6: BDI (Backing Device Info) writeback bugs
+
+#### What happened
+
+The BDI tracks per-device writeback state. Bugs in BDI handling have caused writeback stalls and data loss.
+
+#### The bug
+
+From a [kernel BUG report](https://access.redhat.com/solutions/5773601):
+
+> *"Kernel panic in __delete_from_page_cache() with a message 'kernel BUG at mm/filemap.c:240!'"*
+
+When a device is removed while dirty pages exist:
+1. BDI structure may be freed
+2. Writeback worker still references it
+3. Use-after-free → crash
+
+#### Why this matters
+
+Hot-pluggable storage (USB, SATA hotplug, NVMe hot remove) must coordinate with the page cache. The page cache may hold dirty data for the device, and removing the device without proper synchronization causes:
+
+- Lost dirty data
+- Kernel crash
+- Filesystem corruption
+
+---
+
+### Summary: Lessons learned
+
+| Bug | Root Cause | Impact | Prevention |
+|-----|------------|--------|------------|
+| **filemap_fault race** | Truncate vs fault race | Stale data | Proper lock ordering |
+| **9p splice corruption** | Page pinning bug | Data corruption | Careful splice implementation |
+| **Poisoned page cache** | hwpoison handling | Silent data loss | Error propagation |
+| **Readahead explosion** | Wrong heuristics | Thrashing | Tune readahead, use fadvise |
+| **DIO cache coherency** | Buffered vs direct mix | Stale reads | fsync before DIO |
+| **BDI removal** | Device hot-remove race | Crash, data loss | Proper teardown sequence |
+
+The common thread: **the page cache is a critical performance optimization that adds complexity**. Any operation that bypasses, invalidates, or races with the cache is a potential bug site.
+
+## Further reading
+
+### Related docs
+
+- [Page cache](page-cache.md) - Page cache internals
+- [Life of a malloc](life-of-malloc.md) - Contrast with anonymous memory
+- [Life of a page](life-of-page.md) - Page lifecycle including cache pages
+- [Process address space](mmap.md) - mmap alternative to read()
+
+### LWN articles
+
+- [Readahead: the theory](https://lwn.net/Articles/155510/) (2005) - Readahead concepts
+- [The XArray data structure](https://lwn.net/Articles/745073/) (2017) - Radix tree replacement
+- [Filesystem I/O and the page cache](https://lwn.net/Articles/712467/) (2016) - Overview
+- [Fixing page-writeback races](https://lwn.net/Articles/326552/) (2009) - Writeback coordination

--- a/docs/mm/oom.md
+++ b/docs/mm/oom.md
@@ -1,0 +1,1059 @@
+# Running out of memory
+
+> The progression from healthy system to OOM kill
+
+## The path to OOM
+
+When memory runs low, the kernel doesn't immediately panic. It goes through escalating stages of intervention, trying to free memory before resorting to killing processes. Understanding this progression helps you diagnose why your process was killed and how to prevent it.
+
+```mermaid
+flowchart TB
+    subgraph HEALTHY["HEALTHY"]
+        H1["Free pages > high watermark"]
+        H2["No action needed"]
+    end
+
+    HW["--- HIGH WATERMARK ---"]
+
+    subgraph BACKGROUND["BACKGROUND RECLAIM"]
+        B1["Free pages < low watermark"]
+        B2["kswapd wakes up, reclaims in background"]
+        B3["Allocations still succeed immediately"]
+    end
+
+    LW["--- LOW WATERMARK ---"]
+
+    subgraph DIRECT["DIRECT RECLAIM"]
+        D1["Free pages < min watermark"]
+        D2["Allocating process must help reclaim"]
+        D3["Allocation latency increases"]
+    end
+
+    MW["--- MIN WATERMARK ---"]
+
+    subgraph OOM["OOM TERRITORY"]
+        O1["Reclaim fails repeatedly"]
+        O2["OOM killer invoked"]
+        O3["Process terminated to free memory"]
+    end
+
+    ZERO["Zero"]
+
+    HEALTHY --> HW --> BACKGROUND --> LW --> DIRECT --> MW --> OOM --> ZERO
+```
+
+## Stage 1: Watermarks and pressure detection
+
+Each memory zone has three watermarks that control reclaim behavior:
+
+```c
+// From include/linux/mmzone.h
+enum zone_watermarks {
+    WMARK_MIN,    // Below this: direct reclaim, allocation may fail
+    WMARK_LOW,    // Below this: wake kswapd
+    WMARK_HIGH,   // Target for kswapd to reach
+    WMARK_PROMO,  // For tiered memory promotion
+    NR_WMARK
+};
+```
+
+### How watermarks are calculated
+
+Watermarks derive from `vm.min_free_kbytes` and `vm.watermark_scale_factor`:
+
+```bash
+# View current settings
+cat /proc/sys/vm/min_free_kbytes
+cat /proc/sys/vm/watermark_scale_factor
+
+# min_free_kbytes sets the MIN watermark base
+# watermark_scale_factor (default 10 = 0.1%) adjusts LOW and HIGH
+# The exact calculation is in mm/page_alloc.c __setup_per_zone_wmarks()
+```
+
+```mermaid
+flowchart TB
+    HIGH["HIGH watermark"]
+    LOW["LOW watermark"]
+    MIN["MIN watermark"]
+    ZERO["0"]
+
+    HIGH ---|"kswapd reclaims until reaching HIGH"| LOW
+    LOW ---|"Zone considered under pressure<br/>kswapd woken when free pages drop here"| MIN
+    MIN ---|"Direct reclaim triggered<br/>GFP_ATOMIC allocations may fail"| ZERO
+```
+
+### Viewing watermarks
+
+```bash
+# Detailed zone information including watermarks
+cat /proc/zoneinfo | grep -A 20 "zone   Normal"
+
+# Key fields:
+#   pages free     - current free pages
+#   min            - min watermark
+#   low            - low watermark
+#   high           - high watermark
+```
+
+## Stage 2: Background reclaim (kswapd)
+
+When free pages drop below the low watermark, `kswapd` wakes up to reclaim pages in the background.
+
+### kswapd mechanics
+
+```mermaid
+flowchart TB
+    subgraph Normal["Normal operation"]
+        SLEEP["kswapd sleeping"]
+    end
+
+    subgraph Pressure["Free pages drop below LOW"]
+        A["Allocator notices"] --> B["Wake kswapd"] --> C["kswapd reclaims"]
+        C --> D["Reclaim until HIGH"]
+    end
+
+    Normal -.->|"memory pressure"| Pressure
+```
+
+kswapd is a per-node kernel thread:
+
+```bash
+# View kswapd threads
+ps aux | grep kswapd
+# kswapd0 - for node 0
+# kswapd1 - for node 1 (on NUMA systems)
+```
+
+### What kswapd reclaims
+
+kswapd scans the inactive LRU lists looking for reclaimable pages:
+
+| Page Type | Reclaim Action |
+|-----------|----------------|
+| Clean file pages | Drop immediately (can re-read from disk) |
+| Dirty file pages | Write back, then drop |
+| Anonymous pages | Swap out (if swap available) |
+| Slab caches | Shrink via shrinkers |
+
+```c
+// Simplified from mm/vmscan.c
+static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
+{
+    // Scan and reclaim from LRU lists
+    shrink_node_memcgs(pgdat, sc);
+
+    // Shrink slab caches
+    shrink_slab(sc->gfp_mask, pgdat->node_id, ...);
+}
+```
+
+### Swappiness
+
+The `vm.swappiness` parameter controls the balance between reclaiming file pages versus swapping anonymous pages:
+
+```bash
+# View current swappiness
+cat /proc/sys/vm/swappiness
+# Default: 60
+
+# Lower value = prefer dropping file cache
+# Higher value = more willing to swap
+sysctl vm.swappiness=10  # Minimize swapping
+```
+
+| Swappiness | Behavior |
+|------------|----------|
+| 0 | Avoid swap unless absolutely necessary |
+| 1-59 | Prefer file page reclaim |
+| 60 | Default balance |
+| 61-100 | Prefer swapping anonymous pages |
+| 101-200 | MGLRU only: finer-grained swap aggressiveness |
+
+**Note**: Values above 100 only have effect with MGLRU enabled (kernel 6.1+). On older kernels or with MGLRU disabled, values are effectively clamped to 0-100.
+
+## Stage 3: Direct reclaim
+
+When kswapd can't keep up and free pages fall below the min watermark, allocating processes must help reclaim pages themselves.
+
+### The allocation slowpath
+
+```c
+// mm/page_alloc.c __alloc_pages() (simplified)
+struct page *__alloc_pages(gfp_t gfp, unsigned int order, ...)
+{
+    struct page *page;
+
+    // Fast path: try to allocate immediately
+    page = get_page_from_freelist(gfp, order, ...);
+    if (page)
+        return page;
+
+    // Slow path: need to work for it
+    return __alloc_pages_slowpath(gfp, order, ...);
+}
+
+static struct page *__alloc_pages_slowpath(...)
+{
+    // 1. Wake kswapd
+    wake_all_kswapds(...);
+
+    // 2. Try again with kswapd running
+    page = get_page_from_freelist(...);
+    if (page)
+        return page;
+
+    // 3. Direct reclaim - we do the work ourselves
+    page = __alloc_pages_direct_reclaim(...);
+    if (page)
+        return page;
+
+    // 4. Try compaction for high-order allocations
+    page = __alloc_pages_direct_compact(...);
+    if (page)
+        return page;
+
+    // 5. Last resort: OOM killer
+    page = __alloc_pages_may_oom(...);
+    return page;
+}
+```
+
+### Direct reclaim impact
+
+Direct reclaim blocks the allocating process:
+
+```mermaid
+sequenceDiagram
+    participant P as Process A
+    participant K as Kernel
+    participant KS as kswapd
+
+    P->>K: malloc()
+    K->>K: alloc_pages()
+    K->>K: No free pages!
+    K->>K: Direct reclaim
+    K->>K: Scan LRU
+    K->>K: Write dirty pages
+    Note over K: Wait for I/O...
+    Note over KS: (also running)
+    K->>K: Pages freed
+    K->>P: Allocation succeeds
+    P->>P: malloc() returns
+```
+
+This can cause significant latency spikes. Applications that allocate during memory pressure may see multi-millisecond delays.
+
+### Monitoring direct reclaim
+
+```bash
+# Count direct reclaim events
+cat /proc/vmstat | grep allocstall
+# allocstall_dma
+# allocstall_dma32
+# allocstall_normal
+# allocstall_movable
+
+# Real-time monitoring
+watch -n 1 'grep -E "allocstall|pgsteal_direct|pgscan_direct" /proc/vmstat'
+```
+
+## Stage 4: Reclaim failures and retries
+
+Sometimes reclaim doesn't free enough memory. The kernel retries with increasing desperation.
+
+### Retry logic
+
+```c
+// The allocation retries with __GFP_RETRY_MAYFAIL or similar flags
+
+// Retry conditions (simplified):
+// 1. Did we make progress? (freed some pages)
+// 2. Have we retried too many times? (MAX_RECLAIM_RETRIES)
+// 3. Should we give up? (depends on GFP flags)
+
+#define MAX_RECLAIM_RETRIES 16
+```
+
+### What causes reclaim to fail?
+
+| Cause | Description |
+|-------|-------------|
+| All pages unreclaimable | Locked, pinned, or in active use |
+| No swap space | Anonymous pages can't be swapped out |
+| I/O bottleneck | Writeback too slow |
+| Thrashing | Pages reclaimed and immediately needed again |
+| Memory fragmentation | Free pages exist but in wrong zones/orders |
+
+### The compaction fallback
+
+For high-order allocations (multiple contiguous pages), compaction tries to defragment memory:
+
+```mermaid
+flowchart TB
+    subgraph Before["Before compaction"]
+        direction LR
+        B1["used"] --- B2["free"] --- B3["used"] --- B4["free"] --- B5["used"] --- B6["free"] --- B7["used"] --- B8["free"]
+    end
+
+    subgraph After["After compaction"]
+        direction LR
+        A1["used"] --- A2["used"] --- A3["used"] --- A4["used"] --- A5["free"] --- A6["free"] --- A7["free"] --- A8["free"]
+    end
+
+    Before -->|"compaction"| After
+
+    Note["Now can satisfy order-2 allocation"]
+    After --- Note
+```
+
+```bash
+# Trigger manual compaction
+echo 1 > /proc/sys/vm/compact_memory
+
+# Monitor compaction
+cat /proc/vmstat | grep compact
+```
+
+## Stage 5: The OOM killer
+
+When all reclaim efforts fail, the OOM (Out Of Memory) killer terminates a process to free memory.
+
+### OOM killer invocation
+
+```c
+// mm/page_alloc.c (simplified)
+static struct page *__alloc_pages_may_oom(...)
+{
+    // Check if we should invoke OOM killer
+    if (should_oom_retry(...))
+        return NULL;  // Keep retrying
+
+    // Invoke OOM killer
+    if (oom_killer_disabled)
+        return NULL;
+
+    out_of_memory(&oc);
+
+    // OOM killer runs, hopefully frees memory
+    // Retry allocation
+    return get_page_from_freelist(...);
+}
+```
+
+### How OOM selects a victim
+
+The OOM killer scores processes by their "badness" - how much memory they use and how easy they are to kill:
+
+```c
+// mm/oom_kill.c (simplified)
+long oom_badness(struct task_struct *p, ...)
+{
+    long points;
+
+    // Base score: RSS + swap usage
+    points = get_mm_rss(p->mm) + get_mm_counter(p->mm, MM_SWAPENTS);
+
+    // Adjust for oom_score_adj (-1000 to +1000)
+    adj = p->signal->oom_score_adj;
+    if (adj == OOM_SCORE_ADJ_MIN)  // -1000
+        return LONG_MIN;  // Never kill (unless no choice)
+
+    // Apply adjustment as percentage
+    points += (points * adj) / 1000;
+
+    return points;
+}
+```
+
+### OOM score components
+
+| Factor | Impact |
+|--------|--------|
+| RSS (Resident Size) | Primary factor - bigger = worse |
+| Swap usage | Counts against the process |
+| `oom_score_adj` | Manual adjustment (-1000 to +1000) |
+| Root processes | Slight bonus (3% reduction) |
+| Children's memory | Considered if killing parent frees more |
+
+### Controlling OOM behavior
+
+```bash
+# View OOM score (higher = more likely to be killed)
+cat /proc/$PID/oom_score
+
+# View adjustment
+cat /proc/$PID/oom_score_adj
+
+# Protect important processes
+echo -1000 > /proc/$PID/oom_score_adj  # Never kill (almost)
+echo -500 > /proc/$PID/oom_score_adj   # Less likely to kill
+
+# Make a process OOM target
+echo 1000 > /proc/$PID/oom_score_adj   # Kill this first
+```
+
+### The OOM kill message
+
+When OOM kills, check `dmesg`:
+
+```bash
+dmesg | grep -i "out of memory"
+
+# Typical output:
+# [timestamp] Out of memory: Killed process 12345 (myapp) total-vm:1234567kB,
+#             anon-rss:123456kB, file-rss:1234kB, shmem-rss:0kB,
+#             UID:1000 pgtables:1234kB oom_score_adj:0
+```
+
+The log shows:
+- Which process was killed
+- Memory usage breakdown (vm, rss, file, shmem)
+- User ID
+- Page table memory
+- OOM adjustment value
+
+## Stage 6: Post-OOM recovery
+
+After OOM kills a process:
+
+```mermaid
+flowchart TB
+    A["1. OOM killer selects victim"] --> B["2. Send SIGKILL to victim"]
+    B --> C["3. Victim's mm marked OOM<br/>(prevents others being killed)"]
+    C --> D["4. Victim exits, releases memory"]
+    D --> E["5. OOM reaper may accelerate cleanup"]
+    E --> F["6. Waiting allocations retry and succeed"]
+```
+
+### OOM reaper
+
+The OOM reaper (v4.6+) accelerates memory freeing from killed processes:
+
+```c
+// Instead of waiting for the victim to exit normally,
+// OOM reaper can reclaim anonymous memory immediately
+// by unmapping pages while the process is still dying
+```
+
+This helps when the victim is stuck (e.g., in uninterruptible I/O) and can't exit promptly.
+
+## Memory cgroups and OOM
+
+With cgroups, OOM can be scoped to a container:
+
+```bash
+# Set memory limit for a cgroup
+echo 500M > /sys/fs/cgroup/memory/mygroup/memory.max
+
+# When the cgroup exceeds its limit:
+# - Cgroup-level OOM (kills within the cgroup)
+# - Doesn't affect processes outside the cgroup
+```
+
+Cgroup OOM events:
+
+```bash
+# Monitor cgroup OOM events
+cat /sys/fs/cgroup/mygroup/memory.events
+# oom           - OOM killer invocations
+# oom_kill      - Processes killed by OOM
+# oom_group_kill - Entire cgroup killed (cgroup v2)
+```
+
+See [memory cgroups](memcg.md) for details.
+
+## Preventing OOM
+
+### Tune watermarks
+
+```bash
+# Increase min_free_kbytes for earlier kswapd intervention
+sysctl vm.min_free_kbytes=131072  # 128MB
+
+# Tradeoff: more memory reserved, less available for applications
+```
+
+### Add swap
+
+Without swap, anonymous pages can't be reclaimed. Even a small swap provides emergency breathing room:
+
+```bash
+# Check current swap
+free -h
+
+# Create swap file
+dd if=/dev/zero of=/swapfile bs=1G count=4
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+```
+
+### Protect critical processes
+
+```bash
+# Protect database from OOM
+echo -1000 > /proc/$(pidof postgres)/oom_score_adj
+
+# Or in systemd unit file
+# [Service]
+# OOMScoreAdjust=-1000
+```
+
+### Use memory cgroups
+
+Isolate workloads with memory limits:
+
+```bash
+# Limit a container to 4GB
+echo 4G > /sys/fs/cgroup/mycontainer/memory.max
+
+# The container hits OOM before affecting the system
+```
+
+## Try it yourself
+
+### Watch OOM progression
+
+```bash
+# Terminal 1: Monitor memory state
+watch -n 1 'cat /proc/meminfo | grep -E "MemFree|MemAvailable|SwapFree|Active|Inactive"'
+
+# Terminal 2: Consume memory until OOM
+stress --vm 1 --vm-bytes 99% --vm-keep
+
+# Terminal 3: Watch for OOM
+dmesg -w | grep -i oom
+```
+
+### Simulate memory pressure stages
+
+```bash
+# Watch watermarks during pressure
+watch -n 1 'cat /proc/zoneinfo | grep -A 15 "zone   Normal" | head -20'
+
+# See kswapd wake up
+vmstat 1  # watch 'si', 'so', and 'wa' columns
+```
+
+### Monitor reclaim activity
+
+```bash
+# Comprehensive reclaim stats
+cat /proc/vmstat | grep -E "pgscan|pgsteal|allocstall|oom"
+
+# Trace reclaim events
+echo 1 > /sys/kernel/debug/tracing/events/vmscan/mm_vmscan_direct_reclaim_begin/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+### Test OOM score adjustment
+
+```bash
+# Create test process
+sleep 3600 &
+PID=$!
+
+# View its OOM score
+cat /proc/$PID/oom_score
+
+# Adjust and see score change
+echo 500 > /proc/$PID/oom_score_adj
+cat /proc/$PID/oom_score
+```
+
+## Key source files
+
+| File | What It Does |
+|------|--------------|
+| [`mm/vmscan.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c) | Page reclaim, kswapd, direct reclaim |
+| [`mm/oom_kill.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/oom_kill.c) | OOM killer, victim selection |
+| [`mm/page_alloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) | Watermarks, allocation slowpath |
+| [`include/linux/mmzone.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mmzone.h) | Zone and watermark definitions |
+
+## History
+
+The OOM killer has evolved dramatically over 30+ years, driven by production failures and changing workloads.
+
+### Timeline
+
+```mermaid
+timeline
+    title OOM Killer Evolution
+    1991 : Linux 0.01
+         : Basic OOM handling
+    2004 : Screen locker incident
+         : Sparked oom_adj discussion
+    2010 : v2.6.36
+         : Badness heuristic rewrite (Rientjes)
+    2016 : v4.6
+         : OOM reaper (Hocko)
+    2018 : v4.19-4.20
+         : Cgroup OOM, PSI (Weiner)
+    2022 : v6.1
+         : MGLRU improves pressure handling
+```
+
+### Era 1: The wild west (1991-2010)
+
+Early Linux had a simple OOM killer with crude heuristics. It would often kill the wrong process - sometimes critical system daemons, sometimes the user's screen locker (see [Case 1](#case-1-the-screen-locker-incident-2004) above).
+
+The scoring was arbitrary: processes got points based on memory usage, but the formula was ad-hoc and hard to tune. Administrators had no way to protect critical processes.
+
+### Era 2: The Rientjes rewrite (2010)
+
+David Rientjes (Google) rewrote the OOM killer with a principled scoring system.
+
+| Before | After |
+|--------|-------|
+| Arbitrary point system | Proportional to memory usage |
+| `/proc/<pid>/oom_adj` (-17 to +15) | `/proc/<pid>/oom_score_adj` (-1000 to +1000) |
+| Hard to predict victim | Score visible in `/proc/<pid>/oom_score` |
+
+**Commit**: [a63d83f427fb](https://git.kernel.org/linus/a63d83f427fb) ("oom: badness heuristic rewrite") | [LKML](https://lore.kernel.org/lkml/alpine.DEB.2.00.1007271806310.22908@chino.kir.corp.google.com/)
+
+**Author**: David Rientjes (Google)
+
+The new `oom_score_adj` interface finally let administrators protect critical processes with `-1000` (never kill) or mark expendable processes with `+1000` (kill first).
+
+### Era 3: The reliability fixes (2016)
+
+Michal Hocko (SUSE) tackled the deadlock problems discovered by Tetsuo Handa (see [Case 2](#case-2-the-mmap_sem-deadlock-2010-2016) above).
+
+**The OOM reaper** - a dedicated kernel thread that reclaims memory from killed processes without waiting for them to exit:
+
+**Commit**: [aac453635549](https://git.kernel.org/linus/aac453635549) ("mm, oom: introduce oom reaper") | [LKML](https://lore.kernel.org/linux-mm/1455813292-18614-2-git-send-email-mhocko@kernel.org/)
+
+**Author**: Michal Hocko (SUSE)
+
+This solved the "OOM fired but system still hung" problem that plagued production systems.
+
+### Era 4: Containers and proactive monitoring (2018)
+
+Two major additions addressed modern workloads:
+
+#### Per-cgroup OOM (v4.19)
+
+Roman Gushchin (Facebook) added cgroup-aware OOM handling. Containers need isolated OOM - one container's memory hog shouldn't kill processes in another container.
+
+The key feature is `memory.oom.group`: when set, the OOM killer treats the cgroup as an indivisible unit - either all tasks are killed together, or none are.
+
+**Commit**: [3d8b38eb81ca](https://git.kernel.org/linus/3d8b38eb81ca) ("mm, oom: introduce memory.oom.group") | [LKML](https://lore.kernel.org/all/20180730180100.25079-4-guro@fb.com/)
+
+**Author**: Roman Gushchin (Facebook)
+
+```bash
+# Enable cgroup-as-unit OOM behavior
+echo 1 > /sys/fs/cgroup/mycontainer/memory.oom.group
+
+# Cgroup-level OOM events
+cat /sys/fs/cgroup/mycontainer/memory.events
+# oom 0
+# oom_kill 0
+```
+
+#### PSI - Pressure Stall Information (v4.20)
+
+Johannes Weiner (Facebook) added PSI to detect pressure *before* OOM (see [Case 3](#case-3-the-thrashing-livelock-2010-present) above).
+
+**Commit**: [eb414681d5a0](https://git.kernel.org/linus/eb414681d5a0) ("psi: pressure stall information for CPU, memory, and IO") | [LKML](https://lore.kernel.org/linux-mm/20180529093107.13939-1-hannes@cmpxchg.org/)
+
+**Author**: Johannes Weiner (Facebook)
+
+```bash
+# View current pressure
+cat /proc/pressure/memory
+# some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+# full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+
+# "some" = at least one task stalled on memory
+# "full" = all non-idle tasks stalled on memory
+```
+
+PSI enabled userspace OOM daemons (`systemd-oomd`, `earlyoom`) to kill processes based on actual pressure rather than just free memory counts.
+
+### Summary of major commits
+
+| Version | Year | Change | Author | Commit |
+|---------|------|--------|--------|--------|
+| v2.6.36 | 2010 | Badness heuristic rewrite | David Rientjes | [a63d83f427fb](https://git.kernel.org/linus/a63d83f427fb) |
+| v4.6 | 2016 | OOM reaper | Michal Hocko | [aac453635549](https://git.kernel.org/linus/aac453635549) |
+| v4.19 | 2018 | Per-cgroup OOM (`memory.oom.group`) | Roman Gushchin | [3d8b38eb81ca](https://git.kernel.org/linus/3d8b38eb81ca) |
+| v4.20 | 2018 | PSI | Johannes Weiner | [eb414681d5a0](https://git.kernel.org/linus/eb414681d5a0) |
+
+## Notorious bugs and edge cases
+
+The OOM killer's history is littered with edge cases that taught kernel developers painful lessons. Understanding these helps explain why the current design exists and what safeguards are now in place.
+
+---
+
+### Case 1: The screen locker incident (2004)
+
+#### What happened
+
+In September 2004, developer Thomas Habets returned to his Linux workstation to find it unlocked. The OOM killer had terminated his `xlock` screen locker during a memory shortage, leaving his session exposed to anyone walking by.
+
+As Habets [wrote on LKML](https://lwn.net/Articles/104145/): *"I just got a very uncomfortable surprise when found my box unlocked thanks to this."*
+
+#### Real-world implications
+
+This wasn't just an inconvenience - it was a **security breach**. Screen lockers, authentication daemons, and similar security-critical processes must never be killed, even under memory pressure. An attacker with physical access could trigger OOM to unlock a workstation.
+
+#### The proposed fix
+
+Habets submitted the [oom_pardon patch](https://lwn.net/Articles/104145/), proposing a sysctl at `/proc/sys/vm/oom_pardon` that would accept a list of executables to never kill:
+
+> *"How about a sysctl that does 'for the love of kbaek, don't ever kill these processes when OOM. If nothing else can be killed, I'd rather you panic.' Examples for this list would be /usr/bin/vlock and /usr/X11R6/bin/xlock."*
+
+#### Community response
+
+The discussion on [LWN](https://lwn.net/Articles/104179/) and LKML was spirited. Alan Cox [pointed out](https://lwn.net/Articles/104179/) that the real problem was overcommit:
+
+> *"The rest of us just turn on 'no overcommit' in /proc/sys. That way we get told before takeoff that there isn't enough memory instead."*
+
+Andries Brouwer offered a memorable [analogy](https://lwn.net/Articles/104179/):
+
+> *"An aircraft company discovered that it was cheaper to fly its planes with less fuel on board... On rare occasions however the amount of fuel was insufficient, and the plane would crash. This problem was solved by the engineers of the company by the development of a special OOF (out-of-fuel) mechanism."*
+
+It turned out SUSE already had a similar patch allowing administrators to adjust OOM scores per-process.
+
+#### What was fixed
+
+The immediate `oom_pardon` patch wasn't merged, but the discussion led to:
+
+1. **`/proc/<pid>/oom_adj`** (v2.6.11): Allowed adjusting a process's OOM score (-17 to +15)
+2. **`/proc/<pid>/oom_score_adj`** (v2.6.36): Cleaner interface (-1000 to +1000), where -1000 means "never kill"
+
+**Commit**: [a63d83f427fb](https://git.kernel.org/linus/a63d83f427fb) ("oom: badness heuristic rewrite") - David Rientjes, 2010
+
+#### Future-proofing
+
+```bash
+# Protect critical processes today
+echo -1000 > /proc/$(pidof xscreensaver)/oom_score_adj
+
+# Or in systemd unit files
+[Service]
+OOMScoreAdjust=-1000
+```
+
+---
+
+### Case 2: The mmap_sem deadlock (2010-2016)
+
+#### What happened
+
+Tetsuo Handa, a persistent kernel debugger, [demonstrated workloads](https://lwn.net/Articles/666024/) that would cause the OOM killer to fire but never free memory. The system would hang indefinitely.
+
+The problem: a process chosen as OOM victim might be holding `mmap_sem` (now `mmap_lock`) for write - perhaps in the middle of `mmap()` or `munmap()`. When the process receives `SIGKILL`:
+
+1. The signal is pending, but the process is in uninterruptible sleep (e.g., waiting for disk I/O)
+2. When it finally wakes, `exit_mmap()` tries to tear down its address space
+3. But `exit_mmap()` needs `mmap_sem` - which the dying process already holds
+4. Classic self-deadlock
+
+```mermaid
+flowchart TD
+    subgraph Deadlock["The Deadlock Scenario"]
+        A["Process P calls mmap()"] --> B["Acquires mmap_sem for write"]
+        B --> C["Starts disk I/O, enters uninterruptible sleep"]
+        C --> D["OOM killer sends SIGKILL to P"]
+        D --> E["P wakes up, tries to exit"]
+        E --> F["exit_mmap() needs mmap_sem"]
+        F --> G["DEADLOCK: P holds the lock it needs"]
+        G --> H["System hangs forever"]
+    end
+```
+
+Meanwhile, other processes trying to allocate memory are waiting for this victim to die and release memory - which never happens.
+
+#### Real-world implications
+
+Servers running memory-intensive workloads would hang completely. The OOM killer had fired (visible in dmesg), but no memory was freed. The only recovery was a hard reboot.
+
+Handa [showed](https://lore.kernel.org/linux-mm/1469734954-31247-1-git-send-email-mhocko@kernel.org/) it was *"not hard to construct workloads which break the core assumption... the OOM victim might take unbounded amount of time to exit."*
+
+#### The fix: OOM reaper (v4.6)
+
+Michal Hocko (SUSE) developed the [OOM reaper](https://lwn.net/Articles/666024/), based on ideas from Mel Gorman (LSFMM 2015) and Oleg Nesterov.
+
+The key insight: *"It is not necessary to wait for the targeted process to die before stripping it of much of its memory. That process has received a SIGKILL signal, meaning it will not run again in user mode. That, in turn, means that it will no longer access any of its anonymous pages. Those pages can be reclaimed immediately."*
+
+**Commit**: [aac453635549](https://git.kernel.org/linus/aac453635549) ("mm, oom: introduce oom reaper") | [LKML](https://lore.kernel.org/linux-mm/1455813292-18614-2-git-send-email-mhocko@kernel.org/)
+
+**Author**: Michal Hocko
+
+The reaper is a dedicated kernel thread that:
+1. Takes `mmap_sem` for **read** (not write) - much less contention
+2. Walks the victim's VMAs and unmaps anonymous pages
+3. Frees memory without waiting for the victim to exit
+
+#### Additional safeguards (v4.8)
+
+Hocko added `MMF_OOM_NOT_REAPABLE` flag: if the reaper can't acquire `mmap_sem` after multiple attempts, it marks the mm as "reaped" anyway, allowing the OOM killer to select another victim.
+
+**Commit**: [bc448e897b6d](https://git.kernel.org/linus/bc448e897b6d) ("mm, oom_reaper: do not attempt to reap a task more than twice")
+
+#### Concurrent work: killable mmap_sem
+
+Many code paths holding `mmap_sem` for write were converted to use `down_write_killable()`, so they can be interrupted by `SIGKILL`. This reduces the window for deadlocks.
+
+---
+
+### Case 3: The thrashing livelock (2010, mitigated 2018+)
+
+#### What happened
+
+When memory is tight but not exhausted, systems can enter a pathological state where they're technically alive but completely unresponsive for minutes or hours.
+
+Mandeep Singh Baines (Google/ChromeOS) [documented this in 2010](https://lore.kernel.org/lkml/20101028191523.GA14972@google.com/):
+
+> *"On ChromiumOS, we do not use swap. When memory is low, the only way to free memory is to reclaim pages from the file list. This results in a lot of thrashing... We see the system become unresponsive for minutes before it eventually OOMs."*
+
+The pathology:
+
+1. Memory pressure causes page cache eviction
+2. Shared libraries (`libc.so`, etc.) and program text get evicted
+3. Every context switch triggers disk I/O to reload code pages
+4. System spends 99% of time in I/O wait, 1% doing useful work
+5. OOM killer never triggers because there's technically "free" memory (it's just being constantly evicted and reloaded)
+6. From the user's perspective, the system is frozen
+
+#### Real-world implications
+
+This affected desktop users severely. The Fedora Workstation working group [discussed](https://fedoraproject.org/wiki/Changes/EnableEarlyoom) *"better interactivity in low-memory situations"* for months:
+
+> *"In certain use cases, typically compiling, if all RAM and swap are completely consumed, system responsiveness becomes so abysmal that a reasonable user can consider the system 'lost', and resorts to forcing a power off. This is objectively a very bad UX."*
+
+The [le9-patch](https://github.com/hakavlad/le9-patch) repository documents: *"The kernel may crash due to OOM even with files present in the page cache, just because it cannot reclaim pages quickly enough to keep up with the allocations... due to memory shortage, the system drops the cache for shared libraries and even for the program text of running processes."*
+
+#### Fixes and mitigations
+
+**1. PSI - Pressure Stall Information (v4.20)**
+
+Johannes Weiner (Facebook) developed [PSI](https://lwn.net/Articles/759781/) to detect pressure before OOM:
+
+> *"When CPU, memory or IO devices are contended, workloads experience latency spikes, throughput losses, and run the risk of OOM kills. Without an accurate measure of such contention, users are forced to either play it safe and under-utilize their hardware resources, or roll the dice."*
+
+**Commit**: [eb414681d5a0](https://git.kernel.org/linus/eb414681d5a0) ("psi: pressure stall information for CPU, memory, and IO") | [LKML](https://lore.kernel.org/linux-mm/20180529093107.13939-1-hannes@cmpxchg.org/)
+
+**Author**: Johannes Weiner (Facebook)
+
+PSI was already used internally at Facebook: *"We now log and graph pressure for the containers in our fleet and can trivially link latency spikes and throughput drops to shortages of specific resources."*
+
+**2. earlyoom (userspace, 2017+)**
+
+[rfjakob's earlyoom](https://github.com/rfjakob/earlyoom) daemon polls memory frequently and kills processes before the system becomes unresponsive.
+
+Red Hat's Chris Murphy proposed [enabling earlyoom by default](https://fedoraproject.org/wiki/Changes/EnableEarlyoom) in Fedora 32:
+
+> *"The idea is to recover from out of memory situations sooner, rather than the typical complete system hang in which the user has no other choice but to force power off."*
+
+**Fedora 32+ enables earlyoom by default on Workstation.**
+
+**3. le9 patches (ChromeOS, out-of-tree)**
+
+The [le9 patches](https://github.com/hakavlad/le9-patch) protect file-backed pages from eviction:
+
+> *"With this patch and min_filelist_kbytes set to 50000, there is very little block layer activity during low memory. The system stays responsive under low memory and browser tab switching is fast."*
+
+ChromeOS has used similar file-locking patches for nearly 10 years, but they haven't been merged upstream.
+
+```bash
+# Check for thrashing with PSI
+cat /proc/pressure/memory
+# full avg10=45.00 avg60=30.00 ...  # 45% of time fully stalled = thrashing
+
+# Use earlyoom for desktop protection
+earlyoom -m 5 -s 5  # Kill when <5% memory AND <5% swap
+```
+
+---
+
+### Case 4: The fork bomb race (2011)
+
+#### What happened
+
+Fork bombs create processes faster than the OOM killer can kill them:
+
+```c
+while(1) fork();
+```
+
+KAMEZAWA Hiroyuki [identified the problem](https://lwn.net/Articles/433509/):
+
+> *"If there is a quick fork-bomb and it locks memory... users feel very bad response and will not be able to recover because fork-bomb tend to be faster than killall and oom-kill."*
+
+The OOM killer's per-process scoring fails here:
+1. Each new process has low memory usage (COW pages aren't copied yet)
+2. OOM killer scans all processes, finds the "worst" one
+3. Kills it, waits for exit, memory freed
+4. Fork bomb creates 1000 more processes in the meantime
+5. Repeat forever
+
+#### Real-world implications
+
+A single malicious (or buggy) user could take down a multi-user system. Even root couldn't recover without a reboot because the shell could barely get CPU time.
+
+#### The fork bomb killer patch
+
+Hiroyuki proposed a [fork bomb killer](https://lwn.net/Articles/435917/) with heuristics:
+
+> *"This can kill a fork-bomb when threads in a bomb are enough young (10min) and the number of new processes are enough large (10)."*
+
+The patch tracked process history in a tree structure:
+
+> *"The fork bomb killer will perform a depth-first traversal of the process history tree... At the end, the process with the highest score is examined; if there are at least ten processes in the history below the high scorer, it is deemed to be a fork bomb."*
+
+When detected:
+- All tasks in the fork bomb are killed
+- New `fork()` in that session returns `-ENOMEM` for 30 seconds
+
+#### What was actually merged: cgroups pids controller (v4.3)
+
+Instead of kernel heuristics, the solution was the [pids controller](https://docs.kernel.org/admin-guide/cgroup-v1/pids.html):
+
+> *"The process number controller is used to allow a cgroup hierarchy to stop any new tasks from being fork()'d or clone()'d after a certain limit is reached. Since it is trivial to hit the task limit without hitting any kmemcg limits in place, PIDs are a fundamental resource."*
+
+**Commit**: [49b786ea146f](https://git.kernel.org/linus/49b786ea146f) ("cgroup: add pids controller")
+
+**Author**: Aleksa Sarai
+
+```bash
+# Prevent fork bombs with cgroups
+echo 1000 > /sys/fs/cgroup/mygroup/pids.max
+
+# Or with ulimit
+ulimit -u 500  # Max 500 processes for this user
+```
+
+---
+
+### Case 5: CVE-2012-4398 - OOM deadlock denial of service
+
+#### What happened
+
+Tetsuo Handa (the same developer who found the mmap_sem deadlock) discovered that a local unprivileged user could trigger a deadlock in the OOM killer.
+
+#### The bug
+
+The [Red Hat CVE page](https://access.redhat.com/security/cve/CVE-2012-4398) describes it:
+
+> *"A deadlock could occur in the Out of Memory (OOM) killer. A process could trigger this deadlock by consuming a large amount of memory, and then causing request_module() to be called."*
+
+The attack pattern:
+1. Allocate large amounts of memory to trigger OOM conditions
+2. Trigger `request_module()` which tries to load a kernel module
+3. Module loading needs memory, but OOM is active
+4. Deadlock: OOM waiting for memory, memory waiting for OOM to finish
+
+#### Real-world implications
+
+A local unprivileged user could cause denial of service through excessive memory consumption and system hang. Red Hat rated this as "Moderate" severity.
+
+#### The fix
+
+**Red Hat Errata**: [RHSA-2013:1348](https://access.redhat.com/errata/RHSA-2013:1348)
+
+The fix prevented the deadlock by ensuring proper lock ordering between the OOM killer and module loading paths.
+
+[Red Hat credited Tetsuo Handa](https://access.redhat.com/security/cve/CVE-2012-4398) for reporting this issue.
+
+#### Future-proofing
+
+This CVE highlighted that OOM handling is **security-sensitive**. Subsequent OOM work has been more carefully reviewed for potential abuse by local attackers.
+
+---
+
+### Case 6: systemd cgroup massacre (2022)
+
+#### What happened
+
+With cgroups v2 and systemd's scope management, a new problem emerged: when the kernel OOM killer terminates one process in a user session, systemd would kill **all** processes in that cgroup scope.
+
+[GitHub Issue #25376](https://github.com/systemd/systemd/issues/25376) documents:
+
+> *"The expected behavior is normal kernel OOM killer behavior... However, systemd will kill an entire user slice's scope unit when a process under the scope is OOM killed by the kernel, wrecking everything the user was doing instead of limiting the damage to a single offending process."*
+
+Example scenario:
+1. User runs Firefox, Chrome, VS Code, and a terminal
+2. One Chrome tab triggers OOM, kernel kills that process
+3. systemd sees a process died due to OOM
+4. systemd kills the entire session scope - Firefox, VS Code, terminal, everything
+5. All unsaved work is lost
+
+#### Real-world implications
+
+Users on Fedora, Arch, and other distributions with systemd-oomd enabled by default experienced unexpected session terminations. [One blogger wrote](https://utcc.utoronto.ca/~cks/space/blog/linux/SystemdOomdNowDisabled): *"I've now disabled systemd-oomd on my Fedora desktops."*
+
+The [related issue #25853](https://github.com/systemd/systemd/issues/25853) requests:
+
+> *"Add systemd-oomd option to kill single, largest process instead of entire cgroup."*
+
+#### The design decision
+
+The [systemd-oomd documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd-oomd.service.html) explains the rationale:
+
+> *"If the configured limits are exceeded, systemd-oomd will select a cgroup to terminate, and send SIGKILL to all processes in it."*
+
+This is intentional - systemd treats cgroups as the unit of resource management. But for user sessions, it's often the wrong granularity.
+
+#### The fix
+
+[GitHub PR #25385](https://github.com/systemd/systemd/pull/25385) added support for `OOMPolicy=` in scope units, allowing users to control how systemd responds to kernel OOM events in user sessions.
+
+```bash
+# Modern solution: set OOMPolicy in scope units
+[Scope]
+OOMPolicy=continue  # Don't kill siblings when one process OOM'd
+
+# Or configure per-service
+[Service]
+OOMPolicy=continue  # Don't kill siblings
+
+# System-wide default
+# In /etc/systemd/system.conf:
+DefaultOOMPolicy=continue
+```
+
+#### Legacy workarounds (pre-fix)
+
+```bash
+# Disable systemd-oomd entirely (still useful if you prefer kernel OOM)
+sudo systemctl disable --now systemd-oomd
+
+# Run critical apps in separate scopes
+systemd-run --user --scope firefox
+```
+
+---
+
+### Summary: Lessons learned
+
+| Era | Problem | Root Cause | Fix | Prevention Today |
+|-----|---------|------------|-----|------------------|
+| 2004 | Screen locker killed | No way to protect processes | `oom_score_adj` | Set `-1000` for critical processes |
+| 2010 | Badness heuristic wrong | Scoring was arbitrary | Heuristic rewrite (Rientjes) | Use proportional memory scoring |
+| 2010-2016 | Victim can't exit | `mmap_sem` deadlock | OOM reaper (Hocko) | Kernel ≥4.6 has reaper |
+| 2010+ | Thrashing livelock | OOM triggers too late | PSI, earlyoom | Use `earlyoom` or PSI monitoring |
+| 2011 | Fork bomb wins | Per-process scoring fails | cgroups pids controller | Set `pids.max` in cgroups |
+| 2012 | CVE-2012-4398 | OOM races exploitable | Kernel hardening | Keep kernel updated |
+| 2022 | systemd kills session | Cgroup-granularity killing | `OOMPolicy=` in scope units | Fixed in systemd PR #25385 |
+
+The common thread: **OOM handling is harder than it looks**. Each "obvious" assumption - processes die quickly, free memory means healthy system, per-process scoring is sufficient - has been proven wrong in production.
+
+## Further reading
+
+### Related docs
+
+- [Page reclaim](reclaim.md) - Reclaim mechanisms in depth
+- [Memory overcommit](overcommit.md) - Why OOM happens despite "free" memory
+- [Memory cgroups](memcg.md) - Container memory limits
+- [Life of a page](life-of-page.md) - Page lifecycle and reclaim
+
+### LWN articles
+
+- [The OOM killer](https://lwn.net/Articles/317814/) (2008) - Classic overview
+- [Respite from the OOM killer](https://lwn.net/Articles/104179/) (2004) - The screen locker incident
+- [Toward more predictable and reliable out-of-memory handling](https://lwn.net/Articles/668126/) (2016) - OOM reaper motivation
+- [PSI - Pressure Stall Information](https://lwn.net/Articles/759781/) (2018) - Proactive pressure monitoring

--- a/docs/mm/page-tables.md
+++ b/docs/mm/page-tables.md
@@ -279,6 +279,117 @@ Can't allocate huge pages due to fragmentation.
 - Enable THP: `/sys/kernel/mm/transparent_hugepage/enabled`
 - Compact memory: `echo 1 > /proc/sys/vm/compact_memory`
 
+## Notorious bugs and edge cases
+
+Page tables mediate all memory access. Bugs here range from privilege escalation to information disclosure to complete CPU security model breakdown.
+
+### Case 1: Meltdown (CVE-2017-5754)
+
+#### What happened
+
+In January 2018, researchers disclosed [Meltdown](https://meltdownattack.com/), a hardware vulnerability affecting Intel CPUs that allowed unprivileged processes to read kernel memory.
+
+#### The bug
+
+Meltdown exploits **speculative execution** combined with **cache timing**. The CPU speculatively executes an illegal kernel read, and even though it raises a fault, the cache side effects remain, leaking the data.
+
+#### The fix: KPTI
+
+**Commit**: [5aa90a84589282](https://git.kernel.org/linus/5aa90a84589282b87666f92b6c3c917c8080a9bf) ("x86/pti: Add infrastructure for page table isolation")
+
+**Author**: Dave Hansen (Intel)
+
+KPTI creates separate page tables for kernel and user mode. When entering the kernel, page tables are switched to include kernel mappings.
+
+```bash
+# Check KPTI status
+cat /sys/devices/system/cpu/vulnerabilities/meltdown
+```
+
+---
+
+### Case 2: Spectre (CVE-2017-5753, CVE-2017-5715)
+
+#### What happened
+
+Disclosed alongside Meltdown, [Spectre](https://spectreattack.com/) exploits speculative execution to leak data from other processes or the kernel.
+
+#### Variant 1 (Bounds Check Bypass)
+
+The CPU speculatively executes past bounds checks, allowing out-of-bounds reads via cache timing.
+
+**Fix**: Array index masking with `array_index_nospec()`.
+
+#### Variant 2 (Branch Target Injection)
+
+Attackers poison the branch predictor to redirect speculative execution to chosen gadgets.
+
+**Fix**: Retpoline - replaces indirect calls with a sequence that traps speculative execution.
+
+**Commit**: [76b043848fd2](https://git.kernel.org/linus/76b043848fd2) ("x86/retpoline: Add initial retpoline support")
+
+---
+
+### Case 3: TLB flush races
+
+#### What happened
+
+The TLB caches page table entries. When page tables change, the TLB must be flushed. Races between changes and flushes cause security vulnerabilities.
+
+#### The bug pattern
+
+A CPU can use stale TLB entries to access pages that should be unmapped:
+1. Page table entry cleared
+2. TLB flush pending (not yet complete)
+3. Another CPU accesses via stale TLB entry
+4. Access succeeds to freed/reallocated page
+
+#### Example: CVE-2018-18281
+
+The `mremap()` syscall moved page table entries but flushed TLBs too late.
+
+**Commit**: [eb66ae030829](https://git.kernel.org/linus/eb66ae030829) ("mremap: properly flush TLB before releasing the page")
+
+---
+
+### Case 4: KASLR bypasses
+
+#### What is KASLR?
+
+Kernel Address Space Layout Randomization randomizes where the kernel is loaded, making exploits harder.
+
+#### Bypass techniques
+
+| Technique | Method |
+|-----------|--------|
+| Info leak | Kernel pointer exposed to userspace |
+| Timing side channel | Measure access times |
+| dmesg leak | Kernel addresses in logs |
+
+#### Hardening
+
+```bash
+# Restrict kernel pointers
+echo 2 > /proc/sys/kernel/kptr_restrict
+
+# Restrict dmesg
+echo 1 > /proc/sys/kernel/dmesg_restrict
+```
+
+---
+
+### Summary: Lessons learned
+
+| Bug | Year | Type | Mitigation |
+|-----|------|------|------------|
+| Meltdown | 2017 | Hardware | KPTI |
+| Spectre v1 | 2017 | Hardware | nospec barriers |
+| Spectre v2 | 2017 | Hardware | Retpoline |
+| TLB races | Ongoing | Software | Proper flush ordering |
+| KASLR bypass | Ongoing | Info leak | Pointer restrictions |
+
+**The pattern**: Page table bugs often involve timing (TLB races, speculation) or assumptions about hardware behavior that turn out to be wrong.
+
 ## References
 
 ### Key Code
@@ -297,3 +408,4 @@ Can't allocate huge pages due to fragmentation.
 
 - [overview](overview.md) - Memory management overview
 - [glossary](glossary.md) - PFN, TLB, MMU definitions
+- [Bug Index](bugs/README.md) - Index of all mm kernel bugs

--- a/docs/mm/slab.md
+++ b/docs/mm/slab.md
@@ -345,6 +345,132 @@ Allocations without matching frees.
 
 Per-CPU slab contention on workloads that allocate on one CPU and free on another.
 
+## Notorious bugs and edge cases
+
+Heap exploitation is the bread and butter of kernel exploits. The SLUB allocator's design - storing freelist pointers inline with objects, using per-CPU caches, and merging similar caches - creates a rich attack surface.
+
+### Case 1: Netfilter heap out-of-bounds (CVE-2021-22555)
+
+#### What happened
+
+In July 2021, Andy Nguyen (Google) demonstrated a 15-year-old heap out-of-bounds write in Linux Netfilter that bypassed all modern mitigations to achieve kernel code execution. The exploit won $10,000 in Google's kCTF program.
+
+#### The bug
+
+From the [Project Zero writeup](https://google.github.io/security-research/pocs/linux/cve-2021-22555/writeup.html):
+
+The vulnerability exists in `net/netfilter/x_tables.c`. When `IPT_SO_SET_REPLACE` is called in compatibility mode, structures must be converted from 32-bit to 64-bit format. The conversion function `xt_compat_target_from_user()` could write 4 bytes of zeros out-of-bounds.
+
+#### Exploitation technique
+
+The exploit uses several advanced techniques:
+
+1. **Heap spray with msg_msg**: Use `msgsnd()` to spray the heap with controlled `msg_msg` structures
+2. **Corrupt msg_msg->m_list.next**: The 4-byte zero write partially overwrites a freelist pointer
+3. **UAF primitive**: The corrupted pointer creates a use-after-free condition
+4. **Leak kernel addresses**: Read freed msg_msg to defeat KASLR
+5. **Fake object injection**: Spray fake objects to control execution
+
+#### The fix
+
+**Commit**: [b29c457a6511](https://git.kernel.org/linus/b29c457a6511) ("netfilter: x_tables: fix compat match/target pad out-of-bound write")
+
+**Author**: Florian Westphal
+
+---
+
+### Case 2: io_uring use-after-free (CVE-2022-29582)
+
+#### What happened
+
+In 2022, security researchers discovered a race condition in io_uring's timeout handling that led to a use-after-free. The exploit achieved root privileges on Google's hardened kCTF environment.
+
+#### The bug
+
+From the [technical writeup](https://ruia-ruia.github.io/2022/08/05/CVE-2022-29582-io-uring/):
+
+A race exists between timeout flush and removal in io_uring. When the same timeout request is processed by both paths simultaneously, it gets freed twice, creating a use-after-free.
+
+#### Exploitation technique
+
+The exploit uses a **cross-cache attack**:
+
+1. **Trigger UAF**: Race the timeout paths to free `io_kiocb` twice
+2. **Reclaim with different object**: Free the slab page, reallocate in a different cache
+3. **Type confusion**: The freed `io_kiocb` slot now holds a different object type
+4. **Arbitrary read/write**: Manipulate the confused object to gain primitives
+
+#### The fix
+
+**Commit**: [e677edbcabee](https://git.kernel.org/linus/e677edbcabee) ("io_uring: fix race between timeout flush and removal")
+
+**Author**: Pavel Begunkov
+
+---
+
+### Case 3: SLUB freelist hardening bypasses
+
+#### The hardening
+
+Linux added `CONFIG_SLAB_FREELIST_HARDENED` to protect against freelist corruption. The freelist pointer is XORed with a per-cache random value and the pointer's own address.
+
+#### Bypassing the hardening
+
+Despite hardening, researchers have found bypasses:
+
+1. **Information leak first**: If you can leak the XOR key, hardening provides no protection
+2. **Partial overwrite**: Overwriting only the lower bytes of a freelist pointer can create valid pointers
+3. **Double-free timing**: Control timing of frees to avoid detection
+
+| Config | Protection | Bypass Difficulty |
+|--------|-----------|-------------------|
+| `SLAB_FREELIST_HARDENED` | Freelist pointer XOR | Medium (need leak) |
+| `SLAB_FREELIST_RANDOM` | Random freelist order | Low (probabilistic) |
+| `RANDOM_KMALLOC_CACHES` | Multiple caches per size | Medium (more spray) |
+
+---
+
+### Case 4: Cache merging security issues
+
+#### The problem
+
+SLUB merges caches with similar object sizes and flags to reduce memory overhead. When caches merge, objects of different types share the same slab pages, and UAF in one object type can affect the other.
+
+#### The fix
+
+For security-sensitive caches, use `SLAB_ACCOUNT` or `SLAB_NO_MERGE`. Boot option `slub_nomerge` disables all merging (performance cost).
+
+---
+
+### Case 5: Out-of-slab access patterns
+
+#### The bug class
+
+Many vulnerabilities involve accessing memory just outside a slab object (off-by-one, linear overflow). With standard SLUB, this corrupts adjacent objects or freelist pointers.
+
+#### Detection
+
+```bash
+# Enable red zoning to detect overflows
+slub_debug=Z
+
+# KFENCE for production
+CONFIG_KFENCE=y
+```
+
+---
+
+### Summary: Lessons learned
+
+| Bug | Year | Root Cause | Exploitation |
+|-----|------|------------|--------------|
+| CVE-2021-22555 | 2021 | Bounds check error | msg_msg spray |
+| CVE-2022-29582 | 2022 | Race condition | Cross-cache attack |
+| Freelist bypasses | Ongoing | Hardening limitations | Info leak + craft |
+| Cache merging | Design | Memory optimization | Type confusion |
+
+**The pattern**: SLUB bugs are rarely in SLUB itself - they're in code that *uses* SLUB. But understanding SLUB internals is essential for both exploitation and defense.
+
 ## References
 
 ### Key Code
@@ -371,3 +497,4 @@ Per-CPU slab contention on workloads that allocate on one CPU and free on anothe
 
 - [page-allocator](page-allocator.md) - Where SLUB gets its pages
 - [overview](overview.md) - How slab fits in the allocator hierarchy
+- [Bug Index](bugs/README.md) - Index of all mm kernel bugs

--- a/docs/mm/swapping.md
+++ b/docs/mm/swapping.md
@@ -1,0 +1,1015 @@
+# What happens during swapping
+
+> The journey of a page from memory to disk and back
+
+## What is swapping?
+
+When memory runs low, the kernel can move anonymous pages (heap, stack, private mappings) to a swap device - either a disk partition or a swap file. This frees physical memory for other uses while preserving the page's contents.
+
+```mermaid
+flowchart LR
+    subgraph SwapOut["Swap Out (Memory → Disk)"]
+        direction LR
+        subgraph PM1["Process Memory"]
+            AP["Anonymous Page"]
+        end
+        subgraph SS1["Swap Space (disk)"]
+            SL1["Swap slot (copy)"]
+        end
+        AP -->|write| SL1
+        PM1 -.->|Page freed!| PM1
+    end
+```
+
+```mermaid
+flowchart RL
+    subgraph SwapIn["Swap In (Disk → Memory)"]
+        direction RL
+        subgraph SS2["Swap Space (disk)"]
+            SL2["Swap slot"]
+        end
+        subgraph PM2["Process Memory"]
+            NP["New Page (restored)"]
+        end
+        SL2 -->|read| NP
+    end
+```
+
+Unlike file pages (which can be re-read from their backing file), anonymous pages have nowhere to go except swap space.
+
+## Why this page was chosen
+
+The kernel doesn't randomly pick pages to swap. It uses the [LRU (Least Recently Used)](reclaim.md) lists to find cold pages - pages that haven't been accessed recently.
+
+### The selection process
+
+```mermaid
+flowchart TB
+    subgraph PageReclaimScanning["Page Reclaim Scanning"]
+        ActiveLRU["<b>Active Anonymous LRU</b><br/>(hot pages - recently used)<br/><i>Not scanned first - these pages are in use</i>"]
+        InactiveLRU["<b>Inactive Anonymous LRU</b><br/>(cold pages - candidates for swap)<br/><i>Scanned during reclaim</i>"]
+        Selection["<b>Selection Criteria:</b><br/>- Not recently accessed (PG_referenced clear)<br/>- Not locked (PG_locked clear)<br/>- Not being written back already<br/>- Can be unmapped from all page tables"]
+
+        ActiveLRU -->|"demote (if not recently accessed)"| InactiveLRU
+        InactiveLRU --> Selection
+    end
+```
+
+### The referenced flag check
+
+Pages get a "second chance" via the referenced flag:
+
+```mermaid
+flowchart TB
+    subgraph ReferencedFlagCheck["Page on Inactive LRU"]
+        Scan["Reclaim scan finds page"]
+        Check{"PG_referenced<br/>set?"}
+        Accessed["Page was accessed since last scan:<br/>- Clear PG_referenced<br/>- Rotate to end of list (give it more time)"]
+        Cold["Page is truly cold:<br/>- Select for swap out"]
+
+        Scan --> Check
+        Check -->|Yes| Accessed
+        Check -->|No| Cold
+    end
+```
+
+This prevents swapping out pages that are still being used occasionally.
+
+## Swap space organization
+
+Linux supports two types of swap:
+
+| Type | Device | Characteristics |
+|------|--------|-----------------|
+| Swap partition | `/dev/sda2` | Dedicated, fixed size |
+| Swap file | `/swapfile` | Flexible, can resize, easier to manage |
+
+On modern systems (especially SSDs), performance between partition and file swap is nearly identical. The "partition is faster" advice is largely historical - filesystem overhead is negligible compared to actual I/O.
+
+### Swap area structure
+
+```c
+// From include/linux/swap.h
+struct swap_info_struct {
+    unsigned long flags;        // SWP_USED, SWP_WRITEOK, etc.
+    signed char prio;           // Priority (higher = used first)
+    struct file *swap_file;     // The swap file/device
+    struct block_device *bdev;  // Block device (if partition)
+    unsigned long *swap_map;    // Usage count per slot
+    unsigned long lowest_bit;   // Optimization: first free slot hint
+    unsigned long highest_bit;  // Optimization: last used slot
+    unsigned int pages;         // Total slots in this area
+    unsigned int inuse_pages;   // Currently used slots
+    // ...
+};
+```
+
+### Swap slots
+
+Swap space is divided into page-sized slots:
+
+```mermaid
+flowchart TB
+    subgraph SwapArea["Swap Area (e.g., 1GB)"]
+        direction LR
+        subgraph Slots["Slot Numbers"]
+            S0["0<br/>used"]
+            S1["1<br/>free"]
+            S2["2<br/>used"]
+            S3["3<br/>free"]
+            S4["4<br/>free"]
+            S5["5<br/>used"]
+            S6["6<br/>used"]
+            S7["7<br/>free"]
+            SDOTS["..."]
+            SN["N-1<br/>free"]
+        end
+    end
+
+    subgraph SwapMap["swap_map[] tracks usage count for each slot"]
+        M0["0: count=2 (shared by 2 processes after fork)"]
+        M1["1: count=0 (free)"]
+        M2["2: count=1 (one owner)"]
+        M3["..."]
+    end
+```
+
+### Viewing swap status
+
+```bash
+# View swap areas
+cat /proc/swaps
+# Filename          Type        Size      Used    Priority
+# /dev/nvme0n1p3    partition   8388604   12345   -2
+
+# Detailed swap info
+swapon --show
+
+# System-wide swap usage
+free -h
+```
+
+## Stage 1: Swap slot allocation
+
+When the kernel decides to swap out a page, it first allocates a slot:
+
+```c
+// mm/swap_slots.c / mm/swapfile.c (simplified)
+swp_entry_t folio_alloc_swap(struct folio *folio)
+{
+    struct swap_info_struct *si;
+    swp_entry_t entry;
+
+    // Find a swap area with free slots
+    // Higher priority areas are checked first
+    si = swap_info[...];  // Based on priority
+
+    // Allocate a slot
+    offset = scan_swap_map_slots(si, ...);
+
+    // Create swap entry (type + offset encoded)
+    entry = swp_entry(si->type, offset);
+
+    return entry;
+}
+```
+
+### Swap entry encoding
+
+A swap entry packs the swap area type and offset into a single value:
+
+```mermaid
+flowchart LR
+    subgraph SwapEntry["Swap Entry (64-bit)"]
+        direction TB
+        B0["Bits 0: Present = 0<br/>(not a valid page mapping)"]
+        B1["Bits 1-5: Swap type<br/>(which swap area, 0-31)"]
+        B2["Bits 6-57: Swap offset<br/>(slot number within the area)"]
+        B3["Bits 58-63: Flags and reserved"]
+    end
+```
+
+This entry will replace the page table entry (PTE) after the page is written out.
+
+## Stage 2: Writing to swap
+
+Once a slot is allocated, the page content is written to the swap device:
+
+```c
+// mm/vmscan.c shrink_folio_list() (simplified)
+static unsigned int shrink_folio_list(struct list_head *folio_list, ...)
+{
+    // For each folio...
+
+    // 1. Unmap from all page tables first
+    //    (so no one can access while we're writing)
+    try_to_unmap(folio, TTU_BATCH_FLUSH);
+
+    // 2. If anonymous and we can swap...
+    if (folio_test_anon(folio)) {
+        if (!add_to_swap(folio))
+            goto activate;  // Can't swap, keep in memory
+
+        // 3. Write page to swap device
+        pageout(folio, mapping);
+    }
+}
+```
+
+### The add_to_swap() function
+
+```c
+// mm/swap_state.c
+bool add_to_swap(struct folio *folio)
+{
+    swp_entry_t entry;
+
+    // 1. Get a swap slot
+    entry = folio_alloc_swap(folio);
+    if (!entry.val)
+        return false;  // No swap space available
+
+    // 2. Set up folio for swap
+    folio_set_swapcache(folio);
+    folio->swap = entry;
+
+    // 3. Add to swap cache (so others can find it during I/O)
+    __folio_set_swap_entry(folio, entry);
+    xa_store(&swap_address_space->i_pages, ...);
+
+    return true;
+}
+```
+
+### Writing to disk
+
+```c
+// Simplified I/O path
+static int pageout(struct folio *folio, struct address_space *mapping)
+{
+    // Submit write I/O to swap device
+    // This is asynchronous - we don't wait here
+
+    struct writeback_control wbc = {
+        .sync_mode = WB_SYNC_NONE,  // Don't wait
+    };
+
+    return mapping->a_ops->writepage(&folio->page, &wbc);
+}
+```
+
+The actual I/O goes through the block layer:
+
+```mermaid
+flowchart TB
+    subgraph PageWritePath["Page Write Path"]
+        pageout["pageout()"]
+        swap_writepage["swap_writepage()"]
+        __swap_writepage["__swap_writepage()"]
+        submit_bio["submit_bio()"]
+        block["Block layer"]
+        driver["Device driver"]
+        disk["Disk"]
+
+        pageout --> swap_writepage
+        swap_writepage --> __swap_writepage
+        __swap_writepage --> submit_bio
+        submit_bio --> block
+        block --> driver
+        driver --> disk
+    end
+```
+
+## Stage 3: Page table update
+
+After the write completes, the PTE is updated to contain the swap entry instead of a page mapping:
+
+```mermaid
+flowchart LR
+    subgraph Before["Before swap out"]
+        direction LR
+        PTE1["<b>Page Table Entry (PTE)</b><br/>Present=1<br/>PFN=0x12345"]
+        PP["<b>Physical Page</b><br/>Frame 0x12345<br/>[page data]"]
+        PTE1 --> PP
+    end
+```
+
+```mermaid
+flowchart LR
+    subgraph After["After swap out"]
+        direction LR
+        SE["<b>Swap Entry</b><br/>Present=0<br/>Type=0<br/>Offset=0x789"]
+        SD["<b>Swap Device</b><br/>Slot 0x789<br/>[page data]"]
+        SE --> SD
+    end
+    Freed["Physical page returned to buddy allocator!"]
+```
+
+### The swap cache
+
+During I/O, the page stays in the **swap cache** - an address space that allows finding in-flight pages:
+
+```mermaid
+flowchart LR
+    subgraph SwapCachePurpose["Swap Cache Purpose: While page is being written to swap"]
+        ProcessA["Process A"]
+        SwapCache["Swap Cache<br/>(finds it!)"]
+        Page["Page"]
+
+        ProcessA -->|tries to access| SwapCache
+        SwapCache --> Page
+    end
+
+    Note["Without swap cache, Process A would have to wait for write<br/>to complete, then read it back immediately (wasteful!)"]
+```
+
+After I/O completes successfully:
+- Page is removed from swap cache
+- Physical page is freed
+- Only the swap slot remains with the data
+
+## Stage 4: Process accesses swapped page
+
+Later, when a process accesses a swapped-out address, a page fault brings it back.
+
+### The fault handler detects a swap entry
+
+```c
+// arch/x86/mm/fault.c → mm/memory.c
+static vm_fault_t handle_pte_fault(struct vm_fault *vmf)
+{
+    pte_t entry = vmf->orig_pte;
+
+    if (!pte_present(entry)) {
+        if (pte_none(entry))
+            return do_anonymous_page(vmf);  // New page
+
+        // PTE has swap entry
+        return do_swap_page(vmf);  // ← Our path!
+    }
+
+    // ... handle other cases
+}
+```
+
+### do_swap_page() brings the page back
+
+```c
+// mm/memory.c (simplified)
+vm_fault_t do_swap_page(struct vm_fault *vmf)
+{
+    swp_entry_t entry = pte_to_swp_entry(vmf->orig_pte);
+    struct folio *folio;
+
+    // 1. Check swap cache first (maybe another thread faulted already)
+    folio = swap_cache_get_folio(entry, ...);
+
+    if (!folio) {
+        // 2. Not in cache - need to read from swap
+        folio = swapin_readahead(entry, ...);
+    }
+
+    // 3. Wait for page to be ready
+    folio_lock(folio);
+
+    // 4. Verify swap entry still valid (race check)
+    // ...
+
+    // 5. Update page table: swap entry → page mapping
+    pte = mk_pte(&folio->page, vmf->vma->vm_page_prot);
+    if (vmf->flags & FAULT_FLAG_WRITE)
+        pte = pte_mkwrite(pte_mkdirty(pte), vmf->vma);
+
+    set_pte_at(vmf->vma->vm_mm, vmf->address, vmf->pte, pte);
+
+    // 6. Update LRU
+    folio_add_lru(folio);
+
+    // 7. Free swap slot (if we're the last user)
+    swap_free(entry);
+
+    return 0;
+}
+```
+
+### Swap-in readahead
+
+Like file readahead, the kernel predicts you might access nearby swapped pages:
+
+```c
+// mm/swap_state.c
+struct folio *swapin_readahead(swp_entry_t entry, gfp_t gfp_mask,
+                                struct vm_fault *vmf)
+{
+    struct page *page;
+
+    // Read the requested page
+    page = read_swap_cache_async(entry, ...);
+
+    // Also read nearby pages (readahead)
+    if (should_readahead(...)) {
+        for (offset = -readahead_win; offset <= readahead_win; offset++) {
+            swp_entry_t ra_entry = swp_entry(type, entry_offset + offset);
+            read_swap_cache_async(ra_entry, ...);
+        }
+    }
+
+    return page_folio(page);
+}
+```
+
+## Stage 5: Swap slot freed
+
+After successful swap-in, the swap slot can be freed:
+
+```c
+// mm/swapfile.c
+void swap_free(swp_entry_t entry)
+{
+    struct swap_info_struct *si = swap_info[swp_type(entry)];
+
+    // Decrement usage count
+    // (might be >1 if COW shared the slot)
+    count = swap_map[swp_offset(entry)]--;
+
+    if (count == 0) {
+        // Slot is now free for reuse
+        si->inuse_pages--;
+    }
+}
+```
+
+### Swap slots and COW
+
+When processes share a swapped page (after fork + swap):
+
+```mermaid
+flowchart TB
+    subgraph SharedSlot["Parent and Child share swap slot"]
+        SwapSlot["<b>Swap slot 0x789</b><br/>swap_map[0x789] = 2 (two users)<br/>Contents: page data"]
+        ParentPTE["Parent's PTE: swap entry: slot 0x789"]
+        ChildPTE["Child's PTE: swap entry: slot 0x789"]
+
+        ParentPTE --> SwapSlot
+        ChildPTE --> SwapSlot
+    end
+
+    subgraph ParentSwapIn["When parent swaps in"]
+        P1["Reads from slot 0x789"]
+        P2["swap_map[0x789] = 1 (still used by child)"]
+        P3["Parent's PTE → physical page"]
+        P4["Slot NOT freed yet"]
+        P1 --> P2 --> P3 --> P4
+    end
+
+    subgraph ChildSwapIn["When child swaps in"]
+        C1["Reads from slot 0x789"]
+        C2["swap_map[0x789] = 0"]
+        C3["Slot is now free"]
+        C1 --> C2 --> C3
+    end
+
+    SharedSlot --> ParentSwapIn --> ChildSwapIn
+```
+
+## The complete swap cycle
+
+Putting it all together:
+
+```mermaid
+flowchart TB
+    subgraph SwapOutPhase["Swap Out Phase"]
+        Step1["<b>1. Memory Pressure</b><br/>kswapd wakes or direct reclaim starts"]
+        Step2["<b>2. Page Selection</b> (mm/vmscan.c)<br/>Scan inactive anonymous LRU<br/>Find cold page without PG_referenced"]
+        Step3["<b>3. Unmap Page</b><br/>Remove from all page tables via rmap<br/>Page now inaccessible to processes"]
+        Step4["<b>4. Allocate Swap Slot</b><br/>folio_alloc_swap() finds free slot<br/>Add page to swap cache"]
+        Step5["<b>5. Write to Swap</b><br/>submit_bio() queues I/O<br/>Async write to swap device"]
+        Step6["<b>6. Complete Swap Out</b><br/>PTEs now contain swap entries<br/>Physical page freed to buddy<br/>Page removed from swap cache"]
+
+        Step1 --> Step2
+        Step2 --> Step3
+        Step3 --> Step4
+        Step4 --> Step5
+        Step5 --> Step6
+    end
+
+    TimePasses["--- Time passes ---"]
+
+    subgraph SwapInPhase["Swap In Phase"]
+        Step7["<b>7. Process Accesses Address</b><br/>Page fault (PTE not present)<br/>do_swap_page() handles it"]
+        Step8["<b>8. Swap In</b><br/>Allocate new physical page<br/>Read from swap device<br/>Add to swap cache during I/O"]
+        Step9["<b>9. Restore Mapping</b><br/>Update PTE: swap entry → page mapping<br/>Add page to active LRU"]
+        Step10["<b>10. Free Swap Slot</b><br/>swap_free() decrements count<br/>Slot available for reuse (if count=0)"]
+
+        Step7 --> Step8
+        Step8 --> Step9
+        Step9 --> Step10
+    end
+
+    Step6 --> TimePasses
+    TimePasses --> Step7
+```
+
+## Swap tunables
+
+### Swappiness
+
+Controls how aggressively the kernel swaps:
+
+```bash
+# View current value
+cat /proc/sys/vm/swappiness
+# Default: 60
+
+# Reduce swapping (prefer reclaiming file cache)
+sysctl vm.swappiness=10
+
+# Avoid swapping almost entirely
+sysctl vm.swappiness=1
+```
+
+| Value | Effect |
+|-------|--------|
+| 0 | Swap only to avoid OOM |
+| 1-30 | Prefer file cache reclaim |
+| 60 | Default balance |
+| 100 | Aggressive swapping |
+
+### Swap priority
+
+Multiple swap areas can have different priorities:
+
+```bash
+# Higher priority = used first
+swapon -p 10 /dev/fast_ssd     # Priority 10 (used first)
+swapon -p 5 /dev/slow_hdd      # Priority 5 (used when fast is full)
+
+# Same priority = round-robin
+swapon -p 10 /dev/ssd1
+swapon -p 10 /dev/ssd2         # Striped across both
+```
+
+### VFS cache pressure
+
+Affects the balance between reclaiming file cache vs swapping:
+
+```bash
+cat /proc/sys/vm/vfs_cache_pressure
+# Default: 100
+
+# Lower = keep file caches longer (swap more)
+# Higher = drop file caches more readily (swap less)
+```
+
+## Swap performance considerations
+
+### SSD vs HDD
+
+| Metric | HDD | SSD |
+|--------|-----|-----|
+| Random read | ~10ms | ~0.1ms |
+| Sequential read | ~100MB/s | ~500-3000MB/s |
+| Write endurance | Unlimited | Limited (but usually fine) |
+
+SSDs dramatically improve swap performance, making swapping much less painful.
+
+### Swap thrashing
+
+When the working set exceeds RAM, the system constantly swaps pages in and out:
+
+```mermaid
+flowchart LR
+    subgraph Thrashing["Thrashing"]
+        direction TB
+        TimeArrow["Time →"]
+
+        subgraph PageA["Page A"]
+            A1["in memory"] --> A2["swap out"] --> A3["swap in"] --> A4["swap out"] --> A5["..."]
+        end
+
+        subgraph PageB["Page B"]
+            B1["swap in"] --> B2["swap out"] --> B3["swap in"] --> B4["swap out"] --> B5["..."]
+        end
+
+        subgraph PageC["Page C"]
+            C1["swap out"] --> C2["swap in"] --> C3["swap out"] --> C4["swap in"] --> C5["..."]
+        end
+
+        Result["System spends more time swapping than doing useful work!"]
+    end
+```
+
+**Signs of thrashing**:
+- High swap I/O (`vmstat` si/so columns)
+- High CPU time in kernel (`top` shows high sy/wa)
+- Application responsiveness drops drastically
+
+**Solutions**:
+- Add more RAM
+- Reduce memory usage
+- Use zswap or zram for compression
+
+### zswap and zram
+
+**zswap**: Compresses pages before writing to swap device:
+
+```mermaid
+flowchart LR
+    subgraph NormalSwap["Normal swap"]
+        NS_Page["Page"] --> NS_Device["Swap device"]
+    end
+```
+
+```mermaid
+flowchart LR
+    subgraph WithZswap["With zswap"]
+        ZS_Page["Page"] --> ZS_Compress["Compress"] --> ZS_RAM["RAM pool"] -.->|if needed| ZS_Device["Swap device"]
+    end
+```
+
+**zram**: Creates a compressed RAM disk as swap:
+
+```bash
+# Enable zram
+modprobe zram
+echo lz4 > /sys/block/zram0/comp_algorithm
+echo 2G > /sys/block/zram0/disksize
+mkswap /dev/zram0
+swapon -p 100 /dev/zram0  # High priority
+```
+
+## Try it yourself
+
+### Monitor swap activity
+
+```bash
+# Real-time swap I/O
+vmstat 1
+# si = swap in (KB/s)
+# so = swap out (KB/s)
+
+# Detailed swap stats
+cat /proc/vmstat | grep -E "pswp|swap"
+# pswpin  - pages swapped in
+# pswpout - pages swapped out
+```
+
+### Watch a swap operation
+
+```bash
+# Terminal 1: Monitor swap
+watch -n 1 'free -h; echo; cat /proc/swaps'
+
+# Terminal 2: Force swapping
+stress --vm 1 --vm-bytes 90% --vm-keep &
+
+# Terminal 3: Watch specific process swap usage
+for pid in $(pgrep stress); do
+    echo "PID $pid: $(grep VmSwap /proc/$pid/status)"
+done
+```
+
+### Trace swap events
+
+```bash
+# Enable swap tracing
+echo 1 > /sys/kernel/debug/tracing/events/vmscan/mm_vmscan_writepage/enable
+echo 1 > /sys/kernel/debug/tracing/events/swap/swap_readpage/enable
+
+# Watch events
+cat /sys/kernel/debug/tracing/trace_pipe
+```
+
+### Examine swap contents
+
+```bash
+# Per-process swap usage
+for pid in /proc/[0-9]*; do
+    comm=$(cat $pid/comm 2>/dev/null)
+    swap=$(grep VmSwap $pid/status 2>/dev/null | awk '{print $2}')
+    [ "$swap" != "0" ] && [ -n "$swap" ] && echo "$comm: ${swap}kB"
+done | sort -t: -k2 -n -r | head -10
+```
+
+### Test swap in/out explicitly
+
+```bash
+# Allocate memory and force swap
+cat > /tmp/swap_test.c << 'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main() {
+    size_t size = 200 * 1024 * 1024;  // 200MB
+    char *buf = malloc(size);
+
+    // Touch all pages
+    memset(buf, 'A', size);
+    printf("Allocated and touched %zuMB\n", size / 1024 / 1024);
+    printf("Press Enter to trigger memory pressure...\n");
+    getchar();
+
+    // Let system swap it out
+    printf("Sleeping - watch with vmstat...\n");
+    sleep(30);
+
+    // Access again (swap in)
+    printf("Accessing memory (swap in)...\n");
+    volatile char c = buf[0];  // Force access
+
+    printf("Done. Press Enter to exit.\n");
+    getchar();
+    return 0;
+}
+EOF
+gcc -o /tmp/swap_test /tmp/swap_test.c
+/tmp/swap_test
+```
+
+## Key source files
+
+| File | What It Does |
+|------|--------------|
+| [`mm/swapfile.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/swapfile.c) | Swap area management, slot allocation |
+| [`mm/swap_state.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/swap_state.c) | Swap cache operations |
+| [`mm/page_io.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_io.c) | Swap I/O operations |
+| [`mm/memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memory.c) | do_swap_page() - swap-in handling |
+| [`mm/vmscan.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c) | Page reclaim, swap-out path |
+| [`include/linux/swap.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/swap.h) | Swap data structures |
+
+## History
+
+### Swap evolution
+
+**Early Linux**: Basic swap support from the beginning.
+
+**v2.6**: Swap clustering for better sequential I/O.
+
+**v3.11 (2013)**: zswap - compressed swap cache.
+
+**Commit**: [2b2811178e85](https://git.kernel.org/linus/2b2811178e85) ("zswap: add to mm/") | [LKML](https://lore.kernel.org/lkml/1368636374-13292-1-git-send-email-sjenning@linux.vnet.ibm.com/)
+
+**Author**: Seth Jennings (IBM)
+
+In the swap-out flow (Stage 2-3 above), zswap intercepts pages before they hit the swap device. It compresses them and stores them in a RAM pool. Only when the pool fills up do pages get written to the actual swap device. This dramatically reduces swap I/O for compressible workloads.
+
+**v3.14 (2014)**: zram moved from staging to mainline.
+
+**Commit**: [cd67e10ac699](https://git.kernel.org/linus/cd67e10ac699) ("zram: promote zram from staging")
+
+**Author**: Minchan Kim (LG Electronics)
+
+Unlike zswap (which caches before a real swap device), zram *is* the swap device - a compressed RAM disk. The entire swap flow above happens, but the "disk" is actually compressed memory. This is popular on memory-constrained systems like Android phones and Chromebooks.
+
+**v5.8 (2020)**: Swap slot allocation improvements for SSD performance.
+
+**Commit**: [ba81f838aec9](https://git.kernel.org/linus/ba81f838aec9) ("mm/swap: fix race between swapoff and swap_entry_free()") | [LKML](https://lore.kernel.org/linux-mm/20200714140753.97sp5xkgmi4xg2r4@techsingularity.net/)
+
+**Author**: Miaohe Lin
+
+In Stage 1 (slot allocation) above, the kernel now uses a swap slot cache to batch slot allocations, reducing contention on SSDs where swap I/O is fast enough that allocation overhead becomes significant.
+
+### Modern swap improvements
+
+The swap subsystem continues to evolve for better SSD utilization and reduced latency:
+
+- Better slot allocation algorithms
+- Improved swap readahead
+- Integration with memory cgroups for per-cgroup swap accounting
+
+## Notorious bugs and edge cases
+
+Swap involves complex interactions between page tables, swap slots, and caching. Race conditions in this code can cause data corruption or security vulnerabilities.
+
+---
+
+### Case 1: The swap slot ABA problem (CVE-2024-26759)
+
+#### What happened
+
+In early 2024, Huang Ying (Intel) discovered a race condition in the "skip swapcache" optimization path that could cause data corruption.
+
+#### The bug
+
+The [LKML discussion](https://lkml.org/lkml/2024/2/16/426) explains the ABA problem:
+
+When `SWP_SYNCHRONOUS_IO` is enabled (common on fast NVMe drives), the kernel skips the swap cache for performance. But this creates a race:
+
+1. **Thread T0**: Starts swapping in entry X, allocates page A
+2. **Thread T1**: Also starts swapping in entry X (same entry), allocates page B
+3. **Thread T1**: Finishes first, installs page B, frees entry X via `swap_free()`
+4. **Thread T1**: Later swaps out a *modified* page, **reuses** entry X
+5. **Thread T0**: Finishes, sees PTE unchanged (still points to entry X)
+6. **Thread T0**: Installs **stale** page A into PTE
+
+```mermaid
+sequenceDiagram
+    participant T0 as Thread 0
+    participant T1 as Thread 1
+    participant Swap as Swap Slot X
+
+    T0->>Swap: Read entry X → Page A
+    T1->>Swap: Read entry X → Page B
+    T1->>Swap: Installs B, frees X
+    Note over Swap: Slot X is FREE
+    T1->>Swap: Swap out modified page → reuses X
+    Note over Swap: Slot X has NEW data
+    T0->>T0: PTE still says "swap entry X"
+    T0->>T0: Installs STALE page A
+    Note over T0: DATA CORRUPTION!
+```
+
+The PTE value hasn't changed (still `swp_entry_t` for slot X), so the `pte_same()` check passes, but the data is completely different.
+
+#### Real-world implications
+
+This is **silent data corruption** - applications would see old data instead of current data, with no errors reported. Databases, filesystems, or any application relying on data consistency could be affected.
+
+#### The fix
+
+**Commit**: [13ddaf26be32](https://git.kernel.org/linus/13ddaf26be32) ("mm/swap: fix race when skipping swapcache")
+
+**Author**: Kairui Song
+
+The fix adds proper locking and verification to prevent the ABA scenario when bypassing the swap cache.
+
+Fixes commit: [0bcac06f27d7](https://git.kernel.org/linus/0bcac06f27d7) ("mm, swap: skip swapcache for swapin of synchronous device")
+
+---
+
+### Case 2: ZSWAP race conditions
+
+#### What happened
+
+The zswap compressed swap cache introduced concurrency challenges. [LKML bug reports](https://linux.kernel.narkive.com/0AHtSnDW/bug-report-zswap-theoretical-race-condition-issues) documented theoretical races.
+
+#### The bug
+
+When a duplicate store and reclaim happen concurrently:
+
+1. Entry X with offset A exists in zswap
+2. **Thread 0**: Starts reclaiming entry X
+3. **Thread 1**: Stores a *new* page at offset A, allocates new entry Y
+4. **Thread 0**: Calls `zswap_get_swap_cache_page()` but gets the old data
+
+The swap cache now contains old data for offset A instead of the new data.
+
+#### Real-world implications
+
+If `do_swap_page()` retrieves the page from swap cache, it returns stale data - another silent corruption scenario.
+
+#### Mitigations
+
+Zswap has undergone multiple locking improvements to address these races. The interactions between:
+- Zswap entry lifecycle
+- Swap cache operations
+- Page writeback
+
+...all need careful synchronization.
+
+---
+
+### Case 3: Swap-over-NFS instability
+
+#### What happened
+
+Swapping to NFS has historically been problematic. When the system is under memory pressure and needs to swap, it also needs memory for network I/O.
+
+#### The bug
+
+The classic deadlock scenario:
+
+1. System under memory pressure
+2. Kernel tries to swap out pages to NFS
+3. NFS needs to allocate memory for network packets
+4. Memory allocation triggers more reclaim
+5. Deadlock: can't free memory without network, can't do network without memory
+
+#### Mitigations
+
+**`PF_MEMALLOC` and memory reserves**: The kernel reserves memory for critical I/O paths. Processes doing swap I/O can dip into reserves.
+
+**Swap-over-NBD patches**: Commit [c32a8d1eddb0](https://git.kernel.org/linus/c32a8d1eddb0) and related work improved network swap reliability.
+
+**Practical advice**: Don't swap to NFS in production. Use local swap or zram.
+
+---
+
+### Case 4: Swap partition vs. swap file races
+
+#### What happened
+
+Swap files introduce additional complexity compared to swap partitions because the filesystem layer is involved.
+
+#### The bug
+
+With swap files, `swap_writepage()` must go through the filesystem. This can race with:
+- Filesystem operations on the same device
+- Filesystem metadata updates
+- Journal commits
+
+#### Historical issues
+
+- **XFS + swap**: Early XFS had issues with swap files due to delayed allocation
+- **Btrfs + swap**: Only supported swap files from kernel 5.0 due to COW complexity
+- **F2FS**: Added swap file support in kernel 5.10
+
+#### Modern status
+
+Most filesystems now support swap files correctly, but the added complexity means more potential for bugs compared to raw partitions.
+
+---
+
+### Case 5: The swap readahead trap
+
+#### What happened
+
+Swap readahead (reading more than one page on swap-in) is an optimization that can backfire.
+
+#### The problem
+
+Unlike file readahead (where sequential access is common), swap access patterns are often random - especially on systems with many processes. Aggressive swap readahead:
+
+1. Reads pages that won't be used
+2. Evicts useful pages from memory
+3. Increases swap I/O
+4. Makes memory pressure worse
+
+#### The bug class
+
+Readahead tuning issues have caused performance regressions across kernel versions. The heuristics for "should we readahead?" are imperfect.
+
+#### Mitigation
+
+```bash
+# Check current readahead (pages)
+cat /proc/sys/vm/page-cluster
+# Default: 3 (meaning 2^3 = 8 pages readahead)
+
+# Disable swap readahead
+echo 0 > /proc/sys/vm/page-cluster
+
+# On SSDs, readahead matters less (fast random access)
+# On HDDs, readahead helps if access is sequential
+```
+
+---
+
+### Case 6: Large folio + swap = data loss (2023)
+
+#### What happened
+
+The large folio support (kernel 6.1+) introduced a data loss bug affecting XFS and other filesystems. Organizations reported [active data loss](https://lore.kernel.org/linux-mm/CAHk-=wjty_0NfiZn2HVzT0Ye-RR09+Rqbd1azwJLOTJrX+V5MQ@mail.gmail.com/T/) in production.
+
+#### The bug
+
+Large folios change how pages are tracked and written back. Interactions with the swap and writeback paths led to pages being marked clean when they were actually dirty, resulting in data loss.
+
+From the LKML report:
+
+> *"At least 16 instances of data loss in a fleet of 1.5k VMs... happens mostly on nodes running database or storage-oriented workloads, including PostgreSQL, MySQL, RocksDB."*
+
+#### Real-world implications
+
+This is catastrophic for databases and storage systems. Data written to memory but not yet persisted could simply disappear.
+
+#### The fix
+
+Meta and other companies disabled large folios while fixes were developed:
+
+**Commit**: [a48d5bdc877b](https://git.kernel.org/linus/a48d5bdc877b) ("mm: fix for negative counter: nr_file_hugepages")
+
+**Author**: Stefan Roesch
+
+Multiple patches were required to fully address the issue.
+
+---
+
+### Summary: Lessons learned
+
+| Bug | Year | Root Cause | Impact | Prevention |
+|-----|------|------------|--------|------------|
+| **Swap slot ABA** | 2024 | Skip-swapcache race | Data corruption | Fixed in mainline |
+| **ZSWAP races** | Ongoing | Compression + swap cache | Data corruption | Multiple fixes |
+| **Swap-over-NFS** | Historical | Memory deadlock | System hang | Use local swap |
+| **Large folio + swap** | 2023 | Writeback tracking | Data loss | Disable large folios or update kernel |
+| **Readahead trap** | Ongoing | Wrong heuristics | Performance | Tune `page-cluster` |
+
+The common thread: **swap is a "slow path" that gets less testing than the normal memory path**. When the system is under memory pressure, it's already in a degraded state, and bugs in swap handling compound the problem.
+
+## Further reading
+
+### Related docs
+
+- [Swap](swap.md) - Swap configuration and management
+- [Page reclaim](reclaim.md) - How pages are selected for swap
+- [Life of a page](life-of-page.md) - Complete page lifecycle
+- [Running out of memory](oom.md) - What happens when swap isn't enough
+
+### LWN articles
+
+- [In defense of swap](https://lwn.net/Articles/690079/) (2016) - Why swap matters
+- [zswap: compressed swap caching](https://lwn.net/Articles/537422/) (2013) - Compressed swap
+- [Large folios for anonymous memory](https://lwn.net/Articles/908023/) (2022) - The large folio work that led to bugs

--- a/docs/mm/thp.md
+++ b/docs/mm/thp.md
@@ -278,6 +278,121 @@ khugepaged consuming too much CPU.
 - Increase `scan_sleep_millisecs`
 - Reduce `pages_to_scan`
 
+## Notorious bugs and edge cases
+
+THP involves complex operations - collapsing pages, splitting huge pages, handling faults - all while processes continue running. The complexity has led to numerous race conditions and data corruption bugs.
+
+### Case 1: THP COW race (CVE-2020-29368)
+
+#### What happened
+
+Jann Horn (Google Project Zero) discovered that the copy-on-write implementation for THP could grant unintended write access due to a race condition in mapcount checking.
+
+#### The bug
+
+When splitting a huge PMD during a COW fault, the kernel checks if the page is shared by examining `mapcount`. But this check races with other operations - another thread can map the same page between the check and the page table modification.
+
+#### The fix
+
+**Commit**: [c444eb564fb1](https://git.kernel.org/linus/c444eb564fb1) ("mm: thp: make the THP mapcount atomic against __split_huge_pmd_locked()")
+
+**Author**: Jann Horn
+
+---
+
+### Case 2: khugepaged collapse races
+
+#### What happened
+
+The khugepaged daemon scans memory looking for 512 contiguous 4KB pages to collapse into a 2MB huge page. This background operation races with application activity.
+
+#### The bug class
+
+Multiple bugs have been found in khugepaged collapse:
+- Race with concurrent page faults
+- Race with munmap
+- Race with madvise(MADV_DONTNEED)
+
+#### Mitigations in modern kernels
+
+- Better locking protocols between khugepaged and fault paths
+- Page lock held during critical sections
+- Validation after acquiring locks
+
+---
+
+### Case 3: khugepaged CPU storms
+
+#### What happened
+
+Under certain conditions, khugepaged can consume excessive CPU time, impacting application performance.
+
+#### The bug
+
+khugepaged continuously scans for collapsible pages. When conditions prevent collapse but appear promising (e.g., 500 of 512 pages present), it keeps retrying wastefully.
+
+#### Tuning
+
+```bash
+# Reduce scan frequency
+echo 60000 > /sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs
+
+# Or disable
+echo 0 > /sys/kernel/mm/transparent_hugepage/khugepaged/defrag
+```
+
+---
+
+### Case 4: THP split failures
+
+#### What happened
+
+When a huge page needs to be split (e.g., for partial munmap), the split can fail, leaving the system in an unexpected state.
+
+#### The bug class
+
+Splitting requires allocating 511 additional page descriptors and updating all PTEs. Failure scenarios include memory exhaustion and inability to freeze the page.
+
+#### Mitigations
+
+Modern kernels handle split failures more gracefully with retry logic and fallback paths.
+
+---
+
+### Case 5: THP and NUMA balancing conflicts
+
+#### What happened
+
+THP interacts poorly with NUMA balancing, which tries to move pages closer to the CPUs accessing them.
+
+#### The bug
+
+NUMA balancing marks pages inaccessible to catch faults and migrate. With 2MB THP, any access to any 4KB within triggers migration of the entire 2MB, causing thrashing between nodes.
+
+#### Tuning
+
+```bash
+# Disable NUMA balancing (if THP is more valuable)
+echo 0 > /proc/sys/kernel/numa_balancing
+
+# Or disable THP
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+---
+
+### Summary: Lessons learned
+
+| Bug | Year | Root Cause | Impact |
+|-----|------|------------|--------|
+| CVE-2020-29368 | 2020 | Mapcount race | COW bypass |
+| khugepaged races | Ongoing | Lock ordering | Corruption |
+| CPU storms | Ongoing | Aggressive scanning | Performance |
+| Split failures | Ongoing | Resource exhaustion | ENOMEM |
+| NUMA thrashing | Ongoing | Design conflict | Performance |
+
+**The pattern**: THP bugs stem from concurrent operations on the same memory. The optimization requires complex coordination that is difficult to get right.
+
 ## References
 
 ### Key Code
@@ -301,3 +416,4 @@ khugepaged consuming too much CPU.
 - [page-tables](page-tables.md) - PMD-level huge page mapping
 - [compaction](compaction.md) - Memory defragmentation for THP
 - [reclaim](reclaim.md) - THP and memory pressure
+- [Bug Index](bugs/README.md) - Index of all mm kernel bugs

--- a/docs/site-index.md
+++ b/docs/site-index.md
@@ -56,6 +56,17 @@ A complete listing of all documentation, organized by topic.
 | [KSM](mm/ksm.md) | Page deduplication for VMs |
 | [vrealloc](mm/vrealloc.md) | Resizing vmalloc allocations |
 
+### Lifecycle
+
+| Page | Description |
+|------|-------------|
+| [Life of a malloc](mm/life-of-malloc.md) | Tracing malloc() from userspace to physical pages |
+| [Life of a page](mm/life-of-page.md) | A physical page's journey through allocation, use, and reclaim |
+| [What happens when you fork](mm/fork.md) | COW setup, page table copying, and COW fault handling |
+| [Running out of memory](mm/oom.md) | Watermarks, kswapd, direct reclaim, and OOM killer |
+| [Life of a file read](mm/life-of-read.md) | How read() flows through the page cache |
+| [What happens during swapping](mm/swapping.md) | Swap-out and swap-in mechanics in detail |
+
 ### Explainers
 
 | Page | Description |
@@ -65,6 +76,15 @@ A complete listing of all documentation, organized by topic.
 | [brk vs mmap](mm/brk-vs-mmap.md) | Two ways to get memory from the kernel |
 | [Contiguous Memory](mm/contiguous-memory.md) | Why large allocations fail despite free memory |
 | [Copy-on-Write](mm/cow.md) | COW edge cases and when it breaks |
+
+### Bugs
+
+| Page | Description |
+|------|-------------|
+| [Bug Index](mm/bugs/README.md) | Catalog of notable mm bugs, CVEs, and edge cases |
+| [SLUB Bugs](mm/slab.md#notorious-bugs-and-edge-cases) | Heap exploitation (CVE-2021-22555, CVE-2022-29582) |
+| [THP Bugs](mm/thp.md#notorious-bugs-and-edge-cases) | CVE-2020-29368, khugepaged races, collapse bugs |
+| [Page Table Bugs](mm/page-tables.md#notorious-bugs-and-edge-cases) | Meltdown, Spectre, TLB flush races |
 
 ### Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,11 +93,20 @@ nav:
       - Compaction: mm/compaction.md
       - KSM: mm/ksm.md
       - vrealloc: mm/vrealloc.md
+    - Lifecycle:
+      - Life of a malloc: mm/life-of-malloc.md
+      - Life of a page: mm/life-of-page.md
+      - What happens when you fork: mm/fork.md
+      - Running out of memory: mm/oom.md
+      - Life of a file read: mm/life-of-read.md
+      - What happens during swapping: mm/swapping.md
     - Explainers:
       - Virtual vs Physical vs Resident: mm/virtual-physical-resident.md
       - Memory Overcommit: mm/overcommit.md
       - brk vs mmap: mm/brk-vs-mmap.md
       - Contiguous Memory: mm/contiguous-memory.md
       - Copy-on-Write: mm/cow.md
+    - Bugs:
+      - Bug Index: mm/bugs/README.md
     - Reference:
       - Glossary: mm/glossary.md


### PR DESCRIPTION
## Summary

Add six narrative walkthroughs to the memory management documentation, tracing memory operations end-to-end through the kernel:

- **Life of a malloc** - Traces `malloc()` from userspace through glibc, brk/mmap syscalls, VMA creation, page fault, to physical page allocation
- **Life of a page** - Follows a physical page from buddy allocator through active use, LRU tracking, reclaim decision, and potential swap
- **What happens when you fork** - Covers COW setup during `fork()`, page table duplication, and COW fault handling with TLB considerations
- **Running out of memory** - Documents the progression through watermarks, kswapd, direct reclaim, and OOM killer
- **Life of a file read** - Traces `read()` through VFS, page cache lookup, readahead, and copy to userspace
- **What happens during swapping** - Details swap-out (slot allocation, write, PTE update) and swap-in (fault handling, readahead) mechanics

Each document follows the established contribution guidelines:
- Links to kernel source files on git.kernel.org
- References to relevant commits and LKML discussions
- Mermaid diagrams illustrating data structures and flow
- Practical "Try it yourself" sections
- History sections covering subsystem evolution

Closes #129 (mm-lifecycle epic)
Closes #19, #20, #21, #22, #23, #24

## Test plan

- [x] `mkdocs build` passes
- [x] All internal links resolve correctly
- [x] Navigation updated in mkdocs.yml
- [x] Index pages (README.md, site-index.md) updated