### PR TITLE
Add memblock and CMA documentation

### DIFF
--- a/docs/mm/cma.md
+++ b/docs/mm/cma.md
@@ -1,0 +1,401 @@
+# CMA (Contiguous Memory Allocator)
+
+> Reserved regions that serve double duty: normal pages by day, DMA buffers on demand
+
+## What Is CMA?
+
+CMA reserves regions of physical memory at boot that can be reclaimed for large contiguous allocations when devices need them. The key insight is that these reserved pages are not wasted -- they serve normal movable allocations (page cache, anonymous memory) until a device driver requests a contiguous buffer, at which point the pages are migrated out and the region is handed to the driver.
+
+```
+CMA region (idle):
+┌────────────────────────────────────────────────────────────────┐
+│  Page   Page   Page   Page   Page   Page   Page   Page        │
+│  cache  anon   cache  anon   cache  anon   cache  cache       │
+│  (movable allocations using the CMA region normally)           │
+└────────────────────────────────────────────────────────────────┘
+
+DMA allocation request arrives:
+┌────────────────────────────────────────────────────────────────┐
+│  Migrate all movable pages out...                              │
+│  ← pages moved to other free memory                           │
+└────────────────────────────────────────────────────────────────┘
+
+CMA region (allocated to device):
+┌────────────────────────────────────────────────────────────────┐
+│              Contiguous DMA buffer for device                  │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Why CMA Exists
+
+### The Problem
+
+DMA devices often need physically contiguous memory. Unlike CPUs, many devices cannot use page tables to remap scattered physical pages into a contiguous address range. A camera capturing a frame, a display controller scanning out a framebuffer, or a network card sending a jumbo packet may all need a single contiguous physical buffer.
+
+On a freshly booted system, large contiguous allocations succeed easily. But after days of uptime, physical memory becomes fragmented -- free pages are scattered between persistent allocations. Even with gigabytes free, allocating a contiguous 8MB buffer can fail.
+
+### Previous Solutions and Their Downsides
+
+Before CMA, the options were poor:
+
+| Approach | Downside |
+|----------|----------|
+| Boot-time reservation (`memblock_reserve`) | Memory is exclusively locked away, wasted when devices are idle |
+| High-order `alloc_pages` at runtime | Fails under fragmentation |
+| Compaction before allocation | Slow, unreliable for very large buffers |
+| IOMMU remapping | Not all platforms have an IOMMU; adds complexity and latency |
+
+The boot-time reservation approach was especially wasteful on embedded devices (phones, set-top boxes) where RAM is scarce. A device might reserve 64MB for a camera that is used for a few minutes a day, leaving that memory unavailable for the rest of the system.
+
+### CMA's Insight
+
+CMA eliminates the tradeoff between reliability and waste. It reserves regions at boot (guaranteeing contiguous space is available) but allows movable allocations to use that space in the meantime. When a device needs the memory, CMA migrates the movable pages out and hands over the contiguous region.
+
+This dual-use design was particularly important for ARM-based mobile devices at Samsung, where limited RAM and many DMA-dependent peripherals (camera, display, codec) created constant tension between device driver needs and application memory.
+
+## How CMA Works
+
+### The Dual-Use Design
+
+CMA regions live within `ZONE_NORMAL` (or `ZONE_DMA`/`ZONE_DMA32` depending on architecture). The buddy allocator treats CMA pages as a special migrate type: `MIGRATE_CMA`.
+
+```
+Zone layout with CMA:
+┌──────────────────────────────────────────────────────────────────────┐
+│                           ZONE_NORMAL                                │
+│                                                                      │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────┐  ┌──────────┐    │
+│  │ MOVABLE  │  │UNMOVABLE │  │   MIGRATE_CMA    │  │RECLAIMABLE│   │
+│  │          │  │          │  │  (CMA region)    │  │          │    │
+│  └──────────┘  └──────────┘  └──────────────────┘  └──────────┘    │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The rules for `MIGRATE_CMA` pages:
+
+1. **Movable allocations can use CMA pages freely.** The page allocator falls back to CMA pageblocks when serving `MIGRATE_MOVABLE` requests.
+2. **Unmovable and reclaimable allocations cannot use CMA pages.** This is critical -- if an unmovable kernel allocation landed in a CMA region, the region could never be fully reclaimed.
+3. **When a driver calls `cma_alloc()`, all movable pages in the requested range are migrated out.** The kernel uses the same page migration machinery as compaction.
+
+### Allocation Path
+
+When a driver needs contiguous memory (typically through `dma_alloc_coherent()`):
+
+```
+Driver calls dma_alloc_coherent(dev, size, ...)
+        │
+        ▼
+DMA subsystem selects CMA region for this device
+        │
+        ▼
+cma_alloc(cma, count, align, no_warn)
+        │
+        ▼
+Find a suitable range of pages within the CMA region
+        │
+        ▼
+alloc_contig_range(start, end, MIGRATE_CMA, ...)
+        │
+        ├─── Isolate the range (prevent new allocations)
+        │
+        ├─── Migrate all movable pages out of the range
+        │         Uses the same migration code as compaction
+        │
+        ├─── Drain per-cpu page lists
+        │
+        └─── Return contiguous pages to the caller
+```
+
+If migration fails (e.g., a page is pinned for I/O), `cma_alloc()` retries with a different range within the CMA region. It scans through the region in bitmap-tracked chunks until it finds a range that can be fully cleared, or gives up.
+
+### The CMA Bitmap
+
+Each CMA region tracks allocation state with a bitmap. Each bit represents a block of pages (the granularity is set by `CONFIG_CMA_ALIGNMENT`, defaulting to order-8 or 1MB with 4KB pages):
+
+```c
+struct cma {
+    unsigned long   base_pfn;       /* Start of CMA region */
+    unsigned long   count;          /* Total pages in region */
+    unsigned long   *bitmap;        /* Allocation bitmap */
+    unsigned int    order_per_bit;  /* Pages per bit (power of 2) */
+    spinlock_t      lock;
+    ...
+};
+```
+
+The bitmap tracks which chunks are currently allocated to devices. Pages not marked as allocated in the bitmap are available for movable use by the rest of the system.
+
+### Interaction with the Page Allocator
+
+CMA integrates with the buddy allocator through the `MIGRATE_CMA` migrate type, introduced alongside CMA. Key interactions:
+
+- **Fallback behavior**: When the buddy allocator cannot satisfy a `MIGRATE_MOVABLE` request from the movable free list, it falls back to `MIGRATE_CMA` pages. This is how CMA regions get populated with movable pages during normal operation.
+- **Steal prevention**: The allocator never steals CMA pageblocks for `MIGRATE_UNMOVABLE` or `MIGRATE_RECLAIMABLE` requests. This guarantee is enforced in `__rmqueue_fallback()` in `mm/page_alloc.c`.
+- **Compaction awareness**: When compaction runs, it understands CMA regions and respects their migrate type. CMA pages can be targets for the compaction migration scanner (pages can be moved *into* CMA regions), but CMA pages won't be changed to unmovable types.
+
+## Configuration
+
+### Kernel Command Line
+
+The simplest way to set up CMA:
+
+```bash
+# Reserve 256MB for the default global CMA area
+cma=256M
+
+# With placement hint (base address)
+cma=256M@0x40000000
+```
+
+The `cma=` parameter sets the size of the default CMA area, which is used by any device that does not have a dedicated CMA region.
+
+### Device Tree (ARM/embedded)
+
+Embedded platforms typically define CMA regions in the device tree:
+
+```dts
+reserved-memory {
+    #address-cells = <2>;
+    #size-cells = <2>;
+    ranges;
+
+    /* Default CMA region */
+    linux,cma {
+        compatible = "shared-dma-pool";
+        reusable;
+        size = <0 0x10000000>;  /* 256MB */
+        linux,cma-default;
+    };
+
+    /* Dedicated region for a specific device */
+    camera_mem: camera-buffer {
+        compatible = "shared-dma-pool";
+        reusable;
+        reg = <0 0x78000000 0 0x8000000>;  /* 128MB at specific address */
+    };
+};
+
+camera@0 {
+    memory-region = <&camera_mem>;
+};
+```
+
+The `reusable` property is what makes it CMA rather than a static reservation. Without `reusable`, the region would be exclusively reserved and not available for movable allocations.
+
+### Kernel Config Options
+
+```
+CONFIG_CMA=y                    # Enable CMA support
+CONFIG_CMA_DEBUG=y              # Extra debug checks (development only)
+CONFIG_CMA_DEBUGFS=y            # Expose per-region stats in debugfs
+CONFIG_CMA_SIZE_MBYTES=16       # Default CMA size in MB
+CONFIG_CMA_SIZE_PERCENTAGE=0    # Default CMA size as percentage of RAM
+CONFIG_CMA_ALIGNMENT=8          # Minimum alignment (order), default 8 = 256 pages = 1MB
+CONFIG_DMA_CMA=y                # Use CMA as the DMA contiguous allocator backend
+```
+
+`CONFIG_CMA_SIZE_MBYTES` sets the default size when no `cma=` boot parameter is given. `CONFIG_CMA_SIZE_PERCENTAGE` provides an alternative way to scale CMA with RAM size. The larger of the two values wins.
+
+## Using CMA from Drivers
+
+### The DMA API (Recommended)
+
+Most drivers should use the DMA API, which handles CMA allocation transparently:
+
+```c
+#include <linux/dma-mapping.h>
+
+/* Allocate contiguous DMA buffer -- uses CMA if CONFIG_DMA_CMA=y */
+void *vaddr = dma_alloc_coherent(dev, size, &dma_handle, GFP_KERNEL);
+
+/* Free when done */
+dma_free_coherent(dev, size, vaddr, dma_handle);
+```
+
+The DMA subsystem calls into CMA via `dma_alloc_from_contiguous()`, which maps to `cma_alloc()` internally. The device's CMA region is selected based on its `memory-region` device tree property, or the default global CMA area.
+
+### Direct CMA API (Rare)
+
+For subsystems that need direct control:
+
+```c
+#include <linux/cma.h>
+
+/* Allocate count pages aligned to 1 << align from a specific CMA area */
+struct page *page = cma_alloc(cma, count, align, no_warn);
+
+/* Release back to CMA */
+cma_release(cma, page, count);
+```
+
+After `cma_release()`, the pages return to the buddy allocator as `MIGRATE_CMA` pages and can once again serve movable allocations.
+
+## Monitoring
+
+### /proc/meminfo
+
+```bash
+$ grep Cma /proc/meminfo
+CmaTotal:        262144 kB    # Total CMA reservation
+CmaFree:         245760 kB    # CMA pages not allocated to devices
+```
+
+`CmaFree` shows how much of the CMA region is not currently held by device drivers. These pages are likely in use by movable allocations (page cache, anonymous memory) but can be reclaimed when a device needs them.
+
+Note that `CmaTotal` and `CmaFree` are included in `MemTotal` and `MemFree` respectively -- CMA memory is not "missing" from the system's perspective.
+
+### debugfs (CONFIG_CMA_DEBUGFS)
+
+```bash
+$ ls /sys/kernel/debug/cma/
+cma-reserved/
+
+$ ls /sys/kernel/debug/cma/cma-reserved/
+alloc  base_pfn  bitmap  count  free  maxchunk  order_per_bit  used
+
+$ cat /sys/kernel/debug/cma/cma-reserved/base_pfn
+262144
+$ cat /sys/kernel/debug/cma/cma-reserved/count
+65536        # Total pages in region
+$ cat /sys/kernel/debug/cma/cma-reserved/used
+0            # Pages currently allocated to devices
+$ cat /sys/kernel/debug/cma/cma-reserved/maxchunk
+65536        # Largest contiguous free chunk (in pages)
+```
+
+The `alloc` file is writable -- you can trigger a test allocation to verify CMA is working:
+
+```bash
+# Test-allocate 1024 pages (4MB) from the CMA region
+echo 1024 > /sys/kernel/debug/cma/cma-reserved/alloc
+```
+
+### vmstat Counters
+
+```bash
+$ grep cma /proc/vmstat
+cma_alloc_success 42
+cma_alloc_fail 0
+```
+
+These counters (added in v5.19) track CMA allocation outcomes across all CMA regions.
+
+## Try It Yourself
+
+```bash
+# Check if CMA is enabled and how much is reserved
+grep Cma /proc/meminfo
+
+# View CMA kernel boot parameter
+cat /proc/cmdline | tr ' ' '\n' | grep cma
+
+# If debugfs is available, inspect CMA regions
+ls /sys/kernel/debug/cma/ 2>/dev/null
+
+# Watch CMA allocation stats (kernel 5.19+)
+grep cma /proc/vmstat
+
+# Check buddyinfo to see free page counts per order
+# Low counts at high orders suggest fragmentation that CMA helps avoid
+cat /proc/buddyinfo
+
+# On an embedded device, view device tree CMA configuration
+# (requires dtc; /proc/device-tree may also be available)
+ls /proc/device-tree/reserved-memory/ 2>/dev/null
+```
+
+## History
+
+### Development at Samsung
+
+CMA was developed by Marek Szyprowski at Samsung Electronics. The motivation came from ARM mobile platforms (like Samsung's Exynos SoCs) where multiple peripherals -- cameras, display controllers, multimedia codecs, and GPU -- all needed large contiguous buffers but the system had limited RAM to spare for static reservations.
+
+The feature went through extensive review across 24 revisions of the patch series before being merged.
+
+### Merged in v3.5 (2012)
+
+**Commit**: [c64be2bb1c6e](https://git.kernel.org/linus/c64be2bb1c6e) ("drivers: add Contiguous Memory Allocator")
+
+**Author**: Marek Szyprowski
+
+The initial merge included the core CMA allocator and its integration with the DMA subsystem.
+
+**LWN coverage**: [A deep dive into CMA](https://lwn.net/Articles/486301/) -- discusses the design rationale and review process.
+
+### MIGRATE_CMA Type (v3.5, 2012)
+
+**Commit**: [47118af076f6](https://git.kernel.org/linus/47118af076f6) ("mm: mmzone: MIGRATE_CMA migration type added")
+
+**Author**: Marek Szyprowski
+
+Added the `MIGRATE_CMA` migrate type to the buddy allocator, enabling the dual-use design where CMA pages serve movable allocations while preventing unmovable ones from landing in CMA regions.
+
+### Per-device CMA Areas (v3.17, 2014)
+
+**Commit**: [c1f733aaf1e1](https://git.kernel.org/linus/c1f733aaf1e1) ("drivers: of: add initialization code for dma-reserved-memory")
+
+The device tree `memory-region` property support, allowing individual devices to have their own dedicated CMA regions rather than sharing the global one.
+
+### CMA debugfs (v4.5, 2016)
+
+**Commit**: [28b24c1fc8c4](https://git.kernel.org/linus/28b24c1fc8c4) ("mm/cma: expose all pages to the buddy if activation of an area fails")
+
+The debugfs interface for monitoring CMA was progressively added, giving operators visibility into CMA region usage.
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| [`mm/cma.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/cma.c) | Core CMA allocator: `cma_alloc()`, `cma_release()`, bitmap management |
+| [`mm/cma.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/cma.h) | Internal CMA header (the `struct cma` definition) |
+| [`include/linux/cma.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/cma.h) | Public CMA API for drivers |
+| [`mm/cma_debug.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/cma_debug.c) | debugfs interface for CMA regions |
+| [`kernel/dma/contiguous.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/contiguous.c) | DMA subsystem integration: `dma_alloc_from_contiguous()` |
+| [`mm/page_alloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) | Buddy allocator with `MIGRATE_CMA` fallback logic |
+| [`mm/page_isolation.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_isolation.c) | Page range isolation used during `cma_alloc()` |
+
+## Common Issues
+
+### CMA Allocation Failures
+
+**Symptoms**: `cma_alloc_fail` count increasing, driver probe failures, DMA allocation errors in dmesg.
+
+**Common causes**:
+
+- **Pinned pages in the CMA region**: Pages undergoing I/O or held by `get_user_pages()` cannot be migrated. This is the most common cause of CMA allocation failures.
+- **CMA region too small**: The region must accommodate the largest single contiguous allocation plus any concurrent allocations from other devices.
+- **Fragmentation within CMA**: If device allocations of varying sizes come and go, the CMA bitmap itself can become fragmented (external fragmentation within the CMA region).
+
+**Diagnosis**:
+
+```bash
+# Check for CMA failures
+grep cma /proc/vmstat
+dmesg | grep -i cma
+
+# Check available CMA space
+grep Cma /proc/meminfo
+
+# debugfs for detailed region state
+cat /sys/kernel/debug/cma/*/used
+cat /sys/kernel/debug/cma/*/maxchunk
+```
+
+### CMA Memory Not Appearing
+
+If `CmaTotal` is 0 in `/proc/meminfo`:
+
+- Verify `CONFIG_CMA=y` and `CONFIG_DMA_CMA=y` in the kernel config
+- Check that the `cma=` boot parameter is present, or that `CONFIG_CMA_SIZE_MBYTES` is nonzero
+- On device tree platforms, verify the reserved-memory node has `compatible = "shared-dma-pool"` and the `reusable` property
+
+## References
+
+- [LWN: A deep dive into CMA](https://lwn.net/Articles/486301/) - Design discussion from the merge window
+- [LWN: CMA and compaction](https://lwn.net/Articles/684611/) - Interaction between CMA and compaction
+- [LWN: Contiguous memory allocation for drivers](https://lwn.net/Articles/396657/) - Early CMA proposal
+- [Kernel docs: DMA API](https://docs.kernel.org/core-api/dma-api.html) - How drivers should allocate DMA memory
+- [contiguous-memory](contiguous-memory.md) - The fragmentation problem CMA solves
+- [compaction](compaction.md) - The page migration machinery CMA relies on
+- [page-allocator](page-allocator.md) - Buddy allocator and migrate types

--- a/docs/mm/memblock.md
+++ b/docs/mm/memblock.md
@@ -1,0 +1,479 @@
+# memblock: The Boot-Time Memory Allocator
+
+> Before the buddy system can manage memory, something has to manage memory first
+
+## What is memblock?
+
+memblock is the kernel's early boot-time memory allocator. It tracks which physical memory regions exist and which are already reserved, allowing the kernel to allocate memory during the earliest stages of boot -- long before the buddy allocator (page allocator) is initialized.
+
+```c
+/* Add a region of physical memory */
+int memblock_add(phys_addr_t base, phys_addr_t size);
+
+/* Mark a region as reserved (in use) */
+int memblock_reserve(phys_addr_t base, phys_addr_t size);
+
+/* Allocate memory during early boot */
+void *memblock_alloc(phys_addr_t size, phys_addr_t align);
+```
+
+## The Chicken-and-Egg Problem
+
+The buddy allocator is the kernel's primary physical memory manager at runtime. But setting it up requires memory:
+
+- **Zone structures** (`struct zone`) need to be allocated for each memory zone
+- **Page frame metadata** (`struct page`) needs one entry per physical page -- on a 16GB system that's millions of entries
+- **Per-CPU data structures** for allocation caches
+- **Free lists** for the buddy system itself
+
+But you cannot allocate memory without a memory allocator. Something simpler must come first.
+
+memblock solves this bootstrap problem with a deliberately minimal design: two flat arrays that track memory regions. No page tables, no locking, no per-CPU caches -- just "here's what exists" and "here's what's taken."
+
+```
+Boot sequence:
+
+  1. Firmware / bootloader loads kernel into RAM
+
+  2. Architecture setup discovers physical memory layout
+     (via device tree, ACPI, or e820 on x86)
+
+  3. memblock tracks available and reserved regions
+     +----------------------------------------------+
+     | memblock.memory:   [0 - 4GB], [8GB - 16GB]  |  <- what exists
+     | memblock.reserved: [0 - 16MB], [64MB - 80MB] |  <- what's taken
+     +----------------------------------------------+
+
+  4. Kernel uses memblock_alloc() to get memory for
+     page tables, struct page array, zone structures...
+
+  5. Buddy allocator initialized using memblock info
+
+  6. memblock_free_all() hands remaining free memory
+     to the buddy system
+
+  7. memblock is done (memory can be freed if not needed)
+```
+
+## How memblock Works
+
+### Two Arrays: memory and reserved
+
+The core data structure is simple. memblock maintains two collections of regions:
+
+```c
+struct memblock {
+    bool bottom_up;                          /* allocation direction */
+    phys_addr_t current_limit;               /* allocation limit */
+    struct memblock_type memory;             /* physical memory regions */
+    struct memblock_type reserved;           /* reserved (in-use) regions */
+};
+```
+
+Each `memblock_type` holds a dynamically-growing array of regions:
+
+```c
+struct memblock_type {
+    unsigned long cnt;                       /* number of regions */
+    unsigned long max;                       /* max regions (grows if needed) */
+    phys_addr_t total_size;                  /* total size of all regions */
+    struct memblock_region *regions;         /* array of regions */
+    char *name;                              /* "memory" or "reserved" */
+};
+
+struct memblock_region {
+    phys_addr_t base;                        /* start address */
+    phys_addr_t size;                        /* region size */
+    enum memblock_flags flags;               /* HOTPLUG, MIRROR, NOMAP */
+    int nid;                                 /* NUMA node id */
+};
+```
+
+The `memory` array describes what physical memory exists (as reported by firmware). The `reserved` array describes what's already been claimed -- the kernel image itself, device tree blob, initrd, early allocations, etc.
+
+**Free memory** is implicitly defined as: regions in `memory` that are not covered by `reserved`.
+
+```
+Physical address space:
+0                                                              16GB
+|--------------------------------------------------------------|
+
+memblock.memory (what exists):
+|==========|                  |================================|
+0        4GB                 8GB                             16GB
+
+memblock.reserved (what's taken):
+|==|    |=|                  |=|
+kernel  DTB                  initrd
+
+Free = memory minus reserved
+```
+
+### Region Merging
+
+When adjacent or overlapping regions are added, memblock automatically merges them. This keeps the arrays compact:
+
+```
+memblock_add(0, 1GB)    -> memory: [0, 1GB]
+memblock_add(1GB, 1GB)  -> memory: [0, 2GB]     (merged)
+memblock_add(3GB, 1GB)  -> memory: [0, 2GB], [3GB, 4GB]  (gap, no merge)
+```
+
+### Static Bootstrap
+
+The initial region arrays are statically allocated:
+
+```c
+static struct memblock_region memblock_memory_init_regions[INIT_MEMBLOCK_REGIONS];
+static struct memblock_region memblock_reserved_init_regions[INIT_MEMBLOCK_RESERVED_REGIONS];
+```
+
+`INIT_MEMBLOCK_REGIONS` defaults to 128. If more regions are needed, memblock doubles the array using `memblock_double_array()`, which allocates new space from memblock itself -- a neat self-referential trick that works because the old array remains valid until the copy is complete.
+
+## Key APIs
+
+### Adding and Removing Memory
+
+```c
+/* Tell memblock about physical memory regions (called by arch code) */
+int memblock_add(phys_addr_t base, phys_addr_t size);
+
+/* Remove a region (e.g., firmware reserved areas) */
+int memblock_remove(phys_addr_t base, phys_addr_t size);
+
+/* Mark a region as reserved */
+int memblock_reserve(phys_addr_t base, phys_addr_t size);
+
+/* Free a previously reserved region */
+int memblock_phys_free(phys_addr_t base, phys_addr_t size);
+
+/* Mark memory as not directly usable (won't be mapped) */
+int memblock_mark_nomap(phys_addr_t base, phys_addr_t size);
+```
+
+### Allocating Memory
+
+```c
+/* Allocate aligned memory (most common) */
+void *memblock_alloc(phys_addr_t size, phys_addr_t align);
+
+/* Allocate from a specific address range */
+void *memblock_alloc_range_nid(phys_addr_t size, phys_addr_t align,
+                               phys_addr_t start, phys_addr_t end,
+                               int nid, bool exact_nid);
+
+/* Allocate raw physical address (no virtual mapping) */
+phys_addr_t memblock_phys_alloc(phys_addr_t size, phys_addr_t align);
+```
+
+`memblock_alloc()` does two things: finds a free physical region and maps it into the kernel's virtual address space (via `memblock_alloc_internal()` which calls `memblock_alloc_range_nid()` then `memblock_reserve()` on the result). The returned pointer is a kernel virtual address ready to use.
+
+### Querying Memory
+
+```c
+/* Is this address in a reserved region? */
+bool memblock_is_reserved(phys_addr_t addr);
+
+/* Is this address in a memory region? */
+bool memblock_is_memory(phys_addr_t addr);
+
+/* Total amount of usable RAM */
+phys_addr_t memblock_phys_mem_size(void);
+
+/* Iterate over free (unreserved) memory regions */
+for_each_free_mem_range(i, nid, flags, &start, &end, NULL)
+```
+
+## Memory Discovery: Device Tree and ACPI
+
+memblock does not discover memory on its own. Architecture-specific code populates it using firmware information.
+
+### Device Tree (ARM, RISC-V, PowerPC, etc.)
+
+On device-tree platforms, the `/memory` nodes describe physical RAM:
+
+```dts
+/ {
+    memory@80000000 {
+        device_type = "memory";
+        reg = <0x00 0x80000000 0x00 0x80000000>;  /* 2GB at 0x80000000 */
+    };
+};
+```
+
+The kernel's early DT scanning code (`early_init_dt_scan_memory()` in [`drivers/of/fdt.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/of/fdt.c)) parses these nodes and calls `memblock_add()` for each region. Reserved memory nodes (`/reserved-memory`) result in `memblock_reserve()` calls.
+
+### ACPI (x86, ARM servers)
+
+On ACPI systems, the firmware provides memory maps through different mechanisms:
+
+- **x86**: The BIOS/UEFI provides an **e820 memory map** -- a table of address ranges with types (usable, reserved, ACPI reclaimable, etc.). The function `e820__memblock_setup()` in [`arch/x86/kernel/e820.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/e820.c) translates e820 entries into `memblock_add()` and `memblock_reserve()` calls.
+
+- **ARM64 with ACPI**: Uses EFI memory map entries, processed by `efi_init()`.
+
+### The Pattern
+
+Regardless of platform, the flow is the same:
+
+```
+Firmware provides memory layout
+        |
+        v
+Architecture code parses it
+        |
+        v
+memblock_add() for usable regions
+memblock_reserve() for reserved regions
+        |
+        v
+memblock has complete picture of physical memory
+```
+
+## The Handoff to the Buddy Allocator
+
+Once the kernel has used memblock to set up all the data structures the buddy allocator needs, memblock's job is nearly done. The handoff happens through `memblock_free_all()`:
+
+```c
+void __init memblock_free_all(void)
+{
+    unsigned long pages;
+
+    pages = free_low_memory_core_early();  /* release memblock pages to buddy */
+    totalram_pages_add(pages);
+}
+```
+
+This function walks all memblock memory regions, and for each page that is **not** reserved, calls `__free_pages_core()` to hand it to the buddy allocator. After this point, the buddy system owns all free physical memory and memblock is no longer needed for allocation.
+
+The memblock data structures themselves are marked `__initdata`, meaning they live in the kernel's init section. After boot completes (`free_initmem()`), this memory is reclaimed -- unless `CONFIG_ARCH_KEEP_MEMBLOCK` is enabled (which preserves memblock data for later queries, useful for kexec and memory hotplug).
+
+```
+memblock_free_all() walkthrough:
+
+  For each page in memblock.memory:
+      if not in memblock.reserved:
+          __free_pages_core(page)   ->  buddy allocator now owns it
+          totalram_pages++
+
+  Result: buddy free lists populated, system ready for normal allocation
+```
+
+## History and Evolution
+
+### bootmem: The Original Approach (v2.3 -- v3.x)
+
+Before memblock, the kernel used a **bitmap-based** boot allocator called `bootmem`. Each bit represented one physical page: 1 = allocated, 0 = free.
+
+The problems with bootmem:
+
+- **Bitmap overhead**: A 64GB system needs a 2MB bitmap just for accounting
+- **Linear search**: Finding free memory required scanning the bitmap -- O(n) in the number of pages
+- **No NUMA awareness**: The original bootmem had no concept of memory nodes
+- **Fragile**: The bitmap itself needed to live somewhere in memory, creating another bootstrap problem
+
+### The Rise of memblock (Logical Memory Blocks)
+
+memblock's predecessor was called **lmb** (Logical Memory Blocks), used on PowerPC. It tracked memory as a list of regions rather than a per-page bitmap -- far more efficient when memory is mostly contiguous.
+
+**Commit**: [95f72d1ed41a](https://git.kernel.org/linus/95f72d1ed41a) ("lmb: rename to memblock") | [LWN coverage](https://lwn.net/Articles/382559/)
+**Kernel**: v2.6.35 (2010)
+**Author**: Yinghai Lu
+
+Yinghai Lu renamed lmb to memblock and began extending it for use on x86. The rename was the first step in making it architecture-independent.
+
+### memblock Replaces bootmem
+
+Over several kernel releases, architectures migrated from bootmem to memblock:
+
+- **ARM**: One of the early adopters alongside PowerPC
+- **x86**: Migrated in the v2.6.35 -- v3.x timeframe
+
+**Commit**: [9a8dd708d547](https://git.kernel.org/linus/9a8dd708d547) ("memblock: remove bootmem dependency on memblock")
+**Kernel**: v3.12 (2013)
+
+The final removal of bootmem happened when all architectures had been converted:
+
+**Commit**: [0fa817767102](https://git.kernel.org/linus/0fa817767102) ("mm: remove bootmem allocator")
+**Kernel**: v5.0 (2019)
+
+This was a significant cleanup -- the bootmem code had accumulated decades of workarounds and special cases.
+
+### Recent Improvements
+
+**Commit**: [35fd0808de0e](https://git.kernel.org/linus/35fd0808de0e) ("memblock: introduce memblock_phys_free()")
+**Kernel**: v6.1 (2022)
+**Author**: Mike Rapoport
+
+Part of a broader effort to clean up early memory management and reduce the use of `memblock_free()` which had confusing semantics (it freed from the reserved list, not the memory list).
+
+## Observing memblock
+
+### debugfs Interface
+
+If `CONFIG_ARCH_KEEP_MEMBLOCK` is enabled, you can inspect the memblock state after boot:
+
+```bash
+# View memory regions
+cat /sys/kernel/debug/memblock/memory
+
+# View reserved regions
+cat /sys/kernel/debug/memblock/reserved
+
+# Example output (memory):
+#    0: 0x0000000000000000..0x000000009fffffff (2560 MB)
+#    1: 0x0000000100000000..0x00000004ffffffff (16384 MB)
+```
+
+### Early Boot Messages
+
+memblock logs its activity to dmesg during early boot. Look for lines with the `memblock` prefix:
+
+```bash
+dmesg | grep -i memblock
+
+# Example output:
+# [    0.000000] memblock_add: [mem 0x00000000-0x9fffffff]
+# [    0.000000] memblock_reserve: [mem 0x01000000-0x01ffffff]
+# [    0.000000] memblock: memory size = 16384 MB
+```
+
+For more verbose output, pass `memblock=debug` on the kernel command line. This enables detailed logging of every memblock operation:
+
+```bash
+# In bootloader config (e.g., GRUB):
+linux /vmlinuz memblock=debug ...
+```
+
+### e820 Table (x86)
+
+On x86 systems, you can see the firmware memory map that feeds into memblock:
+
+```bash
+dmesg | grep e820
+
+# Example output:
+# BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+# BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+# BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+# BIOS-e820: [mem 0x0000000000100000-0x000000003fffffff] usable
+```
+
+## Try It Yourself
+
+### Inspect memblock Regions
+
+```bash
+# Check if your kernel preserves memblock data
+ls /sys/kernel/debug/memblock/ 2>/dev/null && echo "memblock debugfs available"
+
+# If available, examine the memory layout
+cat /sys/kernel/debug/memblock/memory
+cat /sys/kernel/debug/memblock/reserved
+
+# Count the number of memory regions
+wc -l < /sys/kernel/debug/memblock/memory
+```
+
+### Trace the Boot Memory Setup
+
+```bash
+# See how firmware reported memory to the kernel
+dmesg | grep -E "(e820|memblock|Memory:)"
+
+# The "Memory:" line shows the final accounting
+# Memory: 16123456K/16777216K available
+#          (X kernel code, Y rwdata, Z rodata, W init, V bss, ...)
+```
+
+### Enable Verbose memblock Logging
+
+```bash
+# Add to kernel command line (requires reboot)
+# For GRUB: edit /etc/default/grub, add memblock=debug to GRUB_CMDLINE_LINUX
+sudo sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 memblock=debug"/' /etc/default/grub
+sudo update-grub
+
+# After reboot, check the detailed log
+dmesg | grep memblock | head -50
+```
+
+### Compare memblock with Runtime View
+
+```bash
+# memblock's view (boot time, if preserved)
+cat /sys/kernel/debug/memblock/memory 2>/dev/null
+
+# Buddy allocator's view (runtime)
+cat /proc/buddyinfo
+
+# Total managed memory
+grep MemTotal /proc/meminfo
+```
+
+## Key Data Structures
+
+### struct memblock (Global State)
+
+The entire memblock state lives in a single global variable:
+
+```c
+struct memblock memblock __initdata_memblock = {
+    .memory.regions     = memblock_memory_init_regions,
+    .memory.cnt         = 1,    /* empty dummy region */
+    .memory.max         = INIT_MEMBLOCK_REGIONS,
+    .memory.name        = "memory",
+
+    .reserved.regions   = memblock_reserved_init_regions,
+    .reserved.cnt       = 1,
+    .reserved.max       = INIT_MEMBLOCK_RESERVED_REGIONS,
+    .reserved.name      = "reserved",
+
+    .bottom_up          = false,
+    .current_limit      = MEMBLOCK_ALLOC_ANYWHERE,
+};
+```
+
+The `__initdata_memblock` annotation means this data is either `__initdata` (freed after boot) or `__meminitdata` (kept for memory hotplug), depending on `CONFIG_ARCH_KEEP_MEMBLOCK`.
+
+### memblock_flags
+
+```c
+enum memblock_flags {
+    MEMBLOCK_NONE       = 0x0,   /* No special flags */
+    MEMBLOCK_HOTPLUG    = 0x1,   /* Hotpluggable memory */
+    MEMBLOCK_MIRROR     = 0x2,   /* Mirrored (EFI) memory */
+    MEMBLOCK_NOMAP      = 0x4,   /* Don't add to direct mapping */
+    MEMBLOCK_DRIVER_MANAGED = 0x8, /* Managed by a driver */
+};
+```
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/memblock.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memblock.c) | Core memblock implementation |
+| [`include/linux/memblock.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/memblock.h) | Public API and data structures |
+| [`drivers/of/fdt.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/of/fdt.c) | Device tree memory scanning |
+| [`arch/x86/kernel/e820.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/e820.c) | x86 e820 to memblock translation |
+
+### Key Commits
+
+| Commit | Kernel | Description |
+|--------|--------|-------------|
+| [95f72d1ed41a](https://git.kernel.org/linus/95f72d1ed41a) | v2.6.35 | Rename lmb to memblock |
+| [9a8dd708d547](https://git.kernel.org/linus/9a8dd708d547) | v3.12 | Remove bootmem dependency on memblock |
+| [0fa817767102](https://git.kernel.org/linus/0fa817767102) | v5.0 | Remove bootmem allocator entirely |
+| [35fd0808de0e](https://git.kernel.org/linus/35fd0808de0e) | v6.1 | Introduce memblock_phys_free() |
+
+### LWN Articles
+
+- [A quick history of early-boot memory allocators](https://lwn.net/Articles/382559/) -- Coverage of the lmb-to-memblock rename and rationale
+- [Improvements to memblock](https://lwn.net/Articles/761215/) -- Mike Rapoport's work cleaning up the early memory allocator
+
+### Related
+
+- [page-allocator](page-allocator.md) - The buddy allocator that memblock hands off to
+- [overview](overview.md) - How memblock fits in the allocator hierarchy
+- [numa](numa.md) - NUMA-aware memblock allocation


### PR DESCRIPTION
## Summary

Two new documentation pages for the mm-boot and mm-dma epics.

### memblock.md (Boot-time memory allocator)
- The chicken-and-egg problem: buddy allocator needs data structures, allocating them needs an allocator
- Two-array design (memory regions + reserved regions)
- Key APIs: memblock_add(), memblock_reserve(), memblock_alloc()
- Handoff to buddy allocator via memblock_free_all()
- Device tree and ACPI memory discovery integration
- History: replaced bootmem allocator (removed v5.0)

### cma.md (Contiguous Memory Allocator)
- Why CMA exists: DMA devices need contiguous memory, fragmentation makes runtime allocation fail
- Dual-use design: CMA pages serve movable allocations normally, migrated out when DMA needs them
- MIGRATE_CMA type and interaction with page allocator
- Configuration via kernel command line and device tree
- Monitoring: /proc/meminfo CmaTotal/CmaFree, debugfs
- History: Marek Szyprowski (Samsung), merged v3.5 (2012)

Addresses #25, #31