### PR TITLE
Add KASAN and KFENCE documentation

### DIFF
--- a/docs/mm/kasan.md
+++ b/docs/mm/kasan.md
@@ -1,0 +1,352 @@
+# KASAN (Kernel Address Sanitizer)
+
+> Detecting memory bugs in the kernel at runtime
+
+## What Is KASAN?
+
+KASAN is a dynamic memory error detector for the Linux kernel. It catches bugs that are notoriously hard to find through code review or normal testing:
+
+- **Out-of-bounds access**: Reading or writing past the end of an allocated object
+- **Use-after-free**: Accessing memory after it has been freed
+- **Double-free**: Freeing the same object twice
+- **Invalid-free**: Freeing a pointer that was never allocated
+
+These bugs cause silent data corruption, random crashes, and security vulnerabilities. Without a tool like KASAN, they can lurk in the kernel for years. A use-after-free in the kernel is especially dangerous because attackers can reclaim the freed object with controlled data, turning a memory bug into arbitrary code execution.
+
+KASAN instruments every memory access the compiler generates, inserting checks that verify the accessed memory is valid. When it detects a violation, it prints a detailed report identifying the bug type, the offending access, and the allocation/deallocation history of the involved object.
+
+## How KASAN Works
+
+### The Three Modes
+
+KASAN has three modes, each with different trade-offs between coverage, performance, and hardware requirements:
+
+| Mode | Config Option | Mechanism | Overhead | Use Case |
+|------|--------------|-----------|----------|----------|
+| Generic KASAN | `CONFIG_KASAN_GENERIC` | Shadow memory | ~2x slowdown, 1/8 memory | Development and CI testing |
+| SW_TAGS KASAN | `CONFIG_KASAN_SW_TAGS` | Software memory tagging | ~1.5x slowdown | Broader testing (arm64 only) |
+| HW_TAGS KASAN | `CONFIG_KASAN_HW_TAGS` | ARM MTE hardware tagging | ~5-10% overhead | Production-like testing, dogfooding |
+
+### Generic KASAN: Shadow Memory
+
+Generic KASAN is the most widely used mode. It works by maintaining a **shadow memory** region that tracks the validity of every byte of kernel memory.
+
+The key insight: one shadow byte can encode the state of eight real bytes.
+
+```
+Real memory (8-byte granule):
+┌───┬───┬───┬───┬───┬───┬───┬───┐
+│ 0 │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │  ← 8 bytes of kernel memory
+└───┴───┴───┴───┴───┴───┴───┴───┘
+                │
+                │  maps to
+                ▼
+         ┌───────────┐
+         │ shadow[N] │  ← 1 byte of shadow memory
+         └───────────┘
+```
+
+**Shadow byte encoding**:
+
+| Shadow Value | Meaning |
+|-------------|---------|
+| `0x00` | All 8 bytes are valid (accessible) |
+| `0x01`-`0x07` | Only the first N bytes are valid (partial granule) |
+| `0xFC` | KASAN internal redzone (between slab objects) |
+| `0xFB` | Object freed (use-after-free detection) |
+| `0xFE` | KASAN-specific redzone (object padding) |
+| `0xF1` | Left redzone (before slab object) |
+| `0xF2` | Right redzone (after slab object) |
+| `0xF8` | kmalloc free shadow (freed kmalloc region) |
+
+For every memory access, the compiler inserts a check:
+
+```
+1. Compute shadow address:  shadow_addr = (addr >> 3) + KASAN_SHADOW_OFFSET
+2. Load shadow byte:        shadow_val  = *shadow_addr
+3. If shadow_val != 0:
+     a. If accessing all 8 bytes → BUG (invalid access)
+     b. If partial access: check if (addr & 7) + size > shadow_val → BUG
+4. Otherwise: access is valid, proceed
+```
+
+This means every 8-byte load or store compiles into roughly 5-10 extra instructions. The shadow memory itself consumes 1/8 of the total kernel address space.
+
+```
+Kernel address space layout with KASAN:
+
+┌──────────────────────────┐  High addresses
+│    Kernel code/data      │
+├──────────────────────────┤
+│    Shadow memory          │  ← 1/8 of kernel address space
+│    (tracks validity of    │
+│     all kernel memory)    │
+├──────────────────────────┤
+│    Normal kernel memory   │
+└──────────────────────────┘  Low addresses
+```
+
+### SW_TAGS KASAN: Software Memory Tagging
+
+SW_TAGS KASAN uses a different approach: instead of tracking per-byte validity, it assigns random **tags** to memory allocations and pointers. On each access, it checks that the pointer tag matches the memory tag.
+
+```
+Tagged pointer (arm64 Top Byte Ignore):
+┌────────┬──────────────────────────────────────────────┐
+│ Tag(8) │              Virtual Address (56)             │
+└────────┴──────────────────────────────────────────────┘
+
+Shadow memory stores the memory tag (1 byte per 16 bytes of real memory).
+
+Access check:
+  pointer_tag = ptr >> 56
+  memory_tag  = shadow[addr >> 4]
+  if pointer_tag != memory_tag → BUG
+```
+
+This relies on arm64's Top Byte Ignore (TBI) feature, which ignores the top byte of pointers during address translation. The kernel stores a random tag in that top byte.
+
+When memory is freed, a new random tag is assigned to the shadow. The old pointer still carries the old tag, so any use-after-free will likely be caught (with probability 1 - 1/256 per access, since tags are 8 bits).
+
+### HW_TAGS KASAN: Hardware Memory Tagging (ARM MTE)
+
+HW_TAGS KASAN uses ARM Memory Tagging Extension (MTE), available on ARMv8.5+ processors. MTE implements the same tag-checking concept entirely in hardware:
+
+- The CPU stores a 4-bit tag in every 16-byte memory granule (using dedicated tag storage in the memory controller)
+- Pointers carry a 4-bit tag in bits [59:56]
+- The CPU checks tags on every memory access with **zero additional instructions**
+
+```
+ARM MTE:
+┌──────────┬─────────────────────────────────────────────┐
+│ Tag(4)   │              Virtual Address (60)            │
+└──────────┴─────────────────────────────────────────────┘
+        │                        │
+        │   hardware checks      │
+        ▼                        ▼
+   pointer tag  ==?  memory tag (stored in DRAM tag bits)
+        │
+        └── mismatch → hardware exception
+```
+
+The major advantage: overhead drops from 2x (Generic) to roughly 5-10%, making it viable for production testing and even dogfooding on real hardware. The trade-off is a coarser tag space (4 bits = 16 possible tags, so ~6% chance of missing a bug per access) and the requirement for MTE-capable hardware.
+
+## What a KASAN Report Looks Like
+
+When KASAN detects a bug, it prints a report to the kernel log. Here is a realistic example of a slab-out-of-bounds access:
+
+```
+==================================================================
+BUG: KASAN: slab-out-of-bounds in example_function+0x58/0x90
+Write of size 4 at addr ffff888012345678 by task insmod/1234
+
+CPU: 2 PID: 1234 Comm: insmod Not tainted 6.8.0-kasan #1
+Hardware name: QEMU Standard PC (Q35 + ICH9, 2009)
+Call trace:
+ dump_backtrace+0x0/0x30
+ show_stack+0x18/0x28
+ dump_stack_lvl+0x48/0x60
+ print_report+0xd0/0x520
+ kasan_report+0xa8/0xe0
+ example_function+0x58/0x90           ← the buggy access
+ test_module_init+0x30/0x48
+ do_one_initcall+0x80/0x2a0
+
+Allocated by task 1234:
+ kmalloc_trace+0x28/0x40
+ example_function+0x20/0x90           ← where the object was allocated
+ test_module_init+0x30/0x48
+ do_one_initcall+0x80/0x2a0
+
+The buggy address belongs to the object at ffff888012345660
+ which belongs to the cache kmalloc-32 of size 32
+The buggy address is located 24 bytes to the right of
+ allocated 32-byte region [ffff888012345660, ffff888012345680)
+
+Memory state around the buggy address:
+ ffff888012345500: fb fb fb fb fc fc fc fc 00 00 00 00 fc fc fc fc
+ ffff888012345580: fb fb fb fb fc fc fc fc 00 00 00 00 fc fc fc fc
+>ffff888012345600: 00 00 00 00 fc fc fc fc 00 00 00 00 fc fc fc fc
+                                                       ^
+ ffff888012345680: fc fc fc fc fb fb fb fb fc fc fc fc 00 00 00 00
+ ffff888012345700: fc fc fc fc fb fb fb fb fc fc fc fc 00 00 00 00
+==================================================================
+```
+
+**Reading the report**:
+
+1. **Bug type**: `slab-out-of-bounds` -- the access went past the end of a slab object
+2. **Access details**: A 4-byte write at address `ffff888012345678`
+3. **Call trace**: Shows exactly where the bad access happened (`example_function+0x58`)
+4. **Allocation trace**: Shows where the object was originally allocated
+5. **Object details**: The object is in `kmalloc-32` (a 32-byte slab cache), and the access was 24 bytes past the end of the 32-byte allocation
+6. **Shadow memory dump**: The `^` marker points to the shadow byte corresponding to the buggy address. `fc` means KASAN redzone -- the code wrote into the padding between slab objects
+
+## Enabling KASAN
+
+### Kernel Configuration
+
+```
+# Enable KASAN (pick one mode)
+CONFIG_KASAN=y
+
+# Generic mode (works on all architectures with compiler support)
+CONFIG_KASAN_GENERIC=y
+
+# OR: Software tag-based mode (arm64 only)
+CONFIG_KASAN_SW_TAGS=y
+
+# OR: Hardware tag-based mode (arm64 with MTE only)
+CONFIG_KASAN_HW_TAGS=y
+
+# Recommended companion options
+CONFIG_KASAN_INLINE=y        # Inline checks (faster than outline)
+CONFIG_STACKTRACE=y          # Better stack traces in reports
+CONFIG_SLUB_DEBUG=y          # Enhanced slab debugging info
+```
+
+### Build Requirements
+
+Generic KASAN requires GCC 8.3+ or Clang 7+. The compiler must support `-fsanitize=kernel-address` (Generic) or `-fsanitize=kernel-hwaddress` (SW_TAGS).
+
+```bash
+# Building a KASAN-enabled kernel
+make defconfig
+./scripts/config -e KASAN -e KASAN_GENERIC -e KASAN_INLINE
+make -j$(nproc)
+```
+
+### Boot-Time Options
+
+```bash
+# For HW_TAGS mode: enable/disable at boot
+kasan.mode=on          # Enable (default)
+kasan.mode=off         # Disable
+kasan.stacktrace=on    # Collect alloc/free stack traces
+kasan.fault=report     # Report but don't panic (default)
+kasan.fault=panic      # Panic on first KASAN error
+```
+
+## Try It Yourself
+
+### Trigger a KASAN Report in QEMU
+
+The kernel includes a built-in test module for KASAN:
+
+```bash
+# Boot a KASAN-enabled kernel in QEMU, then:
+
+# Load the KASAN test module
+modprobe kasan_test
+
+# Or run specific tests via KUnit
+# (KASAN tests are in lib/test_kasan.c / mm/kasan/kasan_test.c)
+./tools/testing/kunit/kunit.py run --kunitconfig=mm/kasan/kasan_test.c
+```
+
+### Check If KASAN Is Active
+
+```bash
+# Check kernel config
+zcat /proc/config.gz | grep KASAN
+
+# Check boot messages
+dmesg | grep -i kasan
+```
+
+### Read KASAN Reports
+
+```bash
+# Watch for KASAN reports in real time
+dmesg -w | grep -A 30 "BUG: KASAN"
+```
+
+## Performance Overhead
+
+| Mode | CPU Overhead | Memory Overhead | Detection Probability |
+|------|-------------|-----------------|----------------------|
+| Generic | ~2x slowdown | 1/8 of kernel memory for shadow | 100% -- deterministic |
+| SW_TAGS | ~1.5x slowdown | 1/16 of kernel memory for shadow | ~99.6% per access (1/256 miss rate) |
+| HW_TAGS | ~5-10% | Hardware tag storage | ~93.75% per access (1/16 miss rate) |
+
+Generic mode has the highest overhead but catches everything. It is the standard choice for kernel CI systems and development builds. HW_TAGS mode is fast enough that Google uses it for testing on production Android devices with MTE-capable hardware.
+
+## History
+
+### v4.0: Introduction (2015)
+
+**Commit**: [0b24becc8105](https://git.kernel.org/linus/0b24becc8105) ("kasan: add kernel address sanitizer infrastructure")
+
+**Author**: Andrey Ryabinin (Samsung/Google)
+
+KASAN was inspired by AddressSanitizer (ASan) for userspace, created by Konstantin Serebryany at Google. Andrey Ryabinin adapted the concept for the Linux kernel, using compiler instrumentation and shadow memory. The initial implementation supported x86_64 only.
+
+**LWN coverage**: [The kernel address sanitizer](https://lwn.net/Articles/612153/) (2014)
+
+### v5.11: Software Tag-Based Mode (2021)
+
+**Commit**: [3c9e3aa11380](https://git.kernel.org/linus/3c9e3aa11380) ("kasan: add CONFIG_KASAN_GENERIC and CONFIG_KASAN_SW_TAGS")
+
+**Author**: Andrey Konovalov (Google)
+
+SW_TAGS KASAN introduced memory tagging in software, leveraging arm64's Top Byte Ignore feature. This mode trades some detection accuracy for significantly lower overhead, aimed at broader testing scenarios.
+
+**LWN coverage**: [Tag-based KASAN](https://lwn.net/Articles/766768/) (2018)
+
+### v5.12: Hardware Tag-Based Mode (2021)
+
+**Commit**: [2e903b914797](https://git.kernel.org/linus/2e903b914797) ("kasan, arm64: implement HW_TAGS runtime")
+
+**Author**: Andrey Konovalov (Google)
+
+HW_TAGS mode leverages ARM Memory Tagging Extension (MTE) to perform tag checks in hardware, reducing overhead to near-zero. This was a major step toward making KASAN viable for production-like environments.
+
+**LWN coverage**: [Arm Memory Tagging Extension and KASAN](https://lwn.net/Articles/834289/) (2020)
+
+### v5.12: KASAN Boot Parameters
+
+**Commit**: [1f600626bc50](https://git.kernel.org/linus/1f600626bc50) ("kasan, mm: allow cache merging with no metadata")
+
+HW_TAGS mode introduced boot-time parameters (`kasan.mode`, `kasan.stacktrace`, `kasan.fault`) to allow enabling/disabling KASAN without recompilation, which is essential for production use.
+
+### Ongoing: KASAN for More Subsystems
+
+KASAN has been progressively extended to cover more kernel memory:
+
+- Stack variables (Generic mode, via compiler instrumentation)
+- Global variables (Generic mode)
+- vmalloc allocations (added in v5.4 by Daniel Axtens)
+- DMA and memory-mapped I/O regions
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| [`mm/kasan/`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan) | KASAN implementation directory |
+| [`mm/kasan/common.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/common.c) | Code shared across all modes (hooks into slab allocator, poisoning) |
+| [`mm/kasan/generic.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/generic.c) | Generic (shadow memory) mode implementation |
+| [`mm/kasan/sw_tags.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/sw_tags.c) | Software tag-based mode |
+| [`mm/kasan/hw_tags.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/hw_tags.c) | Hardware tag-based mode (ARM MTE) |
+| [`mm/kasan/report.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/report.c) | Bug report formatting and printing |
+| [`mm/kasan/quarantine.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/quarantine.c) | Quarantine for freed objects (delays reuse to catch use-after-free) |
+| [`mm/kasan/shadow.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/shadow.c) | Shadow memory management |
+| [`include/linux/kasan.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/kasan.h) | KASAN public API and inline hooks |
+| [`mm/kasan/kasan.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/kasan.h) | Internal KASAN definitions and shadow value constants |
+
+## Further Reading
+
+### Kernel Documentation
+
+- [KASAN official documentation](https://docs.kernel.org/dev-tools/kasan.html) -- comprehensive guide covering all three modes, configuration, and interpretation of reports
+
+### LWN Articles
+
+- [The kernel address sanitizer](https://lwn.net/Articles/612153/) -- original coverage (2014)
+- [Tag-based KASAN](https://lwn.net/Articles/766768/) -- SW_TAGS mode design (2018)
+- [Arm Memory Tagging Extension and KASAN](https://lwn.net/Articles/834289/) -- HW_TAGS mode (2020)
+
+### Related
+
+- [slab](slab.md) -- KASAN instruments slab allocator hooks to track allocations and frees
+- [vmalloc](vmalloc.md) -- KASAN also covers vmalloc memory regions
+- [vrealloc](vrealloc.md) -- KASAN poisoning bugs found during vrealloc development

--- a/docs/mm/kfence.md
+++ b/docs/mm/kfence.md
@@ -1,0 +1,366 @@
+# KFENCE (Kernel Electric Fence)
+
+> Low-overhead sampling-based heap bug detection for production kernels
+
+## What Is KFENCE?
+
+KFENCE is a lightweight memory error detector that catches heap out-of-bounds accesses, use-after-free bugs, and invalid-free errors in the kernel. Unlike full-blown sanitizers that instrument every memory access, KFENCE uses a **sampling-based** approach: it only protects a small fraction of allocations at any time, relying on statistical probability to catch bugs over hours or days of uptime.
+
+The key insight is that bugs that happen frequently in production will eventually hit a KFENCE-protected allocation, even if only 1 in every ~10,000 allocations is protected. This makes KFENCE practical for always-on deployment where KASAN would be prohibitively expensive.
+
+## Why KFENCE Exists
+
+### The Gap Between Testing and Production
+
+Before KFENCE, kernel developers faced a dilemma:
+
+| Tool | Overhead | Where It Runs | Bug Coverage |
+|------|----------|---------------|--------------|
+| KASAN (generic) | ~2-3x slowdown, 1.5-3x memory | CI, testing | Every allocation |
+| KASAN (SW/HW tag) | ~10-50% slowdown | Testing, some hardware | Every allocation |
+| Nothing | 0% | Production | None |
+
+Many heap bugs only manifest under real production workloads -- specific timing, memory pressure, or access patterns that are hard to reproduce in test environments. KFENCE fills this gap: it runs in production with near-zero overhead, catching bugs that would otherwise go undetected until they cause data corruption or crashes.
+
+### Real-World Motivation
+
+Google developed KFENCE after running KASAN-like detection internally and finding that:
+
+1. Many bugs only appeared on production machines under real traffic
+2. Full sanitizer overhead was unacceptable for production fleets
+3. Even a low sampling rate catches high-frequency bugs quickly
+
+## How It Differs from KASAN
+
+```
+KASAN (always-on):
+  Every allocation → instrumented → checked on every access
+  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐
+  │shadow│ │shadow│ │shadow│ │shadow│ │shadow│  ← shadow memory for ALL
+  └──────┘ └──────┘ └──────┘ └──────┘ └──────┘
+
+KFENCE (sampling):
+  1 in ~N allocations → placed in guarded pool → hardware trap on error
+  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐
+  │normal│ │normal│ │KFENCE│ │normal│ │normal│  ← only some protected
+  └──────┘ └──────┘ │guard │ └──────┘ └──────┘
+                     │pages │
+                     └──────┘
+```
+
+| Aspect | KASAN | KFENCE |
+|--------|-------|--------|
+| Detection | Deterministic (every access) | Probabilistic (sampled) |
+| Overhead | 2-3x CPU, 1.5-3x memory | < 1% CPU, fixed ~2MB memory |
+| Deployment | Testing, CI | Production, always-on |
+| Mechanism | Shadow memory + compiler instrumentation | Guard pages + hardware page faults |
+| Coverage | All allocations | Small rotating subset |
+| Configuration | Compile-time only | Runtime tunable via sysfs |
+
+## How It Works
+
+### The Object Pool
+
+KFENCE pre-allocates a fixed pool of memory at boot time. By default, this pool holds space for 255 objects. The pool is laid out with **guard pages** between every object slot:
+
+```
+KFENCE pool layout:
+
+  ┌───────┐ ┌────────┐ ┌───────┐ ┌────────┐ ┌───────┐ ┌────────┐ ┌───────┐
+  │ guard │ │ object │ │ guard │ │ object │ │ guard │ │ object │ │ guard │
+  │ page  │ │ page   │ │ page  │ │ page   │ │ page  │ │ page   │ │ page  │
+  │ (no   │ │        │ │ (no   │ │        │ │ (no   │ │        │ │ (no   │
+  │access)│ │        │ │access)│ │        │ │access)│ │        │ │access)│
+  └───────┘ └────────┘ └───────┘ └────────┘ └───────┘ └────────┘ └───────┘
+  unmapped   mapped     unmapped   mapped     unmapped   mapped     unmapped
+```
+
+Each object slot is a full page (4KB on x86), but the actual object is placed at either the **left edge** or **right edge** of the page:
+
+- **Right-aligned**: object placed at end of page, so out-of-bounds access to the right hits the guard page immediately
+- **Left-aligned**: object placed at start of page, so out-of-bounds access to the left hits the guard page
+
+KFENCE alternates alignment to catch both left and right overflows.
+
+### The Sampling Mechanism
+
+KFENCE does not intercept every `kmalloc()` or `kmem_cache_alloc()` call. Instead, it uses a **timer-based sampling interval**:
+
+1. A static branch (normally not taken) is toggled on a timer
+2. When toggled on, the **next** allocation is redirected to the KFENCE pool
+3. After one allocation is captured, the static branch is toggled off
+4. The timer fires again after the configured interval (default: 100ms)
+
+```
+Time →
+  ─────────────────────────────────────────────────────────────
+  │         │ sample │         │ sample │         │ sample │
+  │  normal │  one   │  normal │  one   │  normal │  one   │
+  │  allocs │ alloc  │  allocs │ alloc  │  allocs │ alloc  │
+  ─────────────────────────────────────────────────────────────
+             ↑ 100ms  ↑         ↑ 100ms  ↑
+            timer    captured   timer    captured
+```
+
+This approach ensures near-zero overhead during normal operation. The static branch (`static_branch_unlikely`) compiles to a NOP in the fast path, meaning zero cost for the 99.99%+ of allocations that are not sampled.
+
+### Detecting Bugs
+
+When a KFENCE-protected allocation is misused, the hardware MMU does the detection:
+
+**Out-of-bounds access**: The access hits an unmapped guard page, triggering a page fault. The KFENCE fault handler identifies the faulting address, finds the nearest KFENCE object, and reports the overflow or underflow.
+
+**Use-after-free**: When an object is freed, its page is unmapped (protection set to `PROT_NONE`). Any subsequent access triggers a page fault. KFENCE keeps metadata about the freed object (including the free stack trace) so it can report what was freed and when.
+
+**Invalid free**: When `kfree()` is called on a KFENCE address, KFENCE validates the pointer. Double-frees and invalid pointers are caught and reported.
+
+## What a KFENCE Report Looks Like
+
+When KFENCE detects a bug, it prints a detailed report to the kernel log. Here is an annotated example of an out-of-bounds write:
+
+```
+==================================================================
+BUG: KFENCE: out-of-bounds write in driver_probe+0x84/0x120      ← Bug type and location
+
+Out-of-bounds write at 0xffff8881045ab000 (1 byte(s) to the right ← Faulting address and
+ of kfence-#72):                                                     which KFENCE slot
+ driver_probe+0x84/0x120                                          ← Stack trace of the
+ really_probe+0x170/0x3e0                                            bad access
+ __driver_probe_device+0x78/0x160
+ driver_probe_device+0x1e/0x90
+ bus_for_each_drv+0x84/0xe0
+
+kfence-#72: 0xffff8881045aafe0-0xffff8881045aafff, size=32,       ← Object details:
+ cache=kmalloc-32                                                    address range, size,
+                                                                     slab cache name
+
+allocated by task 1234 on cpu 3 at 42.010s:                       ← Allocation stack trace
+ kmalloc+0x2e/0x40                                                   with task, CPU, and
+ driver_init+0x30/0x80                                               timestamp
+ do_init_module+0x50/0x200
+ load_module+0x2a4c/0x2e70
+ __do_sys_finit_module+0xac/0x120
+ do_syscall_64+0x5c/0xf0
+==================================================================
+```
+
+For use-after-free bugs, the report also includes the **free stack trace**, showing where the object was freed:
+
+```
+==================================================================
+BUG: KFENCE: use-after-free read in corrupt_data+0x28/0x40
+
+Use-after-free read at 0xffff8881045ab000 (4 byte(s)):
+ corrupt_data+0x28/0x40
+ test_function+0x60/0x90
+
+kfence-#51: 0xffff8881045a6fe0-0xffff8881045a6fff, size=32,
+ cache=kmalloc-32
+
+allocated by task 789 on cpu 1 at 18.500s:
+ kmalloc+0x2e/0x40
+ setup_object+0x24/0x60
+
+freed by task 789 on cpu 1 at 19.200s:                            ← Free stack trace
+ kfree+0x4e/0x60                                                     helps you find the
+ cleanup_object+0x1c/0x40                                            premature free
+ work_handler+0x80/0xa0
+==================================================================
+```
+
+These reports provide enough information to diagnose the root cause: you can see exactly what object was involved, how big it was, which slab cache it came from, and the full call stacks for allocation, free, and the offending access.
+
+## Configuration
+
+### Build-Time Options
+
+Enable KFENCE in your kernel config:
+
+```
+CONFIG_KFENCE=y
+```
+
+This is the only required option. KFENCE is designed to be enabled by default in distribution kernels.
+
+Optional build-time settings:
+
+| Config Option | Default | Description |
+|---------------|---------|-------------|
+| `CONFIG_KFENCE` | n | Enable KFENCE |
+| `CONFIG_KFENCE_SAMPLE_INTERVAL` | 100 | Default sampling interval in milliseconds |
+| `CONFIG_KFENCE_NUM_OBJECTS` | 255 | Number of objects in the KFENCE pool |
+| `CONFIG_KFENCE_STRESS_TEST_FAULTS` | 0 | Inject faults for testing KFENCE itself |
+
+### Runtime Tuning
+
+The sampling interval can be adjusted at runtime without rebooting:
+
+```bash
+# Check current sampling interval (milliseconds)
+cat /sys/module/kfence/parameters/sample_interval
+
+# Increase interval (less overhead, fewer catches)
+echo 500 > /sys/module/kfence/parameters/sample_interval
+
+# Decrease interval (more overhead, more catches)
+echo 50 > /sys/module/kfence/parameters/sample_interval
+
+# Disable KFENCE at runtime
+echo 0 > /sys/module/kfence/parameters/sample_interval
+```
+
+### Boot Parameters
+
+You can also set the interval at boot:
+
+```
+kfence.sample_interval=200
+```
+
+## Performance Characteristics
+
+### Why It Is Safe for Production
+
+KFENCE was designed from the ground up for production use:
+
+**Near-zero fast-path overhead**: The sampling check uses a static branch that compiles to a NOP instruction. On x86, this means zero additional instructions in the allocation fast path when KFENCE is not sampling (which is >99.99% of the time).
+
+**Fixed memory cost**: The KFENCE pool is allocated at boot and has a fixed size. With the default 255 objects, the pool consumes roughly 2MB (255 object pages + 256 guard pages = 511 pages). This does not grow.
+
+**No compiler instrumentation**: Unlike KASAN, KFENCE does not require compiler support or code changes. It works with any compiler and does not increase code size.
+
+**No shadow memory**: KASAN requires shadow memory proportional to total system memory (typically 1/8th of RAM). KFENCE uses only its fixed pool regardless of system memory size.
+
+| Metric | KASAN (generic) | KFENCE |
+|--------|-----------------|--------|
+| CPU overhead | 100-200% | < 1% |
+| Memory overhead | ~12.5% of RAM | ~2MB fixed |
+| Code size increase | Significant | None |
+| Production safe | No | Yes |
+
+### The Trade-off
+
+The cost of low overhead is **probabilistic detection**. KFENCE will not catch every bug immediately. A bug must hit a KFENCE-protected allocation to be detected. For bugs that occur frequently (e.g., on every call to a specific function), detection typically happens within minutes to hours. Rare bugs may take days or weeks, but they will eventually be caught if the system runs long enough.
+
+## Try It Yourself
+
+### Check if KFENCE Is Enabled
+
+```bash
+# Check kernel config
+zcat /proc/config.gz 2>/dev/null | grep KFENCE || grep KFENCE /boot/config-$(uname -r)
+
+# Check if KFENCE is active (non-zero interval means active)
+cat /sys/module/kfence/parameters/sample_interval
+```
+
+### Monitor KFENCE Activity
+
+```bash
+# KFENCE statistics are available via debugfs
+cat /sys/kernel/debug/kfence/stats
+
+# Example output:
+#   enabled: 1
+#   objects allocated: 189
+#   objects freed: 42
+#   zombie allocations: 0
+#   skip allocs (pool full): 312
+#   bugs found: 0
+```
+
+### Trigger a Test Bug (in a VM)
+
+!!! warning
+    Only do this in a test VM or QEMU instance, never on a production system.
+
+The kernel includes a KFENCE test module:
+
+```bash
+# Build with CONFIG_KFENCE_KUNIT_TEST=y
+# Run the KFENCE KUnit tests
+modprobe kfence_test
+
+# Or run via KUnit framework
+./tools/testing/kunit/kunit.py run kfence
+```
+
+### Tuning for Your Workload
+
+```bash
+# Start conservative (default 100ms)
+cat /sys/module/kfence/parameters/sample_interval
+
+# If you want faster detection and can tolerate minimal overhead:
+echo 20 > /sys/module/kfence/parameters/sample_interval
+
+# Monitor for any detected bugs
+dmesg | grep -i kfence
+```
+
+## History
+
+### v5.12: Introduction (2021)
+
+**Commits**:
+
+- [0ce20dd84089](https://git.kernel.org/linus/0ce20dd84089) ("mm: add Kernel Electric Fence infrastructure")
+- [bc8fbc5f305a](https://git.kernel.org/linus/bc8fbc5f305a) ("mm, kfence: insert KFENCE hooks for SLAB")
+- [d3fb45f370d9](https://git.kernel.org/linus/d3fb45f370d9) ("mm, kfence: insert KFENCE hooks for SLUB")
+
+**Authors**: Marco Elver and Alexander Potapenko (Google)
+
+**Kernel**: v5.12
+
+KFENCE was developed at Google, where a similar internal tool had been running in production for years. The upstream submission brought this capability to the wider Linux community.
+
+The patch series went through extensive review on LKML: [KFENCE v7 patch series](https://lore.kernel.org/lkml/20201103175841.3495947-1-elver@google.com/) (originally posted November 2020, merged for v5.12 in early 2021).
+
+**LWN coverage**: [KFENCE: A low-overhead memory safety error detector](https://lwn.net/Articles/832354/) provides an accessible overview of the design rationale.
+
+### v5.17: Improved Reporting and Coverage
+
+**Commit**: [58f116052668](https://git.kernel.org/linus/58f116052668) ("kfence: track memcache for allocations not covered by a slab cache")
+
+Various improvements to reporting quality and coverage were added over subsequent releases, including better integration with memory cgroups and more informative stack traces.
+
+### v5.18: KFENCE for DMA Allocations
+
+**Commit**: [0ddb5349ce00](https://git.kernel.org/linus/0ddb5349ce00) ("kfence: allow use of a deferrable timer")
+
+Added a deferrable timer option to reduce overhead on systems where power consumption matters. The timer does not wake idle CPUs, making KFENCE friendlier to mobile and embedded systems.
+
+### Ongoing Development
+
+KFENCE continues to receive improvements. Key areas of ongoing work include better coverage heuristics, integration with other debugging tools, and expanding the types of bugs it can detect.
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| [`mm/kfence/core.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/core.c) | Main KFENCE implementation: pool init, allocation, sampling |
+| [`mm/kfence/report.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/report.c) | Bug report generation and formatting |
+| [`mm/kfence/kfence_test.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/kfence_test.c) | KUnit test suite |
+| [`include/linux/kfence.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/kfence.h) | Public API and inline hooks |
+| [`mm/kfence/kfence.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/kfence.h) | Internal header with pool metadata structures |
+
+## References
+
+### Kernel Documentation
+
+- [KFENCE official documentation](https://docs.kernel.org/dev-tools/kfence.html) -- comprehensive reference for configuration and design
+
+### LWN Articles
+
+- [KFENCE: A low-overhead memory safety error detector](https://lwn.net/Articles/832354/) -- overview article from the initial submission
+
+### LKML Discussions
+
+- [KFENCE v7 patch series](https://lore.kernel.org/lkml/20201103175841.3495947-1-elver@google.com/) -- the final review series before merge
+- [KFENCE v1 RFC](https://lore.kernel.org/lkml/20200907134055.2878499-1-elver@google.com/) -- the original RFC with design discussion
+
+### Related
+
+- [slab](slab.md) -- KFENCE hooks into the slab allocator (SLUB/SLAB) to intercept allocations
+- [vmalloc](vmalloc.md) -- KFENCE pool uses page-level protection similar to vmalloc guard pages
+- [oom](oom.md) -- KFENCE's fixed pool size means it does not contribute to OOM pressure


### PR DESCRIPTION
## Summary

Two new documentation pages for the mm-debugging epic covering kernel memory error detection tools.

### kasan.md (KASAN - Kernel Address Sanitizer)
- Three modes: Generic (shadow memory), SW_TAGS (ARM64 TBI), HW_TAGS (ARM MTE)
- Shadow memory mechanics (1:8 mapping, encoding table)
- Annotated KASAN report walkthrough
- Performance overhead comparison across modes
- History: v4.0 by Andrey Ryabinin (2015)

### kfence.md (KFENCE - Kernel Electric Fence)
- Sampling-based production bug detection (<1% overhead)
- Guard page mechanism and detection types
- Annotated report examples (OOB write, use-after-free)
- Comparison with KASAN (always-on vs sampling)
- History: v5.12 by Marco Elver and Alexander Potapenko (2021)

Addresses #36, #37