### PR TITLE
Add new mm pages to navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,27 @@ nav:
       - brk vs mmap: mm/brk-vs-mmap.md
       - Contiguous Memory: mm/contiguous-memory.md
       - Copy-on-Write: mm/cow.md
+    - Boot & Subsystems:
+      - memblock: mm/memblock.md
+      - CMA: mm/cma.md
+      - DMA: mm/dma.md
+      - hugetlbfs vs THP: mm/hugetlbfs-vs-thp.md
+    - Tuning:
+      - PSI: mm/psi.md
+      - Sysctl Reference: mm/sysctl-reference.md
+      - Containers: mm/tuning-containers.md
+      - Databases: mm/tuning-databases.md
+      - Swap Thrashing: mm/swap-thrashing.md
+    - Debugging:
+      - KASAN: mm/kasan.md
+      - KFENCE: mm/kfence.md
+      - Why is my process slow?: mm/why-is-my-process-slow.md
+      - Reading an OOM log: mm/reading-oom-log.md
+      - OOM Debugging: mm/oom-debugging.md
+      - Understanding /proc/meminfo: mm/understanding-proc-meminfo.md
+      - Understanding /proc/vmstat: mm/understanding-proc-vmstat.md
+      - /proc/meminfo reference: mm/proc-meminfo.md
+      - /proc/vmstat reference: mm/proc-vmstat.md
     - Bugs:
       - Bug Index: mm/bugs/README.md
     - Reference:


### PR DESCRIPTION
## Summary

- Adds 19 new mm pages to `mkdocs.yml` nav across three new sections:
  - **Boot & Subsystems**: memblock, CMA, DMA, hugetlbfs vs THP
  - **Tuning**: PSI, sysctl reference, containers, databases, swap thrashing
  - **Debugging**: KASAN, KFENCE, why-is-my-process-slow, reading-oom-log, oom-debugging, understanding-proc-meminfo, understanding-proc-vmstat, proc-meminfo reference, proc-vmstat reference

These pages were merged in PRs #198, #199, and #200 but were missing from the site navigation.