### PR TITLE
Add mm performance tuning guides (PSI, containers, databases, swap thrashing)

### DIFF
--- a/docs/mm/psi.md
+++ b/docs/mm/psi.md
@@ -1,0 +1,369 @@
+# Pressure Stall Information (PSI)
+
+> Quantifying resource pressure, not just utilization
+
+## What Is PSI?
+
+Traditional system metrics like CPU utilization, free memory, and I/O throughput tell you how busy resources are, but they don't tell you whether workloads are actually *suffering*. A system can show 90% CPU utilization and be perfectly healthy if all tasks are making progress. Conversely, a system at 30% CPU can be in trouble if tasks are stuck waiting for memory to be reclaimed.
+
+PSI (Pressure Stall Information) measures the amount of time tasks spend *stalled* — waiting for resources instead of doing useful work. This is the difference between utilization (how much of a resource is in use) and pressure (how much work is delayed because of insufficient resources).
+
+```
+Traditional metrics:          PSI:
+"CPU is 85% used"             "Tasks lost 12% of productive time
+                               waiting for CPU"
+
+"500MB free memory"           "Tasks were fully stalled on memory
+                               for 3% of the last 10 seconds"
+
+"Disk is 60% busy"           "No tasks were stalled on I/O"
+```
+
+## Three Resources Tracked
+
+PSI tracks pressure across the three fundamental resources that tasks compete for:
+
+| Resource | Pressure File | What Causes Stalls |
+|----------|--------------|-------------------|
+| CPU | `/proc/pressure/cpu` | Runnable tasks waiting for a CPU core |
+| Memory | `/proc/pressure/memory` | Tasks waiting for page reclaim, swap I/O, refaults |
+| I/O | `/proc/pressure/io` | Tasks waiting for block device I/O |
+
+```bash
+# View all pressure metrics
+cat /proc/pressure/cpu
+cat /proc/pressure/memory
+cat /proc/pressure/io
+```
+
+## "some" vs "full" Pressure
+
+Each pressure file reports two levels of stalling:
+
+```
+$ cat /proc/pressure/memory
+some avg10=0.00 avg60=0.00 avg300=0.00 total=456789
+full avg10=0.00 avg60=0.00 avg300=0.00 total=123456
+```
+
+**some**: At least one task is stalled on this resource. Other tasks may still be running productively. This indicates contention — the workload is partially degraded.
+
+**full**: *All* non-idle tasks are stalled simultaneously. No productive work is happening. This is a much more severe condition — the system (or cgroup) is completely bogged down.
+
+```
+                Time ──────────────────────>
+
+Task A:    [running][stalled ][running ][stalled ]
+Task B:    [running][running ][stalled ][stalled ]
+                         │                   │
+                    "some" pressure     "full" pressure
+                  (one task stalled)   (all tasks stalled)
+```
+
+!!! note
+    `/proc/pressure/cpu` only reports `some`, not `full`. The reasoning: if all tasks are waiting for CPU, then no task is running, which means the CPU is idle — a contradictory state. CPU pressure means runnable tasks are competing for time, so at least one is always making progress.
+
+## Reading the Pressure Files
+
+Each line contains three moving averages and a cumulative total:
+
+```
+some avg10=4.67 avg60=2.13 avg300=0.85 total=2345678
+```
+
+| Field | Meaning |
+|-------|---------|
+| `avg10` | Percentage of time tasks were stalled over the last 10 seconds |
+| `avg60` | Percentage of time stalled over the last 60 seconds |
+| `avg300` | Percentage of time stalled over the last 5 minutes |
+| `total` | Cumulative stall time in microseconds since boot |
+
+The averages are exponentially weighted moving averages (similar to load average), expressed as percentages (0.00 to 100.00). The `total` counter is monotonically increasing and useful for computing exact stall rates over custom intervals.
+
+```bash
+# Compute exact stall rate over a 5-second window
+T1=$(awk '/some/ {print $NF}' /proc/pressure/memory | cut -d= -f2)
+sleep 5
+T2=$(awk '/some/ {print $NF}' /proc/pressure/memory | cut -d= -f2)
+STALL_US=$((T2 - T1))
+echo "Memory stall: ${STALL_US}us over 5 seconds"
+```
+
+## PSI Triggers: Userspace Monitoring
+
+Reading pressure files by polling is fine for dashboards, but for real-time resource management you need event-driven notification. PSI supports poll/epoll on pressure files, allowing userspace to set thresholds and be woken only when pressure exceeds them.
+
+### Setting Up a Trigger
+
+Write a trigger specification to a pressure file, then use `poll()` or `epoll()` to wait for events:
+
+```c
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+    int fd = open("/proc/pressure/memory", O_RDWR | O_NONBLOCK);
+
+    /* Trigger when "some" stall time exceeds 100ms
+       within any 1-second window (values in microseconds) */
+    const char *trigger = "some 100000 1000000";
+    write(fd, trigger, strlen(trigger) + 1);
+
+    struct pollfd fds = { .fd = fd, .events = POLLPRI };
+
+    for (;;) {
+        int ret = poll(&fds, 1, -1);  /* Block until threshold hit */
+        if (ret > 0) {
+            printf("Memory pressure threshold exceeded!\n");
+            /* Take action: drop caches, kill low-priority work, etc. */
+        }
+    }
+}
+```
+
+The trigger format is:
+
+```
+<some|full> <stall_us> <window_us>
+```
+
+- `some 100000 1000000` means: trigger when at least 100ms of stall time (stall_us) occurs within any 1-second window (window_us).
+- The window must be between 500ms and 10 seconds. Unprivileged users are additionally restricted to windows that are multiples of 2 seconds. See [`Documentation/accounting/psi.rst`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/accounting/psi.rst) for the full specification.
+
+PSI trigger support was added in v5.2 by Suren Baghdasaryan ([commit 0e94682b73bf](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0e94682b73bf)).
+
+## PSI in Practice
+
+PSI is not just a monitoring curiosity — it is the foundation for modern out-of-memory management in production systems.
+
+### systemd-oomd
+
+[systemd-oomd](https://www.freedesktop.org/software/systemd/man/latest/systemd-oomd.html) uses PSI memory pressure to decide when to kill cgroups before the kernel OOM killer triggers. It monitors `memory.pressure` for each cgroup and kills the highest-memory consumer when pressure exceeds a threshold. This replaces the blunt global OOM killer with targeted, early intervention.
+
+```ini
+# /etc/systemd/oomd.conf
+[OOM]
+SwapUsedLimit=90%
+DefaultMemoryPressureLimit=60%
+DefaultMemoryPressureDurationUSec=30s
+```
+
+### Meta's oomd
+
+Meta (Facebook) originally developed [oomd](https://github.com/facebookincubator/oomd), the PSI-based OOM daemon that inspired systemd-oomd. In Meta's fleet, PSI-based killing replaced the kernel OOM killer, providing faster response times and better decisions about what to kill. This was a primary motivation for PSI's development — Johannes Weiner built PSI to solve real fleet management problems at Meta.
+
+For more context on the problem PSI was designed to solve, see the [LWN article on tracking pressure-stall information](https://lwn.net/Articles/759658/).
+
+### Android LMKD
+
+Android's Low Memory Killer Daemon (LMKD) uses PSI triggers to detect memory pressure and kill background apps before the system becomes unresponsive. Android moved from the in-kernel lowmemorykiller to a PSI-based userspace approach, giving better responsiveness on memory-constrained mobile devices.
+
+### Resource Management at Scale
+
+Beyond OOM handling, PSI enables:
+
+- **Autoscaling**: Scale up containers or VMs when pressure indicates the workload is suffering, rather than reacting to raw utilization.
+- **Workload placement**: Schedulers can prefer nodes with lower pressure rather than lower utilization.
+- **SLA monitoring**: Define health in terms of "how much time are tasks losing" rather than arbitrary resource thresholds.
+
+## Per-cgroup PSI
+
+PSI is not limited to system-wide metrics. Each cgroup exposes its own pressure information via `memory.pressure`, `cpu.pressure`, and `io.pressure`:
+
+```bash
+# View memory pressure for a specific cgroup
+cat /sys/fs/cgroup/myservice/memory.pressure
+
+# View CPU pressure
+cat /sys/fs/cgroup/myservice/cpu.pressure
+
+# View I/O pressure
+cat /sys/fs/cgroup/myservice/io.pressure
+```
+
+Per-cgroup PSI is what makes tools like systemd-oomd and oomd practical. System-wide pressure might be fine while a single container is thrashing. Per-cgroup pressure catches this.
+
+PSI triggers also work on per-cgroup pressure files, so a daemon can register for threshold notifications on individual cgroups:
+
+```c
+int fd = open("/sys/fs/cgroup/myservice/memory.pressure",
+              O_RDWR | O_NONBLOCK);
+write(fd, "some 50000 1000000", 19);  /* 50ms stall per 1s window */
+/* poll(fd) ... */
+```
+
+## How the Kernel Calculates PSI
+
+### Task State Tracking
+
+PSI works by tracking what every task is doing at any given moment. The scheduler already knows whether a task is running, sleeping, or waiting — PSI hooks into these state transitions to accumulate stall time.
+
+Each task can be in one of several PSI-relevant states:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  TSK_IOWAIT          - Waiting for I/O completion          │
+│  TSK_MEMSTALL        - Waiting for memory (reclaim, swap)  │
+│  TSK_RUNNING         - On a runqueue (may or may not       │
+│                        have a CPU)                         │
+│  TSK_MEMSTALL_RUNNING - Running but inside a memory stall  │
+│                        (e.g. synchronous reclaim)          │
+│  TSK_ONCPU           - Currently executing on a CPU        │
+└────────────────────────────────────────────────────────────┘
+```
+
+These flags are defined in [`include/linux/psi_types.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/psi_types.h). `TSK_MEMSTALL_RUNNING` was added to correctly account for tasks that are executing on CPU while in a synchronous reclaim path — these contribute to `some` pressure but not `full` pressure, since the CPU is not idle.
+
+When a task enters a stall state (e.g., it needs to reclaim memory or wait for swap I/O), the kernel calls `psi_task_change()` to record the transition. When it leaves the stall state, the transition is recorded again.
+
+### Aggregation
+
+PSI tracks time at the per-CPU level, then aggregates. For each CPU, it records how much time was spent with at least one task stalled (`some`) and with all tasks stalled (`full`). These per-CPU samples are aggregated into the exponentially weighted averages you see in the pressure files.
+
+```
+Per-CPU tracking:
+  CPU 0: some=150us  full=30us   (in last period)
+  CPU 1: some=80us   full=0us
+  CPU 2: some=200us  full=100us
+  CPU 3: some=0us    full=0us
+         │
+         v
+  Aggregation → weighted averages → /proc/pressure/*
+```
+
+The aggregation happens in `psi_avgs_work()`, a deferred work function that runs periodically (every 2 seconds) to update the moving averages. When userspace has registered PSI triggers, a faster polling path runs at the trigger's window granularity.
+
+### Growth-based Tracking
+
+An important optimization ([commit df77430639c9](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=df77430639c9)): PSI uses per-CPU "growth" counters rather than locks. Each CPU independently tracks cumulative stall time. The aggregation step reads these counters and computes the deltas, avoiding contention on hot paths.
+
+## History
+
+### Introduction (v4.20, 2018)
+
+**Commit**: [eb414681d5a0](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=eb414681d5a0) ("psi: pressure stall information for CPU, memory, and IO")
+
+**Author**: Johannes Weiner (Facebook/Meta)
+
+PSI was merged in Linux v4.20 (December 2018). The motivation, as described in the [commit message](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=eb414681d5a0) and [LWN coverage](https://lwn.net/Articles/759658/), was that existing metrics (load average, free memory, I/O utilization) were poor indicators of whether workloads were actually affected by resource shortages. Facebook needed a metric that quantified lost work, not just resource consumption, to drive fleet-wide resource management decisions.
+
+### PSI Triggers (v5.2, 2019)
+
+**Commit**: [0e94682b73bf](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0e94682b73bf) ("psi: introduce psi monitor")
+
+**Author**: Suren Baghdasaryan
+
+Added poll/epoll support on PSI files, enabling event-driven userspace monitoring. This was essential for making PSI practical in daemons like oomd — polling files in a loop is expensive and introduces latency.
+
+### Per-cgroup PSI (v4.20)
+
+Per-cgroup PSI was part of the original PSI patchset, since cgroup-level pressure was a core use case from the start.
+
+### Broader Adoption
+
+- **Android**: Adopted PSI for LMKD in Android 10 (2019)
+- **systemd**: systemd-oomd [introduced in systemd v247](https://lwn.net/Articles/837034/) (2020)
+- **Meta**: Used PSI across their entire fleet for OOM prevention and workload scheduling
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| [`kernel/sched/psi.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/sched/psi.c) | Core PSI implementation: state tracking, aggregation, triggers |
+| [`include/linux/psi.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/psi.h) | PSI API and inline functions |
+| [`include/linux/psi_types.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/psi_types.h) | PSI data structure definitions |
+| [`kernel/cgroup/cgroup.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/cgroup/cgroup.c) | Per-cgroup PSI file exposure |
+| [`Documentation/accounting/psi.rst`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/accounting/psi.rst) | Kernel documentation for PSI |
+
+## Try It Yourself
+
+### View System Pressure
+
+```bash
+# Check if PSI is enabled (most modern kernels have it on by default)
+cat /proc/pressure/cpu
+cat /proc/pressure/memory
+cat /proc/pressure/io
+```
+
+If the files don't exist, PSI may be disabled. It can be enabled with the `psi=1` kernel boot parameter. Some distributions disable it by default for performance reasons (the overhead is minimal but nonzero).
+
+### Generate Memory Pressure and Observe
+
+```bash
+# Terminal 1: Watch memory pressure
+watch -n 1 cat /proc/pressure/memory
+
+# Terminal 2: Create memory pressure
+# Allocate more memory than available (adjust size for your system)
+stress --vm 4 --vm-bytes $(awk '/MemAvailable/ {print int($2*0.3)"k"}' \
+    /proc/meminfo) --timeout 30
+```
+
+You should see `avg10` rise for both `some` and `full` lines while memory is under pressure.
+
+### Per-cgroup Pressure Monitoring
+
+```bash
+# Create a memory-limited cgroup
+sudo mkdir /sys/fs/cgroup/psi-test
+echo "+memory" | sudo tee /sys/fs/cgroup/cgroup.subtree_control
+echo 100M | sudo tee /sys/fs/cgroup/psi-test/memory.max
+
+# Move a shell into the cgroup
+echo $$ | sudo tee /sys/fs/cgroup/psi-test/cgroup.procs
+
+# Watch cgroup-specific pressure
+watch -n 1 cat /sys/fs/cgroup/psi-test/memory.pressure
+
+# In the same shell, create pressure
+python3 -c "x = bytearray(80 * 1024 * 1024)"  # 80MB in a 100MB cgroup
+```
+
+### Using the total Counter for Precise Measurements
+
+```bash
+# Measure exact stall time over a custom interval
+read_total() {
+    awk '/^some/ {for(i=1;i<=NF;i++) if($i~/^total=/) print substr($i,7)}' \
+        /proc/pressure/memory
+}
+
+START=$(read_total)
+# Run your workload here
+sleep 10
+END=$(read_total)
+
+STALL_US=$((END - START))
+STALL_PCT=$(echo "scale=2; $STALL_US / 10000000 * 100" | bc)
+echo "Memory stall: ${STALL_US}us (${STALL_PCT}% of 10s)"
+```
+
+### Clean Up
+
+```bash
+# Remove test cgroup (move processes out first)
+echo $$ | sudo tee /sys/fs/cgroup/cgroup.procs
+sudo rmdir /sys/fs/cgroup/psi-test
+```
+
+## References
+
+### Kernel Documentation
+
+- [`Documentation/accounting/psi.rst`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/accounting/psi.rst) — Authoritative PSI documentation
+
+### LWN Articles
+
+- [Tracking pressure-stall information](https://lwn.net/Articles/759658/) — Original coverage of the PSI patchset (2018)
+- [Monitoring memory pressure with PSI](https://lwn.net/Articles/837034/) — systemd-oomd and PSI triggers
+
+### Related
+
+- [Memory Cgroups](memcg.md) — Per-cgroup memory limits and accounting
+- [Page Reclaim](reclaim.md) — What causes memory stalls
+- [Running out of memory](oom.md) — The OOM killer that PSI helps avoid
+- [Glossary](glossary.md) — PSI, cgroup, OOM definitions

--- a/docs/mm/swap-thrashing.md
+++ b/docs/mm/swap-thrashing.md
@@ -1,0 +1,220 @@
+# Detecting and preventing swap thrashing
+
+> When the system spends more time swapping than doing useful work
+
+## What is swap thrashing?
+
+Swap thrashing occurs when the system's working set (pages actively in use) exceeds available RAM, forcing the kernel to continuously swap pages in and out. Each page fault triggers disk I/O to bring a page back, but bringing it in evicts another page that will be needed soon. The system becomes unresponsive because it spends most of its time moving pages between RAM and disk instead of running application code.
+
+```
+Normal swapping:
+  Page out → [idle page] → swap     (page not needed for a while)
+  Page in  ← [needed]    ← swap    (occasional, fast)
+
+Thrashing:
+  Page A out → swap    (to make room for B)
+  Page B out → swap    (to make room for C)
+  Page A in  ← swap    (needed again immediately!)
+  Page C out → swap    (to make room for A)
+  Page B in  ← swap    (needed again immediately!)
+  ... cycle continues, system stalls
+```
+
+The key distinction: normal [swapping](swapping.md) moves cold pages to disk infrequently. Thrashing moves hot pages back and forth continuously.
+
+## How to detect it
+
+### vmstat: swap in/out rates
+
+```bash
+$ vmstat 1
+procs -----------memory---------- ---swap-- -----io----
+ r  b   swpd   free   buff  cache   si   so    bi    bo
+ 5 12 4194304  12340   1024  56000  8500  9200  8600  9300
+ 4 14 4194304  11200   1024  55800  9100  8800  9200  9000
+```
+
+- **si** (swap in) and **so** (swap out): sustained high values (thousands of KB/s) indicate thrashing
+- **b** column: many blocked processes waiting on I/O
+- **r** column: runnable processes piling up
+
+### /proc/vmstat counters
+
+```bash
+$ grep -E 'pswpin|pswpout|pgmajfault' /proc/vmstat
+pswpin 892451
+pswpout 1045823
+pgmajfault 934102
+```
+
+Watch these over time. Rapidly increasing `pswpin` and `pswpout` together means pages are being swapped in both directions. High `pgmajfault` (major page faults) confirms pages are being faulted from disk.
+
+### PSI: Pressure Stall Information (v4.20+)
+
+```bash
+$ cat /proc/pressure/memory
+some avg10=45.00 avg60=38.12 avg300=21.45 total=89234567
+full avg10=32.00 avg60=25.88 avg300=14.22 total=62345678
+```
+
+- **some**: percentage of time at least one task is stalled on memory
+- **full**: percentage of time all tasks are stalled on memory
+
+!!! warning
+    Rising `full avg10` indicates all tasks are simultaneously stalled on memory — no productive work is happening. Any sustained `full` pressure warrants investigation. The [PSI documentation](psi.md) describes how to use PSI triggers to act on these signals programmatically.
+
+### Per-cgroup memory pressure
+
+```bash
+$ cat /sys/fs/cgroup/myapp/memory.pressure
+some avg10=78.00 avg60=65.20 avg300=42.10 total=45678901
+full avg10=55.00 avg60=41.30 avg300=28.50 total=31234567
+```
+
+This isolates pressure to a specific workload, which is how `systemd-oomd` detects thrashing at the cgroup level. See [Memory Cgroups](memcg.md) for more on cgroup memory controls.
+
+## Why it happens
+
+| Cause | What's going on |
+|-------|----------------|
+| Working set > RAM | The most common cause. Applications need more memory than physically available. |
+| `vm.swappiness` too high | Kernel aggressively swaps out anonymous pages even when file cache could be reclaimed instead. See [Page Reclaim](reclaim.md). |
+| No swap configured | Paradoxically worse -- without [swap](swap.md), the system cannot gradually degrade. Instead it goes straight to the OOM killer. |
+| Memory leak | A process slowly consumes all RAM, pushing everything else into swap. |
+| Too many cgroups with soft limits | Multiple cgroups competing for the same memory, each reclaiming from the others. |
+
+## How to fix it
+
+### 1. Add RAM or reduce the working set
+
+The only real fix for a working set that exceeds RAM is to either add memory or run fewer/smaller workloads.
+
+### 2. Tune vm.swappiness
+
+```bash
+# Check current value (default is 60)
+$ sysctl vm.swappiness
+vm.swappiness = 60
+
+# Lower it to prefer reclaiming file cache over swapping anonymous pages
+$ sysctl -w vm.swappiness=10
+```
+
+Lower values make the kernel prefer dropping file-backed pages (page cache) over swapping anonymous pages. This helps when thrashing is caused by the kernel being too eager to swap. See [Swap](swap.md) for details on how swappiness affects reclaim decisions.
+
+### 3. Use zswap or zram
+
+Compressed swap keeps pages in RAM (compressed) instead of writing to disk, dramatically reducing I/O:
+
+```bash
+# Enable zswap (compressed swap cache)
+$ echo 1 > /sys/module/zswap/parameters/enabled
+$ echo lz4 > /sys/module/zswap/parameters/compressor
+$ echo 20 > /sys/module/zswap/parameters/max_pool_percent
+
+# Or use zram (compressed block device as swap)
+$ modprobe zram
+$ echo lz4 > /sys/block/zram0/comp_algorithm
+$ echo 4G > /sys/block/zram0/disksize
+$ mkswap /dev/zram0
+$ swapon -p 100 /dev/zram0
+```
+
+zswap/zram can achieve 2-3x compression, effectively expanding usable memory without disk I/O.
+
+### 4. Set cgroup memory limits
+
+Hard limits prevent a single workload from causing system-wide thrashing:
+
+```bash
+# cgroup v2: limit a workload to 4GB
+$ echo 4G > /sys/fs/cgroup/myapp/memory.max
+
+# Set a high watermark to trigger early reclaim
+$ echo 3G > /sys/fs/cgroup/myapp/memory.high
+```
+
+`memory.high` triggers throttling and reclaim before hitting the hard limit, providing back-pressure to the application. See [Memory Cgroups](memcg.md).
+
+## The thrashing livelock problem
+
+Before kernel v4.20, the system had no good mechanism to detect thrashing at scale. The kernel would:
+
+1. Try to reclaim pages
+2. Swap out pages that are immediately needed again
+3. Swap them back in, evicting other needed pages
+4. Repeat indefinitely
+
+The system would stay alive but make no forward progress -- a **livelock**. The OOM killer wouldn't fire because technically memory allocations were succeeding (just very slowly, via swap). Users saw a system that was completely unresponsive but wouldn't recover on its own.
+
+The core problem: the [reclaim](reclaim.md) path had no way to measure whether its work was useful. It could reclaim pages, but couldn't tell that those same pages were being faulted back immediately.
+
+## Modern solutions
+
+### PSI-based OOM (systemd-oomd)
+
+Kernel v4.20 introduced [Pressure Stall Information (PSI)](https://docs.kernel.org/accounting/psi.html), which measures the actual impact of resource contention on running tasks. `systemd-oomd` uses PSI to detect thrashing and kill workloads proactively:
+
+```
+PSI memory.pressure > threshold for duration
+        │
+        v
+systemd-oomd identifies the cgroup causing pressure
+        │
+        v
+Kills processes in that cgroup before the system locks up
+```
+
+This solves the livelock problem: instead of waiting for allocations to fail (which may never happen during thrashing), the system acts on observed stall time.
+
+```bash
+# Check if systemd-oomd is running
+$ systemctl status systemd-oomd
+
+# View its configuration
+$ cat /etc/systemd/oomd.conf
+```
+
+### MGLRU: better page aging (v6.1+)
+
+[Multi-Gen LRU (MGLRU)](https://docs.kernel.org/mm/multigen_lru.html) replaces the traditional active/inactive LRU with multiple generations, providing more accurate page age tracking. This reduces thrashing by making better eviction decisions -- the kernel is less likely to evict a page that will be needed soon.
+
+```bash
+# Check if MGLRU is enabled
+$ cat /sys/kernel/mm/lru_gen/enabled
+```
+
+MGLRU is particularly effective for workloads with large working sets that just barely fit in memory, where the old LRU would thrash but MGLRU correctly identifies the coldest pages.
+
+## Quick diagnostic checklist
+
+```bash
+# 1. Is the system thrashing right now?
+vmstat 1 5                              # Look at si/so columns
+
+# 2. How bad is memory pressure?
+cat /proc/pressure/memory               # full avg10 > 20% = problem
+
+# 3. What's using all the memory?
+ps aux --sort=-%mem | head -10          # Top memory consumers
+smem -tk                                # Per-process proportional memory
+
+# 4. How much swap is in use?
+swapon --show                           # Swap devices and usage
+free -h                                 # Swap total/used/free
+
+# 5. Check major faults over time
+grep pgmajfault /proc/vmstat            # Run twice, compare values
+
+# 6. Which cgroup is under pressure? (cgroup v2)
+find /sys/fs/cgroup -name memory.pressure \
+  -exec sh -c 'echo "=== $1 ==="; cat "$1"' _ {} \;
+```
+
+## See also
+
+- [Swap](swap.md) -- swap architecture and configuration
+- [What happens during swapping](swapping.md) -- the page-level swap in/out lifecycle
+- [Page Reclaim](reclaim.md) -- how the kernel decides what to evict
+- [Running out of memory](oom.md) -- what happens when reclaim and swap both fail
+- [Memory Cgroups](memcg.md) -- isolating and limiting workload memory

--- a/docs/mm/sysctl-reference.md
+++ b/docs/mm/sysctl-reference.md
@@ -1,0 +1,112 @@
+# Memory Sysctl Tuning Reference
+
+Compact reference for all memory-related sysctls under `/proc/sys/vm/`. Each entry links to the [kernel sysctl documentation](https://docs.kernel.org/admin-guide/sysctl/vm.html).
+
+Read or write any value at runtime:
+
+```bash
+# Read
+sysctl vm.swappiness
+# Write (non-persistent)
+sysctl -w vm.swappiness=10
+# Persistent (survives reboot)
+echo "vm.swappiness = 10" >> /etc/sysctl.d/99-tuning.conf
+sysctl --system
+```
+
+---
+
+## Reclaim
+
+Controls how aggressively the kernel reclaims memory and manages free-page watermarks.
+
+| Sysctl | Default | Description | When to change |
+|--------|---------|-------------|----------------|
+| [`vm.swappiness`](https://docs.kernel.org/admin-guide/sysctl/vm.html#swappiness) | 60 | Weight for reclaiming anonymous pages vs page cache (0-200) | Lower for latency-sensitive workloads that prefer dropping cache over swapping; raise for memory-overcommitted hosts |
+| [`vm.min_free_kbytes`](https://docs.kernel.org/admin-guide/sysctl/vm.html#min-free-kbytes) | Varies (scales with RAM) | Minimum KB of free memory the kernel keeps reserved | Raise on systems that hit direct reclaim stalls or need burst allocations (e.g., high-speed networking) |
+| [`vm.watermark_scale_factor`](https://docs.kernel.org/admin-guide/sysctl/vm.html#watermark-scale-factor) | 10 | Gap between min/low/high watermarks as fraction of zone size (units of 0.01%) | Raise to trigger kswapd earlier, reducing direct reclaim; useful for bursty allocation patterns |
+| [`vm.watermark_boost_factor`](https://docs.kernel.org/admin-guide/sysctl/vm.html#watermark-boost-factor) | 15000 | Temporary watermark boost after memory fragmentation events (units of 0.01%) | Lower or set to 0 on systems where boosted reclaim causes unnecessary swapping |
+| [`vm.vfs_cache_pressure`](https://docs.kernel.org/admin-guide/sysctl/vm.html#vfs-cache-pressure) | 100 | Tendency to reclaim dentry/inode caches vs page cache (0 = never, 100 = fair, >100 = aggressive) | Lower for file-server workloads with many small files; raise when dentry/inode caches consume too much memory |
+
+---
+
+## Dirty Pages
+
+Controls when and how often dirty (modified) page cache is written back to disk.
+
+| Sysctl | Default | Description | When to change |
+|--------|---------|-------------|----------------|
+| [`vm.dirty_ratio`](https://docs.kernel.org/admin-guide/sysctl/vm.html#dirty-ratio) | 20 | Percentage of total memory at which a writing process is forced to start writeback | Lower for latency-sensitive I/O; raise for throughput on fast storage |
+| [`vm.dirty_background_ratio`](https://docs.kernel.org/admin-guide/sysctl/vm.html#dirty-background-ratio) | 10 | Percentage of total memory at which background writeback (per-device writeback threads) kicks in | Lower to keep less dirty data in memory (safer on power loss); raise on fast storage to batch more writes |
+| [`vm.dirty_expire_centisecs`](https://docs.kernel.org/admin-guide/sysctl/vm.html#dirty-expire-centisecs) | 3000 | Age (in centiseconds) at which dirty data becomes eligible for writeback | Lower for data safety; raise to allow more write coalescing |
+| [`vm.dirty_writeback_centisecs`](https://docs.kernel.org/admin-guide/sysctl/vm.html#dirty-writeback-centisecs) | 500 | Interval (in centiseconds) between writeback thread wake-ups | Lower for more frequent flushes; raise (or set to 0 to disable) on battery-powered devices to reduce disk wake-ups |
+
+!!! tip
+    Use `dirty_bytes` / `dirty_background_bytes` instead of the ratio variants when you need an absolute cap that does not scale with RAM.
+
+---
+
+## Overcommit
+
+Controls the kernel's memory overcommit policy. See also [Memory Overcommit](overcommit.md).
+
+| Sysctl | Default | Description | When to change |
+|--------|---------|-------------|----------------|
+| [`vm.overcommit_memory`](https://docs.kernel.org/admin-guide/sysctl/vm.html#overcommit-memory) | 0 | Policy: 0 = heuristic, 1 = always allow, 2 = strict limit | Set to 2 on systems where OOM kills are unacceptable (databases, embedded); set to 1 for certain HPC or container setups |
+| [`vm.overcommit_ratio`](https://docs.kernel.org/admin-guide/sysctl/vm.html#overcommit-ratio) | 50 | When `overcommit_memory=2`: commit limit = swap + RAM * ratio / 100 | Raise when applications legitimately need more virtual memory; only effective with mode 2 |
+| [`vm.overcommit_kbytes`](https://docs.kernel.org/admin-guide/sysctl/vm.html#overcommit-kbytes) | 0 | When `overcommit_memory=2`: absolute overcommit limit in KB (overrides ratio if nonzero) | Use instead of ratio when you need a precise byte-level commit limit |
+
+---
+
+## Huge Pages
+
+Controls static (hugetlbfs) huge page allocation. For transparent huge pages, see [THP](thp.md).
+
+| Sysctl | Default | Description | When to change |
+|--------|---------|-------------|----------------|
+| [`vm.nr_hugepages`](https://docs.kernel.org/admin-guide/sysctl/vm.html#nr-hugepages) | 0 | Number of persistent huge pages to pre-allocate | Set to the number of huge pages your application requires (e.g., DPDK, large databases) |
+| [`vm.nr_overcommit_hugepages`](https://docs.kernel.org/admin-guide/sysctl/vm.html#nr-overcommit-hugepages) | 0 | Additional huge pages that can be allocated on demand beyond `nr_hugepages` | Set when applications may need burst huge-page capacity but you do not want to pin all memory upfront |
+| [`vm.hugetlb_shm_group`](https://docs.kernel.org/admin-guide/sysctl/vm.html#hugetlb-shm-group) | 0 | GID allowed to create SysV shared memory segments backed by huge pages | Set to the group ID of unprivileged users that need huge-page shared memory (e.g., database service accounts) |
+
+---
+
+## NUMA
+
+Tuning knobs for Non-Uniform Memory Access systems. See also [NUMA](numa.md).
+
+| Sysctl | Default | Description | When to change |
+|--------|---------|-------------|----------------|
+| [`vm.zone_reclaim_mode`](https://docs.kernel.org/admin-guide/sysctl/vm.html#zone-reclaim-mode) | 0 | Bitmask controlling whether the kernel reclaims local-node memory before allocating remotely (1 = enable zone reclaim, 2 = writeback, 4 = swap) | Enable on large NUMA systems where local-memory latency matters more than cache retention; leave at 0 for most workloads |
+| [`vm.numa_stat`](https://docs.kernel.org/admin-guide/sysctl/vm.html#numa-stat) | 1 | Enable per-node NUMA hit/miss/foreign statistics in `/proc/vmstat` | Disable (set to 0) on large NUMA machines where the per-update overhead of these counters is measurable |
+
+---
+
+## OOM
+
+Controls Out-Of-Memory killer behavior. See also [Running out of memory](oom.md).
+
+| Sysctl | Default | Description | When to change |
+|--------|---------|-------------|----------------|
+| [`vm.oom_kill_allocating_task`](https://docs.kernel.org/admin-guide/sysctl/vm.html#oom-kill-allocating-task) | 0 | When set to 1, kill the task that triggered OOM instead of scanning for the worst offender | Enable on systems where scanning is too slow or you want deterministic OOM behavior |
+| [`vm.oom_dump_tasks`](https://docs.kernel.org/admin-guide/sysctl/vm.html#oom-dump-tasks) | 1 | Dump per-task memory info to the kernel log on OOM | Disable on systems with thousands of tasks where the dump itself causes problems |
+| [`vm.panic_on_oom`](https://docs.kernel.org/admin-guide/sysctl/vm.html#panic-on-oom) | 0 | Trigger a kernel panic instead of invoking the OOM killer (0 = off, 1 = panic, 2 = panic even for cgroup OOM) | Enable in clusters where a dead node is preferable to a degraded one (lets a watchdog or cluster manager restart the machine) |
+
+---
+
+## Miscellaneous
+
+| Sysctl | Default | Description | When to change |
+|--------|---------|-------------|----------------|
+| [`vm.max_map_count`](https://docs.kernel.org/admin-guide/sysctl/vm.html#max-map-count) | 65530 | Maximum number of VMAs a process may have | Raise for applications with many mappings (e.g., JVMs, Elasticsearch, mmap-heavy databases) |
+| [`vm.mmap_min_addr`](https://docs.kernel.org/admin-guide/sysctl/vm.html#mmap-min-addr) | 0 (kernel default; most distros set 65536) | Lowest virtual address a user-space process is allowed to mmap | Lower only if legacy software requires mapping at address zero; keep high for NULL-pointer dereference protection |
+| [`vm.compact_memory`](https://docs.kernel.org/admin-guide/sysctl/vm.html#compact-memory) | Write-only | Writing 1 triggers synchronous memory compaction across all zones | Use before allocating huge pages on a fragmented system; avoid in production hot paths |
+| [`vm.drop_caches`](https://docs.kernel.org/admin-guide/sysctl/vm.html#drop-caches) | Write-only | Writing 1 = free page cache, 2 = free dentries/inodes, 3 = both | Use only for benchmarking or debugging; not recommended in production as the kernel manages caches effectively on its own |
+
+---
+
+## Quick Tips
+
+- **Check current values**: `sysctl -a | grep vm.` lists every `vm.*` parameter and its value.
+- **Monitor effects**: watch `/proc/vmstat`, `/proc/meminfo`, and per-zone stats in `/proc/zoneinfo` after changing a sysctl.
+- **Persist changes**: place tuning in `/etc/sysctl.d/*.conf` files rather than editing `/etc/sysctl.conf` directly.
+- **Container awareness**: inside a container, many `vm.*` sysctls are host-global and require privileged access. Memory cgroup knobs (see [memcg](memcg.md)) are the per-container equivalent.

--- a/docs/mm/tuning-containers.md
+++ b/docs/mm/tuning-containers.md
@@ -1,0 +1,505 @@
+# Tuning Memory for Containers
+
+> Getting container memory limits right -- and debugging when they're wrong
+
+## Why Container Memory Is Different
+
+On a bare-metal server, all processes share a single pool of memory managed by the kernel. Containers change this model fundamentally: each container gets its own memory boundary enforced by the kernel's **cgroup memory controller**. Understanding how that controller works is the difference between a stable production deployment and mysterious OOM kills at 3 AM.
+
+This page focuses on **cgroup v2**, which is the [recommended cgroup version](https://lwn.net/Articles/679786/) for all new deployments (declared production-ready in kernel v4.5). If you're still on cgroup v1, the concepts are similar but the interface files differ. See [Memory Cgroups](memcg.md) for v1 vs v2 differences.
+
+## The Four Memory Knobs
+
+The cgroup v2 memory controller exposes four files that control how much memory a group of processes can use. They form a hierarchy from hard enforcement to soft protection:
+
+```
+                    memory.max      <- Hard ceiling. Exceed this and die.
+                        |
+                    memory.high     <- Soft ceiling. Exceed this and get throttled.
+                        |
+                        |  (normal operation zone)
+                        |
+                    memory.low      <- Soft floor. Protected from reclaim (best-effort).
+                        |
+                    memory.min      <- Hard floor. Absolutely protected from reclaim.
+```
+
+| File | Type | What Happens | Default |
+|------|------|-------------|---------|
+| [`memory.max`](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files) | Hard limit | OOM killer invoked when exceeded | `max` (no limit) |
+| [`memory.high`](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files) | Soft limit | Processes throttled, aggressive reclaim | `max` (no limit) |
+| [`memory.low`](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files) | Soft protection | Memory below this is protected from reclaim (best-effort) | `0` |
+| [`memory.min`](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files) | Hard protection | Memory below this is never reclaimed | `0` |
+
+### memory.max: The Hard Limit
+
+When a cgroup's memory usage reaches `memory.max`, the kernel tries reclaim within that cgroup. If reclaim fails to free enough memory, the cgroup OOM killer is invoked and a process within the cgroup is killed. The host system is unaffected -- this is a cgroup-scoped OOM, not a global one.
+
+```bash
+# Set a 1GB hard limit
+echo 1G > /sys/fs/cgroup/mycontainer/memory.max
+```
+
+This is the wall your container cannot climb over. It exists to prevent a single container from starving the rest of the system.
+
+### memory.high: The Soft Limit
+
+`memory.high` is more nuanced. When usage exceeds this threshold, the kernel does not kill anything. Instead, it aggressively reclaims memory from the cgroup and **throttles** allocating processes -- they're put to sleep until the reclaim frees enough pages.
+
+```bash
+# Throttle at 800MB, kill at 1GB
+echo 800M > /sys/fs/cgroup/mycontainer/memory.high
+echo 1G > /sys/fs/cgroup/mycontainer/memory.max
+```
+
+Why have both? Because `memory.high` creates back-pressure. Instead of running at full speed until you hit a wall and die, your application slows down gradually. This gives monitoring time to detect the problem and is far gentler than an OOM kill.
+
+!!! tip "Think of it like a speed limit vs a cliff"
+    `memory.high` is a speed limit sign -- you slow down when you hit it. `memory.max` is the edge of a cliff -- you go over it and you're dead.
+
+### memory.low and memory.min: Protection Guarantees
+
+These knobs work in the opposite direction. Instead of limiting how much memory a cgroup can use, they guarantee how much it gets to keep during system-wide memory pressure.
+
+- **`memory.low`**: Best-effort protection. Memory below this threshold won't be reclaimed unless there is no other reclaimable memory anywhere in the system. Think of it as "please don't take this memory unless you absolutely have to."
+
+- **`memory.min`**: Hard protection. Memory below this threshold is never reclaimed, period. Even under extreme pressure, the kernel will OOM-kill other things rather than reclaim this cgroup's protected memory.
+
+```bash
+# Guarantee the database container keeps at least 2GB
+echo 2G > /sys/fs/cgroup/database/memory.min
+
+# Prefer to keep 4GB if possible
+echo 4G > /sys/fs/cgroup/database/memory.low
+```
+
+**Protection is hierarchical**: the effective protection for a child cgroup is limited by its parent's protection. If a parent has `memory.min` of 4GB, the sum of children's `memory.min` values can exceed 4GB, but the effective protection is distributed proportionally up to the parent's 4GB. This is documented in the [cgroup v2 distribution model](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files).
+
+```
+parent (memory.min: 4GB)
+├── child-a (memory.min: 3GB)  <- effective: ~2.4GB (3/5 of 4GB)
+├── child-b (memory.min: 2GB)  <- effective: ~1.6GB (2/5 of 4GB)
+```
+
+## Why Containers See Wrong Memory Numbers
+
+Run `free` inside a typical container and you'll see the **host's** total memory, not the container's limit:
+
+```bash
+# Inside a container with 1GB limit
+$ free -h
+              total        used        free
+Mem:           62Gi        45Gi        17Gi    # <- This is the HOST's memory!
+```
+
+This happens because `/proc/meminfo` is a global file that reports system-wide memory. The container's cgroup limit exists only in the cgroup filesystem, not in `/proc`. Many applications (especially JVMs, databases, and language runtimes) read `/proc/meminfo` to auto-tune themselves. When they see 62GB of total memory instead of 1GB, they allocate far too much and get OOM-killed.
+
+### The Solutions
+
+**LXCFS**: A FUSE filesystem that intercepts reads to `/proc/meminfo`, `/proc/cpuinfo`, and other files, returning cgroup-aware values instead. [LXCFS](https://linuxcontainers.org/lxcfs/) mounts over `/proc` inside the container so existing tools work without modification.
+
+**Runtime-specific flags**: Many runtimes now detect cgroup limits natively:
+
+```bash
+# Java 10+ automatically detects cgroup limits
+java -XX:+UseContainerSupport -jar app.jar
+
+# Java 8u191+ also supports it
+java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar app.jar
+```
+
+**cgroup-aware tools**: Modern versions of `systemd-cgtop`, `cadvisor`, and `kubectl top` read from the cgroup filesystem directly rather than `/proc/meminfo`.
+
+## Common Problems
+
+### Container OOM When Host Has Free Memory
+
+This is the most frequently misdiagnosed container problem. The host shows 17GB free, but your container just got killed.
+
+The cause is simple: the container hit its **cgroup memory limit** (`memory.max`), which triggered a cgroup-scoped OOM kill. Global free memory is irrelevant -- the cgroup has its own accounting.
+
+```bash
+# Confirm the cgroup limit was hit
+cat /sys/fs/cgroup/mycontainer/memory.events
+# oom 3          <- OOM was triggered 3 times
+# oom_kill 3     <- 3 processes were killed
+# max 47         <- memory.max was hit 47 times
+```
+
+**Fixes**:
+
+- Increase `memory.max` if the limit is too low
+- Add `memory.high` below `memory.max` to create back-pressure before the OOM
+- Optimize the application's memory usage
+- Allow swap with `memory.swap.max` to give a buffer
+
+### Page Cache Counting Against the Limit
+
+In cgroup v2, **page cache is charged to the cgroup that read the file**. This catches many people off guard. A container that reads large files will have its page cache counted against its memory limit, even though the kernel can reclaim that cache at any time.
+
+```bash
+# Check how much is cache vs anonymous memory
+cat /sys/fs/cgroup/mycontainer/memory.stat | grep -E '^(anon|file) '
+# anon 524288000     <- actual working memory
+# file 209715200     <- page cache (reclaimable)
+```
+
+The cache is reclaimable, so it won't cause OOM by itself. But it does cause `memory.high` throttling if the combined usage exceeds the soft limit. If this is a problem, size `memory.high` with page cache headroom in mind.
+
+### Slow Container Start Under Memory Pressure
+
+If a container starts slowly, it might be because `memory.high` is set too close to actual usage. Every allocation triggers reclaim and throttling. Check `memory.pressure` to confirm:
+
+```bash
+cat /sys/fs/cgroup/mycontainer/memory.pressure
+# some avg10=45.00 avg60=30.00 avg300=12.00 total=890234
+# full avg10=20.00 avg60=10.00 avg300=5.00 total=234567
+```
+
+If these numbers are high, your container is spending significant time waiting for memory.
+
+## Kubernetes: Requests vs Limits
+
+Kubernetes exposes two memory settings per container, and they map directly to cgroup knobs:
+
+| Kubernetes | cgroup v2 | Behavior |
+|-----------|-----------|----------|
+| `resources.limits.memory` | `memory.max` | Hard limit. Container is OOM-killed if exceeded. |
+| `resources.requests.memory` | `memory.min` (requires MemoryQoS feature gate) | Scheduling guarantee. Used for QoS classification; `memory.min` mapping requires the alpha [MemoryQoS feature gate](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/) (k/enhancements#2570). |
+
+```yaml
+# Pod spec
+resources:
+  requests:
+    memory: "512Mi"   # Schedule on a node with 512Mi available; protect this amount
+  limits:
+    memory: "1Gi"     # Hard ceiling; OOM kill above this
+```
+
+### How QoS Classes Affect Memory
+
+Kubernetes assigns Quality of Service classes based on requests and limits:
+
+- **Guaranteed** (requests == limits): Container gets exactly what it asks for. With MemoryQoS enabled, the kubelet sets `memory.min` equal to the limit, providing hard protection.
+- **Burstable** (requests < limits): Container can use more than requested, up to its limit. With MemoryQoS enabled, gets `memory.min` set to the request value.
+- **BestEffort** (no requests or limits): No cgroup memory limit is set. First to be killed under node pressure.
+
+!!! note "MemoryQoS feature gate"
+    The `memory.min` mapping described above requires the `MemoryQoS` feature gate, which was alpha in Kubernetes 1.22+ and is not enabled by default. In standard Kubernetes deployments, `resources.requests.memory` influences scheduling and QoS class only — it does not set `memory.min` in the cgroup.
+
+```
+Node (16GB)
+├── Guaranteed pod (memory.min=1G, memory.max=1G)  <- always safe
+├── Burstable pod  (memory.min=512M, memory.max=2G) <- protected up to 512M
+└── BestEffort pod (no limits)                       <- first to die
+```
+
+!!! warning "Set requests even if you don't set limits"
+    Without a `requests.memory`, your pod is BestEffort class and will be the first to be evicted when the node runs low on memory. Always set at least requests.
+
+## Docker: --memory and --memory-reservation
+
+Docker exposes container memory settings through command-line flags:
+
+| Docker Flag | cgroup v2 | Behavior |
+|------------|-----------|----------|
+| `--memory` (or `-m`) | `memory.max` | Hard limit. OOM kill if exceeded. |
+| `--memory-reservation` | `memory.low` | Soft protection under system pressure. |
+| `--memory-swap` | `memory.swap.max` + `memory.max` | Total memory + swap limit. |
+| `--oom-kill-disable` | Disables OOM killer | **Dangerous**: can hang the container and host. |
+
+```bash
+# Run a container with 1GB limit and 750MB reservation
+docker run -d \
+  --memory=1g \
+  --memory-reservation=750m \
+  --name myapp myimage
+
+# Equivalent cgroup settings:
+# memory.max = 1073741824
+# memory.low = 786432000
+```
+
+!!! warning "Docker --memory-swap semantics"
+    `--memory-swap` sets the **combined** memory + swap limit, not just swap. So `--memory=1g --memory-swap=2g` means 1GB RAM + 1GB swap. Set `--memory-swap=-1` for unlimited swap.
+
+## Monitoring Container Memory
+
+### Key Files
+
+```bash
+CGROUP=/sys/fs/cgroup/mycontainer
+
+# Current usage (bytes)
+cat $CGROUP/memory.current
+# 734003200
+
+# Peak usage (useful for sizing)
+cat $CGROUP/memory.peak       # v5.19+
+# 891289600
+
+# Detailed breakdown
+cat $CGROUP/memory.stat
+# anon 524288000              # heap, stack, anonymous mmap
+# file 209715200              # page cache
+# slab 12582912               # kernel slab objects
+# sock 4194304                # socket buffers
+# shmem 0                     # shared memory (tmpfs)
+# pgfault 1234567             # page faults
+# pgmajfault 42               # major faults (disk I/O)
+
+# Events (problems that happened)
+cat $CGROUP/memory.events
+# low 0                       # times memory.low was breached
+# high 152                    # times memory.high was exceeded
+# max 3                       # times memory.max was hit
+# oom 1                       # OOM events
+# oom_kill 1                  # processes OOM-killed
+# oom_group_kill 0            # group OOM kills
+```
+
+### Pressure Stall Information (PSI)
+
+PSI gives you the most actionable signal about whether a container is memory-constrained:
+
+```bash
+cat $CGROUP/memory.pressure
+# some avg10=2.50 avg60=1.00 avg300=0.50 total=45678
+# full avg10=0.00 avg60=0.00 avg300=0.00 total=1234
+```
+
+- **some**: Percentage of time that at least one task in the cgroup was stalled waiting for memory. If this is consistently above zero, the container is under pressure.
+- **full**: Percentage of time that all tasks were stalled. If this is above zero, the container is completely blocked on memory.
+
+PSI was introduced as a cgroup-level feature in [v4.20](https://lwn.net/Articles/759658/) and is the foundation of Meta's [oomd](https://facebookincubator.github.io/oomd/) userspace OOM daemon, which uses PSI to proactively kill workloads before the kernel OOM killer fires.
+
+```bash
+# Set up a PSI trigger to get notified when pressure exceeds a threshold
+# (useful for building auto-scaling)
+echo "some 50000 1000000" > $CGROUP/memory.pressure
+# Trigger when "some" exceeds 50ms per 1s window
+```
+
+## Swap in Containers
+
+By default in cgroup v2, swap is allowed up to whatever the system provides. You can control this per-cgroup:
+
+```bash
+# Disable swap entirely for this container
+echo 0 > /sys/fs/cgroup/mycontainer/memory.swap.max
+
+# Allow up to 500MB of swap
+echo 500M > /sys/fs/cgroup/mycontainer/memory.swap.max
+
+# Check current swap usage
+cat /sys/fs/cgroup/mycontainer/memory.swap.current
+```
+
+### Why Allow Swap in Containers?
+
+The conventional wisdom of "disable swap for containers" comes from cgroup v1 where swap accounting was expensive and unreliable. In cgroup v2, swap accounting is efficient and well-integrated.
+
+Swap provides a buffer between "memory.high throttling" and "memory.max OOM kill". Without swap, a sudden spike in memory usage goes directly to OOM. With swap, the spike gets absorbed into swap, giving you time to detect and react.
+
+### memory.zswap.max (v6.5+)
+
+[zswap](https://docs.kernel.org/admin-guide/mm/zswap.html) compresses pages in memory before writing them to swap. The `memory.zswap.max` file limits how much compressed data a cgroup can store in the zswap pool:
+
+```bash
+# Limit zswap usage to 200MB for this cgroup
+echo 200M > /sys/fs/cgroup/mycontainer/memory.zswap.max
+
+# Check zswap usage
+cat /sys/fs/cgroup/mycontainer/memory.zswap.current
+```
+
+This prevents a single container from filling the entire zswap pool and forcing other containers' pages to be written to slow disk swap. The per-cgroup zswap limit was introduced in [commit f4840ccfca25](https://git.kernel.org/linus/f4840ccfca25) ("zswap: memcg accounting").
+
+## Best Practices
+
+### Sizing Limits
+
+1. **Profile first**: Run your application under realistic load and observe `memory.peak` (or `memory.max_usage_in_bytes` on v1). Set `memory.max` to 1.25-1.5x the observed peak.
+
+2. **Set memory.high below memory.max**: A gap of 10-20% between `memory.high` and `memory.max` gives the kernel room to throttle and reclaim before killing.
+
+    ```bash
+    # If your app peaks at 800MB:
+    echo 1200M > /sys/fs/cgroup/mycontainer/memory.max   # 1.5x peak
+    echo 1000M > /sys/fs/cgroup/mycontainer/memory.high  # throttle zone
+    ```
+
+3. **Account for page cache**: If your workload is I/O-heavy, add headroom for page cache. Check `memory.stat`'s `file` field under load.
+
+4. **Use memory.low for critical services**: If a container must not be reclaimed (e.g., database buffer pool), set `memory.low` or `memory.min`.
+
+### Handling OOM Gracefully
+
+**Use `memory.oom.group`** ([commit 3d8b38eb81ca](https://git.kernel.org/linus/3d8b38eb81ca), "mm, oom: introduce memory.oom.group"): When a container OOM occurs, the default behavior kills a single process. For multi-process containers (e.g., a web server with workers), killing one process often leaves the container in a broken state. `memory.oom.group` kills all processes in the cgroup together, ensuring a clean restart.
+
+```bash
+# Kill all processes in the cgroup on OOM (v4.19+)
+echo 1 > /sys/fs/cgroup/mycontainer/memory.oom.group
+```
+
+**Use systemd or container runtime restart policies**: Since OOM is not always preventable, make sure your container can restart cleanly.
+
+```bash
+# Docker: always restart on OOM
+docker run --restart=always --memory=1g myimage
+
+# Kubernetes: the default restartPolicy is Always
+```
+
+**Monitor `memory.events`**: Set up alerts on the `oom` and `oom_kill` counters. An increasing count means the limit is too low or the application has a leak.
+
+### A Complete Production Setup
+
+```bash
+CGROUP=/sys/fs/cgroup/mycontainer
+
+# Hard limit: 1.5x observed peak
+echo 1500M > $CGROUP/memory.max
+
+# Throttle before OOM
+echo 1200M > $CGROUP/memory.high
+
+# Protect critical working set
+echo 500M > $CGROUP/memory.min
+
+# Allow some swap as buffer
+echo 512M > $CGROUP/memory.swap.max
+
+# Kill all processes together on OOM
+echo 1 > $CGROUP/memory.oom.group
+```
+
+## Try It Yourself
+
+### Observe memory.high Throttling
+
+```bash
+# Create a cgroup with a low soft limit
+sudo mkdir -p /sys/fs/cgroup/throttle-test
+echo "+memory" | sudo tee /sys/fs/cgroup/cgroup.subtree_control
+echo 50M | sudo tee /sys/fs/cgroup/throttle-test/memory.high
+echo 100M | sudo tee /sys/fs/cgroup/throttle-test/memory.max
+
+# Run a process that slowly allocates memory
+echo $$ | sudo tee /sys/fs/cgroup/throttle-test/cgroup.procs
+python3 -c "
+import time
+chunks = []
+for i in range(80):
+    chunks.append(b'x' * 1_000_000)  # 1MB per iteration
+    print(f'Allocated {i+1}MB')
+    time.sleep(0.1)
+"
+# Notice it slows down dramatically around 50MB (memory.high)
+# and gets killed around 100MB (memory.max)
+```
+
+### Compare memory.low Protection
+
+```bash
+# Create parent and two children
+sudo mkdir -p /sys/fs/cgroup/parent
+echo "+memory" | sudo tee /sys/fs/cgroup/cgroup.subtree_control
+echo 200M | sudo tee /sys/fs/cgroup/parent/memory.max
+echo "+memory" | sudo tee /sys/fs/cgroup/parent/cgroup.subtree_control
+
+sudo mkdir /sys/fs/cgroup/parent/protected
+sudo mkdir /sys/fs/cgroup/parent/unprotected
+
+# Protect one child
+echo 100M | sudo tee /sys/fs/cgroup/parent/protected/memory.low
+
+# Allocate memory in both, then observe which one gets reclaimed
+# when the parent approaches its 200M limit
+```
+
+### Monitor a Docker Container's Memory
+
+```bash
+# Start a container
+docker run -d --name memtest --memory=256m nginx
+
+# Find its cgroup path
+CGPATH=$(docker inspect memtest --format '{{.HostConfig.CgroupParent}}')
+# Or on systemd-based systems:
+PID=$(docker inspect memtest --format '{{.State.Pid}}')
+CGROUP=$(cat /proc/$PID/cgroup | grep -o '/.*')
+
+# Watch memory in real-time
+watch -n 1 "echo '--- usage ---' && \
+  cat /sys/fs/cgroup${CGROUP}/memory.current && \
+  echo '--- pressure ---' && \
+  cat /sys/fs/cgroup${CGROUP}/memory.pressure && \
+  echo '--- events ---' && \
+  cat /sys/fs/cgroup${CGROUP}/memory.events"
+
+# Cleanup
+docker rm -f memtest
+```
+
+## History
+
+### memory.high Throttling (v4.0+, stable in v4.5)
+
+**Author**: Johannes Weiner
+
+The `memory.high` knob was added as part of the cgroup v2 memory controller in v4.0 ([commit 241994ed8649](https://git.kernel.org/linus/241994ed8649)), but cgroup v2 was experimental until v4.5 when it was [declared production-ready](https://lwn.net/Articles/679786/). The soft-limit throttling model — where processes are slowed down instead of killed — made container memory management much more predictable.
+
+### memory.oom.group (v4.19, 2018)
+
+**Commit**: [3d8b38eb81ca](https://git.kernel.org/linus/3d8b38eb81ca) ("mm, oom: introduce memory.oom.group")
+
+**Author**: Roman Gushchin
+
+Allowed killing all processes in a cgroup together on OOM, which is essential for container-based deployments where partial kills leave broken state.
+
+### Per-cgroup PSI (v4.20, 2018)
+
+**Commit**: [eb414681d5a0](https://git.kernel.org/linus/eb414681d5a0) ("psi: pressure stall information for CPU, memory, and IO") | [LWN](https://lwn.net/Articles/759658/)
+
+**Author**: Johannes Weiner
+
+Enabled fine-grained pressure monitoring per cgroup, replacing the crude `memory.failcnt` counter from v1.
+
+### memory.reclaim (v5.19, 2022)
+
+**Commit**: [94968384dde1](https://git.kernel.org/linus/94968384dde1) ("memcg: introduce per-memcg reclaim interface") | [LWN](https://lwn.net/Articles/894849/)
+
+**Authors**: Shakeel Butt (original author, Google) and Yosry Ahmed (Google, drove subsequent revisions)
+
+Proactive reclaim: allows userspace to trigger reclaim within a cgroup without waiting for memory pressure. Used by Meta and Google for pre-emptive memory management.
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/memcontrol.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memcontrol.c) | Memory controller implementation |
+| [`mm/vmpressure.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmpressure.c) | Memory pressure notifications |
+| [`kernel/sched/psi.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/sched/psi.c) | Pressure Stall Information |
+
+### Kernel Documentation
+
+- [`Documentation/admin-guide/cgroup-v2.rst`](https://docs.kernel.org/admin-guide/cgroup-v2.html) - Authoritative cgroup v2 reference
+- [`Documentation/admin-guide/mm/zswap.rst`](https://docs.kernel.org/admin-guide/mm/zswap.html) - zswap documentation
+
+### LWN Articles
+
+- [Controlling memory with cgroup v2](https://lwn.net/Articles/662925/) - memory.high design and motivation
+- [PSI - Pressure Stall Information](https://lwn.net/Articles/759658/) - per-cgroup pressure tracking
+- [User-space OOM handling](https://lwn.net/Articles/894849/) - memory.reclaim and proactive management
+- [The unified cgroup hierarchy](https://lwn.net/Articles/679786/) - cgroup v2 reaching production readiness
+
+### Related
+
+- [Memory Cgroups](memcg.md) - Detailed memcg internals and v1 vs v2
+- [Running out of memory](oom.md) - The global OOM kill path
+- [Page Reclaim](reclaim.md) - How the kernel reclaims memory
+- [Swap](swap.md) - Swap subsystem internals
+- [Glossary](glossary.md) - cgroup, OOM, PSI definitions

--- a/docs/mm/tuning-databases.md
+++ b/docs/mm/tuning-databases.md
@@ -1,0 +1,644 @@
+# Tuning Memory for Databases
+
+> Why databases fight the kernel's defaults, and how to fix it
+
+## Why Databases Need Special Memory Tuning
+
+A general-purpose Linux kernel is tuned for a mix of workloads: compiling code, serving web pages, running containers. Databases break nearly every assumption those defaults are built on.
+
+Three properties make databases different:
+
+1. **Large shared buffers** - A production PostgreSQL instance might allocate 25% of RAM (32GB+) as a single shared memory region. MySQL's InnoDB buffer pool can be even larger. These are long-lived, heavily accessed allocations that the kernel must not fragment or swap out.
+
+2. **Random I/O patterns** - The kernel's readahead and page cache heuristics assume sequential access. Databases perform random lookups by primary key, index scans that jump across pages, and hash joins. The page cache wastes memory prefetching data that is never read.
+
+3. **Latency sensitivity** - A web server can absorb a 50ms stall without anyone noticing. A database holding row locks during a 50ms compaction stall causes cascading lock waits, connection pile-ups, and visible application latency. Predictability matters more than throughput.
+
+```
+General-purpose workload:              Database workload:
+┌─────────────────────────┐            ┌─────────────────────────┐
+│ Many small allocations  │            │ Few huge allocations    │
+│ Sequential file access  │            │ Random page access      │
+│ Throughput-oriented     │            │ Latency-sensitive       │
+│ Short-lived processes   │            │ Long-lived daemon       │
+│ Tolerates swap          │            │ Cannot tolerate swap    │
+└─────────────────────────┘            └─────────────────────────┘
+```
+
+The rest of this page walks through the kernel tunables that address each of these problems, with practical examples for PostgreSQL, MySQL/MariaDB, and Redis.
+
+## Huge Pages for Shared Buffers
+
+### The Problem
+
+A 32GB shared buffer pool backed by 4KB pages means 8,388,608 page table entries. Every TLB miss during a buffer pool lookup triggers a multi-level page table walk. On a busy OLTP system, TLB misses on the shared buffer become a measurable overhead.
+
+Huge pages (2MB) reduce the page table entry count by 512x. For a 32GB buffer pool, that is 16,384 entries instead of 8 million.
+
+### hugetlbfs: Static Huge Pages
+
+Unlike [THP](thp.md), hugetlbfs pages are pre-allocated at boot and never fragmented or reclaimed. This is exactly what databases want: guaranteed, stable huge page backing for their shared buffers.
+
+#### Reserve Huge Pages
+
+```bash
+# Reserve 16384 huge pages (32GB with 2MB pages)
+echo 16384 > /proc/sys/vm/nr_hugepages
+
+# Or at boot via kernel command line (more reliable for large reservations):
+# hugepages=16384
+
+# Verify allocation:
+cat /proc/meminfo | grep -i huge
+# HugePages_Total:   16384
+# HugePages_Free:    16384
+# HugePages_Rsvd:        0
+# Hugepagesize:       2048 kB
+```
+
+!!! warning "Reserve early"
+    Huge page reservation can fail after the system has been running because physical memory becomes fragmented. For production databases, reserve at boot via the kernel command line or via a systemd unit that runs before the database starts.
+
+The kernel's hugetlb subsystem is implemented in [mm/hugetlb.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/hugetlb.c). The `set_max_huge_pages()` function handles the reservation logic and will attempt compaction if contiguous memory is not immediately available.
+
+#### PostgreSQL with hugetlbfs
+
+PostgreSQL uses System V shared memory or `mmap` for its shared buffers. The `huge_pages` GUC parameter was introduced in PostgreSQL 9.4 ([release notes](https://www.postgresql.org/docs/9.4/release-9-4.html)).
+
+```bash
+# 1. Reserve huge pages (shared_buffers / hugepage size + some overhead)
+#    For shared_buffers = 32GB: 32768MB / 2MB = 16384 pages
+#    Add ~5% overhead for internal structures
+echo 17000 > /proc/sys/vm/nr_hugepages
+
+# 2. Allow the postgres user to use huge pages
+#    Option A: sysctl (preferred)
+echo "vm.hugetlb_shm_group = $(id -g postgres)" > /etc/sysctl.d/hugepages.conf
+sysctl --system
+
+#    Option B: Set memlock limit in /etc/security/limits.conf
+#    postgres  soft  memlock  unlimited
+#    postgres  hard  memlock  unlimited
+
+# 3. Configure PostgreSQL
+# In postgresql.conf:
+#   shared_buffers = '32GB'
+#   huge_pages = on        # 'on' = require, 'try' = best-effort, 'off' = disable
+```
+
+When `huge_pages = on`, PostgreSQL calls `shmget()` with `SHM_HUGETLB` (or uses `mmap` with `MAP_HUGETLB` in newer versions). If the kernel cannot satisfy the request from the hugetlb pool, PostgreSQL refuses to start, which is the correct behavior: you want to know at startup, not discover degraded performance later.
+
+#### Oracle with hugetlbfs
+
+Oracle's SGA (System Global Area) benefits enormously from huge pages. Oracle calls this "HugePages" in its documentation and it has been a best practice since Oracle 11g.
+
+```bash
+# 1. Calculate pages needed: SGA target / hugepage size
+#    For sga_target = 64GB: 65536MB / 2MB = 32768
+echo 33000 > /proc/sys/vm/nr_hugepages
+
+# 2. Set memlock for the oracle user
+#    /etc/security/limits.conf:
+#    oracle  soft  memlock  unlimited
+#    oracle  hard  memlock  unlimited
+
+# 3. Oracle automatically uses huge pages for the SGA if:
+#    - USE_LARGE_PAGES = ONLY (init.ora, recommended)
+#    - Sufficient huge pages are available
+#    - memlock limits are set
+```
+
+#### MySQL/InnoDB with hugetlbfs
+
+```bash
+# 1. Reserve huge pages for the InnoDB buffer pool
+#    For innodb_buffer_pool_size = 48GB: 49152MB / 2MB = 24576
+echo 25000 > /proc/sys/vm/nr_hugepages
+
+# 2. Set memlock for the mysql user
+#    /etc/security/limits.conf:
+#    mysql  soft  memlock  unlimited
+#    mysql  hard  memlock  unlimited
+
+# 3. Enable in my.cnf:
+#    [mysqld]
+#    large-pages
+
+# 4. MySQL must also have CAP_IPC_LOCK capability, or run with sufficient
+#    memlock limits. Check:
+cat /proc/$(pidof mysqld)/status | grep HugetlbPages
+```
+
+## THP: Why Databases Often Disable It
+
+[Transparent Huge Pages](thp.md) sound like they solve the same problem as hugetlbfs, but the "transparent" part is where the trouble starts.
+
+### The Compaction Problem
+
+When THP is enabled, the kernel runs `khugepaged` to collapse 4KB pages into 2MB huge pages. To do this, it must find or create 2MB-aligned contiguous free regions. This triggers [compaction](compaction.md) -- moving pages around in physical memory to defragment it.
+
+Compaction holds zone locks and can stall allocations. For a database handling thousands of queries per second, a compaction stall during a page fault means:
+
+```
+Query arrives
+    │
+    ▼
+Buffer pool miss, need new page
+    │
+    ▼
+Page fault → kernel tries 2MB allocation
+    │
+    ▼
+No contiguous 2MB region → trigger compaction
+    │
+    ▼
+Compaction holds zone lock (10-100ms+)
+    │
+    ▼
+Query blocked, holds row locks
+    │
+    ▼
+Other queries waiting on those locks pile up
+    │
+    ▼
+Latency spike visible to application
+```
+
+This is documented in many database vendor guides. MongoDB, Redis, and Oracle all recommend disabling THP. PostgreSQL recommends hugetlbfs instead of THP.
+
+The compaction code lives in [mm/compaction.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/compaction.c). The `compact_zone()` function is where stalls occur -- it migrates pages while holding the zone lock, and cannot be interrupted mid-migration.
+
+### Disabling THP
+
+```bash
+# Disable immediately (runtime)
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+echo never > /sys/kernel/mm/transparent_hugepage/defrag
+
+# Verify
+cat /sys/kernel/mm/transparent_hugepage/enabled
+# always madvise [never]
+
+# Make persistent via kernel command line:
+# transparent_hugepage=never
+```
+
+!!! note "THP madvise mode"
+    Setting THP to `madvise` instead of `never` allows applications to opt-in to THP via `madvise(MADV_HUGEPAGE)` while keeping the default behavior as 4KB pages. This can be a reasonable middle ground on systems running mixed workloads, but most database-dedicated servers use `never` for simplicity.
+
+### When THP Might Be Acceptable
+
+THP is not universally bad. Analytical/OLAP databases that perform large sequential scans over column stores may benefit from THP because their access patterns align with huge page boundaries. The issue is specifically with random-access OLTP workloads where compaction latency is unpredictable.
+
+## vm.swappiness
+
+### Why Databases Set This Low
+
+`vm.swappiness` controls how aggressively the kernel reclaims anonymous pages (process memory) versus file-backed pages (page cache). The value ranges from 0 to 200, with the default at 60.
+
+For databases, the shared buffer pool is anonymous memory. The kernel has no way to know that those anonymous pages contain hot B-tree index nodes that are accessed thousands of times per second. With the default swappiness, the kernel may decide to swap out buffer pool pages to make room for page cache entries from sequential file reads.
+
+The swappiness value feeds into the reclaim scanner's cost calculation in [mm/vmscan.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c). Higher values make the scanner more willing to scan and reclaim anonymous pages; lower values bias toward reclaiming file pages.
+
+```bash
+# Set swappiness to 1 (strongly prefer reclaiming file pages)
+sysctl -w vm.swappiness=1
+
+# Make persistent
+echo "vm.swappiness = 1" >> /etc/sysctl.d/database.conf
+```
+
+**Why 1 and not 0?**
+
+Setting `vm.swappiness = 0` tells the kernel to avoid swapping anonymous pages unless the system is under severe memory pressure (free + file pages below the high watermark of a zone). This sounds ideal, but in practice it means the kernel goes directly from "no swap" to "OOM pressure" with no graceful middle ground. A value of 1 provides a minimal but non-zero willingness to swap, giving the kernel a pressure release valve before reaching OOM conditions.
+
+!!! info "Databases that manage their own cache"
+    PostgreSQL, MySQL, and Oracle all have their own buffer management with LRU eviction, write-behind, and prefetching. They are better at managing their hot set than the kernel's generic LRU. Keeping `vm.swappiness` low lets the database's own cache management do its job without the kernel second-guessing it.
+
+## vm.dirty_ratio and vm.dirty_background_ratio
+
+### The Write-Ahead Log Pattern
+
+Databases use write-ahead logging (WAL): every data modification is first written sequentially to a log file, then `fsync()`'d. The actual data files are written asynchronously later (checkpointing). This creates two distinct I/O patterns:
+
+```
+WAL writes:                         Data file writes:
+┌──────────────────┐                ┌──────────────────┐
+│ Sequential       │                │ Random           │
+│ Small (8KB-64KB) │                │ Large (pages)    │
+│ Frequent fsync() │                │ Periodic bursts  │
+│ Latency-critical │                │ Throughput-ok     │
+└──────────────────┘                └──────────────────┘
+```
+
+The kernel's dirty page writeback is controlled by two ratios:
+
+- **`vm.dirty_background_ratio`** (default: 10%) - When dirty pages exceed this percentage of available memory, the kernel starts background writeback via per-device writeback threads (`bdi_writeback`).
+- **`vm.dirty_ratio`** (default: 20%) - When dirty pages exceed this, processes performing writes are **blocked** until writeback catches up. This is a synchronous stall.
+
+The writeback logic is in [mm/page-writeback.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page-writeback.c). The `balance_dirty_pages()` function is where processes get throttled when dirty pages exceed the threshold.
+
+### Why the Defaults Hurt Databases
+
+On a 128GB server, 20% means 25GB of dirty pages can accumulate before processes stall. When a checkpoint flushes 25GB of dirty data at once, it creates a thundering herd of I/O that saturates the disk and stalls WAL writes.
+
+```bash
+# Lower the ratios for database workloads
+sysctl -w vm.dirty_background_ratio=3
+sysctl -w vm.dirty_ratio=10
+
+# Or use absolute byte values for more predictable behavior:
+sysctl -w vm.dirty_background_bytes=268435456   # 256MB
+sysctl -w vm.dirty_bytes=1073741824              # 1GB
+
+# Make persistent
+cat >> /etc/sysctl.d/database.conf << 'EOF'
+vm.dirty_background_ratio = 3
+vm.dirty_ratio = 10
+EOF
+```
+
+Lowering these values causes the kernel to write back dirty pages more frequently in smaller batches, which:
+
+- Reduces checkpoint I/O spikes
+- Keeps WAL write latency more predictable
+- Avoids the cliff where processes hit `dirty_ratio` and stall
+
+!!! tip "Byte values vs ratios"
+    On large-memory servers (256GB+), even 3% is ~8GB of dirty data. Using `vm.dirty_background_bytes` and `vm.dirty_bytes` gives you absolute control regardless of total RAM. The byte values override the ratio values when both are set.
+
+## NUMA Pinning
+
+### The Problem with Database Shared Buffers on NUMA
+
+On a [NUMA](numa.md) system, the default memory allocation policy is "local allocation" -- memory is allocated on the node where the requesting CPU runs. For a database shared buffer pool, this means:
+
+```
+Node 0 (CPUs 0-15)           Node 1 (CPUs 16-31)
+┌──────────────────┐          ┌──────────────────┐
+│ Local memory     │          │ Local memory     │
+│ 80% buffer pool  │          │ 20% buffer pool  │
+│ (allocated by    │          │ (allocated by    │
+│  startup thread) │          │  some queries)   │
+└──────────────────┘          └──────────────────┘
+```
+
+If PostgreSQL's postmaster starts on Node 0 and allocates shared buffers there, every backend running on Node 1 pays the cross-node latency penalty for every buffer pool access. Since the buffer pool is the most frequently accessed data structure in a database, this is devastating for throughput.
+
+### numactl --interleave
+
+The fix is to interleave the shared buffer allocation across all NUMA nodes so that, on average, each CPU has equal local/remote access:
+
+```bash
+# Start PostgreSQL with interleaved memory allocation
+numactl --interleave=all pg_ctl start -D /var/lib/postgresql/data
+
+# For MySQL
+numactl --interleave=all mysqld_safe &
+
+# For systemd services, add to the unit file:
+# [Service]
+# ExecStart=/usr/bin/numactl --interleave=all /usr/bin/postgres -D /var/lib/postgresql/data
+```
+
+Interleaving distributes pages round-robin across nodes. No single CPU gets optimal locality, but no CPU gets worst-case remote access for the majority of the buffer pool either. This is the right trade-off for shared data structures accessed by all CPUs.
+
+Linux 6.3 introduced NUMA memory balancing improvements (see [LWN: NUMA balancing gets some tweaks](https://lwn.net/Articles/920920/)) that can automatically migrate pages toward their accessing CPUs. However, for large shared buffers accessed by many CPUs, interleaving remains the recommended approach because automatic balancing cannot satisfy all accessors simultaneously.
+
+### Verifying NUMA Distribution
+
+```bash
+# Check per-node memory usage for a process
+numastat $(pidof postgres) 2>/dev/null || numastat -p $(pidof postgres)
+
+# Look for roughly equal distribution across nodes:
+#                  Node 0      Node 1
+# Heap             15360       15680    <-- interleaved: good
+# Stack               4           0
+# Total            16200       16100
+
+# If you see heavy skew (90%+ on one node), interleaving is not working
+```
+
+## vm.overcommit_memory
+
+### Why Strict Overcommit for Databases
+
+As described in [Memory Overcommit](overcommit.md), Linux defaults to heuristic overcommit (mode 0). This is fine for general workloads, but databases have a specific problem: they allocate large shared buffers at startup and expect that memory to be available for the lifetime of the process.
+
+With heuristic overcommit, the kernel may allow more total allocations than physical memory can support. If this happens, the [OOM killer](oom.md) wakes up and picks a victim -- and a database with a 64GB shared buffer pool is an attractive target due to its high RSS.
+
+```bash
+# Mode 2: strict accounting
+sysctl -w vm.overcommit_memory=2
+
+# Set the ratio to allow enough for the database + OS
+# On a 128GB server with 32GB swap:
+# CommitLimit = (128GB * overcommit_ratio/100) + 32GB
+sysctl -w vm.overcommit_ratio=80
+# CommitLimit = (128 * 0.80) + 32 = 134.4GB
+
+# Make persistent
+cat >> /etc/sysctl.d/database.conf << 'EOF'
+vm.overcommit_memory = 2
+vm.overcommit_ratio = 80
+EOF
+```
+
+The accounting logic is in [mm/mmap.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) (`__vm_enough_memory()`). In mode 2, every `mmap()` and `brk()` call checks the commit charge against the commit limit. If the new allocation would exceed the limit, the syscall fails with `ENOMEM`.
+
+**The trade-off:** Mode 2 means `fork()` from a large process can fail because the child's address space counts against the commit limit, even with copy-on-write. PostgreSQL forks a backend for each connection, so `overcommit_ratio` must be high enough to account for the apparent (not actual) memory cost of all those forked backends. Monitor `Committed_AS` in `/proc/meminfo` to verify headroom.
+
+!!! warning "Commit accounting and fork()"
+    A PostgreSQL server with 32GB `shared_buffers` and 200 connections may show a `Committed_AS` much larger than actual RAM usage because each forked backend inherits the parent's address space in the commit accounting. Set `overcommit_ratio` conservatively and monitor `Committed_AS` vs `CommitLimit`.
+
+## vm.zone_reclaim_mode
+
+### Why Databases Should Disable Zone Reclaim
+
+On NUMA systems, `vm.zone_reclaim_mode` controls whether the kernel tries to reclaim memory from the local node before falling back to remote nodes. When enabled, the kernel may evict page cache or even swap out pages from the local zone rather than allocate from a remote node.
+
+This is exactly wrong for databases. Database buffer pools are not page cache -- they are anonymous memory that is expensive to reconstruct. Even for page cache, evicting a hot cached WAL segment to satisfy a local allocation is worse than paying the cross-node latency.
+
+```bash
+# Disable zone reclaim (default on most modern distros, but verify)
+sysctl -w vm.zone_reclaim_mode=0
+
+# Make persistent
+echo "vm.zone_reclaim_mode = 0" >> /etc/sysctl.d/database.conf
+```
+
+The zone reclaim logic lives in [mm/vmscan.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c) (`node_reclaim()`). When mode is 0, the allocator skips local reclaim and falls back to remote nodes immediately. When mode is non-zero, it attempts local reclaim first, which can cause latency spikes on NUMA database workloads.
+
+The kernel changed the default from 1 to 0 in commit [4f9b16a6 ("mm: disable zone_reclaim_mode by default")](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=4f9b16a64753d0bb607454347036dc997fd03b82), recognizing that the old behavior caused more harm than good for most workloads. Verify your system has the sane default:
+
+```bash
+cat /proc/sys/vm/zone_reclaim_mode
+# Should be: 0
+```
+
+## Monitoring
+
+### Key /proc/meminfo Fields
+
+```bash
+# Essential fields for database workloads
+cat /proc/meminfo | grep -E \
+  'MemTotal|MemFree|MemAvailable|Buffers|Cached|SwapTotal|SwapFree|Dirty|Writeback|AnonPages|Mapped|Shmem|HugePages|Committed_AS|CommitLimit'
+```
+
+| Field | What It Tells You | Warning Sign |
+|-------|-------------------|--------------|
+| `MemAvailable` | How much memory can be allocated without swapping | Dropping below database buffer pool size |
+| `SwapFree` | Remaining swap space | Any swap usage on a tuned database server is a red flag |
+| `Dirty` | Pages modified but not yet written to disk | Sustained high values mean writeback cannot keep up |
+| `Writeback` | Pages currently being written to disk | Sustained non-zero means I/O bottleneck |
+| `AnonPages` | Non-file-backed pages (includes buffer pools) | Should be stable once database is warmed up |
+| `Shmem` | Shared memory (PostgreSQL shared buffers use this) | Should match your shared_buffers roughly |
+| `HugePages_Free` | Unused huge pages | Should drop after database starts, stay stable |
+| `Committed_AS` | Total committed address space | Approaching `CommitLimit` means new allocations will fail (mode 2) |
+
+### Key /proc/vmstat Fields
+
+```bash
+# Real-time monitoring of reclaim and compaction
+watch -n 1 'cat /proc/vmstat | grep -E \
+  "pgscan_direct|pgsteal_direct|pgscan_kswapd|pgsteal_kswapd|pswpin|pswpout|compact_stall|compact_fail|thp_fault_alloc|thp_fault_fallback|numa_hit|numa_miss|numa_foreign"'
+```
+
+| Counter | What It Tells You | Warning Sign |
+|---------|-------------------|--------------|
+| `pgscan_direct` | Direct reclaim scanning (process stalled) | Any increase under normal load |
+| `pgsteal_direct` | Pages reclaimed by direct reclaim | Process had to wait for memory |
+| `pswpin` / `pswpout` | Pages swapped in/out | Any activity on a tuned server |
+| `compact_stall` | Processes stalled waiting for compaction | Increasing = THP or hugepage allocation issues |
+| `compact_fail` | Failed compaction attempts | High ratio to compact_stall = fragmentation |
+| `thp_fault_fallback` | THP allocations that fell back to 4KB | Indicates fragmentation if THP is enabled |
+| `numa_hit` / `numa_miss` | Local vs remote NUMA allocations | High `numa_miss` = memory policy misconfiguration |
+
+### A Practical Monitoring Script
+
+```bash
+#!/bin/bash
+# db-memcheck.sh: Quick health check for database memory configuration
+
+echo "=== Huge Pages ==="
+grep -i huge /proc/meminfo
+
+echo ""
+echo "=== Swap Activity ==="
+grep -E "SwapTotal|SwapFree" /proc/meminfo
+echo "Swap I/O: $(grep -E 'pswpin|pswpout' /proc/vmstat)"
+
+echo ""
+echo "=== Dirty Pages ==="
+grep -E "^Dirty|^Writeback" /proc/meminfo
+
+echo ""
+echo "=== Reclaim Pressure ==="
+echo "Direct reclaim scans: $(awk '/pgscan_direct/ {sum+=$2} END {print sum}' /proc/vmstat)"
+echo "Compaction stalls:    $(grep compact_stall /proc/vmstat | awk '{print $2}')"
+
+echo ""
+echo "=== NUMA Balance ==="
+grep -E "numa_hit|numa_miss" /proc/vmstat
+
+echo ""
+echo "=== Commit Status ==="
+grep -E "Committed_AS|CommitLimit" /proc/meminfo
+
+echo ""
+echo "=== THP Status ==="
+echo "Enabled: $(cat /sys/kernel/mm/transparent_hugepage/enabled)"
+echo "Defrag:  $(cat /sys/kernel/mm/transparent_hugepage/defrag)"
+```
+
+## Practical Examples
+
+### PostgreSQL
+
+A complete sysctl and configuration for a 128GB server dedicated to PostgreSQL:
+
+```bash
+# /etc/sysctl.d/postgresql.conf
+
+# Huge pages: reserve for 32GB shared_buffers + overhead
+vm.nr_hugepages = 17000
+
+# Swap: strongly prefer keeping anonymous pages in RAM
+vm.swappiness = 1
+
+# Dirty pages: frequent small flushes instead of large bursts
+vm.dirty_background_ratio = 3
+vm.dirty_ratio = 10
+
+# NUMA: disable zone reclaim
+vm.zone_reclaim_mode = 0
+
+# Overcommit: strict accounting
+vm.overcommit_memory = 2
+vm.overcommit_ratio = 80
+```
+
+```ini
+# postgresql.conf
+shared_buffers = '32GB'
+huge_pages = on
+effective_cache_size = '80GB'    # Tells planner about OS cache, not an allocation
+wal_buffers = '64MB'
+```
+
+```bash
+# systemd override: /etc/systemd/system/postgresql.service.d/numa.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/numactl --interleave=all /usr/bin/postgres -D /var/lib/postgresql/data
+LimitMEMLOCK=infinity
+```
+
+```bash
+# Disable THP
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+echo never > /sys/kernel/mm/transparent_hugepage/defrag
+
+# Or via kernel command line (persistent):
+# transparent_hugepage=never
+```
+
+### MySQL / MariaDB
+
+A complete configuration for a 64GB server dedicated to MySQL:
+
+```bash
+# /etc/sysctl.d/mysql.conf
+
+# Huge pages for 40GB InnoDB buffer pool
+vm.nr_hugepages = 21000
+
+vm.swappiness = 1
+vm.dirty_background_ratio = 3
+vm.dirty_ratio = 10
+vm.zone_reclaim_mode = 0
+vm.overcommit_memory = 2
+vm.overcommit_ratio = 85
+```
+
+```ini
+# /etc/my.cnf.d/server.cnf
+[mysqld]
+innodb_buffer_pool_size = 40G
+innodb_buffer_pool_instances = 8    # Reduce mutex contention
+large-pages                         # Enable huge pages
+
+# InnoDB manages its own flushing; these complement the sysctl settings:
+innodb_flush_method = O_DIRECT      # Bypass page cache for data files
+innodb_io_capacity = 2000           # Match your storage IOPS
+innodb_io_capacity_max = 4000
+```
+
+Using `O_DIRECT` for InnoDB is important: it tells the kernel to bypass the page cache for data file I/O, since InnoDB maintains its own buffer pool. This avoids double-caching and reduces memory pressure. The interaction between `O_DIRECT` and the page cache is implemented in [mm/filemap.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/filemap.c).
+
+```bash
+# Start with NUMA interleaving
+numactl --interleave=all mysqld_safe &
+
+# Disable THP
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+echo never > /sys/kernel/mm/transparent_hugepage/defrag
+```
+
+### Redis
+
+Redis is single-threaded (per shard) and keeps its entire dataset in anonymous memory. Its tuning needs are different from disk-based databases but the memory management concerns overlap.
+
+```bash
+# /etc/sysctl.d/redis.conf
+
+# Redis does not use huge pages for its main data structures
+# (it uses jemalloc with small allocations), but if you use
+# large Redis instances, huge pages can still help.
+# vm.nr_hugepages = ...  # Usually not needed for Redis
+
+# Critical: Redis forks for BGSAVE/BGREWRITEAOF
+# Overcommit must allow fork() to succeed
+vm.overcommit_memory = 1    # Redis recommends mode 1, not mode 2!
+
+vm.swappiness = 1
+vm.zone_reclaim_mode = 0
+
+# Lower dirty ratios help BGSAVE complete faster
+vm.dirty_background_ratio = 3
+vm.dirty_ratio = 10
+```
+
+!!! warning "Redis and overcommit mode 2"
+    Unlike PostgreSQL and MySQL, Redis recommends `vm.overcommit_memory = 1` (always overcommit). This is because Redis uses `fork()` for background persistence (BGSAVE, BGREWRITEAOF). A Redis instance using 50GB of RAM needs to fork, creating a child with a 50GB address space. With mode 2, this fork will fail unless `CommitLimit` has 50GB of headroom, which defeats the purpose of strict accounting. Mode 1 allows the fork to succeed, relying on copy-on-write to avoid actually needing 100GB.
+
+```bash
+# Disable THP: Redis strongly recommends this
+# Redis will log a warning at startup if THP is enabled
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+echo never > /sys/kernel/mm/transparent_hugepage/defrag
+```
+
+## Try It Yourself
+
+### Check Your Current Settings
+
+```bash
+# Display all relevant sysctl values at once
+echo "=== Current Database Memory Tunables ==="
+sysctl vm.swappiness vm.dirty_ratio vm.dirty_background_ratio \
+       vm.overcommit_memory vm.overcommit_ratio vm.zone_reclaim_mode \
+       vm.nr_hugepages
+echo ""
+echo "THP enabled: $(cat /sys/kernel/mm/transparent_hugepage/enabled)"
+```
+
+### Observe Swap Behavior Under Memory Pressure
+
+```bash
+# Terminal 1: Monitor swap activity
+watch -n 1 'grep -E "SwapTotal|SwapFree|SwapCached" /proc/meminfo; echo "---"; grep -E "pswpin|pswpout" /proc/vmstat'
+
+# Terminal 2: Create memory pressure (adjust size for your system)
+stress-ng --vm 2 --vm-bytes 80% --timeout 30s
+
+# Compare behavior with vm.swappiness=60 vs vm.swappiness=1
+```
+
+### Measure NUMA Effects
+
+```bash
+# Allocate memory on a specific node vs interleaved
+# and measure access latency with numactl:
+numactl --membind=0 -- stress-ng --vm 1 --vm-bytes 1G --timeout 10s --metrics
+numactl --interleave=all -- stress-ng --vm 1 --vm-bytes 1G --timeout 10s --metrics
+
+# Check where a running process has its memory:
+numastat -p $(pidof postgres)
+```
+
+### Watch Dirty Page Writeback
+
+```bash
+# Terminal 1: Watch dirty page count
+watch -n 0.5 'grep -E "^Dirty|^Writeback" /proc/meminfo'
+
+# Terminal 2: Generate writes
+dd if=/dev/zero of=/tmp/testfile bs=1M count=2048 conv=fdatasync
+
+# Observe how dirty pages accumulate up to dirty_background_ratio
+# then writeback kicks in, and how they are capped at dirty_ratio
+```
+
+## Further Reading
+
+- [docs.kernel.org: vm.overcommit_memory](https://docs.kernel.org/admin-guide/sysctl/vm.html#overcommit-memory) - Kernel documentation for all vm sysctl tunables
+- [docs.kernel.org: hugetlbpage](https://docs.kernel.org/admin-guide/mm/hugetlbpage.html) - Kernel documentation for huge page configuration
+- [LWN: NUMA in a hurry](https://lwn.net/Articles/473440/) - Overview of NUMA memory management in Linux
+- [LWN: Transparent huge pages](https://lwn.net/Articles/423584/) - Original THP design and trade-offs
+- [LWN: Better active/inactive list balancing](https://lwn.net/Articles/495543/) - How the kernel decides what to reclaim
+- [mm/vmscan.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmscan.c) - Reclaim, swappiness, and zone reclaim logic
+- [mm/page-writeback.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page-writeback.c) - Dirty page writeback and throttling
+- [mm/hugetlb.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/hugetlb.c) - Huge page reservation and allocation


### PR DESCRIPTION
## Summary

Documentation for five performance tuning topics under `docs/mm/`:

- **psi.md**: Pressure Stall Information — task states, gauges vs moving averages, trigger API (v5.2, Suren Baghdasaryan), integration with systemd-oomd / Android LMKD
- **tuning-containers.md**: cgroup v2 memory knobs (memory.max/high/low/min), container OOM behavior, Kubernetes QoS classes, Docker flag semantics, monitoring with PSI and memory.events
- **tuning-databases.md**: huge pages for PostgreSQL (9.4+) / MySQL / Oracle, THP compaction latency, vm.swappiness, dirty page ratios, NUMA interleaving, vm.zone_reclaim_mode
- **swap-thrashing.md**: detection via vmstat/PSI/vmstat counters, root causes, zswap/zram, PSI-based OOM (systemd-oomd), MGLRU (v6.1)
- **sysctl-reference.md**: reference table of all vm.* memory sysctls, defaults, and when to change them

## Fixes applied (post-initial review)

- **psi.md**: Corrected PSI task state flags per `include/linux/psi_types.h`: `TSK_IDLE` does not exist; added missing `TSK_MEMSTALL_RUNNING`; fixed trigger window constraint (500ms–10s, not "multiple of 500ms")
- **tuning-databases.md**: PostgreSQL `huge_pages` GUC introduced in 9.4, not version 11
- **swap-thrashing.md**: Removed unsourced numeric PSI thresholds; replaced with factual description
- **tuning-containers.md**: `memory.reclaim` (94968384dde1) co-authored by Shakeel Butt and Yosry Ahmed

## Citations

All claims cite git.kernel.org commits, docs.kernel.org, or LWN.net. No Wikipedia or vendor wikis.