### PR TITLE
Add DAMON and zswap internals documentation

### DIFF
--- a/docs/mm/damon.md
+++ b/docs/mm/damon.md
@@ -1,0 +1,725 @@
+# DAMON: Data Access Monitoring
+
+> A lightweight, accurate, and scalable kernel framework for observing how memory is accessed — and acting on that knowledge
+
+## What Is DAMON?
+
+DAMON (Data Access MONitoring) is a kernel subsystem that tracks how frequently each memory region is accessed at runtime. It is **not** a reclaim policy on its own. Instead, it is a monitoring framework that produces access-frequency data which other subsystems — most importantly DAMOS (DAMON-based Operation Schemes) — can act on.
+
+The key design goals are:
+
+- **Accuracy**: access frequency is tracked per-region, not per-page, but remains close enough to reality to drive useful decisions
+- **Scalability**: works across address spaces of arbitrary size without O(n) page-scan cost
+- **Adaptivity**: regions grow and shrink automatically to focus monitoring effort where it matters
+
+```
+Without DAMON:                        With DAMON:
+                                      ┌──────────────────────────────┐
+Kernel reclaims pages based on        │  Kernel observes access      │
+LRU age alone — no knowledge of       │  patterns over time, then    │
+which regions are truly cold.         │  targets cold regions        │
+                                      │  precisely via DAMOS         │
+                                      └──────────────────────────────┘
+```
+
+!!! note "DAMON vs. DAMOS"
+    DAMON collects data. DAMOS uses that data to trigger actions (page out cold memory, promote hot memory, etc.). You configure both together via the sysfs interface.
+
+---
+
+## Core Concepts
+
+### Regions: The Unit of Monitoring
+
+DAMON divides a monitoring target's address space into a list of `struct damon_region` objects. Each region represents a contiguous address range `[ar.start, ar.end)` and carries:
+
+- `nr_accesses` — how many sampling intervals detected an access in the current aggregation window
+- `nr_accesses_bp` — a basis-point (1/10,000) moving-average version updated every sample interval, useful when you cannot wait for a full aggregation to elapse
+- `age` — how many aggregation intervals the region's access frequency has stayed roughly the same; resets to zero when access frequency changes significantly
+- `sampling_addr` — the specific address within the region that will be checked for access next interval
+
+For virtual address monitoring (`DAMON_OPS_VADDR`), DAMON initialises regions from the process's VMAs. For physical address monitoring (`DAMON_OPS_PADDR`), regions are initialised to cover the target physical address range.
+
+### Sampling: Catching Accesses
+
+Every `sample_interval` microseconds (field `damon_attrs.sample_interval`), the kdamond thread:
+
+1. Checks whether `sampling_addr` within each region was accessed since the last sample (by testing and clearing the accessed/young bit in the page table entry)
+2. Increments `nr_accesses` if an access was found
+3. Picks a new `sampling_addr` randomly within the region for the next interval
+
+The default `sample_interval` is 5,000 µs (5 ms).
+
+### Aggregation: Building the Picture
+
+Every `aggr_interval` microseconds (`damon_attrs.aggr_interval`), DAMON:
+
+1. Reports (or acts on) the accumulated `nr_accesses` counts for each region
+2. Resets `nr_accesses` to zero
+3. Updates each region's `age`
+4. Runs the adaptive region sizing logic (split/merge)
+
+The default `aggr_interval` is 100,000 µs (100 ms), meaning each reported `nr_accesses` value represents accesses observed over the last 20 sampling intervals (`100 ms / 5 ms`).
+
+### Adaptive Region Sizing
+
+DAMON maintains `damon_attrs.min_nr_regions` and `damon_attrs.max_nr_regions` bounds (defaults: 10 and 1,000). After each aggregation it adjusts regions:
+
+- **Split**: a region that has been accessed unevenly (some sub-ranges hot, others cold) is split into smaller regions to capture the gradient
+- **Merge**: adjacent regions with similar access frequencies are merged to reduce overhead
+
+This keeps the total region count within bounds while concentrating resolution where access patterns vary.
+
+!!! tip "Minimum region size"
+    `DAMON_MIN_REGION_SZ` is `PAGE_SIZE`. No region can be smaller than one page. The field `damon_ctx.min_region_sz` stores this lower bound.
+
+### Intervals Auto-tuning
+
+DAMON can automatically tune `sample_interval` and `aggr_interval` together. The goal is expressed as a `struct damon_intervals_goal`:
+
+| Field | Meaning |
+|---|---|
+| `access_bp` | Target ratio of observed access events to theoretical maximum, in basis points (1/10,000) |
+| `aggrs` | Number of aggregation windows over which to achieve the ratio |
+| `min_sample_us` | Lower bound on the resulting sample interval |
+| `max_sample_us` | Upper bound on the resulting sample interval |
+
+If `aggrs` is zero, auto-tuning is disabled. Via sysfs, these fields appear under `monitoring_attrs/intervals/intervals_goal/`.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    A[User space / kernel module] -->|sysfs write / API call| B[damon_ctx]
+    B --> C[kdamond thread\ntask_struct]
+    C --> D{ops_id}
+    D -->|DAMON_OPS_VADDR| E[vaddr.c\nVMA-based ops]
+    D -->|DAMON_OPS_FVADDR| F[vaddr.c\nFixed-range vaddr ops]
+    D -->|DAMON_OPS_PADDR| G[paddr.c\nPhysical address ops]
+
+    E & F & G --> H[ops-common.c\ndamon_get_folio\ndamon_ptep_mkold\ndamon_folio_mkold]
+
+    C --> I[damon_target list\nadaptive_targets]
+    I --> J[damon_region list\nregions_list]
+    J --> K[nr_accesses\nnr_accesses_bp\nage]
+
+    C --> L[damos list\nschemes]
+    L --> M[DAMOS engine\ncore.c]
+    M -->|action| N[DAMOS_PAGEOUT\nDAMOS_LRU_PRIO\nDAMOS_MIGRATE_COLD\n...]
+```
+
+### The `damon_ctx` Structure
+
+Every monitoring session is anchored by a `struct damon_ctx` (`include/linux/damon.h`):
+
+```c
+struct damon_ctx {
+    struct damon_attrs attrs;         /* sample/aggr/update intervals, nr_regions */
+    struct damon_operations ops;      /* pluggable ops set (vaddr/paddr) */
+    unsigned long addr_unit;          /* scale factor for core-to-ops address conversion */
+    unsigned long min_region_sz;      /* minimum region size (DAMON_MIN_REGION_SZ) */
+    struct list_head adaptive_targets;/* list of damon_target */
+    struct list_head schemes;         /* list of damos */
+    struct task_struct *kdamond;      /* the monitoring thread */
+    /* ... private fields ... */
+};
+```
+
+### The kdamond Thread
+
+Each `damon_ctx` gets exactly one kernel thread — kdamond. Its main loop (in `mm/damon/core.c`) runs as:
+
+```
+while (!should_stop):
+    ops.prepare_access_checks(ctx)     # mark pages as old (clear accessed bits)
+    sleep(sample_interval)
+    ops.check_accesses(ctx)            # re-read accessed bits → nr_accesses
+    if aggregation_interval_elapsed:
+        report / apply DAMOS schemes
+        adaptive_merge_regions()
+        adaptive_split_regions()
+        reset nr_accesses
+    if ops_update_interval_elapsed:
+        ops.update(ctx)                # refresh VMAs, etc.
+```
+
+The thread is started by `damon_start()` and stopped by `damon_stop()`. While running, all external access to `damon_ctx` internals must go through `damon_call()` or `damos_walk()` to serialize with the kdamond loop.
+
+### Operations Sets (`damon_operations`)
+
+DAMON separates the monitoring algorithm from address-space specifics via `struct damon_operations`:
+
+```c
+struct damon_operations {
+    enum damon_ops_id id;                           /* DAMON_OPS_VADDR / _FVADDR / _PADDR */
+    void (*init)(struct damon_ctx *context);
+    void (*update)(struct damon_ctx *context);
+    void (*prepare_access_checks)(struct damon_ctx *context);
+    unsigned int (*check_accesses)(struct damon_ctx *context);
+    int (*get_scheme_score)(struct damon_ctx *context,
+                            struct damon_target *t,
+                            struct damon_region *r,
+                            struct damos *scheme);
+    unsigned long (*apply_scheme)(struct damon_ctx *context,
+                                  struct damon_target *t,
+                                  struct damon_region *r,
+                                  struct damos *scheme,
+                                  unsigned long *sz_filter_passed);
+    bool (*target_valid)(struct damon_target *t);
+    void (*cleanup_target)(struct damon_target *t);
+};
+```
+
+| `damon_ops_id` | sysfs name | Description |
+|---|---|---|
+| `DAMON_OPS_VADDR` | `vaddr` | Monitors a process's virtual address space; initialises regions from VMAs; requires `CONFIG_DAMON_VADDR` |
+| `DAMON_OPS_FVADDR` | `fvaddr` | Like `vaddr` but monitors only user-specified fixed address ranges, not the full VMA set |
+| `DAMON_OPS_PADDR` | `paddr` | Monitors the physical address space system-wide; requires `CONFIG_DAMON_PADDR`; used by `DAMON_RECLAIM` and `DAMON_LRU_SORT` |
+
+Both `vaddr` and `paddr` use the page idle flag (`PAGE_IDLE_FLAG`) to detect accesses without modifying the page table's dirty bit.
+
+---
+
+## DAMOS: Data Access Monitoring-based Operation Schemes
+
+DAMOS is the policy engine layered on top of DAMON's monitoring data. A DAMOS scheme (`struct damos`) specifies:
+
+1. Which regions to act on (access pattern filter)
+2. What action to take
+3. How aggressively to act (quota)
+4. Under what system conditions to activate (watermarks)
+
+### Access Pattern
+
+`struct damos_access_pattern` selects regions whose metrics fall within all of these ranges:
+
+| Field | Meaning |
+|---|---|
+| `min_sz_region` / `max_sz_region` | Region byte size range |
+| `min_nr_accesses` / `max_nr_accesses` | Observed accesses in the last aggregation window |
+| `min_age_region` / `max_age_region` | Number of aggregation intervals the pattern has been stable |
+
+A cold region that has never been accessed since DAMON started would have `nr_accesses == 0` and a large `age`. A frequently-accessed hot region has high `nr_accesses` and resets its `age` often.
+
+### Actions
+
+The `enum damos_action` values and their effects:
+
+| Action | Effect |
+|---|---|
+| `DAMOS_WILLNEED` | `madvise(MADV_WILLNEED)` — prefetch the region |
+| `DAMOS_COLD` | `madvise(MADV_COLD)` — deactivate pages (move toward LRU tail) |
+| `DAMOS_PAGEOUT` | Reclaim (page out) the region |
+| `DAMOS_HUGEPAGE` | `madvise(MADV_HUGEPAGE)` — promote to THP |
+| `DAMOS_NOHUGEPAGE` | `madvise(MADV_NOHUGEPAGE)` — demote from THP |
+| `DAMOS_LRU_PRIO` | Prioritize region on its LRU lists (move to active) |
+| `DAMOS_LRU_DEPRIO` | Deprioritize region on its LRU lists (move to inactive) |
+| `DAMOS_MIGRATE_HOT` | Migrate region to a faster NUMA node (warmer regions first) |
+| `DAMOS_MIGRATE_COLD` | Migrate region to a slower NUMA node (colder regions first) |
+| `DAMOS_STAT` | No action — only update statistics counters |
+
+!!! warning "DAMOS_PAGEOUT does not demote"
+    `DAMOS_PAGEOUT` reclaims pages to swap. It does **not** demote to a slower NUMA tier. For tiered-memory demotion use `DAMOS_MIGRATE_COLD`.
+
+### Quotas
+
+Without limits, DAMOS could apply its action to gigabytes of memory per second. `struct damos_quota` rate-limits it:
+
+| Field | Meaning |
+|---|---|
+| `reset_interval` | Window for quota accounting, in milliseconds |
+| `ms` | Maximum CPU time (milliseconds) the scheme may spend per `reset_interval` |
+| `sz` | Maximum bytes the action may be applied to per `reset_interval` |
+| `esz` | Effective size quota (computed internally from `ms`, `sz`, and any goals) |
+| `weight_sz` | Prioritization weight for region size |
+| `weight_nr_accesses` | Prioritization weight for access frequency |
+| `weight_age` | Prioritization weight for region age |
+
+When a quota is reached, DAMON stops applying the action for the remainder of the `reset_interval` and increments `damos_stat.qt_exceeds`.
+
+#### Quota Auto-tuning with Goals
+
+Instead of (or in addition to) hard `ms`/`sz` caps, DAMOS can auto-tune the effective quota using a feedback loop. Goals are expressed as `struct damos_quota_goal` objects. Available goal metrics (`enum damos_quota_goal_metric`):
+
+| sysfs name | Meaning |
+|---|---|
+| `user_input` | Manually supplied feedback value (user writes `current_value`) |
+| `some_mem_psi_us` | System-level "some" memory PSI in µs per reset interval |
+| `node_mem_used_bp` | Memory used ratio of a NUMA node in basis points |
+| `node_mem_free_bp` | Memory free ratio of a NUMA node in basis points |
+| `node_memcg_used_bp` | Memory used ratio of a NUMA node for a specific cgroup |
+| `node_memcg_free_bp` | Memory free ratio of a NUMA node for a specific cgroup |
+| `active_mem_bp` | Active-to-total LRU memory ratio in basis points |
+| `inactive_mem_bp` | Inactive-to-total LRU memory ratio in basis points |
+
+DAMOS increases or decreases the effective quota so that the observed metric value converges toward `target_value`.
+
+### Watermarks
+
+`struct damos_watermarks` controls whether a scheme is active based on a system-level metric:
+
+| Field | Meaning |
+|---|---|
+| `metric` | `none` (always active) or `free_mem_rate` |
+| `interval` | How often to check the metric, in µs |
+| `high` | Deactivate scheme when metric is above this value |
+| `mid` | Activate scheme when metric is between `mid` and `low` |
+| `low` | Deactivate scheme when metric falls below this value |
+
+When all schemes of a context are inactive (watermarks not met), kdamond stops monitoring and only polls the watermarks — greatly reducing overhead.
+
+### DAMOS Filters
+
+Before applying an action to a region, DAMOS can test individual pages within the region against filters (`struct damos_filter`). Filter types (`enum damos_filter_type`):
+
+| sysfs name | Type | Scope |
+|---|---|---|
+| `anon` | Anonymous pages | ops layer |
+| `active` | Active LRU pages | core layer |
+| `memcg` | Pages belonging to a specific cgroup | ops layer |
+| `young` | Recently accessed (young) pages | core layer |
+| `hugepage_size` | Pages that are part of a huge page | core layer |
+| `unmapped` | Unmapped pages | core layer |
+| `addr` | Specific address range | core layer |
+| `target` | Specific DAMON target index | core layer |
+
+Each filter has a `matching` bool (apply to matching pages vs. non-matching) and an `allow` bool (include or exclude the matched pages).
+
+!!! note "Filter handling layers"
+    Filters in the "ops layer" (`anon`, `memcg`) are handled by the `damon_operations` implementation and are counted toward `sz_tried` statistics. Core-layer filters are evaluated before `sz_tried` is incremented.
+
+---
+
+## The sysfs Interface
+
+`CONFIG_DAMON_SYSFS` exposes the full DAMON API under `/sys/kernel/mm/damon/admin/`. All monitoring is controlled by reading and writing files in this hierarchy.
+
+### Directory Tree
+
+```
+/sys/kernel/mm/damon/admin/
+└── kdamonds/
+    ├── nr_kdamonds                        # write N to create N kdamond directories
+    └── 0/
+        ├── state                          # write: on|off|commit|update_schemes_stats|...
+        ├── pid                            # read: PID of the kdamond thread
+        ├── refresh_ms                     # auto-refresh interval for sysfs reads
+        └── contexts/
+            ├── nr_contexts                # currently only 1 context per kdamond
+            └── 0/
+                ├── avail_operations       # read: available ops (vaddr fvaddr paddr)
+                ├── operations             # write: vaddr | fvaddr | paddr
+                ├── addr_unit              # scale factor for address values
+                ├── monitoring_attrs/
+                │   ├── intervals/
+                │   │   ├── sample_us      # sampling interval in µs (default 5000)
+                │   │   ├── aggr_us        # aggregation interval in µs (default 100000)
+                │   │   ├── update_us      # ops update interval in µs (default 60000000)
+                │   │   └── intervals_goal/
+                │   │       ├── access_bp
+                │   │       ├── aggrs
+                │   │       ├── min_sample_us
+                │   │       └── max_sample_us
+                │   └── nr_regions/
+                │       ├── min            # minimum number of regions (default 10)
+                │       └── max            # maximum number of regions (default 1000)
+                ├── targets/
+                │   ├── nr_targets
+                │   └── 0/
+                │       ├── pid_target     # PID to monitor (vaddr/fvaddr only)
+                │       ├── obsolete_target
+                │       └── regions/
+                │           ├── nr_regions # for fvaddr: number of fixed regions
+                │           └── 0/
+                │               ├── start  # region start address
+                │               └── end    # region end address
+                └── schemes/
+                    ├── nr_schemes
+                    └── 0/
+                        ├── action         # willneed|cold|pageout|hugepage|nohugepage|
+                        │                  # lru_prio|lru_deprio|migrate_hot|migrate_cold|stat
+                        ├── target_nid     # destination NUMA node for migrate actions
+                        ├── apply_interval_us  # override aggr_interval for this scheme
+                        ├── access_pattern/
+                        │   ├── sz/
+                        │   │   ├── min
+                        │   │   └── max
+                        │   ├── nr_accesses/
+                        │   │   ├── min
+                        │   │   └── max
+                        │   └── age/
+                        │       ├── min
+                        │       └── max
+                        ├── quotas/
+                        │   ├── ms
+                        │   ├── bytes
+                        │   ├── reset_interval_ms
+                        │   ├── effective_bytes    # read-only: current effective quota
+                        │   ├── weights/
+                        │   │   ├── sz_permil
+                        │   │   ├── nr_accesses_permil
+                        │   │   └── age_permil
+                        │   └── goals/
+                        │       ├── nr_goals
+                        │       └── 0/
+                        │           ├── target_metric
+                        │           ├── target_value
+                        │           ├── current_value
+                        │           ├── nid
+                        │           └── path
+                        ├── watermarks/
+                        │   ├── metric         # none | free_mem_rate
+                        │   ├── interval_us
+                        │   ├── high
+                        │   ├── mid
+                        │   └── low
+                        ├── filters/           # core + ops filters combined
+                        │   ├── nr_filters
+                        │   └── 0/
+                        │       ├── type        # anon|active|memcg|young|hugepage_size|
+                        │       │               # unmapped|addr|target
+                        │       ├── matching
+                        │       ├── allow
+                        │       ├── memcg_path
+                        │       ├── addr_start
+                        │       ├── addr_end
+                        │       ├── min         # for hugepage_size filter
+                        │       ├── max
+                        │       └── damon_target_idx
+                        ├── dests/             # for migrate_hot/cold actions
+                        │   ├── nr_dests
+                        │   └── 0/
+                        │       ├── id         # destination NUMA node id
+                        │       └── weight
+                        ├── stats/             # read-only counters
+                        │   ├── nr_tried
+                        │   ├── sz_tried
+                        │   ├── nr_applied
+                        │   ├── sz_applied
+                        │   ├── sz_ops_filter_passed
+                        │   ├── qt_exceeds
+                        │   ├── nr_snapshots
+                        │   └── max_nr_snapshots
+                        └── tried_regions/     # regions that matched this scheme
+                            ├── total_bytes
+                            └── 0/
+                                ├── start
+                                ├── end
+                                ├── nr_accesses
+                                ├── age
+                                └── sz_filter_passed
+```
+
+### kdamond State Commands
+
+Write one of these strings to `kdamonds/0/state`:
+
+| Command | Effect |
+|---|---|
+| `on` | Start the kdamond thread |
+| `off` | Stop the kdamond thread |
+| `commit` | Apply updated parameters to a running kdamond |
+| `commit_schemes_quota_goals` | Push updated quota goal `current_value` fields to the kernel |
+| `update_schemes_stats` | Refresh the `stats/` files from kernel state |
+| `update_schemes_tried_bytes` | Refresh `tried_regions/total_bytes` |
+| `update_schemes_tried_regions` | Populate `tried_regions/` with current matching regions |
+| `clear_schemes_tried_regions` | Remove all entries from `tried_regions/` |
+| `update_schemes_effective_quotas` | Refresh `quotas/effective_bytes` |
+| `update_tuned_intervals` | Refresh `intervals/` with auto-tuned values |
+
+---
+
+## Practical Examples
+
+### 1. Proactive Reclaim: Page Out Cold Pages
+
+This example sets up a physical-address DAMOS scheme that pages out memory regions not accessed for approximately 120 seconds. It mirrors what `CONFIG_DAMON_RECLAIM` does internally.
+
+```bash
+#!/bin/bash
+ADMIN=/sys/kernel/mm/damon/admin
+
+# Create one kdamond with one context
+echo 1 > $ADMIN/kdamonds/nr_kdamonds
+echo 1 > $ADMIN/kdamonds/0/contexts/nr_contexts
+
+# Use the physical address space ops (system-wide, no PID needed)
+echo paddr > $ADMIN/kdamonds/0/contexts/0/operations
+
+# Tune monitoring intervals
+echo 5000   > $ADMIN/kdamonds/0/contexts/0/monitoring_attrs/intervals/sample_us
+echo 100000 > $ADMIN/kdamonds/0/contexts/0/monitoring_attrs/intervals/aggr_us
+
+# One target (paddr needs exactly one target; no pid_target needed)
+echo 1 > $ADMIN/kdamonds/0/contexts/0/targets/nr_targets
+
+# Create one DAMOS scheme
+echo 1 > $ADMIN/kdamonds/0/contexts/0/schemes/nr_schemes
+SCHEME=$ADMIN/kdamonds/0/contexts/0/schemes/0
+
+# Action: page out
+echo pageout > $SCHEME/action
+
+# Access pattern: size [4KB, unlimited], nr_accesses [0,0], age [24000,max]
+# age 24000 = 24000 aggr intervals × 100ms = 2,400,000ms ≈ 2400s ... too long
+# Better: age in aggr intervals. 120s / 100ms = 1200 aggregation intervals
+echo 4096           > $SCHEME/access_pattern/sz/min
+echo 18446744073709551615 > $SCHEME/access_pattern/sz/max
+echo 0              > $SCHEME/access_pattern/nr_accesses/min
+echo 0              > $SCHEME/access_pattern/nr_accesses/max
+echo 1200           > $SCHEME/access_pattern/age/min
+echo 18446744073709551615 > $SCHEME/access_pattern/age/max
+
+# Quota: use at most 10ms CPU, page out at most 128MiB per second
+echo 10            > $SCHEME/quotas/ms
+echo 134217728     > $SCHEME/quotas/bytes       # 128 MiB
+echo 1000          > $SCHEME/quotas/reset_interval_ms
+# Prioritize older (colder) regions first
+echo 0 > $SCHEME/quotas/weights/sz_permil
+echo 0 > $SCHEME/quotas/weights/nr_accesses_permil
+echo 1000 > $SCHEME/quotas/weights/age_permil
+
+# Watermarks: only activate when free memory is between 20% and 50%
+echo free_mem_rate > $SCHEME/watermarks/metric
+echo 5000000       > $SCHEME/watermarks/interval_us   # check every 5s
+echo 500           > $SCHEME/watermarks/high           # deactivate above 50%
+echo 400           > $SCHEME/watermarks/mid            # activate at 40%
+echo 200           > $SCHEME/watermarks/low            # deactivate below 20%
+
+# Start monitoring
+echo on > $ADMIN/kdamonds/0/state
+```
+
+After a few seconds, check what has happened:
+
+```bash
+# Trigger stats refresh
+echo update_schemes_stats > $ADMIN/kdamonds/0/state
+
+STATS=$ADMIN/kdamonds/0/contexts/0/schemes/0/stats
+echo "Regions tried:   $(cat $STATS/nr_tried)"
+echo "Bytes tried:     $(cat $STATS/sz_tried)"
+echo "Regions applied: $(cat $STATS/nr_applied)"
+echo "Bytes applied:   $(cat $STATS/sz_applied)"
+echo "Quota exceeded:  $(cat $STATS/qt_exceeds)"
+```
+
+### 2. Working Set Estimation: Count Accesses by Region
+
+Use `DAMOS_STAT` to observe which regions are hot without taking any action:
+
+```bash
+ADMIN=/sys/kernel/mm/damon/admin
+echo 1 > $ADMIN/kdamonds/nr_kdamonds
+echo 1 > $ADMIN/kdamonds/0/contexts/nr_contexts
+echo vaddr > $ADMIN/kdamonds/0/contexts/0/operations
+
+# Monitor a specific process
+echo 1 > $ADMIN/kdamonds/0/contexts/0/targets/nr_targets
+echo $(pidof myapp) > $ADMIN/kdamonds/0/contexts/0/targets/0/pid_target
+
+# Scheme: stat action, capture all regions
+echo 1 > $ADMIN/kdamonds/0/contexts/0/schemes/nr_schemes
+SCHEME=$ADMIN/kdamonds/0/contexts/0/schemes/0
+echo stat > $SCHEME/action
+echo 0                       > $SCHEME/access_pattern/sz/min
+echo 18446744073709551615    > $SCHEME/access_pattern/sz/max
+echo 0                       > $SCHEME/access_pattern/nr_accesses/min
+echo 18446744073709551615    > $SCHEME/access_pattern/nr_accesses/max
+echo 0                       > $SCHEME/access_pattern/age/min
+echo 18446744073709551615    > $SCHEME/access_pattern/age/max
+
+echo on > $ADMIN/kdamonds/0/state
+
+# After a monitoring window, snapshot matched regions
+echo update_schemes_tried_regions > $ADMIN/kdamonds/0/state
+
+# Read which regions matched
+for dir in $SCHEME/tried_regions/[0-9]*/; do
+    start=$(cat $dir/start)
+    end=$(cat $dir/end)
+    acc=$(cat $dir/nr_accesses)
+    age=$(cat $dir/age)
+    printf "0x%x - 0x%x  accesses=%d  age=%d\n" $start $end $acc $age
+done
+```
+
+### 3. Memory Tiering: Demote Cold Pages to Slow NUMA Memory
+
+For systems with CXL-attached memory or slow NUMA nodes, use `DAMOS_MIGRATE_COLD` to demote cold pages:
+
+```bash
+ADMIN=/sys/kernel/mm/damon/admin
+echo 1 > $ADMIN/kdamonds/nr_kdamonds
+echo 1 > $ADMIN/kdamonds/0/contexts/nr_contexts
+echo paddr > $ADMIN/kdamonds/0/contexts/0/operations
+echo 1 > $ADMIN/kdamonds/0/contexts/0/targets/nr_targets
+
+echo 1 > $ADMIN/kdamonds/0/contexts/0/schemes/nr_schemes
+SCHEME=$ADMIN/kdamonds/0/contexts/0/schemes/0
+
+# Demote cold, large regions to NUMA node 2 (slow tier)
+echo migrate_cold > $SCHEME/action
+echo 2 > $SCHEME/target_nid
+
+# Pattern: any size, zero accesses, aged at least 60 aggr intervals (6s at 100ms)
+echo 0                       > $SCHEME/access_pattern/sz/min
+echo 18446744073709551615    > $SCHEME/access_pattern/sz/max
+echo 0                       > $SCHEME/access_pattern/nr_accesses/min
+echo 0                       > $SCHEME/access_pattern/nr_accesses/max
+echo 60                      > $SCHEME/access_pattern/age/min
+echo 18446744073709551615    > $SCHEME/access_pattern/age/max
+
+# Demote at most 256MiB per second
+echo 0          > $SCHEME/quotas/ms
+echo 268435456  > $SCHEME/quotas/bytes
+echo 1000       > $SCHEME/quotas/reset_interval_ms
+
+echo on > $ADMIN/kdamonds/0/state
+```
+
+!!! tip "Multiple migration destinations"
+    For workloads that benefit from weighted distribution across multiple tiers, use the `dests/` subdirectory of the scheme instead of `target_nid`. Create `nr_dests` entries, each with an `id` (NUMA node) and a `weight`.
+
+---
+
+## Built-in DAMOS Modules
+
+### CONFIG_DAMON_RECLAIM
+
+`DAMON_RECLAIM` (`mm/damon/reclaim.c`) is a prebuilt kernel module that runs a `DAMOS_PAGEOUT` scheme against the physical address space. It is designed for proactive, lightweight reclaim under mild memory pressure, complementing `kswapd`'s reactive scanning.
+
+**Kernel config**: `CONFIG_DAMON_RECLAIM` (depends on `CONFIG_DAMON_PADDR`)
+
+**Module parameters** (readable/writable via `/sys/module/damon_reclaim/parameters/`):
+
+| Parameter | Default | Description |
+|---|---|---|
+| `enabled` | `N` | Enable/disable DAMON_RECLAIM at runtime |
+| `commit_inputs` | `N` | Set to `Y` to re-read all parameters without restarting |
+| `min_age` | 120,000,000 µs (120 s) | Minimum age of a cold region before reclaim |
+| `quota_mem_pressure_us` | 0 (disabled) | Auto-tune quota to achieve this PSI level (µs per reset interval) |
+| `quota_autotune_feedback` | 0 (disabled) | Manual feedback value for auto-tuning (target: 10,000) |
+| `skip_anon` | `N` | If `Y`, skip anonymous pages (file-backed only) |
+| `monitor_region_start` | 0 | Start of physical address range to monitor |
+| `monitor_region_end` | 0 | End of physical address range (0 = largest System RAM region) |
+
+Default quota: 10 ms CPU time and 128 MiB bytes per 1-second window. Default watermarks: activate when free memory is between 20% and 50%.
+
+```bash
+# Enable DAMON_RECLAIM with more aggressive settings
+echo Y > /sys/module/damon_reclaim/parameters/enabled
+
+# Reclaim pages cold for 60 seconds instead of 120
+echo 60000000 > /sys/module/damon_reclaim/parameters/min_age
+
+# Apply changes without restarting
+echo Y > /sys/module/damon_reclaim/parameters/commit_inputs
+```
+
+!!! warning "When to use DAMON_RECLAIM vs. direct sysfs configuration"
+    `DAMON_RECLAIM` is a coarse-grained knob for system-wide proactive reclaim. If you need fine-grained control — per-cgroup targeting, custom watermarks, multiple schemes, or migration rather than swap — configure DAMON directly via the sysfs interface.
+
+### CONFIG_DAMON_LRU_SORT
+
+`DAMON_LRU_SORT` (`mm/damon/lru_sort.c`) uses two DAMOS schemes to influence the LRU lists before `kswapd` sees them: hot pages are prioritized (`DAMOS_LRU_PRIO`) and cold pages are deprioritized (`DAMOS_LRU_DEPRIO`). This makes subsequent kswapd reclaim more precise without bypassing the LRU machinery.
+
+**Kernel config**: `CONFIG_DAMON_LRU_SORT` (depends on `CONFIG_DAMON_PADDR`)
+
+Key module parameters (`/sys/module/damon_lru_sort/parameters/`):
+
+| Parameter | Default | Description |
+|---|---|---|
+| `enabled` | `N` | Enable/disable |
+| `active_mem_bp` | 0 (disabled) | Auto-tune to achieve this active/total LRU ratio |
+| `autotune_monitoring_intervals` | `N` | Automatically tune sample/aggr intervals |
+
+### CONFIG_DAMON_STAT
+
+`DAMON_STAT` (`mm/damon/stat.c`) runs DAMON against the physical address space and exposes aggregated access statistics as simple metrics, useful for observability without taking any memory management action.
+
+**Kernel config**: `CONFIG_DAMON_STAT`
+
+`CONFIG_DAMON_STAT_ENABLED_DEFAULT` controls whether it starts automatically at boot.
+
+---
+
+## DAMON and MGLRU
+
+DAMON and Multi-Generational LRU (MGLRU) both track memory access patterns, but at different granularities and for different purposes:
+
+| | DAMON | MGLRU |
+|---|---|---|
+| **Granularity** | `damon_region` (pages to megabytes, adaptively sized) | Individual page (folio) generation |
+| **Mechanism** | Samples a random address per region per interval | Walks page tables, updates folio generations |
+| **Output** | `nr_accesses`, `age` per region | Generation number per folio (0=youngest) |
+| **Actionable via** | DAMOS schemes (policy-agnostic) | kswapd generation-based eviction |
+| **Overhead** | Configurable via intervals; sub-1% typical | Amortized across page table walks |
+| **Use case** | Custom policies, tiering, prefetch, working set sizing | General-purpose reclaim ordering |
+
+They complement each other: MGLRU efficiently orders pages for reclaim within the LRU, while DAMON provides region-level access data that can drive actions MGLRU cannot express — proactive demotion to CXL memory, THP promotion decisions, or working set reports for capacity planning.
+
+!!! note "No conflict"
+    DAMON and MGLRU can run concurrently. DAMON_LRU_SORT specifically cooperates with MGLRU by manipulating LRU priority before generation-based eviction runs.
+
+---
+
+## Performance Overhead
+
+DAMON's overhead is primarily controlled by three parameters:
+
+```
+overhead ≈ (nr_regions × cost_per_region) / sample_interval
+```
+
+| Parameter | Effect on overhead | Effect on accuracy |
+|---|---|---|
+| `sample_interval` (↑) | Reduces CPU time in kdamond | Fewer samples → may miss short-lived accesses |
+| `aggr_interval` (↑) | No direct overhead effect | Larger window smooths out transient spikes |
+| `max_nr_regions` (↑) | More regions → more page table lookups per sample | Finer spatial resolution |
+
+Typical configurations achieve well under 1% CPU overhead. The `DAMON_RECLAIM` defaults (5ms sample, 100ms aggr, 1000 max regions) are designed for near-zero impact on production workloads.
+
+!!! tip "Overhead tuning guidance"
+    - For background observability (working set sizing), prefer longer intervals: `sample_us=50000`, `aggr_us=1000000`
+    - For reactive policies (proactive reclaim under pressure), use the defaults or enable `intervals_goal` auto-tuning to let DAMON adjust dynamically
+
+---
+
+## Kernel Configuration
+
+| Config option | Description | Depends on |
+|---|---|---|
+| `CONFIG_DAMON` | Core DAMON framework | — |
+| `CONFIG_DAMON_VADDR` | Virtual address space ops (`vaddr`, `fvaddr`) | `DAMON`, `MMU`, selects `PAGE_IDLE_FLAG` |
+| `CONFIG_DAMON_PADDR` | Physical address space ops (`paddr`) | `DAMON`, `MMU`, selects `PAGE_IDLE_FLAG` |
+| `CONFIG_DAMON_SYSFS` | sysfs interface under `/sys/kernel/mm/damon/` | `DAMON`, `SYSFS` |
+| `CONFIG_DAMON_RECLAIM` | Built-in proactive reclaim module | `DAMON_PADDR` |
+| `CONFIG_DAMON_LRU_SORT` | Built-in LRU sorting module | `DAMON_PADDR` |
+| `CONFIG_DAMON_STAT` | Built-in access statistics module | `DAMON_PADDR` |
+| `CONFIG_DAMON_STAT_ENABLED_DEFAULT` | Enable `DAMON_STAT` at boot | `DAMON_STAT` |
+| `CONFIG_DAMON_KUNIT_TEST` | KUnit tests for DAMON core | `DAMON`, `KUNIT=y` |
+| `CONFIG_DAMON_VADDR_KUNIT_TEST` | KUnit tests for vaddr ops | `DAMON_VADDR`, `KUNIT=y` |
+| `CONFIG_DAMON_SYSFS_KUNIT_TEST` | KUnit tests for sysfs interface | `DAMON_SYSFS`, `KUNIT=y` |
+
+---
+
+## Key Source Files
+
+| File | Role |
+|---|---|
+| `include/linux/damon.h` | All public structs and enums: `damon_region`, `damon_target`, `damon_ctx`, `damon_attrs`, `damon_operations`, `damos`, `damos_access_pattern`, `damos_quota`, `damos_watermarks`, `damos_filter`, `damos_stat` |
+| `mm/damon/core.c` | kdamond main loop, region split/merge, DAMOS engine, `damon_new_ctx()`, `damon_start()`, `damon_stop()`, `damon_register_ops()`, `damon_select_ops()` |
+| `mm/damon/vaddr.c` | `DAMON_OPS_VADDR` and `DAMON_OPS_FVADDR` implementation: VMA-based region init, page table walk for access checks |
+| `mm/damon/paddr.c` | `DAMON_OPS_PADDR` implementation: physical address region management, folio-level access checks via `damon_pa_mkold()` |
+| `mm/damon/ops-common.c` | Shared helpers: `damon_get_folio()`, `damon_ptep_mkold()`, `damon_folio_mkold()` |
+| `mm/damon/sysfs.c` | sysfs directory tree: kdamond, contexts, targets, regions, monitoring_attrs |
+| `mm/damon/sysfs-schemes.c` | sysfs for schemes: access_pattern, quotas, watermarks, filters, stats, tried_regions |
+| `mm/damon/sysfs-common.c` | Shared sysfs helpers: `damon_sysfs_ul_range` for min/max pairs |
+| `mm/damon/reclaim.c` | `DAMON_RECLAIM` built-in module: module parameters, DAMOS_PAGEOUT scheme configuration |
+| `mm/damon/lru_sort.c` | `DAMON_LRU_SORT` built-in module: DAMOS_LRU_PRIO and DAMOS_LRU_DEPRIO schemes |
+| `mm/damon/stat.c` | `DAMON_STAT` built-in module: observability-only DAMOS_STAT scheme |
+| `mm/damon/modules-common.c` | Shared helpers for the built-in modules |
+| `mm/damon/Kconfig` | All `CONFIG_DAMON_*` options |

--- a/docs/mm/zswap.md
+++ b/docs/mm/zswap.md
@@ -1,0 +1,590 @@
+# zswap Internals: Compressed Swap Cache
+
+> A compressed RAM cache that intercepts pages on their way to the swap device — trading CPU cycles for I/O reduction
+
+## What zswap Is (and Is Not)
+
+zswap is a **write-back compressed cache** that sits in front of the swap device. When the kernel decides to swap out an anonymous page, zswap intercepts it, compresses it, and stores the compressed data in a RAM-based pool. If the compressed pool fills up, zswap evicts the coldest entries back to the backing swap device.
+
+The key insight: reading from compressed RAM is orders of magnitude faster than a disk or even SSD read. zswap trades CPU cycles for I/O reduction, which is usually a favorable trade.
+
+!!! note "zswap vs zram — they are not the same thing"
+    These two are frequently confused:
+
+    - **zswap**: A compressed *cache* in front of any swap device. It does not appear as a block device. The backing swap device (disk, SSD, or even a zram device) still exists.
+    - **zram**: A compressed *block device* that acts as the swap device itself. It replaces the swap device entirely in memory.
+
+    You can stack them: use zram as the swap device and zswap in front of it. However, this means pages get compressed twice — once by zswap and once by zram — which wastes CPU with minimal additional benefit. See [Interaction with zram](#interaction-with-zram).
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    subgraph "Store path (swap-out)"
+        A[Anonymous page\nneeds reclaim] --> B{zswap enabled\nand pool not full?}
+        B -- No --> G[Write to swap device\ndirectly]
+        B -- Yes --> C[zswap_store]
+        C --> D[zswap_compress\nper-CPU acomp_ctx]
+        D --> E{Compresses\nsmaller than PAGE_SIZE?}
+        E -- Yes --> F[zs_malloc + zs_obj_write\ninto zsmalloc pool]
+        E -- No --> F2[Store uncompressed\nlength == PAGE_SIZE]
+        F --> H[zswap_entry added\nto xarray + LRU]
+        F2 --> H
+    end
+
+    subgraph "Fault path (swap-in)"
+        I[Page fault on\nswap PTE] --> J[zswap_load]
+        J --> K{Entry in\nxarray?}
+        K -- No --> L[Read from swap device]
+        K -- Yes --> M[zswap_decompress\ninto target folio]
+        M --> N[Invalidate entry,\nfree from pool]
+    end
+
+    subgraph "Writeback path (pool full)"
+        O[shrink_worker /\nzswap_shrinker] --> P[Walk LRU,\nshrink_memcg_cb]
+        P --> Q{entry.referenced?}
+        Q -- Yes --> R[Clear referenced,\nrotate in LRU]
+        Q -- No --> S[zswap_writeback_entry]
+        S --> T[Decompress into\nswap cache folio]
+        T --> U[__swap_writepage\nto backing device]
+        T --> V[zswap_entry_free]
+    end
+
+    H -.->|pool full| O
+```
+
+!!! info "Frontswap is gone"
+    Prior to Linux 6.x, zswap hooked into the kernel via the **frontswap** interface (`frontswap_store`, `frontswap_load`, etc.). That interface was removed. zswap now integrates directly: `zswap_store()` and `zswap_load()` are called explicitly from the swap writeback and swapin code paths. The entry points are declared in `include/linux/zswap.h`.
+
+## Key Data Structures
+
+### `struct zswap_pool`
+
+```c
+struct zswap_pool {
+    struct zs_pool *zs_pool;              /* zsmalloc pool for compressed data */
+    struct crypto_acomp_ctx __percpu *acomp_ctx; /* per-CPU compression contexts */
+    struct percpu_ref ref;                /* reference count */
+    struct list_head list;               /* entry in global zswap_pools list */
+    struct work_struct release_work;
+    struct hlist_node node;              /* for cpuhp callback */
+    char tfm_name[CRYPTO_MAX_ALG_NAME]; /* compressor name */
+};
+```
+
+Each pool is tied to a single compression algorithm. When you change the compressor at runtime, a new pool is created. The old pool lives on until all its entries are evicted or loaded, then it is destroyed via `zswap_pool_destroy()`.
+
+### `struct zswap_entry`
+
+```c
+struct zswap_entry {
+    swp_entry_t swpentry;    /* swap type + offset — the lookup key */
+    unsigned int length;     /* compressed size in bytes;
+                                == PAGE_SIZE means incompressible */
+    bool referenced;         /* second-chance bit for LRU writeback */
+    struct zswap_pool *pool; /* owning pool */
+    unsigned long handle;    /* zsmalloc allocation handle */
+    struct obj_cgroup *objcg;/* cgroup charge */
+    struct list_head lru;    /* position in global zswap_list_lru */
+};
+```
+
+Each compressed page stored in zswap has one `zswap_entry`. Entries are stored in per-swap-type xarrays, sharded into 64 MiB regions:
+
+```c
+#define ZSWAP_ADDRESS_SPACE_SHIFT  14   /* 2^14 = 16384 pages = 64 MiB */
+static struct xarray *zswap_trees[MAX_SWAPFILES];
+```
+
+The `swap_zswap_tree()` helper maps a `swp_entry_t` to the right xarray shard.
+
+### `struct crypto_acomp_ctx`
+
+```c
+struct crypto_acomp_ctx {
+    struct crypto_acomp *acomp; /* async compression transform */
+    struct acomp_req    *req;   /* pre-allocated request */
+    struct crypto_wait   wait;  /* completion wait */
+    u8                  *buffer;/* PAGE_SIZE scratch buffer */
+    struct mutex         mutex; /* one operation at a time per CPU */
+};
+```
+
+One context per CPU per pool. `acomp_ctx_get_cpu_lock()` acquires the mutex for the current CPU's context; `acomp_ctx_put_unlock()` releases it.
+
+## The Compression Pipeline
+
+### Store Path: `zswap_store()`
+
+When the MM subsystem wants to swap out a folio, it calls `zswap_store(struct folio *folio)`:
+
+```
+zswap_store(folio)
+  ├── Check zswap_enabled
+  ├── obj_cgroup_may_zswap()  ← cgroup zswap.max limit
+  ├── zswap_check_limits()    ← global max_pool_percent limit
+  ├── zswap_pool_current_get() ← RCU-safe ref on current pool
+  └── for each page in folio:
+        zswap_store_page(page, objcg, pool)
+          ├── zswap_entry_cache_alloc()  ← kmem_cache alloc
+          ├── zswap_compress(page, entry, pool)
+          │     ├── acomp_ctx_get_cpu_lock()
+          │     ├── crypto_acomp_compress() + crypto_wait_req()
+          │     ├── if dlen >= PAGE_SIZE and writeback enabled:
+          │     │       store uncompressed (dlen = PAGE_SIZE)
+          │     └── zs_malloc() + zs_obj_write()
+          ├── xa_store() into swap xarray
+          └── zswap_lru_add()  ← entry.referenced = true
+```
+
+If the store fails for any reason (pool full, allocation failure, compression error), any previously stored entry for that swap slot is invalidated via `xa_erase()` + `zswap_entry_free()`. This prevents stale compressed data from being written over by a new version of the page.
+
+### Compression: `zswap_compress()`
+
+zswap uses the kernel's **async compression API** (`crypto/acompress.h`):
+
+1. The input scatter-gather list is set to the source page.
+2. `crypto_acomp_compress()` is called — despite the async API, zswap waits synchronously via `crypto_wait_req()`.
+3. If `dlen >= PAGE_SIZE` (incompressible) and writeback is permitted for this cgroup, the page is stored **uncompressed** (`entry->length == PAGE_SIZE`). This preserves LRU ordering so cold incompressible pages can still be written back.
+4. `zs_malloc()` allocates space in the zsmalloc pool; `zs_obj_write()` writes the compressed bytes.
+
+!!! note "Incompressible pages"
+    When a page cannot be compressed below PAGE_SIZE, zswap stores the raw content using `kmap_local_page()` and copies it directly. The entry is tracked as incompressible via `zswap_stored_incompressible_pages`. This counter is exposed in debugfs.
+
+    If writeback is disabled for the cgroup (`memory.zswap.writeback=0`), incompressible pages are **rejected** outright — there is no point storing an uncompressible page if it can never be evicted.
+
+### Decompression: `zswap_decompress()`
+
+Called from both `zswap_load()` (fault path) and `zswap_writeback_entry()` (writeback path):
+
+```c
+zs_obj_read_sg_begin()   // map zsmalloc object as scatter-gather
+if entry->length == PAGE_SIZE:
+    memcpy_from_sglist()  // incompressible: straight copy
+else:
+    crypto_acomp_decompress() + crypto_wait_req()
+zs_obj_read_sg_end()
+```
+
+zsmalloc objects can span page boundaries, so the input is always a scatter-gather list of 1–2 entries.
+
+### Load Path: `zswap_load()`
+
+On a page fault, swapin code calls `zswap_load(struct folio *folio)`:
+
+1. Look up `swp_entry_t` in the xarray → get `zswap_entry`.
+2. Call `zswap_decompress()` into the fault's target folio.
+3. If loading into the swap cache (the common case), **invalidate** the zswap entry immediately — the swap cache becomes the authoritative owner.
+4. Mark the folio up-to-date and unlock it.
+
+!!! warning "Large folio limitation"
+    `zswap_load()` explicitly rejects large folios with `WARN_ON_ONCE(folio_test_large(folio))` and returns `-EINVAL`. Large folios may be only partially stored in zswap (each constituent page independently), and the load path does not handle this case. The result is a `SIGBUS` from `do_swap_page()`.
+
+## Pool Backend: zsmalloc
+
+In current kernels, zswap **exclusively** uses **zsmalloc** as its memory allocator. The older backends (zbud, z3fold) are no longer used by zswap.
+
+`CONFIG_ZSWAP` selects `CONFIG_ZSMALLOC` automatically.
+
+### How zsmalloc Works
+
+zsmalloc is a variable-size slab allocator designed for compressed page storage. Its key properties:
+
+| Property | Detail |
+|----------|--------|
+| Allocation granularity | 8-byte aligned size classes from ~32 bytes to PAGE_SIZE |
+| Internal structure | Groups of physical pages called **zspages** |
+| Addressing | Objects are not directly addressable — accessed via opaque `handle` |
+| Fragmentation control | Pages grouped by fullness ratio (0%, 10%, …, 99%, 100%) |
+| Maximum pages per zspage | Configurable via `CONFIG_ZSMALLOC_CHAIN_SIZE` |
+
+Because zsmalloc objects are not directly addressable, `zs_obj_write()` and `zs_obj_read_sg_begin()` handle the mapping and scatter-gather setup internally.
+
+```mermaid
+graph LR
+    subgraph "zsmalloc pool"
+        subgraph "size class: 128 bytes"
+            Z1[zspage\n4KB physical\n→ 31 objects]
+            Z2[zspage\n4KB physical\n→ 31 objects]
+        end
+        subgraph "size class: 512 bytes"
+            Z3[zspage\n4KB physical\n→ 7 objects]
+        end
+        subgraph "size class: 3840 bytes"
+            Z4[zspage\n8KB physical\n→ 2 objects]
+        end
+    end
+
+    E1[zswap_entry\nhandle=H1] -->|zs_obj_write| Z1
+    E2[zswap_entry\nhandle=H2] -->|zs_obj_write| Z3
+```
+
+The high object density of zsmalloc (especially for small compressed outputs) is why it replaced zbud (2 pages per physical page) and z3fold (up to 3 pages per physical page) — workloads with good compression ratios benefit enormously.
+
+## Pool Management and Writeback
+
+### Global Pool Size Limit
+
+```c
+static unsigned int zswap_max_pool_percent = 20;
+```
+
+The pool is limited to `totalram_pages() * zswap_max_pool_percent / 100` physical pages of compressed storage. `zswap_check_limits()` is called on every store:
+
+```c
+static bool zswap_check_limits(void)
+{
+    unsigned long cur_pages = zswap_total_pages();
+    unsigned long max_pages = zswap_max_pages();
+
+    if (cur_pages >= max_pages) {
+        zswap_pool_limit_hit++;
+        zswap_pool_reached_full = true;
+    } else if (zswap_pool_reached_full &&
+               cur_pages <= zswap_accept_thr_pages()) {
+        zswap_pool_reached_full = false;
+    }
+    return zswap_pool_reached_full;
+}
+```
+
+When the pool hits the limit, `zswap_pool_reached_full = true`. New stores are rejected until the pool drains back below `accept_threshold_percent` of the maximum (default 90%). This hysteresis prevents thrashing at the boundary.
+
+When the pool is full and a store fails, `zswap_store()` queues `zswap_shrink_work` to trigger background writeback.
+
+### The Global LRU
+
+All `zswap_entry` objects across all pools share a single global `list_lru`:
+
+```c
+static struct list_lru zswap_list_lru;
+```
+
+The LRU is NUMA-aware and memcg-aware. Entries are added to the LRU at store time with `entry->referenced = true`.
+
+### The Shrinker and Writeback: `shrink_worker()`
+
+Two mechanisms trigger writeback to the backing swap device:
+
+**1. Memory pressure shrinker** (`zswap_shrinker`):
+Registered as a standard kernel shrinker (`SHRINKER_NUMA_AWARE | SHRINKER_MEMCG_AWARE`). When the memory allocator sees pressure, it calls `zswap_shrinker_scan()` → `list_lru_shrink_walk()` → `shrink_memcg_cb()` for each LRU entry.
+
+**2. Pool-full work queue** (`shrink_worker`):
+When `zswap_pool_reached_full` is set and a store fails, `shrink_worker()` is queued on the `zswap-shrink` workqueue. It iterates memcgs round-robin and calls `shrink_memcg()` on each, continuing until the pool drains below `zswap_accept_thr_pages()`.
+
+### Second-Chance LRU Algorithm
+
+`shrink_memcg_cb()` implements a **second-chance** eviction policy:
+
+```c
+if (entry->referenced) {
+    entry->referenced = false;
+    return LRU_ROTATE;  /* give it another chance */
+}
+/* referenced == false: write back to swap device */
+writeback_result = zswap_writeback_entry(entry, swpentry);
+```
+
+New entries start with `referenced = true`. The shrinker clears this flag on first encounter and rotates the entry to the tail. Only on the second encounter (when `referenced` is already false) does writeback happen.
+
+### Shrinker Calibration
+
+`zswap_shrinker_count()` scales the number of shrinkable objects by several factors to avoid over-shrinking:
+
+1. **Compression ratio**: `mult_frac(nr_freeable, nr_backing, nr_stored)` — if the pool compresses 4:1, fewer physical pages are freed per writeback, so fewer candidates are reported.
+2. **Disk swapin penalty**: `nr_disk_swapins` (tracked in `zswap_lruvec_state.nr_disk_swapins`) is subtracted from `nr_freeable`. If we observe swapins from disk, it means we previously over-evicted from zswap, so we slow down.
+
+### `zswap_writeback_entry()`
+
+The writeback of a single entry:
+
+```
+zswap_writeback_entry(entry, swpentry)
+  ├── swap_cache_alloc_folio()    ← allocate folio in swap cache
+  ├── xa_load() to verify entry is still valid
+  ├── zswap_decompress(entry, folio)
+  ├── xa_erase() from xarray
+  ├── zswap_entry_free()         ← free from pool
+  ├── folio_mark_uptodate()
+  └── __swap_writepage()         ← issue write to backing swap device
+```
+
+If a concurrent swapin allocated the folio first (`!folio_was_allocated`), writeback is skipped — the page just became hot, so evicting it would be wrong.
+
+## Same-Filled Page Detection
+
+!!! info "Note on this kernel version"
+    The upstream kernel documentation for older versions describes a same-value-filled (zero page) optimization where pages are checked for uniform content before compression, and only the fill pattern is stored. However, searching the current `mm/zswap.c` source reveals that this optimization **is not present in this version** of the code. There is no `page_same_filled()` call or similar logic in `zswap_store_page()` or `zswap_compress()`. Incompressible pages are handled (stored uncompressed at full PAGE_SIZE when writeback is enabled), but there is no separate path for same-value detection.
+
+    The `stored_incompressible_pages` debugfs counter tracks pages stored at full size.
+
+## Per-Cgroup Limits
+
+Three cgroup v2 files control zswap per cgroup:
+
+| File | Description |
+|------|-------------|
+| `memory.zswap.max` | Maximum bytes of compressed memory this cgroup can use in zswap. Default: `max` (unlimited). |
+| `memory.zswap.current` | Read-only: current bytes used in zswap by this cgroup. |
+| `memory.zswap.writeback` | Whether pages can be written back from zswap to the swap device. `0` disables writeback for this cgroup. Default: `1`. |
+
+`obj_cgroup_may_zswap()` checks `memory.zswap.max` before each store. If the cgroup is over its limit, `zswap_store()` first tries to shrink this cgroup's pages via `shrink_memcg()`. If shrinking fails, the store is rejected and the folio goes directly to the swap device.
+
+```bash
+# Limit a cgroup to 512 MiB of zswap usage
+echo 536870912 > /sys/fs/cgroup/myapp/memory.zswap.max
+
+# Disable zswap writeback for a cgroup (pages stay in zswap or are rejected)
+echo 0 > /sys/fs/cgroup/myapp/memory.zswap.writeback
+```
+
+!!! warning "writeback=0 and incompressible pages"
+    If `memory.zswap.writeback=0` and a page is incompressible, zswap **rejects the store entirely** (returns `false` from `zswap_compress()`). The page then falls through to the swap device. This can cause a feedback loop: the same incompressible page may be rejected repeatedly by zswap and keep triggering swap I/O.
+
+## Sysfs Tunables
+
+All tunables live under `/sys/module/zswap/parameters/`:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `enabled` | `CONFIG_ZSWAP_DEFAULT_ON` | Enable/disable zswap at runtime. Disabling stops new stores but does not flush existing entries. |
+| `compressor` | `CONFIG_ZSWAP_COMPRESSOR_DEFAULT` (lzo) | Compression algorithm. Changing creates a new pool; old pools drain and are freed. |
+| `max_pool_percent` | `20` | Maximum percentage of total RAM the compressed pool may occupy. |
+| `accept_threshold_percent` | `90` | After hitting `max_pool_percent`, resume accepting pages only when pool drops to this percentage of max. Setting to `100` disables hysteresis. |
+| `shrinker_enabled` | `CONFIG_ZSWAP_SHRINKER_DEFAULT_ON` (off) | Enable the memory-pressure-driven shrinker. When off, writeback only happens when the pool is full. |
+
+```bash
+# Enable zswap at runtime
+echo 1 > /sys/module/zswap/parameters/enabled
+
+# Switch compressor to zstd (creates a new pool; old entries remain in lzo pool)
+echo zstd > /sys/module/zswap/parameters/compressor
+
+# Increase pool limit to 30% of RAM
+echo 30 > /sys/module/zswap/parameters/max_pool_percent
+
+# Enable the memory pressure shrinker
+echo Y > /sys/module/zswap/parameters/shrinker_enabled
+
+# Reduce hysteresis — resume accepting when pool is at 70% of max
+echo 70 > /sys/module/zswap/parameters/accept_threshold_percent
+```
+
+Alternatively, set these at boot time:
+
+```
+zswap.enabled=1 zswap.compressor=zstd zswap.max_pool_percent=25
+```
+
+## Kconfig Options
+
+| Option | Description |
+|--------|-------------|
+| `CONFIG_ZSWAP` | Enable zswap support. Automatically selects `CONFIG_ZSMALLOC`. |
+| `CONFIG_ZSWAP_DEFAULT_ON` | Enable zswap by default at boot. |
+| `CONFIG_ZSWAP_SHRINKER_DEFAULT_ON` | Enable the memory pressure shrinker by default. |
+| `CONFIG_ZSWAP_COMPRESSOR_DEFAULT_LZO` | Default compressor: LZO |
+| `CONFIG_ZSWAP_COMPRESSOR_DEFAULT_LZ4` | Default compressor: LZ4 |
+| `CONFIG_ZSWAP_COMPRESSOR_DEFAULT_LZ4HC` | Default compressor: LZ4HC |
+| `CONFIG_ZSWAP_COMPRESSOR_DEFAULT_ZSTD` | Default compressor: zstd |
+| `CONFIG_ZSWAP_COMPRESSOR_DEFAULT_DEFLATE` | Default compressor: deflate |
+| `CONFIG_ZSWAP_COMPRESSOR_DEFAULT_842` | Default compressor: 842 |
+| `CONFIG_ZSMALLOC` | zsmalloc allocator (required by zswap). |
+| `CONFIG_ZSMALLOC_STAT` | Export per-size-class statistics for zsmalloc via debugfs. |
+
+## Observability
+
+### debugfs: `/sys/kernel/debug/zswap/`
+
+All counters are read-only and approximate (not atomically consistent with each other, but individually accurate to `u64`):
+
+| File | Description |
+|------|-------------|
+| `pool_total_size` | Total bytes of physical RAM consumed by all zswap pools (compressed data only). |
+| `stored_pages` | Number of pages currently stored in zswap (compressed + incompressible). |
+| `stored_incompressible_pages` | Pages stored at full PAGE_SIZE (could not be compressed below PAGE_SIZE). |
+| `pool_limit_hit` | Times a store was rejected because the pool was at `max_pool_percent`. |
+| `written_back_pages` | Pages successfully written back to the backing swap device. |
+| `reject_reclaim_fail` | Store rejected: pool was full and background writeback failed. |
+| `reject_alloc_fail` | Store rejected: `zs_malloc()` returned an error (pool exhausted). |
+| `reject_kmemcache_fail` | Store rejected: `zswap_entry` metadata allocation failed (rare). |
+| `reject_compress_fail` | Store rejected: compression algorithm returned an error. |
+| `reject_compress_poor` | Store rejected: compressed output did not fit in the allocator (ENOSPC). |
+| `decompress_fail` | Decompression failed during load or writeback (data corruption indicator). |
+
+```bash
+# Quick zswap health check
+for f in /sys/kernel/debug/zswap/*; do
+    printf "%-40s %s\n" "$(basename $f)" "$(cat $f)"
+done
+```
+
+### vmstat Events
+
+Three events are counted in `/proc/vmstat`:
+
+| Event | Description |
+|-------|-------------|
+| `zswpout` | Pages stored into zswap (successful `zswap_store()`). |
+| `zswpin` | Pages loaded from zswap (successful `zswap_load()`). |
+| `zswpwb` | Pages written back from zswap to the swap device. |
+
+```bash
+# Watch zswap activity in real time
+watch -n1 'grep -E "^zswp" /proc/vmstat'
+```
+
+### Per-Cgroup Stats
+
+For cgroup v2, `memory.stat` includes:
+
+| Field | Description |
+|-------|-------------|
+| `zswap` | Bytes of compressed memory used in zswap by this cgroup. |
+| `zswapped` | Number of pages currently stored in zswap by this cgroup. |
+
+```bash
+cat /sys/fs/cgroup/myapp/memory.stat | grep zswap
+```
+
+### Estimating Compression Ratio
+
+```bash
+stored=$(cat /sys/kernel/debug/zswap/stored_pages)
+pool_bytes=$(cat /sys/kernel/debug/zswap/pool_total_size)
+page_size=4096
+
+if [ "$stored" -gt 0 ]; then
+    uncompressed=$((stored * page_size))
+    echo "Stored pages:    $stored"
+    echo "Uncompressed:    $((uncompressed / 1048576)) MiB"
+    echo "Compressed:      $((pool_bytes / 1048576)) MiB"
+    echo "Ratio:           $(echo "scale=2; $uncompressed / $pool_bytes" | bc):1"
+fi
+```
+
+## Interaction with zram
+
+zswap can sit in front of a zram device. The full stack looks like this:
+
+```mermaid
+graph TD
+    A[Anonymous page\nneeds to be swapped] --> B[zswap_store]
+    B -->|compressed + stored| C[zswap pool\nin RAM]
+    B -->|pool full / rejected| D[swap_writepage]
+    D --> E[zram block device\n/dev/zram0]
+    E -->|compressed again!| F[zram pool\nin RAM]
+    C -->|writeback| D
+```
+
+!!! warning "Double compression"
+    When zswap sits in front of zram, pages that miss the zswap pool (or get written back by the shrinker) are compressed a **second time** by zram. This means:
+
+    - **CPU overhead is doubled** for those pages.
+    - The additional compression benefit is minimal — data already compressed by zswap will not compress meaningfully again.
+    - Memory saving is marginal because zswap already compressed the data.
+
+    **Recommendation**: Use either zswap (with a real swap device) or zram, not both. If your goal is to avoid all disk I/O, zram alone is simpler and more efficient. If you have a swap device and want to reduce I/O, use zswap in front of it.
+
+    If you must use both (e.g., the system has both a zram swap and a disk swap), consider disabling zswap for the zram swap type.
+
+## Performance Tradeoffs
+
+### CPU vs. Memory vs. I/O
+
+```
+Low compression ratio (data is random, already compressed):
+  → zswap stores at PAGE_SIZE (incompressible)
+  → Pool fills quickly (no density gain over uncompressed swap)
+  → Writeback to swap device happens soon anyway
+  → Net result: CPU overhead for no benefit
+
+High compression ratio (text, code, zeroed pages):
+  → 4:1 or better compression is common
+  → Pool holds 4x more pages than uncompressed
+  → Significant reduction in swap I/O
+  → Net result: CPU overhead well justified
+```
+
+### Compressor Comparison
+
+| Algorithm | Speed | Ratio | Best for |
+|-----------|-------|-------|----------|
+| `lzo` | Fastest | Moderate | Interactive desktops, latency-sensitive |
+| `lz4` | Very fast | Moderate | High-throughput servers, low-overhead environments |
+| `lz4hc` | Moderate | Better than lz4 | Balanced; slower compression, same decompression speed as lz4 |
+| `zstd` | Moderate | Best | High memory pressure; worth the CPU cost for good ratios |
+| `deflate` | Slow | Good | Legacy; generally superseded by zstd |
+| `842` | Hardware-accelerated (IBM POWER) | Moderate | POWER systems with hardware offload |
+
+!!! tip "Choosing a compressor"
+    - For **latency-sensitive** workloads: `lzo` or `lz4` — fast decompression keeps fault latency low.
+    - For **memory-constrained** systems where saving RAM matters most: `zstd` — highest density.
+    - The default `lzo` is a safe middle ground for most use cases.
+
+    The compressor can be changed at runtime without flushing existing entries:
+    ```bash
+    echo zstd > /sys/module/zswap/parameters/compressor
+    ```
+    Old entries remain in their old pool and are decompressed with the old algorithm until they are evicted.
+
+### When to Enable the Shrinker
+
+By default (`CONFIG_ZSWAP_SHRINKER_DEFAULT_ON=n`), writeback only triggers when the pool hits `max_pool_percent`. This means cold pages can accumulate in the pool indefinitely until the limit is reached.
+
+Enabling the shrinker (`shrinker_enabled=Y`) allows the memory allocator to proactively write cold zswap pages to the backing swap device under memory pressure — before the pool fills. This:
+
+- Reduces the risk of the pool becoming a "black hole" for cold memory.
+- Introduces more swap I/O under sustained memory pressure.
+- Is governed by the compression ratio and disk swapin penalty to avoid over-eviction.
+
+```bash
+echo Y > /sys/module/zswap/parameters/shrinker_enabled
+```
+
+### Pool Size Tuning
+
+The default `max_pool_percent=20` is conservative. On systems with ample RAM and slow swap (spinning disk), a larger pool is beneficial:
+
+```bash
+# For systems with fast RAM and slow swap
+echo 40 > /sys/module/zswap/parameters/max_pool_percent
+```
+
+On systems where RAM is more precious (containers, embedded), keep the default or reduce it.
+
+## Initialization and Lifecycle
+
+zswap initializes lazily via `late_initcall(zswap_init)`. This ensures the crypto subsystem is available:
+
+```
+zswap_init()
+  └── zswap_setup()
+        ├── KMEM_CACHE(zswap_entry, 0)
+        ├── cpuhp_setup_state_multi(CPUHP_MM_ZSWP_POOL_PREPARE,
+        │       zswap_cpu_comp_prepare, zswap_cpu_comp_dead)
+        ├── alloc_workqueue("zswap-shrink", WQ_UNBOUND|WQ_MEM_RECLAIM, 1)
+        ├── zswap_alloc_shrinker()
+        ├── list_lru_init_memcg(&zswap_list_lru, zswap_shrinker)
+        ├── shrinker_register(zswap_shrinker)
+        ├── __zswap_pool_create_fallback()  ← creates the initial pool
+        └── zswap_debugfs_init()
+```
+
+CPU hotplug callbacks (`zswap_cpu_comp_prepare` / `zswap_cpu_comp_dead`) allocate and free the per-CPU `crypto_acomp_ctx` as CPUs come online and offline.
+
+When a swap device is enabled (`swapon`), `zswap_swapon()` allocates the xarray shards for that swap type. When disabled (`swapoff`), `zswap_swapoff()` frees them (all entries must have been invalidated by `try_to_unuse()` first).
+
+## Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `mm/zswap.c` | Main zswap implementation: store, load, writeback, shrinker, pool management, debugfs |
+| `include/linux/zswap.h` | Public API: `zswap_store()`, `zswap_load()`, `zswap_invalidate()`, `zswap_swapon()`, `zswap_swapoff()`; `struct zswap_lruvec_state` with `nr_disk_swapins` |
+| `mm/zsmalloc.c` | zsmalloc allocator: variable-size compressed object pool used by zswap |
+| `include/linux/zsmalloc.h` | zsmalloc API: `zs_create_pool()`, `zs_malloc()`, `zs_obj_write()`, `zs_obj_read_sg_begin()`, `zs_free()`, `zs_destroy_pool()` |
+| `mm/memcontrol.c` | Per-cgroup zswap limits: `memory.zswap.max`, `memory.zswap.current`, `memory.zswap.writeback`, `obj_cgroup_may_zswap()` |
+| `mm/Kconfig` | Kconfig options: `CONFIG_ZSWAP`, `CONFIG_ZSWAP_DEFAULT_ON`, `CONFIG_ZSWAP_SHRINKER_DEFAULT_ON`, compressor defaults |
+| `include/linux/vm_event_item.h` | vmstat events: `ZSWPIN`, `ZSWPOUT`, `ZSWPWB` |
+| `include/linux/memcontrol.h` | `MEMCG_ZSWAP_B`, `MEMCG_ZSWAPPED`, `obj_cgroup_may_zswap()`, `mem_cgroup_zswap_writeback_enabled()`; `zswap_max` field in `struct mem_cgroup` |
+| `Documentation/admin-guide/mm/zswap.rst` | Upstream admin guide (may lag the source) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,12 +86,17 @@ nav:
     - Caching & Reclaim:
       - Page Cache: mm/page-cache.md
       - Page Reclaim: mm/reclaim.md
+      - DAMON: mm/damon.md
       - Swap: mm/swap.md
+      - zswap: mm/zswap.md
     - Advanced:
       - Memory Cgroups: mm/memcg.md
       - Transparent Huge Pages: mm/thp.md
+      - Multi-Size THP: mm/mthp.md
       - Compaction: mm/compaction.md
       - KSM: mm/ksm.md
+      - Per-VMA Locks: mm/per-vma-locks.md
+      - CXL Memory Tiering: mm/cxl-memory-tiering.md
       - vrealloc: mm/vrealloc.md
     - Memory Cgroups:
       - Container Memory Limits: mm/container-memory-limits.md


### PR DESCRIPTION
## Summary

- **damon.md**: DAMON (Data Access MONitor) kernel interface — tri-color monitoring model, kdamond lifecycle, DAMOS schemes with all 10 actions, complete sysfs interface, watermarks, quota goals, and tunables. Verified from `mm/damon/`.
- **zswap.md**: zswap internals — zsmalloc pool, per-CPU compression pipeline, `zswap_store()`/`zswap_load()` folio API, shrinker, same-filled page optimization, debugfs counters. Verified from `mm/zswap.c`. Documents the removal of frontswap and zbud/z3fold backends.

Closes #178, #182