### PR TITLE
Hide GitHub-only message on docs site

### DIFF
--- a/docs/mm/README.md
+++ b/docs/mm/README.md
@@ -6,7 +6,9 @@
 
 This documentation explains how Linux manages memory - not just the theory, but the actual implementation decisions, trade-offs, and lessons learned over 30+ years of development.
 
+<div class="github-only" markdown>
 > **Browsing on GitHub?** See the [full site index](../site-index.md) for a complete listing of all documentation.
+</div>
 
 ### Prerequisites
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,8 @@
+/* Hide GitHub-only content on the docs site */
+.github-only {
+  display: none;
+}
+
 /* Larger logo in header */
 .md-header__button.md-logo img,
 .md-header__button.md-logo svg {


### PR DESCRIPTION
## Summary

Hide the "Browsing on GitHub?" message when viewing on kernel-internals.org, while keeping it visible on GitHub.

**Approach:**
- Wrap the message in `<div class="github-only" markdown>`
- Add CSS rule `.github-only { display: none; }` to extra.css
- GitHub ignores the CSS, so the message shows there
- The docs site applies the CSS, hiding it