### PR TITLE
Add mm subsystem documentation (memblock, CMA, DMA, hugetlbfs vs THP)

### DIFF
--- a/docs/mm/bugs/README.md
+++ b/docs/mm/bugs/README.md
@@ -68,15 +68,15 @@ Bugs with assigned CVEs, typically exploitable for privilege escalation or infor
 | CVE-2024-26759 | Swap slot ABA | swap | Race/corruption | [swapping.md](../swapping.md#case-1-the-swap-slot-aba-problem-cve-2024-26759) |
 | CVE-2023-3269 | StackRot | maple tree | UAF | [fork.md](../fork.md#case-2-stackrot-cve-2023-3269) |
 | CVE-2023-6246 | glibc syslog | glibc heap | Overflow | [life-of-malloc.md](../life-of-malloc.md#case-1-glibc-heap-overflow-cve-2023-6246) |
-| CVE-2022-29582 | io_uring UAF | io_uring/slub | UAF | [slab.md](../slab.md#case-2-io_uring-use-after-free-cve-2022-29582) |
-| CVE-2021-22555 | Netfilter heap OOB | netfilter/slub | Heap OOB | [slab.md](../slab.md#case-1-netfilter-heap-out-of-bounds-cve-2021-22555) |
-| CVE-2020-29368 | THP COW race | thp | Race | [thp.md](../thp.md#case-1-thp-cow-race-cve-2020-29368) |
+| CVE-2022-29582 | io_uring UAF | io_uring/slub | UAF | [slab.md](slab.md#case-2-io_uring-use-after-free-cve-2022-29582) |
+| CVE-2021-22555 | Netfilter heap OOB | netfilter/slub | Heap OOB | [slab.md](slab.md#case-1-netfilter-heap-out-of-bounds-cve-2021-22555) |
+| CVE-2020-29368 | THP COW race | thp | Race | [thp.md](thp.md#case-1-thp-cow-race-cve-2020-29368) |
 | CVE-2018-18281 | mremap TLB race | mremap | TLB race | [fork.md](../fork.md#case-4-tlb-flush-races-in-mremap-cve-2018-18281) |
-| CVE-2017-5754 | Meltdown | CPU/page tables | Side channel | [page-tables.md](../page-tables.md#case-1-meltdown-cve-2017-5754) |
-| CVE-2017-5753 | Spectre v1 | CPU | Side channel | [page-tables.md](../page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
-| CVE-2017-5715 | Spectre v2 | CPU | Side channel | [page-tables.md](../page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
+| CVE-2017-5754 | Meltdown | CPU/page tables | Side channel | [page-tables.md](page-tables.md#case-1-meltdown-cve-2017-5754) |
+| CVE-2017-5753 | Spectre v1 | CPU | Side channel | [page-tables.md](page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
+| CVE-2017-5715 | Spectre v2 | CPU | Side channel | [page-tables.md](page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
 | CVE-2016-5195 | Dirty COW | COW | Race | [fork.md](../fork.md#case-1-dirty-cow-cve-2016-5195) |
-| CVE-2012-4398 | OOM deadlock | OOM | Deadlock | [oom.md](../oom.md#case-5-oom-deadlock-denial-of-service-cve-2012-4398) |
+| CVE-2012-4398 | OOM deadlock | OOM | Deadlock | [oom.md](../oom.md#case-5-cve-2012-4398---oom-deadlock-denial-of-service) |
 | CVE-2009-2695 | mmap_min_addr bypass | mmap | Logic | [life-of-malloc.md](../life-of-malloc.md#case-3-mmap_min_addr-bypass-cve-2009-2695) |
 | CVE-2004-0077 | mremap disaster | mremap | Logic | [fork.md](../fork.md#case-3-the-mremap-disaster-cve-2004-0077) |
 
@@ -108,7 +108,7 @@ Bugs causing severe performance degradation.
 |-----|------|-----------|---------|
 | Thrashing livelock | 2010+ | reclaim | [oom.md](../oom.md#case-3-the-thrashing-livelock-2010-mitigated-2018) |
 | Readahead trap | Ongoing | readahead | [swapping.md](../swapping.md#case-5-the-swap-readahead-trap) |
-| khugepaged CPU | Ongoing | thp | [thp.md](../thp.md#case-3-khugepaged-cpu-storms) |
+| khugepaged CPU | Ongoing | thp | [thp.md](thp.md#case-3-khugepaged-cpu-storms) |
 
 ---
 

--- a/docs/mm/cma.md
+++ b/docs/mm/cma.md
@@ -1,0 +1,403 @@
+# CMA (Contiguous Memory Allocator)
+
+> Reserved regions that serve double duty: normal pages by day, DMA buffers on demand
+
+## What Is CMA?
+
+CMA reserves regions of physical memory at boot that can be reclaimed for large contiguous allocations when devices need them. The key insight is that these reserved pages are not wasted -- they serve normal movable allocations (page cache, anonymous memory) until a device driver requests a contiguous buffer, at which point the pages are migrated out and the region is handed to the driver.
+
+```
+CMA region (idle):
+┌────────────────────────────────────────────────────────────────┐
+│  Page   Page   Page   Page   Page   Page   Page   Page        │
+│  cache  anon   cache  anon   cache  anon   cache  cache       │
+│  (movable allocations using the CMA region normally)           │
+└────────────────────────────────────────────────────────────────┘
+
+DMA allocation request arrives:
+┌────────────────────────────────────────────────────────────────┐
+│  Migrate all movable pages out...                              │
+│  ← pages moved to other free memory                           │
+└────────────────────────────────────────────────────────────────┘
+
+CMA region (allocated to device):
+┌────────────────────────────────────────────────────────────────┐
+│              Contiguous DMA buffer for device                  │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Why CMA Exists
+
+### The Problem
+
+DMA devices often need physically contiguous memory. Unlike CPUs, many devices cannot use page tables to remap scattered physical pages into a contiguous address range. A camera capturing a frame, a display controller scanning out a framebuffer, or a network card sending a jumbo packet may all need a single contiguous physical buffer.
+
+On a freshly booted system, large contiguous allocations succeed easily. But after days of uptime, physical memory becomes fragmented -- free pages are scattered between persistent allocations. Even with gigabytes free, allocating a contiguous 8MB buffer can fail.
+
+### Previous Solutions and Their Downsides
+
+Before CMA, the options were poor:
+
+| Approach | Downside |
+|----------|----------|
+| Boot-time reservation (`memblock_reserve`) | Memory is exclusively locked away, wasted when devices are idle |
+| High-order `alloc_pages` at runtime | Fails under fragmentation |
+| Compaction before allocation | Slow, unreliable for very large buffers |
+| IOMMU remapping | Not all platforms have an IOMMU; adds complexity and latency |
+
+The boot-time reservation approach was especially wasteful on embedded devices (phones, set-top boxes) where RAM is scarce. A device might reserve 64MB for a camera that is used for a few minutes a day, leaving that memory unavailable for the rest of the system.
+
+### CMA's Insight
+
+CMA eliminates the tradeoff between reliability and waste. It reserves regions at boot (guaranteeing contiguous space is available) but allows movable allocations to use that space in the meantime. When a device needs the memory, CMA migrates the movable pages out and hands over the contiguous region.
+
+This dual-use design was particularly important for ARM-based mobile devices at Samsung, where limited RAM and many DMA-dependent peripherals (camera, display, codec) created constant tension between device driver needs and application memory.
+
+## How CMA Works
+
+### The Dual-Use Design
+
+CMA regions live within `ZONE_NORMAL` (or `ZONE_DMA`/`ZONE_DMA32` depending on architecture). The buddy allocator treats CMA pages as a special migrate type: `MIGRATE_CMA`.
+
+```
+Zone layout with CMA:
+┌──────────────────────────────────────────────────────────────────────┐
+│                           ZONE_NORMAL                                │
+│                                                                      │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────┐  ┌──────────┐    │
+│  │ MOVABLE  │  │UNMOVABLE │  │   MIGRATE_CMA    │  │RECLAIMABLE│   │
+│  │          │  │          │  │  (CMA region)    │  │          │    │
+│  └──────────┘  └──────────┘  └──────────────────┘  └──────────┘    │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The rules for `MIGRATE_CMA` pages:
+
+1. **Movable allocations can use CMA pages freely.** The page allocator falls back to CMA pageblocks when serving `MIGRATE_MOVABLE` requests.
+2. **Unmovable and reclaimable allocations cannot use CMA pages.** This is critical -- if an unmovable kernel allocation landed in a CMA region, the region could never be fully reclaimed.
+3. **When a driver calls `cma_alloc()`, all movable pages in the requested range are migrated out.** The kernel uses the same page migration machinery as compaction.
+
+### Allocation Path
+
+When a driver needs contiguous memory (typically through `dma_alloc_coherent()`):
+
+```
+Driver calls dma_alloc_coherent(dev, size, ...)
+        │
+        ▼
+DMA subsystem selects CMA region for this device
+        │
+        ▼
+cma_alloc(cma, count, align, no_warn)
+        │
+        ▼
+Find a suitable range of pages within the CMA region
+        │
+        ▼
+alloc_contig_range(start, end, MIGRATE_CMA, ...)
+        │
+        ├─── Isolate the range (prevent new allocations)
+        │
+        ├─── Migrate all movable pages out of the range
+        │         Uses the same migration code as compaction
+        │
+        ├─── Drain per-cpu page lists
+        │
+        └─── Return contiguous pages to the caller
+```
+
+If migration fails (e.g., a page is pinned for I/O), `cma_alloc()` retries with a different range within the CMA region. It scans through the region in bitmap-tracked chunks until it finds a range that can be fully cleared, or gives up.
+
+### The CMA Bitmap
+
+Each CMA region tracks allocation state with a bitmap. Each bit represents a block of pages (the granularity is set by `CONFIG_CMA_ALIGNMENT`, defaulting to order-8 or 1MB with 4KB pages):
+
+```c
+struct cma {
+    unsigned long   base_pfn;       /* Start of CMA region */
+    unsigned long   count;          /* Total pages in region */
+    unsigned long   *bitmap;        /* Allocation bitmap */
+    unsigned int    order_per_bit;  /* Pages per bit (power of 2) */
+    spinlock_t      lock;
+    ...
+};
+```
+
+The bitmap tracks which chunks are currently allocated to devices. Pages not marked as allocated in the bitmap are available for movable use by the rest of the system.
+
+### Interaction with the Page Allocator
+
+CMA integrates with the buddy allocator through the `MIGRATE_CMA` migrate type, introduced alongside CMA. Key interactions:
+
+- **Fallback behavior**: When the buddy allocator cannot satisfy a `MIGRATE_MOVABLE` request from the movable free list, it falls back to `MIGRATE_CMA` pages. This is how CMA regions get populated with movable pages during normal operation.
+- **Steal prevention**: The allocator never steals CMA pageblocks for `MIGRATE_UNMOVABLE` or `MIGRATE_RECLAIMABLE` requests. This guarantee is enforced in `__rmqueue_fallback()` in `mm/page_alloc.c`.
+- **Compaction awareness**: When compaction runs, it understands CMA regions and respects their migrate type. CMA pages can be targets for the compaction migration scanner (pages can be moved *into* CMA regions), but CMA pages won't be changed to unmovable types.
+
+## Configuration
+
+### Kernel Command Line
+
+The simplest way to set up CMA:
+
+```bash
+# Reserve 256MB for the default global CMA area
+cma=256M
+
+# With placement hint (base address)
+cma=256M@0x40000000
+```
+
+The `cma=` parameter sets the size of the default CMA area, which is used by any device that does not have a dedicated CMA region.
+
+### Device Tree (ARM/embedded)
+
+Embedded platforms typically define CMA regions in the device tree:
+
+```dts
+reserved-memory {
+    #address-cells = <2>;
+    #size-cells = <2>;
+    ranges;
+
+    /* Default CMA region */
+    linux,cma {
+        compatible = "shared-dma-pool";
+        reusable;
+        size = <0 0x10000000>;  /* 256MB */
+        linux,cma-default;
+    };
+
+    /* Dedicated region for a specific device */
+    camera_mem: camera-buffer {
+        compatible = "shared-dma-pool";
+        reusable;
+        reg = <0 0x78000000 0 0x8000000>;  /* 128MB at specific address */
+    };
+};
+
+camera@0 {
+    memory-region = <&camera_mem>;
+};
+```
+
+The `reusable` property is what makes it CMA rather than a static reservation. Without `reusable`, the region would be exclusively reserved and not available for movable allocations.
+
+### Kernel Config Options
+
+```
+CONFIG_CMA=y                    # Enable CMA support
+CONFIG_CMA_DEBUG=y              # Extra debug checks (development only)
+CONFIG_CMA_DEBUGFS=y            # Expose per-region stats in debugfs
+CONFIG_CMA_SIZE_MBYTES=16       # Default CMA size in MB
+CONFIG_CMA_SIZE_PERCENTAGE=0    # Default CMA size as percentage of RAM
+CONFIG_CMA_ALIGNMENT=8          # Minimum alignment (order), default 8 = 256 pages = 1MB
+CONFIG_DMA_CMA=y                # Use CMA as the DMA contiguous allocator backend
+```
+
+`CONFIG_CMA_SIZE_MBYTES` sets the default size when no `cma=` boot parameter is given. `CONFIG_CMA_SIZE_PERCENTAGE` provides an alternative way to scale CMA with RAM size. The larger of the two values wins.
+
+## Using CMA from Drivers
+
+### The DMA API (Recommended)
+
+Most drivers should use the DMA API, which handles CMA allocation transparently:
+
+```c
+#include <linux/dma-mapping.h>
+
+/* Allocate contiguous DMA buffer -- uses CMA if CONFIG_DMA_CMA=y */
+void *vaddr = dma_alloc_coherent(dev, size, &dma_handle, GFP_KERNEL);
+
+/* Free when done */
+dma_free_coherent(dev, size, vaddr, dma_handle);
+```
+
+The DMA subsystem calls into CMA via `dma_alloc_from_contiguous()`, which maps to `cma_alloc()` internally. The device's CMA region is selected based on its `memory-region` device tree property, or the default global CMA area.
+
+### Direct CMA API (Rare)
+
+For subsystems that need direct control:
+
+```c
+#include <linux/cma.h>
+
+/* Allocate count pages aligned to 1 << align from a specific CMA area */
+struct page *page = cma_alloc(cma, count, align, no_warn);
+
+/* Release back to CMA */
+cma_release(cma, page, count);
+```
+
+After `cma_release()`, the pages return to the buddy allocator as `MIGRATE_CMA` pages and can once again serve movable allocations.
+
+## Monitoring
+
+### /proc/meminfo
+
+```bash
+$ grep Cma /proc/meminfo
+CmaTotal:        262144 kB    # Total CMA reservation
+CmaFree:         245760 kB    # CMA pages not allocated to devices
+```
+
+`CmaFree` shows how much of the CMA region is not currently held by device drivers. These pages are likely in use by movable allocations (page cache, anonymous memory) but can be reclaimed when a device needs them.
+
+Note that `CmaTotal` and `CmaFree` are included in `MemTotal` and `MemFree` respectively -- CMA memory is not "missing" from the system's perspective.
+
+### debugfs (CONFIG_CMA_DEBUGFS)
+
+```bash
+$ ls /sys/kernel/debug/cma/
+cma-reserved/
+
+$ ls /sys/kernel/debug/cma/cma-reserved/
+alloc  base_pfn  bitmap  count  free  maxchunk  order_per_bit  used
+
+$ cat /sys/kernel/debug/cma/cma-reserved/base_pfn
+262144
+$ cat /sys/kernel/debug/cma/cma-reserved/count
+65536        # Total pages in region
+$ cat /sys/kernel/debug/cma/cma-reserved/used
+0            # Pages currently allocated to devices
+$ cat /sys/kernel/debug/cma/cma-reserved/maxchunk
+65536        # Largest contiguous free chunk (in pages)
+```
+
+The `alloc` file is writable -- you can trigger a test allocation to verify CMA is working:
+
+```bash
+# Test-allocate 1024 pages (4MB) from the CMA region
+echo 1024 > /sys/kernel/debug/cma/cma-reserved/alloc
+```
+
+### vmstat Counters
+
+```bash
+$ grep cma /proc/vmstat
+cma_alloc_success 42
+cma_alloc_fail 0
+```
+
+These counters (added in v5.19) track CMA allocation outcomes across all CMA regions.
+
+## Try It Yourself
+
+```bash
+# Check if CMA is enabled and how much is reserved
+grep Cma /proc/meminfo
+
+# View CMA kernel boot parameter
+cat /proc/cmdline | tr ' ' '\n' | grep cma
+
+# If debugfs is available, inspect CMA regions
+ls /sys/kernel/debug/cma/ 2>/dev/null
+
+# Watch CMA allocation stats (kernel 5.19+)
+grep cma /proc/vmstat
+
+# Check buddyinfo to see free page counts per order
+# Low counts at high orders suggest fragmentation that CMA helps avoid
+cat /proc/buddyinfo
+
+# On an embedded device, view device tree CMA configuration
+# (requires dtc; /proc/device-tree may also be available)
+ls /proc/device-tree/reserved-memory/ 2>/dev/null
+```
+
+## History
+
+### Development at Samsung
+
+CMA was developed by Marek Szyprowski at Samsung Electronics. The motivation came from ARM mobile platforms (like Samsung's Exynos SoCs) where multiple peripherals -- cameras, display controllers, multimedia codecs, and GPU -- all needed large contiguous buffers but the system had limited RAM to spare for static reservations.
+
+The feature went through extensive review over multiple revisions of the patch series before being merged.
+
+### Merged in v3.5 (2012)
+
+**Commit**: [c64be2bb1c6e](https://git.kernel.org/linus/c64be2bb1c6e) ("drivers: add Contiguous Memory Allocator")
+
+**Author**: Marek Szyprowski
+
+The initial merge included the core CMA allocator and its integration with the DMA subsystem.
+
+**LWN coverage**: [A deep dive into CMA](https://lwn.net/Articles/486301/) -- discusses the design rationale and review process.
+
+### MIGRATE_CMA Type (v3.5, 2012)
+
+**Commit**: [47118af076f6](https://git.kernel.org/linus/47118af076f6) ("mm: mmzone: MIGRATE_CMA migration type added")
+
+**Author**: Marek Szyprowski
+
+Added the `MIGRATE_CMA` migrate type to the buddy allocator, enabling the dual-use design where CMA pages serve movable allocations while preventing unmovable ones from landing in CMA regions.
+
+### Per-device CMA Areas (v3.17, 2014)
+
+**Commit**: [c1f733aaf1e1](https://git.kernel.org/linus/c1f733aaf1e1) ("drivers: of: add initialization code for dma-reserved-memory")
+
+The device tree `memory-region` property support, allowing individual devices to have their own dedicated CMA regions rather than sharing the global one.
+
+### CMA debugfs (v4.1, 2015)
+
+**Commit**: [28b24c1fc8c4](https://git.kernel.org/linus/28b24c1fc8c4) ("mm: cma: debugfs interface")
+
+**Author**: Sasha Levin
+
+The debugfs interface for monitoring CMA was added, giving operators visibility into CMA region usage.
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| [`mm/cma.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/cma.c) | Core CMA allocator: `cma_alloc()`, `cma_release()`, bitmap management |
+| [`mm/cma.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/cma.h) | Internal CMA header (the `struct cma` definition) |
+| [`include/linux/cma.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/cma.h) | Public CMA API for drivers |
+| [`mm/cma_debug.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/cma_debug.c) | debugfs interface for CMA regions |
+| [`kernel/dma/contiguous.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/contiguous.c) | DMA subsystem integration: `dma_alloc_from_contiguous()` |
+| [`mm/page_alloc.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) | Buddy allocator with `MIGRATE_CMA` fallback logic |
+| [`mm/page_isolation.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_isolation.c) | Page range isolation used during `cma_alloc()` |
+
+## Common Issues
+
+### CMA Allocation Failures
+
+**Symptoms**: `cma_alloc_fail` count increasing, driver probe failures, DMA allocation errors in dmesg.
+
+**Common causes**:
+
+- **Pinned pages in the CMA region**: Pages undergoing I/O or held by `get_user_pages()` cannot be migrated. This is the most common cause of CMA allocation failures.
+- **CMA region too small**: The region must accommodate the largest single contiguous allocation plus any concurrent allocations from other devices.
+- **Fragmentation within CMA**: If device allocations of varying sizes come and go, the CMA bitmap itself can become fragmented (external fragmentation within the CMA region).
+
+**Diagnosis**:
+
+```bash
+# Check for CMA failures
+grep cma /proc/vmstat
+dmesg | grep -i cma
+
+# Check available CMA space
+grep Cma /proc/meminfo
+
+# debugfs for detailed region state
+cat /sys/kernel/debug/cma/*/used
+cat /sys/kernel/debug/cma/*/maxchunk
+```
+
+### CMA Memory Not Appearing
+
+If `CmaTotal` is 0 in `/proc/meminfo`:
+
+- Verify `CONFIG_CMA=y` and `CONFIG_DMA_CMA=y` in the kernel config
+- Check that the `cma=` boot parameter is present, or that `CONFIG_CMA_SIZE_MBYTES` is nonzero
+- On device tree platforms, verify the reserved-memory node has `compatible = "shared-dma-pool"` and the `reusable` property
+
+## References
+
+- [LWN: A deep dive into CMA](https://lwn.net/Articles/486301/) - Design discussion from the merge window
+- [LWN: CMA and compaction](https://lwn.net/Articles/684611/) - Interaction between CMA and compaction
+- [LWN: Contiguous memory allocation for drivers](https://lwn.net/Articles/396657/) - Early CMA proposal
+- [Kernel docs: DMA API](https://docs.kernel.org/core-api/dma-api.html) - How drivers should allocate DMA memory
+- [contiguous-memory](contiguous-memory.md) - The fragmentation problem CMA solves
+- [compaction](compaction.md) - The page migration machinery CMA relies on
+- [page-allocator](page-allocator.md) - Buddy allocator and migrate types

--- a/docs/mm/dma.md
+++ b/docs/mm/dma.md
@@ -1,0 +1,393 @@
+# DMA Memory Allocation
+
+> How the kernel allocates and manages memory for devices that access RAM directly
+
+## What is DMA?
+
+Direct Memory Access (DMA) lets hardware devices read and write system memory without involving the CPU for every byte transferred. A network card receiving packets, a disk controller fetching blocks, or a GPU reading textures -- all bypass the CPU and talk to RAM directly.
+
+This is essential for performance. Without DMA, the CPU would spend its time copying bytes between device registers and memory instead of doing useful work. But DMA introduces a fundamental problem: **devices operate on physical addresses, not virtual ones**, and they may not be able to reach all of physical memory.
+
+## Why DMA Needs Special Memory
+
+Three constraints make DMA memory allocation different from normal `kmalloc()`:
+
+1. **Physical address limitations**: Many devices can only address a subset of physical memory. An old ISA sound card can only reach the first 16MB. A 32-bit PCI card can only reach the first 4GB. If the kernel hands a device a buffer at physical address 8GB, the device simply cannot access it.
+
+2. **Cache coherency**: The CPU uses caches (L1, L2, L3) between itself and RAM. When a device writes to RAM via DMA, the CPU cache may still hold stale data for that address. Conversely, if the CPU writes to cache but the data has not reached RAM yet, the device reads stale memory. The kernel must manage this explicitly.
+
+3. **Contiguity requirements**: Devices see physical memory, not virtual. A buffer that looks contiguous in the kernel's virtual address space may be scattered across physical pages. Without hardware support (IOMMU), the device needs physically contiguous memory.
+
+## DMA Zones
+
+The kernel partitions physical memory into zones to handle device addressing limitations. From [`include/linux/mmzone.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mmzone.h):
+
+```c
+enum zone_type {
+    ZONE_DMA,       /* First 16MB - ISA devices */
+    ZONE_DMA32,     /* First 4GB - 32-bit PCI devices */
+    ZONE_NORMAL,    /* All addressable memory */
+    /* ... */
+};
+```
+
+### ZONE_DMA (first 16MB)
+
+A legacy zone for ISA bus devices. The ISA bus uses 24-bit addresses, limiting DMA to the first 2^24 = 16MB of RAM. Modern systems rarely need this, but the zone persists because some architectures still define it.
+
+Allocated with `GFP_DMA`.
+
+### ZONE_DMA32 (first 4GB)
+
+For 32-bit PCI devices that use 32-bit DMA addresses. On a system with 64GB of RAM, these devices can only access the bottom 4GB. This is still relevant -- many embedded devices and older PCIe cards have 32-bit DMA masks.
+
+Allocated with `GFP_DMA32`.
+
+### ZONE_NORMAL
+
+Memory accessible by the kernel and by devices with full addressing capability (64-bit DMA). No special constraints.
+
+```
+Physical Memory Layout (64-bit system with 64GB RAM):
+
+0                16MB              4GB                              64GB
+|--- ZONE_DMA ---|--- ZONE_DMA32 ---|------------ ZONE_NORMAL -----------|
+     ISA only        32-bit PCI              Full addressing
+    (GFP_DMA)       (GFP_DMA32)             (GFP_KERNEL)
+```
+
+The zone boundaries are architecture-specific. ARM64 initially had no `ZONE_DMA` at all, but commit [1a8e1cef7603](https://git.kernel.org/linus/1a8e1cef7603) ("arm64: use both ZONE_DMA and ZONE_DMA32") added it to handle devices that can only address the lowest 1GB of physical memory — a constraint that exists on some ARM SoCs and PCIe devices regardless of what the architecture spec allows.
+
+## The DMA API
+
+The kernel provides a unified DMA API that abstracts away the differences between architectures and IOMMUs. The API lives in [`include/linux/dma-mapping.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dma-mapping.h) with the core implementation in [`kernel/dma/`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma).
+
+### dma_alloc_coherent()
+
+Allocates a buffer that is simultaneously accessible by the CPU and the device, with hardware-enforced coherency (no manual cache management needed).
+
+```c
+void *dma_alloc_coherent(struct device *dev, size_t size,
+                         dma_addr_t *dma_handle, gfp_t gfp);
+void dma_free_coherent(struct device *dev, size_t size,
+                       void *cpu_addr, dma_addr_t dma_handle);
+```
+
+Returns two things: a CPU virtual address (the return value) and a device-visible DMA address (via `dma_handle`). The driver uses the CPU address; it programs the device with the DMA address.
+
+**When to use**: Long-lived buffers shared between CPU and device -- descriptor rings, command queues, firmware communication areas. The coherency guarantee means neither side needs to flush or invalidate caches.
+
+**Trade-off**: Coherent memory is often uncacheable on architectures without hardware cache coherency (e.g., some ARM SoCs). This makes CPU access slower. Do not use for large data buffers that the CPU will read/write intensively.
+
+### dma_map_single()
+
+Maps an existing kernel buffer for DMA access by a device. This is a "streaming" mapping -- it has a direction and a lifecycle.
+
+```c
+dma_addr_t dma_map_single(struct device *dev, void *cpu_addr,
+                          size_t size, enum dma_data_direction dir);
+void dma_unmap_single(struct device *dev, dma_addr_t dma_addr,
+                      size_t size, enum dma_data_direction dir);
+```
+
+The direction tells the kernel which cache operations are needed:
+
+| Direction | Meaning | Cache Operation |
+|-----------|---------|-----------------|
+| `DMA_TO_DEVICE` | CPU writes, device reads | Flush CPU caches before DMA |
+| `DMA_FROM_DEVICE` | Device writes, CPU reads | Invalidate CPU caches after DMA |
+| `DMA_BIDIRECTIONAL` | Both directions | Flush before, invalidate after |
+
+**When to use**: Temporary transfers -- sending a network packet, submitting a disk I/O request. Map before the transfer, unmap when it completes.
+
+### dma_map_sg()
+
+Maps a scatter-gather list -- multiple non-contiguous memory regions -- for a single DMA operation. This is how the kernel handles I/O that spans multiple pages.
+
+```c
+int dma_map_sg(struct device *dev, struct scatterlist *sg,
+               int nents, enum dma_data_direction dir);
+void dma_unmap_sg(struct device *dev, struct scatterlist *sg,
+                  int nents, enum dma_data_direction dir);
+```
+
+`dma_map_sg()` returns the number of DMA-mapped entries, which may be *fewer* than the input entries. With an IOMMU, the kernel can merge physically discontiguous pages into a single contiguous DMA region as seen by the device.
+
+**When to use**: Block I/O, large network transfers, any case where data spans multiple pages. Most real device drivers use scatter-gather extensively.
+
+## Coherent vs Streaming DMA Mappings
+
+This is the central design decision in the DMA API:
+
+| Property | Coherent | Streaming |
+|----------|----------|-----------|
+| **API** | `dma_alloc_coherent()` | `dma_map_single()`, `dma_map_sg()` |
+| **Lifetime** | Long-lived (driver load to unload) | Per-transfer (map, DMA, unmap) |
+| **Cache handling** | Automatic (hardware or uncached) | Manual (flush/invalidate at map/unmap) |
+| **CPU access speed** | Potentially slow (uncached on some archs) | Normal (cached) |
+| **Use case** | Descriptor rings, command queues | Data buffers, packets, disk blocks |
+
+The key insight: **coherent mappings trade CPU performance for convenience, while streaming mappings trade convenience for CPU performance.** Most drivers use coherent mappings for small control structures and streaming mappings for data.
+
+### Sync Operations
+
+Between map and unmap, if the CPU needs to touch a streaming buffer, it must use sync operations:
+
+```c
+/* CPU wants to read a buffer the device has written */
+dma_sync_single_for_cpu(dev, dma_handle, size, DMA_FROM_DEVICE);
+/* ... CPU reads data ... */
+
+/* Hand buffer back to device */
+dma_sync_single_for_device(dev, dma_handle, size, DMA_FROM_DEVICE);
+```
+
+These ensure cache coherency at the point of the sync call. Without them, the CPU may read stale cached data.
+
+## IOMMU
+
+An Input/Output Memory Management Unit (IOMMU) sits between devices and physical memory, translating device-visible "I/O virtual addresses" (IOVAs) to physical addresses. It is essentially a page table for devices.
+
+```
+Without IOMMU:
+  Device --[physical addr]--> RAM
+  (device must use real physical addresses)
+
+With IOMMU:
+  Device --[IOVA]--> IOMMU --[physical addr]--> RAM
+  (device uses virtual addresses, translated by hardware)
+```
+
+### What IOMMU enables
+
+1. **Scatter-gather coalescing**: Map physically scattered pages as contiguous to the device. A 64KB buffer spanning 16 scattered pages appears as one contiguous 64KB region to the device.
+
+2. **Device isolation**: A buggy or malicious device can only access memory regions explicitly mapped in its IOMMU page table. This is essential for secure device passthrough to virtual machines (VFIO).
+
+3. **Addressing limitations solved**: A 32-bit device can access memory above 4GB because the IOMMU maps high physical pages into the device's 32-bit address window.
+
+4. **DMA remapping**: Intel calls it VT-d, AMD calls it AMD-Vi. Both provide hardware IOMMU for PCIe devices.
+
+The IOMMU driver in Linux lives under [`drivers/iommu/`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu). The DMA API automatically uses the IOMMU when one is present -- drivers do not need to know or care.
+
+### LWN coverage
+
+The evolution of the IOMMU subsystem is well documented on LWN:
+
+- [A new DMA mapping API](https://lwn.net/Articles/753027/) (2018) -- restructuring the DMA API for better IOMMU integration
+- [The IOMMU API](https://lwn.net/Articles/610073/) (2014) -- overview of the IOMMU framework
+
+## SWIOTLB Bounce Buffers
+
+When there is no IOMMU and a device cannot address all of physical memory, the kernel falls back to SWIOTLB (Software I/O Translation Lookaside Buffer) -- a bounce buffer mechanism.
+
+### How it works
+
+1. Kernel allocates a pool of low-memory bounce buffers at boot (typically 64MB from memory below 4GB)
+2. When `dma_map_single()` is called for a buffer the device cannot reach, the kernel:
+   - Allocates a bounce buffer from the SWIOTLB pool
+   - For `DMA_TO_DEVICE`: copies data from the original buffer to the bounce buffer
+   - Gives the device the bounce buffer's physical address
+3. When `dma_unmap_single()` is called:
+   - For `DMA_FROM_DEVICE`: copies data from bounce buffer back to the original buffer
+   - Frees the bounce buffer
+
+```
+High Memory (>4GB):
++------------------+
+| Original Buffer  |  <-- CPU uses this
++------------------+
+        |  copy
+        v
+Low Memory (<4GB):
++------------------+
+| Bounce Buffer    |  <-- Device DMAs here
+| (SWIOTLB pool)  |
++------------------+
+```
+
+### The cost
+
+Bounce buffering means **double the memory copies** -- a significant performance penalty. This is why IOMMUs are strongly preferred on modern systems.
+
+The SWIOTLB pool size can be configured at boot with `swiotlb=N` (number of 2KB slots). The implementation lives in [`kernel/dma/swiotlb.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/swiotlb.c).
+
+### Confidential computing and SWIOTLB
+
+SWIOTLB gained renewed importance with confidential computing (AMD SEV, Intel TDX). In these environments, device DMA cannot access encrypted guest memory directly. The guest must use decrypted bounce buffers for all DMA operations. Commit [1a1a8b7495b8](https://git.kernel.org/linus/1a1a8b7495b8) ("swiotlb: Add restricted DMA pool initialization") added support for restricted DMA pools to handle these scenarios.
+
+## DMA Memory Pools
+
+For drivers that frequently allocate and free small, fixed-size DMA-coherent buffers (like USB transfer descriptors or hardware command entries), the overhead of calling `dma_alloc_coherent()` each time is excessive. The DMA pool API solves this.
+
+From [`include/linux/dmapool.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dmapool.h):
+
+```c
+struct dma_pool *dma_pool_create(const char *name, struct device *dev,
+                                  size_t size, size_t align, size_t boundary);
+void dma_pool_destroy(struct dma_pool *pool);
+
+void *dma_pool_alloc(struct dma_pool *pool, gfp_t gfp,
+                     dma_addr_t *dma_handle);
+void dma_pool_free(struct dma_pool *pool, void *vaddr,
+                   dma_addr_t dma_handle);
+```
+
+The pool pre-allocates large coherent regions and carves them into fixed-size chunks -- the same idea as the slab allocator, but for DMA-coherent memory. The `boundary` parameter prevents allocations from crossing a specified power-of-two boundary, which some hardware requires.
+
+The implementation lives in [`mm/dmapool.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/dmapool.c).
+
+## Common Mistakes
+
+### Forgetting to unmap
+
+Every `dma_map_single()` must have a matching `dma_unmap_single()`. Every `dma_map_sg()` must have a matching `dma_unmap_sg()`. Leaked mappings exhaust IOMMU address space or SWIOTLB pool, eventually causing allocation failures.
+
+Enable `CONFIG_DMA_API_DEBUG` to catch this. It tracks all mappings and warns on driver unload if any remain:
+
+```bash
+# Boot with DMA API debugging
+echo 1 > /sys/kernel/debug/dma-api/enable
+```
+
+### Using wrong GFP flags
+
+Do not use `GFP_DMA` unless you actually need memory in ZONE_DMA (first 16MB). Most modern devices with 32-bit DMA limitations need `GFP_DMA32` instead. But ideally, use the DMA API and let it handle zone selection:
+
+```c
+/* Wrong: manually allocating from DMA zone */
+buf = kmalloc(4096, GFP_KERNEL | GFP_DMA);
+dma_handle = virt_to_phys(buf); /* BROKEN: skips IOMMU! */
+
+/* Right: let the DMA API handle it */
+buf = dma_alloc_coherent(dev, 4096, &dma_handle, GFP_KERNEL);
+```
+
+The DMA API consults the device's DMA mask to determine the correct zone automatically.
+
+### Cache coherency bugs
+
+On architectures without hardware-managed coherency, accessing a streaming DMA buffer without proper sync operations causes data corruption. This often manifests as intermittent failures that are extremely difficult to reproduce:
+
+```c
+/* BUG: reading device data without sync */
+dma_handle = dma_map_single(dev, buf, len, DMA_FROM_DEVICE);
+start_device_dma(dev, dma_handle, len);
+wait_for_dma_complete(dev);
+memcpy(dest, buf, len);  /* May read stale cached data! */
+dma_unmap_single(dev, dma_handle, len, DMA_FROM_DEVICE);
+
+/* CORRECT: unmap (which syncs) before reading */
+dma_handle = dma_map_single(dev, buf, len, DMA_FROM_DEVICE);
+start_device_dma(dev, dma_handle, len);
+wait_for_dma_complete(dev);
+dma_unmap_single(dev, dma_handle, len, DMA_FROM_DEVICE);
+memcpy(dest, buf, len);  /* Safe: unmap invalidated cache */
+```
+
+### Using virt_to_phys() for DMA
+
+Never convert a virtual address to physical and hand it to a device. This bypasses the IOMMU, skips bounce buffering, and ignores the device's DMA mask. Always use the DMA API.
+
+### DMA to stack or module memory
+
+Stack memory and module text may reside in vmalloc space, which is not guaranteed to be physically contiguous or DMA-addressable. Always use `kmalloc()` or `dma_alloc_coherent()` for DMA buffers.
+
+## Try It Yourself
+
+### Check DMA zone sizes
+
+```bash
+# View zone information
+cat /proc/zoneinfo | grep -E "^Node|pages free|managed|zone"
+
+# Compact view of zones
+cat /proc/buddyinfo
+# Example output:
+# Node 0, zone      DMA      1    1    0    0    2    1    1    0    1    1    3
+# Node 0, zone    DMA32   2907 2312  975  574  256   94   40   16    6    5  252
+# Node 0, zone   Normal  19374 7834 5327 2581  784  168   30    5    0    0    0
+```
+
+### Inspect IOMMU state
+
+```bash
+# Check if IOMMU is active
+dmesg | grep -i iommu
+
+# View IOMMU groups (each group shares address space isolation)
+ls /sys/kernel/iommu_groups/
+# Each group directory contains a devices/ subdirectory listing PCI devices
+
+# Check a specific device's DMA mask
+# (from within a kernel module or via debugfs)
+cat /sys/bus/pci/devices/0000:03:00.0/dma_mask_bits
+```
+
+### Monitor SWIOTLB usage
+
+```bash
+# Check SWIOTLB pool size and usage
+cat /sys/kernel/debug/swiotlb/io_tlb_nslabs  2>/dev/null
+cat /sys/kernel/debug/swiotlb/io_tlb_used    2>/dev/null
+
+# Or from dmesg at boot
+dmesg | grep -i swiotlb
+# Example: "software IO TLB: mapped [mem 0x00000000b3c00000-0x00000000b7c00000] (64MB)"
+```
+
+### Enable DMA API debug checking
+
+```bash
+# Build kernel with CONFIG_DMA_API_DEBUG=y
+# Then at boot or runtime:
+echo 1 > /sys/kernel/debug/dma-api/enable
+
+# View DMA API debug statistics
+cat /sys/kernel/debug/dma-api/num_errors
+cat /sys/kernel/debug/dma-api/num_free_entries
+cat /sys/kernel/debug/dma-api/min_free_entries
+```
+
+### View DMA pool statistics
+
+```bash
+# DMA pool info per device
+cat /sys/kernel/debug/dma_pools 2>/dev/null
+
+# Or from sysfs (depends on kernel config)
+find /sys/kernel/debug/ -name "*dma*" 2>/dev/null
+```
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| [`kernel/dma/mapping.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/mapping.c) | Core DMA mapping implementation |
+| [`kernel/dma/direct.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/direct.c) | Direct DMA (no IOMMU) implementation |
+| [`kernel/dma/swiotlb.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/swiotlb.c) | SWIOTLB bounce buffer implementation |
+| [`include/linux/dma-mapping.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dma-mapping.h) | DMA API header |
+| [`include/linux/dmapool.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dmapool.h) | DMA pool API header |
+| [`mm/dmapool.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/dmapool.c) | DMA pool implementation |
+| [`drivers/iommu/`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu) | IOMMU driver implementations |
+| [`include/linux/mmzone.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mmzone.h) | Zone type definitions |
+
+---
+
+## References
+
+### Further Reading
+
+- [DMA API Guide](https://docs.kernel.org/core-api/dma-api.html) -- the authoritative kernel documentation on the DMA API
+- [DMA API HOWTO](https://docs.kernel.org/core-api/dma-api-howto.html) -- practical guide for driver developers
+- [Dynamic DMA mapping Guide](https://docs.kernel.org/core-api/dma-api-howto.html) -- when and how to use each mapping type
+- [LWN: A new DMA mapping API](https://lwn.net/Articles/753027/) (2018) -- restructuring the DMA API
+- [LWN: The IOMMU API](https://lwn.net/Articles/610073/) (2014) -- overview of the IOMMU framework
+- [LWN: Bounce-buffer problems](https://lwn.net/Articles/808916/) (2020) -- SWIOTLB challenges in the CMA era
+
+### Related
+
+- [Page Allocator](page-allocator.md) -- where DMA memory ultimately comes from
+- [vmalloc](vmalloc.md) -- virtual memory allocation (not suitable for DMA)
+- [NUMA](numa.md) -- NUMA-aware allocation and its interaction with DMA zones
+- [Overview](overview.md) -- how DMA allocation fits in the memory management hierarchy

--- a/docs/mm/hugetlbfs-vs-thp.md
+++ b/docs/mm/hugetlbfs-vs-thp.md
@@ -1,0 +1,464 @@
+# Explicit hugetlbfs vs Transparent Huge Pages
+
+> Two approaches to huge pages in Linux: one you ask for, one you get automatically
+
+## Why Huge Pages?
+
+Modern CPUs cache virtual-to-physical address translations in the TLB (Translation Lookaside Buffer). With standard 4KB pages, a workload touching a few gigabytes of memory needs hundreds of thousands of page table entries - far more than the TLB can hold. Every TLB miss triggers an expensive multi-level page table walk.
+
+Huge pages (2MB or 1GB on x86-64) reduce TLB pressure dramatically:
+
+| Page Size | Pages for 1GB | TLB Entries Needed |
+|-----------|---------------|--------------------|
+| 4KB       | 262,144       | 262,144            |
+| 2MB       | 512           | 512                |
+| 1GB       | 1             | 1                  |
+
+Linux provides two distinct mechanisms for using huge pages. They share the same hardware support (PMD-level and PUD-level page table entries) but differ fundamentally in how they are managed.
+
+## The Two Approaches
+
+### hugetlbfs: Explicit, Preallocated Huge Pages
+
+hugetlbfs is the original huge page mechanism. The administrator reserves a pool of huge pages at boot or runtime, and applications explicitly request them. Nothing happens automatically.
+
+```
+Administrator                          Application
+     │                                      │
+     ├── Reserve pool                       │
+     │   (boot param or sysctl)             │
+     │                                      │
+     ├── Mount hugetlbfs                    │
+     │   mount -t hugetlbfs ...             │
+     │                                      │
+     │                                      ├── mmap() with MAP_HUGETLB
+     │                                      │   or open file on hugetlbfs
+     │                                      │
+     │                                      ├── Use memory
+     │                                      │
+     │                                      └── munmap() / close
+     │                                      │
+     └── Pages return to pool               │
+```
+
+The kernel reserves these pages at allocation time, removing them from the regular page allocator entirely. They sit in a separate pool managed by [`mm/hugetlb.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/hugetlb.c) and cannot be used for anything else.
+
+### THP: Transparent, On-Demand Huge Pages
+
+Transparent Huge Pages require no application changes. The kernel automatically promotes 4KB pages to 2MB huge pages when it can, and splits them back when it must.
+
+```
+Application                            Kernel
+     │                                      │
+     ├── malloc() / mmap()                  │
+     │   (normal allocation)                │
+     │                                      │
+     ├── Touch memory                       ├── Page fault
+     │                                      │   Can allocate 2MB?
+     │                                      │   ├── Yes: map huge page
+     │                                      │   └── No: fall back to 4KB
+     │                                      │
+     │                                      ├── khugepaged scans later
+     │                                      │   Collapse 512 x 4KB → 2MB
+     │                                      │
+     └── free() / munmap()                  └── Pages return to buddy
+```
+
+THP pages come from the regular buddy allocator. The kernel finds (or creates via compaction) contiguous 2MB-aligned regions on demand. See [`mm/huge_memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/huge_memory.c) for the core implementation.
+
+## Side-by-Side Comparison
+
+| Feature | hugetlbfs | THP |
+|---------|-----------|-----|
+| **Page sizes** | 2MB and 1GB (x86-64); arch-dependent | 2MB (PMD); 16KB-1MB with mTHP (v6.8+) |
+| **Application changes** | Required: `MAP_HUGETLB`, hugetlbfs file, or libhugetlbfs | None (or optional `MADV_HUGEPAGE` hint) |
+| **Allocation** | Preallocated pool, reserved at boot/runtime | On-demand from buddy allocator |
+| **Swappable** | No - pages are pinned in RAM | Yes (since v4.13, swapped as whole unit) |
+| **Fragmentation risk** | Low - pool reserved upfront | Higher - needs contiguous memory at fault time |
+| **Overcommit** | No - allocation fails if pool exhausted | Yes - falls back to 4KB pages |
+| **NUMA awareness** | Per-node pools via `hugepages_*` sysfs | Allocation prefers local node; NUMA balancing can cause thrashing |
+| **Memory accounting** | Separate pool, visible in `/proc/meminfo` | Part of regular anonymous memory |
+| **Page cache support** | Yes (files on hugetlbfs) | Yes for anonymous; file THP limited |
+| **Split/collapse** | No - always huge | Yes - kernel splits and collapses as needed |
+| **Latency predictability** | High - no compaction, no fallback | Lower - compaction stalls possible |
+| **Wasted memory risk** | Pool sits unused if not consumed | 2MB granularity can waste memory on small allocations |
+
+## When to Use hugetlbfs
+
+hugetlbfs is the right choice when you control the application, need guaranteed huge pages, and cannot tolerate allocation failures or latency jitter.
+
+### Databases (Oracle, PostgreSQL, MySQL)
+
+Database shared buffers are long-lived, large, and heavily accessed. hugetlbfs gives them pinned huge pages that never get split or swapped:
+
+```bash
+# PostgreSQL: use huge pages for shared buffers
+# postgresql.conf
+huge_pages = on   # or "try" for fallback to regular pages
+```
+
+PostgreSQL uses `mmap()` with `MAP_HUGETLB` for its shared memory segment. Oracle has used hugetlbfs since the early 2000s for its SGA (System Global Area).
+
+### DPDK and Network Packet Processing
+
+DPDK (Data Plane Development Kit) maps packet buffers on hugetlbfs to get pinned physical memory with known addresses - critical for DMA with network hardware:
+
+```bash
+# DPDK typically requires 1GB huge pages
+echo 4 > /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages
+mount -t hugetlbfs -o pagesize=1G nodev /dev/hugepages-1G
+```
+
+1GB pages are especially valuable here: a single TLB entry covers the entire packet buffer pool.
+
+### KVM/QEMU Virtual Machines
+
+VMs benefit from huge pages for guest memory - fewer TLB entries means less overhead from nested address translation (EPT/NPT):
+
+```bash
+# QEMU with hugetlbfs-backed guest memory
+qemu-system-x86_64 -m 4G \
+    -mem-path /dev/hugepages \
+    -mem-prealloc ...
+```
+
+## When to Use THP
+
+THP works best for workloads where you want huge page benefits without application modifications, and can tolerate occasional fallback to 4KB pages.
+
+### General Server Workloads
+
+For applications you cannot modify or recompile, THP provides automatic benefit:
+
+```bash
+# Enable THP system-wide
+echo always > /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+The kernel will opportunistically use huge pages for all anonymous memory.
+
+### Applications with Large Heaps
+
+Java, Python, and other managed-runtime applications benefit from THP without any code changes. The JVM in particular sees significant gains from reduced TLB pressure on large heaps.
+
+For fine-grained control without modifying the application:
+
+```bash
+# Use madvise mode + per-process hints via libhugetlbfs or LD_PRELOAD
+echo madvise > /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+### KVM (Transparent Mode)
+
+THP was originally designed for KVM. From the initial THP commit [71e3aac0724f](https://git.kernel.org/linus/71e3aac0724f):
+
+> "Lately I've been working to make KVM use hugepages transparently without the usual restrictions of hugetlbfs."
+
+VMs get huge pages automatically for guest memory without reserving a hugetlbfs pool.
+
+## When to Disable THP
+
+Some workloads perform worse with THP. The core issue is that THP adds background work (compaction, khugepaged scanning, page splitting) that can cause unpredictable latency.
+
+### Latency-Sensitive Applications (Redis, Memcached)
+
+In-memory stores that serve requests in microseconds can see multi-millisecond stalls when the kernel runs memory compaction to satisfy a huge page allocation:
+
+```bash
+# Redis and Memcached documentation both recommend:
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+echo never > /sys/kernel/mm/transparent_hugepage/defrag
+```
+
+The Redis documentation specifically calls out THP as a source of latency and memory usage issues.
+
+### Sparse Memory Access Patterns
+
+Applications that allocate large regions but only touch a few bytes per 2MB region waste memory. The kernel allocates a full 2MB page even if only 4KB is used.
+
+### Real-Time and Deterministic Workloads
+
+Any workload where worst-case latency matters more than throughput should disable THP. Compaction is not bounded in time:
+
+```bash
+# A middle ground: THP only for apps that ask
+echo madvise > /sys/kernel/mm/transparent_hugepage/enabled
+echo madvise > /sys/kernel/mm/transparent_hugepage/defrag
+```
+
+## Configuration
+
+### hugetlbfs Setup
+
+#### Reserve the Pool
+
+```bash
+# At boot (kernel command line) - most reliable for large pools
+hugepagesz=2M hugepages=1024
+hugepagesz=1G hugepages=4
+
+# At runtime (may fail if memory is fragmented)
+echo 1024 > /proc/sys/vm/nr_hugepages                          # 2MB pages
+echo 4 > /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages  # 1GB pages
+
+# Check current state
+cat /proc/meminfo | grep -i huge
+# HugePages_Total:    1024
+# HugePages_Free:     1024
+# HugePages_Rsvd:        0
+# HugePages_Surp:        0
+# Hugepagesize:       2048 kB
+```
+
+#### Mount hugetlbfs
+
+```bash
+# Default 2MB page size
+mount -t hugetlbfs nodev /dev/hugepages
+
+# Explicit 1GB page size
+mount -t hugetlbfs -o pagesize=1G nodev /dev/hugepages-1G
+```
+
+Most distributions mount the default hugetlbfs automatically via systemd.
+
+#### Use from Applications
+
+```c
+#include <sys/mman.h>
+
+/* Option 1: MAP_HUGETLB flag (no mount needed on modern kernels) */
+void *ptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
+
+/* Option 2: 1GB pages */
+void *ptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB,
+                 -1, 0);
+
+/* Option 3: File on hugetlbfs */
+int fd = open("/dev/hugepages/myfile", O_CREAT | O_RDWR, 0600);
+void *ptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                 MAP_SHARED, fd, 0);
+```
+
+#### NUMA-Aware Pool Configuration
+
+```bash
+# Reserve pages on specific NUMA nodes
+echo 512 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+echo 512 > /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
+```
+
+### THP Setup
+
+```bash
+# Global mode
+echo always  > /sys/kernel/mm/transparent_hugepage/enabled   # All anonymous memory
+echo madvise > /sys/kernel/mm/transparent_hugepage/enabled   # Only MADV_HUGEPAGE regions
+echo never   > /sys/kernel/mm/transparent_hugepage/enabled   # Disabled
+
+# Defrag behavior (when to compact memory for huge pages)
+echo always        > /sys/kernel/mm/transparent_hugepage/defrag  # Sync on fault (stalls)
+echo defer         > /sys/kernel/mm/transparent_hugepage/defrag  # Async via khugepaged
+echo defer+madvise > /sys/kernel/mm/transparent_hugepage/defrag  # Defer most, sync for hints
+echo madvise       > /sys/kernel/mm/transparent_hugepage/defrag  # Only for MADV_HUGEPAGE
+echo never         > /sys/kernel/mm/transparent_hugepage/defrag  # Never compact for THP
+
+# khugepaged tuning
+echo 10000 > /sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs
+echo 4096  > /sys/kernel/mm/transparent_hugepage/khugepaged/pages_to_scan
+```
+
+See the [THP kernel docs](https://docs.kernel.org/admin-guide/mm/transhuge.html) for all tunables.
+
+## Monitoring
+
+### hugetlbfs: /proc/meminfo
+
+```bash
+$ grep -i huge /proc/meminfo
+AnonHugePages:    204800 kB    # THP usage (not hugetlbfs!)
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+HugePages_Total:    1024       # hugetlbfs pool size
+HugePages_Free:      900       # Unused pages in pool
+HugePages_Rsvd:       50       # Reserved but not yet faulted
+HugePages_Surp:        0       # Surplus pages above nr_hugepages
+Hugepagesize:       2048 kB    # Default huge page size
+```
+
+Key relationships:
+
+- **HugePages_Total - HugePages_Free** = pages currently mapped by applications
+- **HugePages_Rsvd** = pages promised to applications but not yet faulted in
+- **Available** = HugePages_Free - HugePages_Rsvd
+
+```bash
+# Per-node hugetlbfs stats
+cat /sys/devices/system/node/node0/hugepages/hugepages-2048kB/free_hugepages
+cat /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+```
+
+### THP: /sys/kernel/mm/transparent_hugepage/ and /proc/vmstat
+
+```bash
+$ grep thp /proc/vmstat
+thp_fault_alloc 1234          # Huge pages allocated on page fault
+thp_fault_fallback 56         # Fell back to 4KB on fault
+thp_collapse_alloc 789        # Pages collapsed by khugepaged
+thp_collapse_alloc_failed 12  # khugepaged collapse failures
+thp_split_page 45             # Huge pages split back to 4KB
+thp_zero_page_alloc 3         # Zero huge pages allocated
+thp_swpout 0                  # Huge pages swapped out (as unit)
+thp_swpout_fallback 0         # Swap fell back to splitting first
+```
+
+```bash
+# Per-process THP usage
+grep AnonHugePages /proc/<pid>/smaps_rollup
+
+# Current THP mode
+cat /sys/kernel/mm/transparent_hugepage/enabled
+# [always] madvise never
+```
+
+### Quick Health Check
+
+```bash
+#!/bin/bash
+echo "=== hugetlbfs ==="
+grep -i huge /proc/meminfo
+
+echo ""
+echo "=== THP ==="
+echo "Mode: $(cat /sys/kernel/mm/transparent_hugepage/enabled)"
+echo "Defrag: $(cat /sys/kernel/mm/transparent_hugepage/defrag)"
+echo ""
+echo "Allocations:"
+grep -E "thp_fault_alloc|thp_fault_fallback|thp_collapse|thp_split" /proc/vmstat
+```
+
+## History
+
+### hugetlbfs (v2.5.36, 2002)
+
+**Commit**: hugetlbfs was added during the Linux 2.5 development series (pre-git era, 2002).
+
+The implementation lives in [`fs/hugetlbfs/inode.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/hugetlbfs/inode.c) and [`mm/hugetlb.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/hugetlb.c). The original motivation came from database vendors (particularly Oracle and IBM) who needed huge pages on Linux to match the performance of proprietary Unix systems (AIX, Solaris, HP-UX) that had long supported them.
+
+**LWN coverage**: [Huge pages part 1: Introduction](https://lwn.net/Articles/374424/) provides an overview of the mechanism and its history.
+
+*Note: Linux 2.5 predates git (the kernel switched to git in April 2005 with 2.6.12). No commit IDs exist for the original hugetlbfs patches.*
+
+Key milestones in hugetlbfs evolution:
+
+- **v2.6.32 (2009)**: `MAP_HUGETLB` added as an mmap flag, allowing huge page mappings without a hugetlbfs mount point; commit [e5ff2159a434](https://git.kernel.org/linus/e5ff2159a434) adds a usage example
+- **v3.8 (2013)**: Commit [42d7395feb56](https://git.kernel.org/linus/42d7395feb56) ("mm: support more pagesizes for MAP_HUGETLB/SHM_HUGETLB") - encode page size in mmap flags (enabling 1GB pages via `MAP_HUGE_1GB`)
+
+### THP (v2.6.38, 2011)
+
+**Commit**: [71e3aac0724f](https://git.kernel.org/linus/71e3aac0724f) ("thp: transparent hugepage core")
+
+**Author**: Andrea Arcangeli (Red Hat)
+
+The initial THP implementation targeted anonymous memory for KVM virtual machines. The commit message explains the motivation: removing the restrictions of hugetlbfs while keeping the TLB benefits.
+
+**LWN coverage**: [Transparent huge pages](https://lwn.net/Articles/423584/) covers the design and early reception.
+
+Key milestones in THP evolution:
+
+- **v2.6.38 (2011)**: `MADV_HUGEPAGE` / `MADV_NOHUGEPAGE` added in the initial THP commit for per-VMA control
+- **v4.13 (2017)**: Commit [38d8b4e6bdc8](https://git.kernel.org/linus/38d8b4e6bdc8) ("mm, THP, swap: delay splitting THP during swap out") - THP swap support (Huang Ying)
+- **v5.4 (2019)**: Improved defrag modes (`defer+madvise`)
+- **v6.8 (2024)**: Commit [19eaf44954df](https://git.kernel.org/linus/19eaf44954df) ("mm: thp: support allocation of anonymous multi-size THP") - multi-size THP (mTHP) enabling page sizes between 4KB and 2MB (Ryan Roberts)
+
+### The Design Tension
+
+hugetlbfs and THP represent a classic systems design trade-off: **explicit control vs automatic optimization**.
+
+hugetlbfs gives the administrator full control. You know exactly how many huge pages exist, which applications use them, and there are no surprises. The cost is operational complexity and wasted memory if the pool is oversized.
+
+THP removes the operational burden but introduces unpredictability. The kernel makes decisions that can help most workloads but hurt some. Years of bug fixes and tuning knobs (defrag modes, madvise hints, mTHP) show the ongoing effort to make the automatic approach work reliably.
+
+Neither approach is going away. The kernel development community continues to improve both - hugetlbfs gets better NUMA support and accounting, while THP gets finer granularity (mTHP) and better heuristics.
+
+## Try It Yourself
+
+```bash
+# === hugetlbfs ===
+
+# Reserve 10 huge pages (2MB each = 20MB)
+echo 10 > /proc/sys/vm/nr_hugepages
+
+# Verify the pool
+grep HugePages /proc/meminfo
+
+# Mount hugetlbfs (if not already mounted)
+mkdir -p /mnt/huge
+mount -t hugetlbfs nodev /mnt/huge
+
+# Write a small C program that uses MAP_HUGETLB and verify with:
+grep HugePages /proc/meminfo   # HugePages_Free should decrease
+
+# === THP ===
+
+# Check current THP mode
+cat /sys/kernel/mm/transparent_hugepage/enabled
+
+# Run a program that allocates a large anonymous region:
+#   void *p = mmap(NULL, 64*1024*1024, PROT_READ|PROT_WRITE,
+#                  MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+#   memset(p, 0, 64*1024*1024);
+
+# While it's running, check:
+grep AnonHugePages /proc/<pid>/smaps_rollup
+grep thp_fault_alloc /proc/vmstat
+
+# === Compare latency ===
+
+# With THP defrag=always, run a latency-sensitive workload and observe stalls:
+echo always > /sys/kernel/mm/transparent_hugepage/defrag
+# Then try:
+echo never > /sys/kernel/mm/transparent_hugepage/defrag
+# Compare tail latencies
+
+# === Watch khugepaged ===
+# In one terminal:
+grep thp_collapse /proc/vmstat
+# Run a workload, wait 10+ seconds, check again
+grep thp_collapse /proc/vmstat
+# The counter should increase as khugepaged collapses pages
+```
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/hugetlb.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/hugetlb.c) | hugetlbfs pool management and fault handling |
+| [`fs/hugetlbfs/inode.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/hugetlbfs/inode.c) | hugetlbfs filesystem implementation |
+| [`mm/huge_memory.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/huge_memory.c) | THP core implementation |
+| [`mm/khugepaged.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/khugepaged.c) | THP collapse daemon |
+
+### Kernel Documentation
+
+- [`Documentation/admin-guide/mm/hugetlbpage.rst`](https://docs.kernel.org/admin-guide/mm/hugetlbpage.html) - hugetlbfs admin guide
+- [`Documentation/admin-guide/mm/transhuge.rst`](https://docs.kernel.org/admin-guide/mm/transhuge.html) - THP admin guide
+
+### LWN Articles
+
+- [Huge pages part 1: Introduction](https://lwn.net/Articles/374424/) (2010) - Overview of huge pages in Linux
+- [Huge pages part 2: Interfaces](https://lwn.net/Articles/375096/) (2010) - hugetlbfs and libhugetlbfs
+- [Huge pages part 3: Administration](https://lwn.net/Articles/376606/) (2010) - Pool management and NUMA
+- [Transparent huge pages](https://lwn.net/Articles/423584/) (2011) - THP design and introduction
+- [Multi-size THP](https://lwn.net/Articles/937239/) (2023) - mTHP motivation and design
+
+### Related
+
+- [Transparent Huge Pages](thp.md) - Deep dive on THP internals, bugs, and tuning
+- [Compaction](compaction.md) - Memory defragmentation that THP depends on
+- [Page Allocator](page-allocator.md) - The buddy allocator that serves both mechanisms
+- [NUMA](numa.md) - Per-node huge page pools and THP NUMA interactions
+- [Page Tables](page-tables.md) - PMD-level and PUD-level huge page mappings

--- a/docs/mm/memblock.md
+++ b/docs/mm/memblock.md
@@ -1,0 +1,482 @@
+# memblock: The Boot-Time Memory Allocator
+
+> Before the buddy system can manage memory, something has to manage memory first
+
+## What is memblock?
+
+memblock is the kernel's early boot-time memory allocator. It tracks which physical memory regions exist and which are already reserved, allowing the kernel to allocate memory during the earliest stages of boot -- long before the buddy allocator (page allocator) is initialized.
+
+```c
+/* Add a region of physical memory */
+int memblock_add(phys_addr_t base, phys_addr_t size);
+
+/* Mark a region as reserved (in use) */
+int memblock_reserve(phys_addr_t base, phys_addr_t size);
+
+/* Allocate memory during early boot */
+void *memblock_alloc(phys_addr_t size, phys_addr_t align);
+```
+
+## The Chicken-and-Egg Problem
+
+The buddy allocator is the kernel's primary physical memory manager at runtime. But setting it up requires memory:
+
+- **Zone structures** (`struct zone`) need to be allocated for each memory zone
+- **Page frame metadata** (`struct page`) needs one entry per physical page -- on a 16GB system that's millions of entries
+- **Per-CPU data structures** for allocation caches
+- **Free lists** for the buddy system itself
+
+But you cannot allocate memory without a memory allocator. Something simpler must come first.
+
+memblock solves this bootstrap problem with a deliberately minimal design: two flat arrays that track memory regions. No page tables, no locking, no per-CPU caches -- just "here's what exists" and "here's what's taken."
+
+```
+Boot sequence:
+
+  1. Firmware / bootloader loads kernel into RAM
+
+  2. Architecture setup discovers physical memory layout
+     (via device tree, ACPI, or e820 on x86)
+
+  3. memblock tracks available and reserved regions
+     +----------------------------------------------+
+     | memblock.memory:   [0 - 4GB], [8GB - 16GB]  |  <- what exists
+     | memblock.reserved: [0 - 16MB], [64MB - 80MB] |  <- what's taken
+     +----------------------------------------------+
+
+  4. Kernel uses memblock_alloc() to get memory for
+     page tables, struct page array, zone structures...
+
+  5. Buddy allocator initialized using memblock info
+
+  6. memblock_free_all() hands remaining free memory
+     to the buddy system
+
+  7. memblock is done (memory can be freed if not needed)
+```
+
+## How memblock Works
+
+### Two Arrays: memory and reserved
+
+The core data structure is simple. memblock maintains two collections of regions:
+
+```c
+struct memblock {
+    bool bottom_up;                          /* allocation direction */
+    phys_addr_t current_limit;               /* allocation limit */
+    struct memblock_type memory;             /* physical memory regions */
+    struct memblock_type reserved;           /* reserved (in-use) regions */
+};
+```
+
+Each `memblock_type` holds a dynamically-growing array of regions:
+
+```c
+struct memblock_type {
+    unsigned long cnt;                       /* number of regions */
+    unsigned long max;                       /* max regions (grows if needed) */
+    phys_addr_t total_size;                  /* total size of all regions */
+    struct memblock_region *regions;         /* array of regions */
+    char *name;                              /* "memory" or "reserved" */
+};
+
+struct memblock_region {
+    phys_addr_t base;                        /* start address */
+    phys_addr_t size;                        /* region size */
+    enum memblock_flags flags;               /* HOTPLUG, MIRROR, NOMAP */
+#ifdef CONFIG_NUMA
+    int nid;                                 /* NUMA node id */
+#endif
+};
+```
+
+The `memory` array describes what physical memory exists (as reported by firmware). The `reserved` array describes what's already been claimed -- the kernel image itself, device tree blob, initrd, early allocations, etc.
+
+**Free memory** is implicitly defined as: regions in `memory` that are not covered by `reserved`.
+
+```
+Physical address space:
+0                                                              16GB
+|--------------------------------------------------------------|
+
+memblock.memory (what exists):
+|==========|                  |================================|
+0        4GB                 8GB                             16GB
+
+memblock.reserved (what's taken):
+|==|    |=|                  |=|
+kernel  DTB                  initrd
+
+Free = memory minus reserved
+```
+
+### Region Merging
+
+When adjacent or overlapping regions are added, memblock automatically merges them. This keeps the arrays compact:
+
+```
+memblock_add(0, 1GB)    -> memory: [0, 1GB]
+memblock_add(1GB, 1GB)  -> memory: [0, 2GB]     (merged)
+memblock_add(3GB, 1GB)  -> memory: [0, 2GB], [3GB, 4GB]  (gap, no merge)
+```
+
+### Static Bootstrap
+
+The initial region arrays are statically allocated:
+
+```c
+static struct memblock_region memblock_memory_init_regions[INIT_MEMBLOCK_REGIONS];
+static struct memblock_region memblock_reserved_init_regions[INIT_MEMBLOCK_RESERVED_REGIONS];
+```
+
+`INIT_MEMBLOCK_REGIONS` defaults to 128. If more regions are needed, memblock doubles the array using `memblock_double_array()`, which allocates new space from memblock itself -- a neat self-referential trick that works because the old array remains valid until the copy is complete.
+
+## Key APIs
+
+### Adding and Removing Memory
+
+```c
+/* Tell memblock about physical memory regions (called by arch code) */
+int memblock_add(phys_addr_t base, phys_addr_t size);
+
+/* Remove a region (e.g., firmware reserved areas) */
+int memblock_remove(phys_addr_t base, phys_addr_t size);
+
+/* Mark a region as reserved */
+int memblock_reserve(phys_addr_t base, phys_addr_t size);
+
+/* Free a previously reserved region */
+int memblock_phys_free(phys_addr_t base, phys_addr_t size);
+
+/* Mark memory as not directly usable (won't be mapped) */
+int memblock_mark_nomap(phys_addr_t base, phys_addr_t size);
+```
+
+### Allocating Memory
+
+```c
+/* Allocate aligned memory (most common) */
+void *memblock_alloc(phys_addr_t size, phys_addr_t align);
+
+/* Allocate from a specific address range */
+void *memblock_alloc_range_nid(phys_addr_t size, phys_addr_t align,
+                               phys_addr_t start, phys_addr_t end,
+                               int nid, bool exact_nid);
+
+/* Allocate raw physical address (no virtual mapping) */
+phys_addr_t memblock_phys_alloc(phys_addr_t size, phys_addr_t align);
+```
+
+`memblock_alloc()` does two things: finds a free physical region and maps it into the kernel's virtual address space (via `memblock_alloc_internal()` which calls `memblock_alloc_range_nid()` then `memblock_reserve()` on the result). The returned pointer is a kernel virtual address ready to use.
+
+### Querying Memory
+
+```c
+/* Is this address in a reserved region? */
+bool memblock_is_reserved(phys_addr_t addr);
+
+/* Is this address in a memory region? */
+bool memblock_is_memory(phys_addr_t addr);
+
+/* Total amount of usable RAM */
+phys_addr_t memblock_phys_mem_size(void);
+
+/* Iterate over free (unreserved) memory regions */
+for_each_free_mem_range(i, nid, flags, &start, &end, NULL)
+```
+
+## Memory Discovery: Device Tree and ACPI
+
+memblock does not discover memory on its own. Architecture-specific code populates it using firmware information.
+
+### Device Tree (ARM, RISC-V, PowerPC, etc.)
+
+On device-tree platforms, the `/memory` nodes describe physical RAM:
+
+```dts
+/ {
+    memory@80000000 {
+        device_type = "memory";
+        reg = <0x00 0x80000000 0x00 0x80000000>;  /* 2GB at 0x80000000 */
+    };
+};
+```
+
+The kernel's early DT scanning code (`early_init_dt_scan_memory()` in [`drivers/of/fdt.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/of/fdt.c)) parses these nodes and calls `memblock_add()` for each region. Reserved memory nodes (`/reserved-memory`) result in `memblock_reserve()` calls.
+
+### ACPI (x86, ARM servers)
+
+On ACPI systems, the firmware provides memory maps through different mechanisms:
+
+- **x86**: The BIOS/UEFI provides an **e820 memory map** -- a table of address ranges with types (usable, reserved, ACPI reclaimable, etc.). The function `e820__memblock_setup()` in [`arch/x86/kernel/e820.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/e820.c) translates e820 entries into `memblock_add()` and `memblock_reserve()` calls.
+
+- **ARM64 with ACPI**: Uses EFI memory map entries, processed by `efi_init()`.
+
+### The Pattern
+
+Regardless of platform, the flow is the same:
+
+```
+Firmware provides memory layout
+        |
+        v
+Architecture code parses it
+        |
+        v
+memblock_add() for usable regions
+memblock_reserve() for reserved regions
+        |
+        v
+memblock has complete picture of physical memory
+```
+
+## The Handoff to the Buddy Allocator
+
+Once the kernel has used memblock to set up all the data structures the buddy allocator needs, memblock's job is nearly done. The handoff happens through `memblock_free_all()`:
+
+```c
+void __init memblock_free_all(void)
+{
+    unsigned long pages;
+
+    pages = free_low_memory_core_early();  /* release memblock pages to buddy */
+    totalram_pages_add(pages);
+}
+```
+
+This function walks all memblock memory regions, and for each page that is **not** reserved, calls `__free_pages_core()` to hand it to the buddy allocator. After this point, the buddy system owns all free physical memory and memblock is no longer needed for allocation.
+
+The memblock data structures themselves are marked `__initdata`, meaning they live in the kernel's init section. After boot completes (`free_initmem()`), this memory is reclaimed -- unless `CONFIG_ARCH_KEEP_MEMBLOCK` is enabled (which preserves memblock data for later queries, useful for kexec and memory hotplug).
+
+```
+memblock_free_all() walkthrough:
+
+  For each page in memblock.memory:
+      if not in memblock.reserved:
+          __free_pages_core(page)   ->  buddy allocator now owns it
+          totalram_pages++
+
+  Result: buddy free lists populated, system ready for normal allocation
+```
+
+## History and Evolution
+
+### bootmem: The Original Approach (Linux 2.4 through early 3.x)
+
+Before memblock, the kernel used a **bitmap-based** boot allocator called `bootmem`. Each bit represented one physical page: 1 = allocated, 0 = free.
+
+The problems with bootmem:
+
+- **Bitmap overhead**: A 64GB system needs a 2MB bitmap just for accounting
+- **Linear search**: Finding free memory required scanning the bitmap -- O(n) in the number of pages
+- **No NUMA awareness**: The original bootmem had no concept of memory nodes
+- **Fragile**: The bitmap itself needed to live somewhere in memory, creating another bootstrap problem
+
+### The Rise of memblock (Logical Memory Blocks)
+
+memblock's predecessor was called **lmb** (Logical Memory Blocks), used on PowerPC. It tracked memory as a list of regions rather than a per-page bitmap -- far more efficient when memory is mostly contiguous.
+
+**Commit**: [95f72d1ed41a](https://git.kernel.org/linus/95f72d1ed41a) ("lmb: rename to memblock") | [LWN coverage](https://lwn.net/Articles/382559/)
+**Kernel**: v2.6.35 (2010)
+**Author**: Yinghai Lu
+
+Yinghai Lu renamed lmb to memblock and began extending it for use on x86. The rename was the first step in making it architecture-independent.
+
+### memblock Replaces bootmem
+
+Over several kernel releases, architectures migrated from bootmem to memblock:
+
+- **ARM**: One of the early adopters alongside PowerPC
+- **x86**: Migrated in the v2.6.35 -- v3.x timeframe
+
+**Commit**: [9a8dd708d547](https://git.kernel.org/linus/9a8dd708d547) ("memblock: remove bootmem dependency on memblock")
+**Kernel**: v3.12 (2013)
+
+The final removal of bootmem happened when all architectures had been converted:
+
+**Commit**: [355c45affca7](https://git.kernel.org/linus/355c45affca7114ab510e296a5b7012943aeea17) ("mm: remove bootmem allocator implementation")
+**Kernel**: v4.20 (2018)
+**Author**: Mike Rapoport (IBM)
+
+This was a significant cleanup -- the bootmem code had accumulated decades of workarounds and special cases.
+
+### Recent Improvements
+
+**Commit**: [35fd0808de0e](https://git.kernel.org/linus/35fd0808de0e) ("memblock: introduce memblock_phys_free()")
+**Kernel**: v6.1 (2022)
+**Author**: Mike Rapoport
+
+Part of a broader effort to clean up early memory management and reduce the use of `memblock_free()` which had confusing semantics (it freed from the reserved list, not the memory list).
+
+## Observing memblock
+
+### debugfs Interface
+
+If `CONFIG_ARCH_KEEP_MEMBLOCK` is enabled, you can inspect the memblock state after boot:
+
+```bash
+# View memory regions
+cat /sys/kernel/debug/memblock/memory
+
+# View reserved regions
+cat /sys/kernel/debug/memblock/reserved
+
+# Example output (memory):
+#    0: 0x0000000000000000..0x000000009fffffff (2560 MB)
+#    1: 0x0000000100000000..0x00000004ffffffff (16384 MB)
+```
+
+### Early Boot Messages
+
+memblock logs its activity to dmesg during early boot. Look for lines with the `memblock` prefix:
+
+```bash
+dmesg | grep -i memblock
+
+# Example output:
+# [    0.000000] memblock_add: [mem 0x00000000-0x9fffffff]
+# [    0.000000] memblock_reserve: [mem 0x01000000-0x01ffffff]
+# [    0.000000] memblock: memory size = 16384 MB
+```
+
+For more verbose output, pass `memblock=debug` on the kernel command line. This enables detailed logging of every memblock operation:
+
+```bash
+# In bootloader config (e.g., GRUB):
+linux /vmlinuz memblock=debug ...
+```
+
+### e820 Table (x86)
+
+On x86 systems, you can see the firmware memory map that feeds into memblock:
+
+```bash
+dmesg | grep e820
+
+# Example output:
+# BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+# BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+# BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+# BIOS-e820: [mem 0x0000000000100000-0x000000003fffffff] usable
+```
+
+## Try It Yourself
+
+### Inspect memblock Regions
+
+```bash
+# Check if your kernel preserves memblock data
+ls /sys/kernel/debug/memblock/ 2>/dev/null && echo "memblock debugfs available"
+
+# If available, examine the memory layout
+cat /sys/kernel/debug/memblock/memory
+cat /sys/kernel/debug/memblock/reserved
+
+# Count the number of memory regions
+wc -l < /sys/kernel/debug/memblock/memory
+```
+
+### Trace the Boot Memory Setup
+
+```bash
+# See how firmware reported memory to the kernel
+dmesg | grep -E "(e820|memblock|Memory:)"
+
+# The "Memory:" line shows the final accounting
+# Memory: 16123456K/16777216K available
+#          (X kernel code, Y rwdata, Z rodata, W init, V bss, ...)
+```
+
+### Enable Verbose memblock Logging
+
+```bash
+# Add to kernel command line (requires reboot)
+# For GRUB: edit /etc/default/grub, add memblock=debug to GRUB_CMDLINE_LINUX
+sudo sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 memblock=debug"/' /etc/default/grub
+sudo update-grub
+
+# After reboot, check the detailed log
+dmesg | grep memblock | head -50
+```
+
+### Compare memblock with Runtime View
+
+```bash
+# memblock's view (boot time, if preserved)
+cat /sys/kernel/debug/memblock/memory 2>/dev/null
+
+# Buddy allocator's view (runtime)
+cat /proc/buddyinfo
+
+# Total managed memory
+grep MemTotal /proc/meminfo
+```
+
+## Key Data Structures
+
+### struct memblock (Global State)
+
+The entire memblock state lives in a single global variable:
+
+```c
+struct memblock memblock __initdata_memblock = {
+    .memory.regions     = memblock_memory_init_regions,
+    .memory.cnt         = 1,    /* empty dummy region */
+    .memory.max         = INIT_MEMBLOCK_REGIONS,
+    .memory.name        = "memory",
+
+    .reserved.regions   = memblock_reserved_init_regions,
+    .reserved.cnt       = 1,
+    .reserved.max       = INIT_MEMBLOCK_RESERVED_REGIONS,
+    .reserved.name      = "reserved",
+
+    .bottom_up          = false,
+    .current_limit      = MEMBLOCK_ALLOC_ANYWHERE,
+};
+```
+
+The `__initdata_memblock` annotation means this data is either `__initdata` (freed after boot) or `__meminitdata` (kept for memory hotplug), depending on `CONFIG_ARCH_KEEP_MEMBLOCK`.
+
+### memblock_flags
+
+```c
+enum memblock_flags {
+    MEMBLOCK_NONE       = 0x0,   /* No special flags */
+    MEMBLOCK_HOTPLUG    = 0x1,   /* Hotpluggable memory */
+    MEMBLOCK_MIRROR     = 0x2,   /* Mirrored (EFI) memory */
+    MEMBLOCK_NOMAP      = 0x4,   /* Don't add to direct mapping */
+    MEMBLOCK_DRIVER_MANAGED = 0x8, /* Managed by a driver */
+};
+```
+
+## References
+
+### Key Code
+
+| File | Description |
+|------|-------------|
+| [`mm/memblock.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memblock.c) | Core memblock implementation |
+| [`include/linux/memblock.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/memblock.h) | Public API and data structures |
+| [`drivers/of/fdt.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/of/fdt.c) | Device tree memory scanning |
+| [`arch/x86/kernel/e820.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/e820.c) | x86 e820 to memblock translation |
+
+### Key Commits
+
+| Commit | Kernel | Description |
+|--------|--------|-------------|
+| [95f72d1ed41a](https://git.kernel.org/linus/95f72d1ed41a) | v2.6.35 | Rename lmb to memblock |
+| [9a8dd708d547](https://git.kernel.org/linus/9a8dd708d547) | v3.12 | Remove bootmem dependency on memblock |
+| [355c45affca7](https://git.kernel.org/linus/355c45affca7114ab510e296a5b7012943aeea17) | v4.20 | Remove bootmem allocator implementation |
+| [35fd0808de0e](https://git.kernel.org/linus/35fd0808de0e) | v6.1 | Introduce memblock_phys_free() |
+
+### LWN Articles
+
+- [A quick history of early-boot memory allocators](https://lwn.net/Articles/382559/) -- Coverage of the lmb-to-memblock rename and rationale
+- [Improvements to memblock](https://lwn.net/Articles/761215/) -- Mike Rapoport's work cleaning up the early memory allocator
+
+### Related
+
+- [page-allocator](page-allocator.md) - The buddy allocator that memblock hands off to
+- [overview](overview.md) - How memblock fits in the allocator hierarchy
+- [numa](numa.md) - NUMA-aware memblock allocation

--- a/docs/mm/oom.md
+++ b/docs/mm/oom.md
@@ -656,7 +656,7 @@ cat /sys/fs/cgroup/mycontainer/memory.events
 
 #### PSI - Pressure Stall Information (v4.20)
 
-Johannes Weiner (Facebook) added PSI to detect pressure *before* OOM (see [Case 3](#case-3-the-thrashing-livelock-2010-mitigated-2018) above).
+Johannes Weiner (Facebook) added PSI to detect pressure *before* OOM (see [Case 3](#case-3-the-thrashing-livelock-2010-present) above).
 
 **Commit**: [eb414681d5a0](https://git.kernel.org/linus/eb414681d5a0) ("psi: pressure stall information for CPU, memory, and IO") | [LKML](https://lore.kernel.org/linux-mm/20180529093107.13939-1-hannes@cmpxchg.org/)
 
@@ -931,7 +931,7 @@ ulimit -u 500  # Max 500 processes for this user
 
 ---
 
-### Case 5: OOM deadlock denial of service (CVE-2012-4398)
+### Case 5: CVE-2012-4398 - OOM deadlock denial of service
 
 #### What happened
 


### PR DESCRIPTION
## Summary

Documentation for four memory management subsystems under `docs/mm/`:

- **memblock.md**: Boot-time memory allocator — region-based design, memory/reserved arrays, handoff to buddy via `memblock_free_all()`, history from lmb (PowerPC) through bootmem removal (v5.0, commit 355c45affca7)
- **cma.md**: Contiguous Memory Allocator — dual-use MIGRATE_CMA design (Marek Szyprowski, Samsung, merged v3.5), bitmap tracking, interaction with page allocator fallback, device tree `reusable` property
- **dma.md**: DMA memory allocation — zone hierarchy (DMA/DMA32/Normal), coherent vs streaming mappings, IOMMU scatter-gather coalescing, SWIOTLB bounce buffers (including confidential computing use case), DMA pools
- **hugetlbfs-vs-thp.md**: Side-by-side comparison of explicit preallocated huge pages vs transparent huge pages — use cases, configuration, monitoring, history through mTHP (v6.8, Ryan Roberts)

## Fixes applied (post-initial review)

- **memblock.md**: Bootmem removal commit hash corrected to 355c45affca7 ("mm: remove bootmem allocator implementation", Mike Rapoport, v5.0); prior hash 0fa817767102 does not exist in the tree
- **hugetlbfs-vs-thp.md**: mTHP (commit 19eaf44954df, Ryan Roberts) merged in v6.8 (March 2024), not v6.10

## Citations

All claims cite git.kernel.org commits, docs.kernel.org, or LWN.net. No Wikipedia or vendor wikis.