### PR TITLE
Add boot and DMA documentation (SRAT/SLIT, memory reservation, boot page tables, device coherency, PCI BARs)

### DIFF
--- a/docs/mm/boot-page-tables.md
+++ b/docs/mm/boot-page-tables.md
@@ -1,0 +1,501 @@
+# x86_64 Boot Page Table Setup
+
+> How the Linux kernel builds its own address space from scratch on x86_64 — from the first assembly instructions through the direct physical map, KASLR, and 5-level paging
+
+!!! note "Architecture scope"
+    This page covers x86_64 exclusively. ARM64, RISC-V, and other architectures have different boot paging sequences. For the generic page table abstraction that Linux uses across architectures, see [Page Tables](page-tables.md).
+
+## Key Source Files
+
+| File | Role |
+|------|------|
+| `arch/x86/kernel/head_64.S` | Entry point, early page table data (`early_top_pgt`, `init_top_pgt`, `level3_kernel_pgt`) |
+| `arch/x86/boot/startup/map_kernel.c` | `__startup_64()` — first C code that fixes up page table physical addresses |
+| `arch/x86/mm/init.c` | `init_mem_mapping()`, `memory_map_top_down()`, `memory_map_bottom_up()` |
+| `arch/x86/mm/init_64.c` | `paging_init()`, `mem_init()` |
+| `arch/x86/mm/kaslr.c` | `kernel_randomize_memory()` — virtual layout randomization |
+| `arch/x86/lib/kaslr.c` | `kaslr_get_random_long()` — hardware entropy (RDRAND, TSC, i8254) |
+| `arch/x86/boot/compressed/kaslr.c` | Physical KASLR during decompression |
+| `arch/x86/include/asm/page_64_types.h` | `__PAGE_OFFSET_BASE_L4`, `__START_KERNEL_map`, `KERNEL_IMAGE_SIZE` |
+| `arch/x86/include/asm/pgtable_64_types.h` | `__VMALLOC_BASE_L4`, `VMALLOC_SIZE_TB_L4`, page table level constants |
+| `arch/x86/include/asm/pgtable_64.h` | `init_top_pgt[]` declaration, `swapper_pg_dir` alias |
+| `Documentation/arch/x86/x86_64/mm.rst` | Authoritative virtual memory map for 4-level and 5-level paging |
+
+---
+
+## The Boot Paging Problem
+
+When the kernel first receives control at `startup_64` in `arch/x86/kernel/head_64.S`, the CPU is already in 64-bit long mode — but the page tables are not the kernel's own. The bootloader or UEFI firmware created a temporary identity mapping (virtual address == physical address) that covers enough memory to load and decompress the kernel image, but no more.
+
+Before the kernel can run normally it must:
+
+1. Fix up the early page tables it compiled in, adjusting for the physical load address
+2. Build an identity mapping covering its own code so the switch from physical to virtual addresses does not crash the CPU mid-instruction
+3. Map the kernel text and data at their high virtual addresses (`0xffffffff80000000` and above)
+4. Build the direct physical memory map — a complete mapping of all RAM into kernel virtual space
+5. Set up vmalloc space, vmemmap, and fixmap regions
+6. Optionally randomize all of these regions with KASLR
+
+The challenge is that much of this must happen before the allocator exists, before `printk` works, and before exception handlers are fully in place — using only statically allocated page table arrays declared in assembly.
+
+---
+
+## Early Boot Page Tables in head_64.S
+
+### The Static Arrays
+
+`arch/x86/kernel/head_64.S` declares several page table arrays in the `.data` and `__INITDATA` sections. These are the only page tables available from the very first instruction:
+
+```asm
+/* arch/x86/kernel/head_64.S */
+
+SYM_DATA_START_PTI_ALIGNED(early_top_pgt)
+    .fill   511,8,0
+    .quad   level3_kernel_pgt - __START_KERNEL_map + _PAGE_TABLE_NOENC
+    /* [+ PTI_USER_PGD_FILL padding if CONFIG_MITIGATION_PAGE_TABLE_ISOLATION] */
+SYM_DATA_END(early_top_pgt)
+
+SYM_DATA_START_PTI_ALIGNED(init_top_pgt)
+    .fill   512,8,0
+    /* [+ PTI_USER_PGD_FILL padding if CONFIG_MITIGATION_PAGE_TABLE_ISOLATION] */
+SYM_DATA_END(init_top_pgt)
+
+SYM_DATA_START_PAGE_ALIGNED(level4_kernel_pgt)  /* used only in 5-level mode */
+    .fill   511,8,0
+    .quad   level3_kernel_pgt - __START_KERNEL_map + _PAGE_TABLE_NOENC
+SYM_DATA_END(level4_kernel_pgt)
+
+SYM_DATA_START_PAGE_ALIGNED(level3_kernel_pgt)
+    .fill   L3_START_KERNEL,8,0   /* empty entries up to the kernel's PUD slot */
+    .quad   level2_kernel_pgt - __START_KERNEL_map + _KERNPG_TABLE_NOENC
+    .quad   level2_fixmap_pgt - __START_KERNEL_map + _PAGE_TABLE_NOENC
+SYM_DATA_END(level3_kernel_pgt)
+
+SYM_DATA_START_PAGE_ALIGNED(level2_kernel_pgt)
+    /* 2MB huge-page PMD entries for the kernel image region */
+    PMDS(0, __PAGE_KERNEL_LARGE_EXEC, KERNEL_IMAGE_SIZE/PMD_SIZE)
+SYM_DATA_END(level2_kernel_pgt)
+```
+
+`L3_START_KERNEL` is `pud_index(__START_KERNEL_map)`, placing the kernel in slot 510 of `level3_kernel_pgt`. Slot 511 maps the fixmap region.
+
+`init_top_pgt` starts out completely empty. It becomes the permanent kernel PGD after `__startup_64` runs. On x86_64, `swapper_pg_dir` is simply an alias for `init_top_pgt` (defined in `arch/x86/include/asm/pgtable_64.h`):
+
+```c
+extern pgd_t init_top_pgt[];
+#define swapper_pg_dir init_top_pgt
+```
+
+A pool of 64 scratch PMD tables (`early_dynamic_pgts[EARLY_DYNAMIC_PAGE_TABLES]`) is declared alongside these. `__startup_64()` carves from this pool to build the temporary identity mapping.
+
+### What `__startup_64()` Does
+
+The first C function to run is `__startup_64()` in `arch/x86/boot/startup/map_kernel.c`. It is called from `startup_64` before `CR3` is loaded with the kernel's own tables.
+
+```c
+/* arch/x86/boot/startup/map_kernel.c */
+unsigned long __init __startup_64(unsigned long p2v_offset,
+                                  struct boot_params *bp)
+```
+
+Because the kernel may be loaded at a different physical address than it was compiled for (due to KASLR or bootloader placement), all addresses in the pre-built page table arrays are wrong. `__startup_64()` corrects them:
+
+1. **Compute `load_delta`** — the difference between the compiled-in virtual address `__START_KERNEL_map` and the actual physical address, expressed as an addend.
+
+2. **Fix `early_top_pgt`** — add `load_delta` to the PGD entry pointing at `level3_kernel_pgt` (slot 511, the `__START_KERNEL_map` region).
+
+3. **Fix `level3_kernel_pgt`** — add `load_delta` to its two populated PUD entries (kernel image and fixmap).
+
+4. **Fix `level2_fixmap_pgt`** — relocate the fixmap PMD entries.
+
+5. **Build the identity map in `early_dynamic_pgts`** — allocate PUD and PMD tables from the pool and wire them into `early_top_pgt`. The identity mapping covers the physical pages that contain the kernel image itself so the CPU can keep fetching instructions while `CR3` is being reloaded. These entries deliberately do **not** have the global (`_PAGE_GLOBAL`) bit set so they are flushed when the kernel later switches to `init_top_pgt`.
+
+6. **Validate `level2_kernel_pgt`** — pages before the kernel text and after `_end` have `_PAGE_PRESENT` cleared so speculative accesses cannot reach reserved memory.
+
+### The Two-Stage CR3 Switch
+
+```
+startup_64 entry
+    │
+    ├─ call __startup_64()           ← fix physical addresses, build identity map
+    │
+    ├─ mov early_top_pgt → CR3       ← activate kernel's tables (identity map live)
+    │
+    └─ jmp common_startup_64         ← jump to virtual address (identity map used here)
+           │
+           ├─ secondary_startup_64:
+           │    mov init_top_pgt → CR3   ← switch to permanent PGD
+           │    (identity map gone)
+           │
+           └─ start_kernel()
+```
+
+`early_top_pgt` is only used for this brief window. Once `secondary_startup_64` loads `init_top_pgt` into `CR3`, the identity mapping disappears. From this point all code runs at its compiled-in kernel virtual addresses.
+
+---
+
+## The x86_64 Virtual Memory Layout
+
+x86_64 splits the 64-bit address space at the canonical boundary. The 4-level (48-bit) layout is the baseline; 5-level (57-bit) is described in the next section.
+
+### 4-Level Paging (48-bit virtual addresses)
+
+The constants below are from `arch/x86/include/asm/page_64_types.h` and `arch/x86/include/asm/pgtable_64_types.h`. KASLR can shift `page_offset_base`, `vmalloc_base`, and `vmemmap_base` within their ranges (see [KASLR](#kaslr-kernel-address-space-layout-randomization) below).
+
+```
+Virtual address range                    Size   Region
+─────────────────────────────────────────────────────────────────────────
+0x0000000000000000 – 0x00007ffffffff000  ~128TB  User space
+                   [ non-canonical hole ]
+0xffff800000000000 – 0xffff87ffffffffff    8TB  Guard hole (hypervisor)
+0xffff880000000000 – 0xffff887fffffffff  0.5TB  LDT remap (PTI)
+0xffff888000000000 – 0xffffc87fffffffff   64TB  Direct physical map
+                                                (page_offset_base,
+                                                 __PAGE_OFFSET_BASE_L4 =
+                                                 0xffff888000000000)
+0xffffc88000000000 – 0xffffc8ffffffffff  0.5TB  Unused hole
+0xffffc90000000000 – 0xffffe8ffffffffff   32TB  vmalloc / ioremap
+                                                (vmalloc_base,
+                                                 __VMALLOC_BASE_L4 =
+                                                 0xffffc90000000000)
+0xffffe90000000000 – 0xffffe9ffffffffff    1TB  Unused hole
+0xffffea0000000000 – 0xffffeaffffffffff    1TB  vmemmap (struct page array)
+0xffffec0000000000 – 0xfffffbffffffffff   16TB  KASAN shadow
+0xfffffe0000000000 – 0xfffffe7fffffffff  0.5TB  cpu_entry_area
+0xffffff0000000000 – 0xffffff7fffffffff  0.5TB  %esp fixup stacks
+0xffffffef00000000 – 0xfffffffeffffffff   64GB  EFI runtime services
+0xffffffff00000000 – 0xffffffff7fffffff    2GB  Unused hole
+0xffffffff80000000 – 0xffffffff9fffffff  512MB  Kernel text+data
+                                                (__START_KERNEL_map =
+                                                 0xffffffff80000000)
+0xffffffffa0000000 – 0xfffffffffeffffff 1520MB  Module mapping space
+   FIXADDR_START   – 0xffffffffff5fffff ~0.5MB  Fixmap
+0xffffffffff600000 – 0xffffffffff600fff    4KB  vsyscall ABI
+─────────────────────────────────────────────────────────────────────────
+```
+
+Key constants from source:
+
+| Symbol | Value | File |
+|--------|-------|------|
+| `__PAGE_OFFSET_BASE_L4` | `0xffff888000000000` | `page_64_types.h` |
+| `__PAGE_OFFSET_BASE_L5` | `0xff11000000000000` | `page_64_types.h` |
+| `__START_KERNEL_map` | `0xffffffff80000000` | `page_64_types.h` |
+| `__VMALLOC_BASE_L4` | `0xffffc90000000000` | `pgtable_64_types.h` |
+| `VMALLOC_SIZE_TB_L4` | `32` | `pgtable_64_types.h` |
+| `__VMEMMAP_BASE_L4` | `0xffffea0000000000` | `pgtable_64_types.h` |
+| `KERNEL_IMAGE_SIZE` | 1 GB (KASLR) / 512 MB (no KASLR) | `page_64_types.h` |
+
+!!! note "KASLR shifts base addresses"
+    `__PAGE_OFFSET` is the runtime variable `page_offset_base`, not `__PAGE_OFFSET_BASE_L4`. Similarly `VMALLOC_START` is `vmalloc_base` and `VMEMMAP_START` is `vmemmap_base`. The `_BASE_` constants are the no-KASLR defaults. When `CONFIG_RANDOMIZE_MEMORY=y`, the actual runtime addresses differ.
+
+---
+
+## `init_mem_mapping()` — Building the Direct Physical Map
+
+The direct physical map is what lets the kernel address any byte of RAM with a simple pointer arithmetic offset from `page_offset_base`. Without it, the kernel could only access the memory covered by the static `level2_kernel_pgt` PMDs — roughly 1 GB around the kernel image.
+
+`init_mem_mapping()` in `arch/x86/mm/init.c` is called from `setup_arch()` at line 1126 in `arch/x86/kernel/setup.c`, after `kernel_randomize_memory()` has already fixed the base addresses of the various regions.
+
+```c
+/* arch/x86/mm/init.c */
+void __init init_mem_mapping(void)
+{
+    unsigned long end = max_pfn << PAGE_SHIFT;   /* highest physical address */
+
+    pti_check_boottime_disable();
+    probe_page_size_mask();   /* decide 4KB / 2MB / 1GB page sizes to use */
+    setup_pcid();
+
+    /* The ISA range [0, 1MB) is always mapped regardless of memory holes */
+    init_memory_mapping(0, ISA_END_ADDRESS, PAGE_KERNEL);
+
+    init_trampoline();        /* SMP AP trampoline needs its own mapping */
+
+    if (memblock_bottom_up()) {
+        /* Bottom-up: map above kernel first so page tables land above kernel */
+        memory_map_bottom_up(kernel_end, end);
+        memory_map_bottom_up(ISA_END_ADDRESS, kernel_end);
+    } else {
+        /* Top-down: map from the top of RAM downward */
+        memory_map_top_down(ISA_END_ADDRESS, end);
+    }
+
+    load_cr3(swapper_pg_dir);
+    __flush_tlb_all();
+}
+```
+
+The choice between top-down and bottom-up depends on `memblock_bottom_up()`, which reflects how memblock is configured to allocate page table memory itself. KASLR forces bottom-up mode so page table allocations end up above the kernel image.
+
+The inner workhorse is `init_range_memory_mapping()`, which calls `init_memory_mapping()` in chunks. `init_memory_mapping()` walks down the page table hierarchy — allocating PUD, PMD, and PTE tables as needed from memblock — and uses large pages (2 MB PMD entries or 1 GB PUD entries) wherever the physical range and alignment permit.
+
+After `init_mem_mapping()` returns, `swapper_pg_dir` (which is `init_top_pgt`) has entries covering all physical RAM translated through `page_offset_base`. The kernel can now read and write any physical memory by computing `phys_addr + page_offset_base`.
+
+---
+
+## KASLR: Kernel Address Space Layout Randomization
+
+KASLR on x86_64 has two independent components:
+
+### 1. Physical KASLR — image placement
+
+This happens during decompression, long before the main kernel runs. `arch/x86/boot/compressed/kaslr.c` scans the firmware memory map (e820 or EFI memmap), collects candidate 2 MB-aligned slots where the kernel image fits, and picks one using `kaslr_get_random_long("Physical")`. The chosen offset is stored in `boot_params` and consumed by `__startup_64()` as the `p2v_offset` argument.
+
+Physical KASLR is controlled by `CONFIG_RANDOMIZE_BASE` and disabled at runtime by passing `nokaslr` on the kernel command line.
+
+### 2. Memory layout KASLR — virtual region randomization
+
+After the kernel image is running, `kernel_randomize_memory()` in `arch/x86/mm/kaslr.c` randomizes the virtual base addresses of the three major kernel memory regions:
+
+```c
+/* arch/x86/mm/kaslr.c */
+static __initdata struct kaslr_memory_region {
+    unsigned long *base;   /* pointer to the runtime base variable */
+    unsigned long *end;    /* optional end pointer */
+    unsigned long size_tb; /* region size in TB */
+} kaslr_regions[] = {
+    { .base = &page_offset_base, .end = &direct_map_physmem_end },  /* direct map */
+    { .base = &vmalloc_base,     },                                  /* vmalloc */
+    { .base = &vmemmap_base,     },                                  /* vmemmap */
+};
+```
+
+The available entropy is the slack between these regions and their neighbors (up to `CPU_ENTRY_AREA_BASE`). Randomization is done at PGD/P4D/PUD granularity — each region's base is rounded to a PUD boundary — giving around 30,000 possible positions per region in a typical configuration.
+
+`kernel_randomize_memory()` seeds a PRNG with `kaslr_get_random_long("Memory")`. The entropy function itself, in `arch/x86/lib/kaslr.c`, mixes hardware sources:
+
+```c
+/* arch/x86/lib/kaslr.c */
+unsigned long kaslr_get_random_long(const char *purpose)
+{
+    unsigned long random = get_boot_seed();   /* kaslr_offset() of image */
+
+    if (has_cpuflag(X86_FEATURE_RDRAND)) {
+        rdrand_long(&raw);
+        random ^= raw;           /* RDRAND if available */
+    }
+
+    if (has_cpuflag(X86_FEATURE_TSC)) {
+        raw = rdtsc();
+        random ^= raw;           /* TSC for timing jitter */
+    } else {
+        random ^= i8254();       /* legacy i8254 timer as fallback */
+    }
+
+    /* Circular multiply for bit diffusion */
+    asm(_ASM_MUL "%3" ...);
+    return random;
+}
+```
+
+Memory layout KASLR is controlled by `CONFIG_RANDOMIZE_MEMORY` and is disabled when `CONFIG_KASAN` is enabled (checked in `kaslr_memory_enabled()`).
+
+`kernel_randomize_memory()` is called from `setup_arch()` at line 1047, **before** `init_mem_mapping()` at line 1126. By the time page tables are being built, the final base addresses are already fixed.
+
+!!! warning "KASAN disables memory KASLR"
+    `kaslr_memory_enabled()` returns `false` when `CONFIG_KASAN=y` because KASAN requires a fixed shadow memory layout. Physical KASLR (`CONFIG_RANDOMIZE_BASE`) is independent and remains active with KASAN.
+
+---
+
+## 5-Level Paging (LA57)
+
+x86_64 CPUs that support the LA57 feature bit expose 57-bit virtual addresses using a fifth level of page tables. The kernel option is `CONFIG_X86_5LEVEL`.
+
+### Detection and Activation
+
+5-level paging is detected and activated during decompression. The decompressor sets `CR4.LA57` if the CPU supports it and the kernel is built with `CONFIG_X86_5LEVEL`. By the time `startup_64` runs, either LA57 is already in effect or it is not.
+
+`__startup_64()` checks at runtime:
+
+```c
+/* arch/x86/boot/startup/map_kernel.c */
+static inline bool check_la57_support(void)
+{
+    if (!(native_read_cr4() & X86_CR4_LA57))
+        return false;
+
+    __pgtable_l5_enabled = 1;
+    pgdir_shift           = 48;   /* was 39 in 4-level mode */
+    ptrs_per_p4d          = 512;  /* P4D level is no longer folded */
+
+    return true;
+}
+```
+
+The global variable `__pgtable_l5_enabled` (declared in `arch/x86/include/asm/pgtable_64_types.h`) is then used by the `pgtable_l5_enabled()` inline throughout the rest of boot. After early boot, the normal kernel uses `cpu_feature_enabled(X86_FEATURE_LA57)` instead.
+
+### Structural Difference
+
+In 4-level mode the P4D level is **folded** — the PGD entry points directly to a PUD. In 5-level mode P4D is real:
+
+```
+4-level:  CR3 → PGD[9] → PUD[9] → PMD[9] → PTE[9] → page offset[12]  = 48 bits
+5-level:  CR3 → PGD[9] → P4D[9] → PUD[9] → PMD[9] → PTE[9] → offset[12] = 57 bits
+```
+
+When 5-level mode is active, `__startup_64()` inserts `level4_kernel_pgt` (a real P4D page) between `early_top_pgt` (PGD) and `level3_kernel_pgt` (PUD):
+
+```c
+if (la57) {
+    p4d = (p4dval_t *)rip_rel_ptr(level4_kernel_pgt);
+    p4d[MAX_PTRS_PER_P4D - 1] += load_delta;   /* fix the P4D entry */
+
+    pgd[pgd_index(__START_KERNEL_map)] = (pgdval_t)p4d | _PAGE_TABLE;
+}
+```
+
+### Virtual Layout Changes
+
+With 57-bit addresses, the layout shifts dramatically. From `Documentation/arch/x86/x86_64/mm.rst`:
+
+| Region | 4-level base | 5-level base | Size change |
+|--------|-------------|-------------|-------------|
+| Direct physical map | `0xffff888000000000` (-119.5 TB) | `0xff11000000000000` (-59.75 PB) | 64 TB → 32 PB |
+| vmalloc/ioremap | `0xffffc90000000000` (-55 TB) | `0xffa0000000000000` (-24 PB) | 32 TB → 12.5 PB |
+| vmemmap | `0xffffea0000000000` (-22 TB) | `0xffd4000000000000` (-11 PB) | 1 TB → 0.5 PB |
+| User space | ~128 TB | ~64 PB | 512x larger |
+
+The `VMALLOC_SIZE_TB_L5` constant is 12,800 (TB), compared to `VMALLOC_SIZE_TB_L4` at 32 (TB).
+
+---
+
+## Finalizing Page Tables: `paging_init()` and Beyond
+
+### Call Sequence in `setup_arch()`
+
+The page table lifecycle in `setup_arch()` (`arch/x86/kernel/setup.c`) proceeds as:
+
+```
+setup_arch()
+  │
+  ├─ kernel_randomize_memory()     # fix virtual region base addresses
+  │
+  ├─ init_mem_mapping()            # build direct physical map in init_top_pgt
+  │    ├─ memory_map_top_down()    # or
+  │    └─ memory_map_bottom_up()
+  │    └─ load_cr3(swapper_pg_dir) # reload CR3 with completed mapping
+  │
+  └─ x86_init.paging.pagetable_init()
+       └─ native_pagetable_init()
+            └─ paging_init()       # arch/x86/mm/init_64.c
+```
+
+`paging_init()` on x86_64 (`arch/x86/mm/init_64.c:834`) is deliberately minimal — it clears NUMA node state so zone initialization can set it correctly — because the heavy lifting was already done by `init_mem_mapping()`.
+
+After `x86_init.paging.pagetable_init()` returns, `setup_arch()` continues with KASAN initialization (`kasan_init()`), after which the permanent page tables are in place.
+
+### `mem_init()` — Handing Off to the Buddy Allocator
+
+`mem_init()` (`arch/x86/mm/init_64.c:1368`) is called from `mm_core_init()` in `init/main.c`. At this point `memblock_free_all()` has already transferred all unreserved memory to the buddy allocator. `mem_init()` itself:
+
+- Sets `after_bootmem = 1`, marking the point of no return for early-boot allocations
+- Calls `register_page_bootmem_info()` to register memmap pages for memory hotplug tracking
+- Calls `preallocate_vmalloc_pages()` to pre-fault vmalloc page table entries for performance
+
+### Permanent vs. Early Tables
+
+| Table | Lifetime | Purpose |
+|-------|----------|---------|
+| `early_top_pgt` | Only until `secondary_startup_64` loads `init_top_pgt` | Has identity map + kernel |
+| `early_dynamic_pgts` | Same — scratch space for `__startup_64` | Identity map PUD/PMD tables |
+| `init_top_pgt` (`swapper_pg_dir`) | Permanent — `init_mm.pgd` | Full kernel PGD after `init_mem_mapping` |
+| `level3_kernel_pgt` / `level2_kernel_pgt` | Permanent | Kernel text/data PUD and PMD tables |
+
+---
+
+## Debugging Boot Page Tables
+
+### `CONFIG_PTDUMP_DEBUGFS`
+
+When `CONFIG_PTDUMP_DEBUGFS=y`, the kernel registers debugfs files under `/sys/kernel/debug/page_tables/` (implemented in `arch/x86/mm/debug_pagetables.c`):
+
+```
+/sys/kernel/debug/page_tables/kernel         # init_mm page tables
+/sys/kernel/debug/page_tables/current_kernel # current process kernel mapping
+/sys/kernel/debug/page_tables/current_user   # current process user mapping (PTI)
+/sys/kernel/debug/page_tables/efi            # EFI runtime page tables
+```
+
+Reading `kernel` calls `ptdump_walk_pgd_level_debugfs()` and walks `init_top_pgt`, printing every mapped range with the permission bits (RW, NX, Global, etc.) and the page size (4K, 2M, 1G) used.
+
+### W+X Check
+
+After `mark_rodata_ro()` finalizes the permission bits, the kernel checks that no page is simultaneously writable and executable. The result is logged to dmesg:
+
+```
+x86/mm: Checked W+X mappings: passed, no W+X pages found.
+```
+
+or on failure:
+
+```
+x86/mm: Found insecure W+X mapping at address <symbol>
+x86/mm: Checked W+X mappings: FAILED, N W+X pages found.
+```
+
+This is implemented in `arch/x86/mm/dump_pagetables.c`.
+
+### Other Useful Interfaces
+
+```bash
+# Physical memory regions from firmware (e820 map)
+cat /proc/iomem
+
+# Show page fault statistics
+cat /proc/vmstat | grep pgfault
+
+# Dump kernel log for early mapping messages
+dmesg | grep -E "x86/mm|PAGE|mapping"
+
+# Check if 5-level paging is active
+grep . /sys/devices/system/cpu/cpu0/cpufreq/../topology/physical_package_id
+# or inspect /proc/cpuinfo for 'la57' in flags
+grep la57 /proc/cpuinfo
+```
+
+### Boot Parameters
+
+| Parameter | Effect |
+|-----------|--------|
+| `nokaslr` | Disables both physical and memory KASLR |
+| `no5lvl` | Disables 5-level paging even if CPU and kernel support it |
+| `memmap=exactmap` | Override e820 memory map (useful for testing) |
+
+---
+
+## Summary
+
+The x86_64 boot paging sequence moves through distinct phases, each unlocking more of the system:
+
+```
+Bootloader / UEFI
+  └─ Identity-mapped page tables loaded, CPU in 64-bit long mode
+        │
+        ▼
+startup_64  (arch/x86/kernel/head_64.S)
+  └─ __startup_64() fixes early_top_pgt physical addresses,
+     builds identity map in early_dynamic_pgts
+        │
+        ▼
+CR3 = early_top_pgt
+  └─ Identity map + high kernel map both active
+        │
+        ▼
+secondary_startup_64 → CR3 = init_top_pgt
+  └─ Identity map gone; kernel runs at virtual addresses only
+        │
+        ▼
+setup_arch()
+  ├─ kernel_randomize_memory()   ← KASLR: randomize region bases
+  └─ init_mem_mapping()          ← direct physical map built
+        │
+        ▼
+x86_init.paging.pagetable_init() → paging_init()
+  └─ NUMA zone state cleared; buddy allocator ready to take over
+        │
+        ▼
+mem_init() → memblock_free_all()
+  └─ All free memory handed to the buddy allocator
+     Boot page table setup complete
+```

--- a/docs/mm/device-coherency.md
+++ b/docs/mm/device-coherency.md
@@ -1,0 +1,441 @@
+# Device Memory Coherency and Cache Management
+
+> CPUs cache aggressively; DMA devices do not. Bridging that gap correctly is the difference between a working driver and one that corrupts data silently.
+
+## The Cache Coherency Problem
+
+Modern CPUs do not access RAM on every load and store. Instead, they fill cache lines from RAM and operate on those cached copies. Writes may sit in L1 or L2 cache for microseconds before being flushed to RAM. This is invisible to software running purely on the CPU — two cores share the same physical memory and their caches snoop each other.
+
+DMA-capable devices break this assumption. A device performing DMA reads and writes RAM directly, bypassing the CPU caches entirely. Two failure modes result:
+
+**CPU writes, device reads stale data (DMA transmit bug)**
+
+```
+1. CPU writes packet data to buffer[0..N]      → data in CPU cache, NOT yet in RAM
+2. Driver programs NIC: "send buffer at phys X"
+3. NIC reads physical address X from RAM        → reads STALE data (pre-write content)
+4. Packet sent with wrong content
+```
+
+**Device writes, CPU reads stale data (DMA receive bug)**
+
+```
+1. Driver programs NIC: "DMA receive to buffer at phys X"
+2. NIC writes received packet to RAM at phys X
+3. CPU reads buffer[0..N]                       → reads STALE cache line (old content)
+4. Driver processes garbage data
+```
+
+These bugs are intermittent, load-dependent, and architecture-specific. On x86 they are invisible. On non-coherent ARM they cause real corruption.
+
+## Coherent vs Non-Coherent Systems
+
+Whether hardware enforces coherency between CPU caches and DMA devices depends on the platform's memory interconnect.
+
+### x86: Hardware-Enforced Coherency
+
+On x86, PCIe DMA transactions snoop the CPU caches. When a device reads from a physical address, the CPU cache controller intercepts the transaction and supplies the most recent data — even if it has not yet been written back to RAM. When a device writes, the corresponding CPU cache lines are invalidated automatically.
+
+The result: on x86, software never needs to flush or invalidate CPU caches for DMA correctness. `dma_map_single()` and `dma_sync_*` functions are no-ops at the cache level on x86.
+
+### ARM64: Optional Coherency
+
+ARM64 coherency depends on the System-on-Chip design:
+
+- **Coherent interconnect (CCI, CMN)**: devices attached via a coherent interconnect participate in cache snooping. Most server-class ARM64 platforms (Ampere, Neoverse, ThunderX) and recent mobile SoCs fall here. DMA operations are coherent.
+- **Non-coherent devices**: devices attached to a non-coherent interconnect or behind a simple bus bridge. The software must explicitly clean and invalidate CPU caches to match device ownership.
+
+Whether a device is coherent is recorded in the device tree or ACPI tables and surfaced through `dev->dma_coherent`. The kernel checks this flag — set by `arch_setup_dma_ops()` in [`arch/arm64/mm/dma-mapping.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/mm/dma-mapping.c) — to decide whether to perform cache maintenance.
+
+```
+Coherent platform (x86, coherent ARM64):
+  CPU cache ←→ Memory controller ←→ RAM
+                      ↑ snoop
+                   PCIe device
+
+Non-coherent platform (some ARM64 SoCs):
+  CPU cache           RAM
+       ↑               ↑
+       |       (separate paths, no snooping)
+  CPU core         DMA device
+```
+
+### Key Source Files
+
+| File | Purpose |
+|------|---------|
+| [`include/linux/dma-mapping.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dma-mapping.h) | Public DMA API: `dma_alloc_coherent()`, `dma_map_single()`, `dma_sync_*()` |
+| [`include/linux/dma-direction.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dma-direction.h) | `enum dma_data_direction` values |
+| [`kernel/dma/direct.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/direct.h) | Non-IOMMU DMA path: calls `arch_sync_dma_for_device()` / `arch_sync_dma_for_cpu()` |
+| [`arch/arm64/mm/dma-mapping.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/mm/dma-mapping.c) | ARM64 `arch_sync_dma_for_device()` → `dcache_clean_poc()` |
+| [`arch/arm64/include/asm/cacheflush.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/include/asm/cacheflush.h) | ARM64 cache ops: `dcache_clean_poc()`, `dcache_inval_poc()`, `dcache_clean_inval_poc()` |
+| [`arch/x86/mm/ioremap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/ioremap.c) | `ioremap()`, `ioremap_wc()`, `ioremap_uc()` implementations |
+| [`arch/x86/mm/pat/memtype.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/pat/memtype.c) | PAT memory type management: WB, WC, UC-, WT |
+
+## DMA Coherent Allocation
+
+`dma_alloc_coherent()` allocates a buffer that is guaranteed coherent between the CPU and the device for its entire lifetime. No cache flushes are ever needed when accessing it.
+
+```c
+void *dma_alloc_coherent(struct device *dev, size_t size,
+                         dma_addr_t *dma_handle, gfp_t gfp);
+
+void dma_free_coherent(struct device *dev, size_t size,
+                       void *cpu_addr, dma_addr_t dma_handle);
+```
+
+`dma_alloc_coherent()` returns two values: a CPU virtual address (the return value) and a device DMA address written into `*dma_handle`. The CPU address is used for normal memory accesses; the DMA address is programmed into the device's descriptor ring or DMA register.
+
+From [`include/linux/dma-mapping.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dma-mapping.h):
+
+```c
+static inline void *dma_alloc_coherent(struct device *dev, size_t size,
+        dma_addr_t *dma_handle, gfp_t gfp)
+{
+    return dma_alloc_attrs(dev, size, dma_handle, gfp,
+            (gfp & __GFP_NOWARN) ? DMA_ATTR_NO_WARN : 0);
+}
+```
+
+**How coherency is achieved per architecture:**
+
+- **x86**: allocates normal cacheable memory. Hardware coherency makes CPU cache flushes unnecessary.
+- **Non-coherent ARM64**: allocates uncached memory (mapped with `pgprot_dmacoherent`). CPU accesses bypass the cache entirely, so there is never stale data — at the cost of slower CPU reads and writes.
+
+**When to use coherent allocation:**
+
+- Descriptor rings (NVMe submission/completion queues, network TX/RX rings)
+- Command and status regions shared with firmware
+- Small, long-lived control structures accessed frequently by both CPU and device
+
+**When not to use it:**
+
+Avoid `dma_alloc_coherent()` for large data buffers (packet payloads, disk read buffers) that the CPU will access heavily. On non-coherent systems, uncached memory access for large transfers is significantly slower than cached memory with explicit sync operations.
+
+## DMA Streaming Mappings
+
+Streaming mappings are used for buffers allocated by normal kernel means (`kmalloc`, `__get_free_pages`, `vmalloc` is **not** supported) that need to be temporarily handed to a device. Unlike coherent allocations, these buffers are normally cacheable; the DMA API performs cache maintenance only when needed.
+
+### Ownership Model
+
+Streaming mappings enforce a strict ownership model: **a buffer belongs either to the CPU or to the device — never both at the same time.**
+
+```
+CPU owns buffer → dma_map_single() → Device owns buffer
+                                           ↓
+                                    (device performs DMA)
+                                           ↓
+Device owns buffer → dma_unmap_single() → CPU owns buffer
+```
+
+While the device owns the buffer (between map and unmap), the CPU must not read or write it. Violating this rule causes corruption on non-coherent platforms.
+
+### dma_map_single() / dma_unmap_single()
+
+```c
+/* Map a virtually contiguous buffer */
+dma_addr_t dma_map_single(struct device *dev, void *ptr,
+                          size_t size, enum dma_data_direction dir);
+
+void dma_unmap_single(struct device *dev, dma_addr_t addr,
+                      size_t size, enum dma_data_direction dir);
+```
+
+These are macros expanding to `dma_map_single_attrs()` / `dma_unmap_single_attrs()` with zero attributes. The `dir` argument controls which direction cache maintenance is applied:
+
+- `DMA_TO_DEVICE` — CPU writes data, device reads it (transmit). On map: flush CPU cache to RAM so device sees the data. On unmap: no-op (device only read).
+- `DMA_FROM_DEVICE` — device writes data, CPU reads it (receive). On map: invalidate CPU cache so the CPU cannot read stale data. On unmap: invalidate CPU cache again to expose what the device wrote.
+- `DMA_BIDIRECTIONAL` — both directions; conservative. Performs both clean and invalidate.
+
+```c
+/* TX path: CPU filled the buffer, hand it to the device */
+dma_addr_t dma_addr = dma_map_single(dev, skb->data, skb->len,
+                                     DMA_TO_DEVICE);
+if (dma_mapping_error(dev, dma_addr))
+    goto drop;
+/* Program device descriptor with dma_addr */
+desc->addr = dma_addr;
+desc->len  = skb->len;
+kick_tx_queue(dev);
+
+/* After device completes (TX completion interrupt): */
+dma_unmap_single(dev, dma_addr, skb->len, DMA_TO_DEVICE);
+dev_kfree_skb(skb);
+```
+
+!!! warning "Always check `dma_mapping_error()`"
+    `dma_map_single()` can fail (IOMMU exhaustion, device address range overflow). Always check the return value with `dma_mapping_error(dev, addr)`. Using `DMA_MAPPING_ERROR` as a device address causes a hardware fault or silent corruption.
+
+### dma_map_page()
+
+```c
+dma_addr_t dma_map_page(struct device *dev, struct page *page,
+                        size_t offset, size_t size,
+                        enum dma_data_direction dir);
+
+void dma_unmap_page(struct device *dev, dma_addr_t addr,
+                    size_t size, enum dma_data_direction dir);
+```
+
+Used when the buffer is described by a `struct page` rather than a virtual address. Common in network drivers receiving into page-based skb fragments.
+
+### dma_map_sg() / dma_unmap_sg()
+
+```c
+unsigned int dma_map_sg(struct device *dev, struct scatterlist *sg,
+                        int nents, enum dma_data_direction dir);
+
+void dma_unmap_sg(struct device *dev, struct scatterlist *sg,
+                  int nents, enum dma_data_direction dir);
+```
+
+Maps a scatter-gather list of physically discontiguous pages as a single DMA operation. The IOMMU maps them into a contiguous range of I/O virtual addresses. Without an IOMMU, the device must support scatter-gather natively.
+
+`dma_map_sg()` returns the number of DMA segments — which may be fewer than `nents` if the IOMMU merged adjacent entries.
+
+## dma_sync_*: Partial Ownership Transfers
+
+Full unmap and remap on every access is expensive. `dma_sync_*` functions allow the CPU to temporarily reclaim ownership of a mapped buffer without unmapping it. This is the right pattern for high-performance descriptor rings.
+
+```c
+/* Defined in include/linux/dma-mapping.h */
+void dma_sync_single_for_cpu(struct device *dev, dma_addr_t addr,
+                             size_t size, enum dma_data_direction dir);
+
+void dma_sync_single_for_device(struct device *dev, dma_addr_t addr,
+                                size_t size, enum dma_data_direction dir);
+
+void dma_sync_sg_for_cpu(struct device *dev, struct scatterlist *sg,
+                         int nelems, enum dma_data_direction dir);
+
+void dma_sync_sg_for_device(struct device *dev, struct scatterlist *sg,
+                             int nelems, enum dma_data_direction dir);
+```
+
+### Ownership Protocol with sync
+
+```
+Initial state: CPU owns buffer
+
+dma_map_single(DMA_FROM_DEVICE)   → Device owns buffer
+   [device writes to buffer]
+dma_sync_single_for_cpu(...)      → CPU temporarily owns buffer
+   [CPU reads completed data]
+dma_sync_single_for_device(...)   → Device owns buffer again
+   [device writes next chunk]
+...
+dma_unmap_single(...)             → CPU owns buffer, mapping torn down
+```
+
+### RX Ring Pattern
+
+A receive ring holds N pre-mapped buffers. The device writes into the current head; the driver reads completed entries from the tail.
+
+```c
+/* Setup: pre-map all RX buffers */
+for (int i = 0; i < RING_SIZE; i++) {
+    rx_ring[i].buf = kmalloc(BUF_SIZE, GFP_KERNEL);
+    rx_ring[i].dma = dma_map_single(dev, rx_ring[i].buf,
+                                    BUF_SIZE, DMA_FROM_DEVICE);
+    /* Program buffer address into hardware descriptor */
+    hw_ring[i].addr = rx_ring[i].dma;
+}
+
+/* Interrupt handler: device has written received data */
+void rx_interrupt(struct device *dev)
+{
+    int idx = rx_tail;
+
+    /* Transfer ownership back to CPU */
+    dma_sync_single_for_cpu(dev, rx_ring[idx].dma,
+                            BUF_SIZE, DMA_FROM_DEVICE);
+
+    /* Safe to read the received data now */
+    process_packet(rx_ring[idx].buf, hw_ring[idx].len);
+
+    /* Replenish: give the buffer back to the device */
+    dma_sync_single_for_device(dev, rx_ring[idx].dma,
+                               BUF_SIZE, DMA_FROM_DEVICE);
+    hw_ring[idx].addr = rx_ring[idx].dma;  /* re-arm descriptor */
+
+    rx_tail = (rx_tail + 1) % RING_SIZE;
+}
+```
+
+### Direction Values
+
+From [`include/linux/dma-direction.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dma-direction.h):
+
+```c
+enum dma_data_direction {
+    DMA_BIDIRECTIONAL = 0,
+    DMA_TO_DEVICE     = 1,  /* CPU → device: flush cache before DMA */
+    DMA_FROM_DEVICE   = 2,  /* device → CPU: invalidate cache after DMA */
+    DMA_NONE          = 3,  /* error sentinel, not a real direction */
+};
+```
+
+## Cache Attributes and ioremap for MMIO
+
+Device registers (MMIO) must never be accessed through a cached mapping. A CPU that caches a write to a control register may delay it indefinitely; a cached read may return a stale value rather than querying the device.
+
+The `ioremap` family maps physical MMIO regions into the kernel's virtual address space with appropriate cache attributes. On x86, these mappings use the **PAT (Page Attribute Table)** to encode the memory type directly in the page table entry.
+
+### ioremap Variants (x86)
+
+From [`arch/x86/mm/ioremap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/ioremap.c):
+
+```c
+/* Standard uncached mapping (UC-minus: honors existing MTRRs) */
+void __iomem *ioremap(resource_size_t phys_addr, unsigned long size);
+
+/* Strongly uncached (UC: ignores MTRRs, truly uncached) */
+void __iomem *ioremap_uc(resource_size_t phys_addr, unsigned long size);
+
+/* Write-combining (WC: writes coalesced in write buffer before flush) */
+void __iomem *ioremap_wc(resource_size_t phys_addr, unsigned long size);
+
+/* Write-through (WT: writes go to both cache and memory) */
+void __iomem *ioremap_wt(resource_size_t phys_addr, unsigned long size);
+
+void iounmap(volatile void __iomem *addr);
+```
+
+**Which variant to use:**
+
+| Variant | PAT Mode | Use Case |
+|---------|----------|----------|
+| `ioremap()` | UC-minus | Default for device registers; honors MTRR ranges |
+| `ioremap_uc()` | UC | When you need strictly uncached access regardless of MTRR |
+| `ioremap_wc()` | WC | Framebuffers, PCIe BAR for bulk data (GPU VRAM, NVMe doorbells) |
+| `ioremap_wt()` | WT | Rare; use when reads must be cached but writes must be visible immediately |
+
+Write-combining (`ioremap_wc`) is particularly important for framebuffers and other bulk write destinations. The CPU batches writes into a write-combining buffer and flushes them as a burst, dramatically reducing PCIe transactions compared to individual uncached writes.
+
+### ioremap_np: Non-Posted Writes
+
+```c
+/* Non-posted writes: CPU waits for write completion acknowledgment */
+void __iomem *ioremap_np(phys_addr_t offset, size_t size);
+```
+
+From [`include/asm-generic/io.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/asm-generic/io.h): `ioremap_np()` requests stricter non-posted write semantics — the CPU stalls until the device acknowledges the write. This guarantees ordering between a register write and subsequent reads. Not all architectures implement it; portable drivers should fall back to `ioremap()` if `ioremap_np()` returns `NULL`.
+
+### PAT Memory Types on x86
+
+x86 PAT supports four memory types relevant to MMIO (from [`arch/x86/mm/pat/memtype.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/pat/memtype.c)):
+
+```
+_PAGE_CACHE_MODE_WB       Write-back (normal RAM, cached)
+_PAGE_CACHE_MODE_WC       Write-combining (framebuffers, PCIe bulk)
+_PAGE_CACHE_MODE_UC_MINUS UC-minus (device registers, honors MTRRs)
+_PAGE_CACHE_MODE_WT       Write-through
+```
+
+PAT encodes the memory type in bits of the page table entry (PWT, PCD, PAT bit). The kernel manages this through `ioremap_change_attr()`, which calls `_set_memory_uc()`, `_set_memory_wc()`, etc., to update the PTE and flush the TLB.
+
+## ARM64 Cache Operations for DMA
+
+On non-coherent ARM64 platforms, the DMA mapping layer performs explicit cache maintenance. The call chain for `dma_map_single()` on a non-coherent device, from [`kernel/dma/direct.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/direct.h) and [`arch/arm64/mm/dma-mapping.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/mm/dma-mapping.c):
+
+```
+dma_map_single()
+  └─ dma_map_single_attrs()
+       └─ dma_map_page_attrs()
+            └─ dma_direct_map_phys()       [kernel/dma/direct.h]
+                 └─ if (!dev_is_dma_coherent(dev)):
+                      arch_sync_dma_for_device(paddr, size, dir)
+                        └─ dcache_clean_poc(start, start + size)
+```
+
+For the CPU-side sync on receive:
+
+```
+dma_sync_single_for_cpu()
+  └─ __dma_sync_single_for_cpu()
+       └─ dma_direct_sync_single_for_cpu()
+            └─ if (!dev_is_dma_coherent(dev)):
+                 arch_sync_dma_for_cpu(paddr, size, dir)
+                   └─ if dir != DMA_TO_DEVICE:
+                        dcache_inval_poc(start, start + size)
+```
+
+The ARM64 cache functions operate on ranges `[start, end)` to the **Point of Coherency (PoC)** — the level of the cache hierarchy shared by all observers, including DMA-capable devices:
+
+From [`arch/arm64/include/asm/cacheflush.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/include/asm/cacheflush.h):
+
+```c
+/* Clean (write back dirty lines, keep valid) */
+extern void dcache_clean_poc(unsigned long start, unsigned long end);
+
+/* Invalidate (discard cache lines, force re-fetch from RAM) */
+extern void dcache_inval_poc(unsigned long start, unsigned long end);
+
+/* Clean + Invalidate (write back then discard) */
+extern void dcache_clean_inval_poc(unsigned long start, unsigned long end);
+```
+
+**What each operation does in the DMA context:**
+
+- `dcache_clean_poc`: used on `DMA_TO_DEVICE` — flushes CPU cache to RAM so the device reads the latest data.
+- `dcache_inval_poc`: used on `DMA_FROM_DEVICE` — discards CPU cache lines so the CPU will re-fetch from RAM after the device has written.
+- `dcache_clean_inval_poc`: used on `DMA_BIDIRECTIONAL` — combines both, used when the direction of data flow is unknown.
+
+On coherent ARM64 platforms (where `dev->dma_coherent` is true), `arch_sync_dma_for_device()` and `arch_sync_dma_for_cpu()` are not called — the hardware handles it transparently, matching x86 behavior.
+
+## The IOMMU and Coherency
+
+The IOMMU translates device DMA addresses (I/O virtual addresses) into physical addresses. It enables address space isolation — a device can only access memory the kernel has explicitly mapped into its I/O page tables.
+
+The IOMMU does **not** solve CPU cache coherency. It operates on the memory bus between the device and RAM, not between the CPU and RAM. On a non-coherent system, even with an IOMMU, the software must still perform cache maintenance through `dma_sync_*` or `dma_map_*` / `dma_unmap_*`.
+
+The one exception: some IOMMUs on ARM SoCs are placed on the coherent interconnect side and can participate in snooping. In those cases, the device's coherency is determined by where in the interconnect hierarchy the device is placed, which is reflected in `dev->dma_coherent`.
+
+For IOMMU address translation and memory protection, see [DMA Memory Allocation](dma.md).
+
+## Common Bugs
+
+!!! warning "Accessing a mapped buffer from the CPU"
+    Calling `dma_map_single()` transfers ownership to the device. Any CPU read or write to that buffer before `dma_unmap_single()` (or `dma_sync_single_for_cpu()`) is undefined behavior. On coherent x86 the bug is invisible; on non-coherent ARM64 the CPU reads stale cache or the device reads stale RAM.
+
+    ```c
+    /* WRONG: CPU accesses buffer after mapping */
+    dma_addr_t dma = dma_map_single(dev, buf, len, DMA_FROM_DEVICE);
+    buf[0] = 0;                    /* undefined: device owns buf */
+    submit_to_device(dev, dma);
+
+    /* CORRECT: map after CPU is done writing */
+    buf[0] = 0;
+    dma_addr_t dma = dma_map_single(dev, buf, len, DMA_TO_DEVICE);
+    submit_to_device(dev, dma);
+    ```
+
+!!! warning "Forgetting DMA_FROM_DEVICE sync before reading RX buffer"
+    After a device fills an RX buffer, calling `dma_sync_single_for_cpu()` with `DMA_FROM_DEVICE` is required before reading it. Without this, on a non-coherent platform the CPU reads its own stale cache rather than what the device wrote.
+
+    ```c
+    /* WRONG on non-coherent ARM64: */
+    /* Device has written packet data to rx_buf */
+    process_packet(rx_buf, len);   /* reads stale cache */
+
+    /* CORRECT: */
+    dma_sync_single_for_cpu(dev, rx_dma, len, DMA_FROM_DEVICE);
+    process_packet(rx_buf, len);   /* reads fresh data from RAM */
+    ```
+
+!!! warning "Using dma_alloc_coherent() for large streaming buffers"
+    Coherent allocations on non-coherent ARM64 are backed by uncached memory. Reading or writing large amounts of data through an uncached mapping is slow — the CPU cannot use its write buffer or load multiple cache lines at once. For bulk data (packet payloads, DMA scatter lists), use `dma_map_single()` / `dma_map_sg()` with explicit sync instead.
+
+!!! warning "Accessing MMIO through a cached mapping"
+    Mapping device registers with `ioremap_cache()` (write-back) instead of `ioremap()` causes reads to return cached values and may delay writes indefinitely. Always use `ioremap()` or `ioremap_wc()` for MMIO regions. Never access a device register through a pointer obtained from `phys_to_virt()` — that mapping is write-back cached.
+
+!!! warning "Ignoring dma_mapping_error()"
+    `dma_map_single()` and `dma_map_sg()` can fail. The failure return is `DMA_MAPPING_ERROR` (~0ULL on 64-bit). Programming this value into a device DMA register will cause a device fault or access physical memory at the wrong address.
+
+    ```c
+    dma_addr_t addr = dma_map_single(dev, buf, len, DMA_TO_DEVICE);
+    if (dma_mapping_error(dev, addr)) {
+        /* handle error: drop packet, return error, etc. */
+        return -ENOMEM;
+    }
+    ```

--- a/docs/mm/memory-reservation.md
+++ b/docs/mm/memory-reservation.md
@@ -1,0 +1,408 @@
+# Kernel Memory Reservation Mechanisms
+
+> Not all physical RAM is yours to use — the kernel, firmware, and hardware carve out regions long before user space ever runs
+
+## Why reservations exist
+
+Physical memory is not a flat, uniformly available resource. By the time the kernel reaches `start_kernel()`, several parties have already laid claim to portions of the physical address space:
+
+- **Firmware tables** — the BIOS, ACPI tables (RSDT, XSDT, DSDT), and SMBIOS data reside in RAM and must not be overwritten
+- **Kernel text and data** — `.text`, `.rodata`, `.data`, `.bss`, and related sections occupy fixed physical addresses set by the bootloader
+- **EFI runtime services** — on UEFI systems, boot services memory and the EFI memory map itself need protection
+- **EBDA and legacy BIOS region** — the Extended BIOS Data Area and the top of the first megabyte are historically corrupt-prone
+- **Device memory and memory-mapped I/O** — firmware may describe ranges as `E820_TYPE_RESERVED` rather than RAM
+- **crashkernel regions** — a dedicated region held in reserve for the kdump capture kernel
+- **CMA pools** — contiguous memory for DMA that doubles as ordinary movable memory until needed
+- **Hardware quirks** — some chipsets corrupt specific physical ranges (Sandy Bridge iGPU is a canonical x86 example)
+
+The buddy allocator, which manages all general-purpose page allocation, can only hand out pages it knows are free. Anything outside that set must be reserved before `memblock_free_all()` hands memory over.
+
+!!! note "Key Source Files"
+    | File | Role |
+    |---|---|
+    | `mm/memblock.c` | Core memblock allocator and reservation engine |
+    | `include/linux/memblock.h` | Public API, flag definitions, inline wrappers |
+    | `arch/x86/kernel/setup.c` | `setup_arch()` — orchestrates all x86 boot reservations |
+    | `arch/x86/kernel/ebda.c` | `reserve_bios_regions()` — EBDA and legacy BIOS area |
+    | `arch/x86/realmode/init.c` | `reserve_real_mode()` — first 1 MB and trampoline |
+    | `arch/x86/platform/efi/efi.c` | `efi_memblock_x86_reserve_range()` — EFI memory map |
+    | `arch/x86/kernel/e820.c` | `e820__memblock_setup()` — translates e820 map to memblock |
+    | `kernel/crash_reserve.c` | `reserve_crashkernel_generic()` — kdump region |
+    | `mm/memory_hotplug.c` | `movable_node` parameter handling |
+
+---
+
+## memblock reservations
+
+memblock is the kernel's boot-time memory manager. It maintains two flat arrays of `struct memblock_region`: one for all available physical memory (`memblock.memory`) and one for reserved regions (`memblock.reserved`). When `memblock_free_all()` is called late in `mm_init()`, only pages that appear in `memblock.memory` but *not* in `memblock.reserved` are released to the buddy allocator. Everything else stays off-limits.
+
+### memblock_reserve()
+
+The primary reservation function is a thin inline wrapper in `include/linux/memblock.h`:
+
+```c
+static __always_inline int memblock_reserve(phys_addr_t base, phys_addr_t size)
+{
+    return __memblock_reserve(base, size, NUMA_NO_NODE, 0);
+}
+```
+
+`__memblock_reserve()` calls `memblock_add_range()` against `memblock.reserved`, merging overlapping and adjacent regions as it goes. The function is safe to call from the earliest stages of `setup_arch()`, before paging is fully initialized.
+
+A variant, `memblock_reserve_kern()`, sets the additional `MEMBLOCK_RSRV_KERN` flag to indicate the region is consumed by the kernel itself (versus firmware, device memory, etc.):
+
+```c
+static __always_inline int memblock_reserve_kern(phys_addr_t base, phys_addr_t size)
+{
+    return __memblock_reserve(base, size, NUMA_NO_NODE, MEMBLOCK_RSRV_KERN);
+}
+```
+
+All internal memblock allocations automatically set `MEMBLOCK_RSRV_KERN`.
+
+### memblock_phys_alloc()
+
+Before the buddy allocator is available, the kernel must allocate memory for its own data structures (page tables, `struct page` arrays, zone structures). `memblock_phys_alloc()` satisfies these requests and returns a physical address:
+
+```c
+static __always_inline phys_addr_t memblock_phys_alloc(phys_addr_t size,
+                                                        phys_addr_t align)
+{
+    return memblock_phys_alloc_range(size, align, 0, MEMBLOCK_ALLOC_ACCESSIBLE);
+}
+```
+
+The call both allocates and implicitly marks the region reserved via `__memblock_reserve()` with `MEMBLOCK_RSRV_KERN`. A mapped virtual-address variant, `memblock_alloc()`, is also widely used for kernel data structure initialization.
+
+### memblock_mark_nomap()
+
+A reserved region still gets struct pages allocated for it and is covered by the kernel direct map by default. `memblock_mark_nomap()` goes further by setting the `MEMBLOCK_NOMAP` flag, which prevents the region from being included in the kernel's direct physical mapping altogether:
+
+```c
+int __init_memblock memblock_mark_nomap(phys_addr_t base, phys_addr_t size)
+{
+    return memblock_setclr_flag(&memblock.memory, base, size, 1, MEMBLOCK_NOMAP);
+}
+```
+
+Regions marked `MEMBLOCK_NOMAP` are still covered by the memory map (struct pages exist and are `PageReserved()`), but the kernel has no linear-map virtual address for them. This is used for device memory ranges or persistent memory that requires special mapping treatment. As the comment in `include/linux/memblock.h` states: *"don't add to kernel direct mapping and treat as reserved in the memory map."*
+
+### memblock flags summary
+
+| Flag | Meaning |
+|---|---|
+| `MEMBLOCK_NONE` | Plain reserved region |
+| `MEMBLOCK_HOTPLUG` | Firmware-described hot(un)pluggable memory |
+| `MEMBLOCK_MIRROR` | Mirrored (redundant) memory region |
+| `MEMBLOCK_NOMAP` | Exclude from kernel direct map |
+| `MEMBLOCK_DRIVER_MANAGED` | Always added via driver, not firmware RAM |
+| `MEMBLOCK_RSRV_NOINIT` | Reserved; struct pages not fully initialized |
+| `MEMBLOCK_RSRV_KERN` | Reserved for kernel use |
+
+---
+
+## What gets reserved at boot on x86
+
+`setup_arch()` in `arch/x86/kernel/setup.c` orchestrates all physical memory reservations for x86. The sequence matters — later stages depend on earlier reservations already being in place.
+
+### Phase 1: early_reserve_memory()
+
+Called before `e820__memory_setup()` adds any RAM to `memblock.memory`, so nothing gets allocated on top of these regions:
+
+```c
+static void __init early_reserve_memory(void)
+{
+    /*
+     * Reserve the memory occupied by the kernel between _text and
+     * __end_of_kernel_reserve symbols.
+     */
+    memblock_reserve_kern(__pa_symbol(_text),
+                  (unsigned long)__end_of_kernel_reserve - (unsigned long)_text);
+
+    /* Reserve the first 64K; BIOSes are known to corrupt low memory */
+    memblock_reserve(0, SZ_64K);
+
+    early_reserve_initrd();
+
+    memblock_x86_reserve_range_setup_data();
+
+    reserve_bios_regions();
+    trim_snb_memory();
+}
+```
+
+**Kernel image:** The range from `_text` to `__end_of_kernel_reserve` (a linker-defined symbol in `arch/x86/kernel/vmlinux.lds.S`) covers `.text`, `.rodata`, `.data`, `.bss`, and related sections. Any sections placed *after* `__end_of_kernel_reserve` (such as `.brk`) must be reserved separately.
+
+**Low memory:** The first 64 KB (raised to 1 MB later by `reserve_real_mode()`) is reserved because legacy BIOSes corrupt low RAM and the first page must be reserved to prevent L1TF side-channel leaks.
+
+**initrd:** `early_reserve_initrd()` immediately calls `memblock_reserve_kern()` on the ramdisk image address from `boot_params`, ensuring memblock cannot allocate over it before full setup completes.
+
+**BIOS/EBDA:** `reserve_bios_regions()` in `arch/x86/kernel/ebda.c` reads the EBDA pointer and reserves everything from the EBDA start through the top of the first megabyte:
+
+```c
+memblock_reserve(bios_start, 0x100000 - bios_start);
+```
+
+### Phase 2: e820 and EFI memory map processing
+
+`e820__memory_setup()` reads the firmware's physical memory map (BIOS e820 or EFI memory map) and constructs the authoritative picture of what is RAM, what is reserved, and what is absent. Regions typed `E820_TYPE_RAM` are subsequently added to `memblock.memory` by `e820__memblock_setup()`.
+
+On EFI systems, `efi_memblock_x86_reserve_range()` reserves the EFI memory map table itself:
+
+```c
+memblock_reserve(pmap, efi.memmap.nr_map * efi.memmap.desc_size);
+```
+
+### Phase 3: post-e820 reservations
+
+After `e820__memblock_setup()`, the full memory topology is known and further reservations are made:
+
+- **EFI boot services:** `efi_reserve_boot_services()` pins EFI boot service memory so runtime services remain accessible until `efi_free_boot_services()` is called after the boot CPU is up.
+- **Real mode trampoline:** `x86_platform.realmode_reserve()` calls `reserve_real_mode()`, which allocates a sub-1 MB trampoline region (for AP startup) and then unconditionally reserves the entire first megabyte with `memblock_reserve(0, SZ_1M)`.
+- **initrd (final):** `reserve_initrd()` later verifies the initrd mapping and frees the physical pages once they have been copied.
+- **ACPI tables:** `acpi_boot_table_init()` ultimately calls `memblock_reserve()` on ACPI table ranges found in the firmware map.
+- **CMA:** `dma_contiguous_reserve()` carves out the CMA region (see [CMA reservations](#cma-reservations) below).
+- **crashkernel:** `arch_reserve_crashkernel()` reserves the kdump region (see [crashkernel reservation](#crashkernel-reservation) below).
+
+### Reading the reservation log
+
+The kernel logs all memblock reservations at early boot. A typical x86 dmesg contains:
+
+```
+[    0.000000] BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffdffff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffe0000-0x00000000bfffffff] reserved
+...
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffdffff]
+[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x00000000bfffffff]
+[    0.000000] crashkernel reserved: 0x0000000009000000 - 0x0000000049000000 (1024 MB)
+```
+
+---
+
+## The reserved memory map
+
+### /proc/iomem
+
+`/proc/iomem` is the canonical view of the kernel resource tree — a hierarchical record of every claimed physical address range. Every reservation that calls `insert_resource()` or `request_resource()` appears here:
+
+```
+# cat /proc/iomem
+00000000-00000fff : Reserved
+00001000-0009fbff : System RAM
+0009fc00-0009ffff : Reserved
+000a0000-000bffff : PCI Bus 0000:00
+000c0000-000c99ff : Video ROM
+000f0000-000fffff : Reserved
+  000f0000-000fffff : System ROM
+00100000-bffdffff : System RAM
+  01000000-01c0ae8b : Kernel code
+  01c0ae8c-0228317f : Kernel rodata
+  02284000-02430abf : Kernel data
+  02623000-02ffffff : Kernel bss
+09000000-48ffffff : Crash kernel
+bffe0000-bfffffff : Reserved
+fd000000-fdffffff : PCI Bus 0000:00
+...
+```
+
+Fields to note:
+
+- `System RAM` — memory available to the kernel
+- `Kernel code` / `Kernel rodata` / `Kernel data` / `Kernel bss` — exact regions occupied by the kernel image
+- `Crash kernel` — the crashkernel-reserved region
+- `Reserved` — firmware-reserved areas the kernel does not use
+- `PCI Bus` — memory-mapped I/O ranges claimed by PCI
+
+### /sys/kernel/debug/memblock/reserved
+
+When `CONFIG_DEBUG_FS` is enabled, `memblock_init_debugfs()` in `mm/memblock.c` registers debugfs entries:
+
+```c
+static int __init memblock_init_debugfs(void)
+{
+    struct dentry *root = debugfs_create_dir("memblock", NULL);
+
+    debugfs_create_file("memory", 0444, root,
+                &memblock.memory, &memblock_debug_fops);
+    debugfs_create_file("reserved", 0444, root,
+                &memblock.reserved, &memblock_debug_fops);
+    ...
+}
+```
+
+```
+# cat /sys/kernel/debug/memblock/reserved
+   0: 0x0000000000000000..0x00000000000fffff
+   1: 0x0000000001000000..0x0000000002ffffff
+   2: 0x0000000009000000..0x0000000048ffffff
+   3: 0x00000000bffe0000..0x00000000bfffffff
+```
+
+!!! note
+    This file reflects the memblock state at the time of reading. After `memblock_free_all()` is called (during `mm_init()`), memblock's internal arrays may be freed if `CONFIG_ARCH_KEEP_MEMBLOCK` is not set. On such kernels, the debugfs file may be absent or empty post-boot. On x86, `CONFIG_ARCH_KEEP_MEMBLOCK` is typically enabled, preserving the data.
+
+---
+
+## crashkernel reservation
+
+The `crashkernel=` kernel command line parameter reserves a contiguous region of physical memory at boot that is handed over to a secondary "capture kernel" when the running kernel panics. This is the foundation of kdump.
+
+### How it works
+
+`arch_reserve_crashkernel()` in `arch/x86/kernel/setup.c` parses the command line and delegates to `reserve_crashkernel_generic()` in `kernel/crash_reserve.c`:
+
+```c
+static void __init arch_reserve_crashkernel(void)
+{
+    unsigned long long crash_base, crash_size, low_size = 0, cma_size = 0;
+    bool high = false;
+
+    ret = parse_crashkernel(boot_command_line, memblock_phys_mem_size(),
+                &crash_size, &crash_base, &low_size, &cma_size, &high);
+    ...
+    reserve_crashkernel_generic(crash_size, crash_base, low_size, high);
+    reserve_crashkernel_cma(cma_size);
+}
+```
+
+`reserve_crashkernel_generic()` uses `memblock_phys_alloc_range()` to find and reserve a suitable region:
+
+```c
+crash_base = memblock_phys_alloc_range(crash_size, CRASH_ALIGN,
+                                       search_base, search_end);
+```
+
+Once allocated, the region is recorded in `crashk_res` and registered in the iomem resource tree:
+
+```c
+crashk_res.start = crash_base;
+crashk_res.end   = crash_base + crash_size - 1;
+insert_resource(&iomem_resource, &crashk_res);
+```
+
+The reserved memory is removed from the running kernel's linear map so it cannot be accidentally written. `kexec_load()` places the capture kernel image and initrd inside this region; on panic, `crash_kexec()` jumps into it.
+
+### Syntax options
+
+| Syntax | Meaning |
+|---|---|
+| `crashkernel=256M` | Reserve 256 MB, kernel chooses address |
+| `crashkernel=256M@512M` | Reserve 256 MB at physical offset 512 MB |
+| `crashkernel=256M,high` | Prefer memory above 4 GB |
+| `crashkernel=256M,high crashkernel=64M,low` | 256 MB high + 64 MB DMA-accessible region |
+| `crashkernel=512M-2G:64M,2G-:128M` | Size range: 64 MB if RAM is 512 M–2 G, 128 MB if > 2 G |
+
+!!! tip
+    On x86-64, if the initial low-memory search fails, the kernel automatically retries in high memory and allocates a small `crashk_low_res` region below 4 GB to satisfy DMA-capable hardware in the capture kernel.
+
+### Timing
+
+Note in `setup_arch()` that `arch_reserve_crashkernel()` is called *after* `initmem_init()` (which parses ACPI SRAT) so that the reservation avoids hotpluggable memory regions:
+
+```c
+initmem_init();
+dma_contiguous_reserve(max_pfn_mapped << PAGE_SHIFT);
+
+/*
+ * Reserve memory for crash kernel after SRAT is parsed so that it
+ * won't consume hotpluggable memory.
+ */
+arch_reserve_crashkernel();
+```
+
+---
+
+## CMA reservations
+
+CMA (Contiguous Memory Allocator) carves out a physically contiguous region at boot, but unlike a hard reservation it remains productive: the kernel places movable pages (page cache, anonymous memory) in the CMA region during normal operation. When a device driver requests a large contiguous DMA buffer, the kernel migrates those movable pages out and hands the now-empty contiguous range to the driver.
+
+On x86, `setup_arch()` calls `dma_contiguous_reserve(max_pfn_mapped << PAGE_SHIFT)` to size and reserve the default CMA region.
+
+See [CMA](cma.md) for full coverage of the CMA lifecycle, `dma_contiguous_reserve()`, `cma_declare_contiguous()`, and `alloc_contig_range()`.
+
+---
+
+## Runtime reservations
+
+Once `memblock_free_all()` hands unreserved pages to the buddy allocator, the reservation landscape changes fundamentally. There is **no runtime equivalent of `memblock_reserve()`** for arbitrary physical ranges — the memblock arrays may have been freed, and the buddy allocator has no concept of marking an arbitrary range as off-limits after initialization.
+
+To hold memory at runtime, the kernel must allocate it and keep it allocated:
+
+```c
+/* Allocate and pin pages — never free them */
+struct page *page = alloc_pages(GFP_KERNEL, order);
+```
+
+Calling `alloc_pages()` removes the pages from the free pool. As long as the kernel holds the reference and never calls `__free_pages()`, those pages remain unavailable for other use.
+
+!!! warning
+    There is no way to "reserve" a specific physical address at runtime. If a driver or subsystem needs a particular physical range, it must be reserved at boot time via `memblock_reserve()` from an `early_param` handler or architecture setup code, or mapped through a mechanism like persistent memory (pmem) that uses `MEMBLOCK_NOMAP`.
+
+### Memory hotplug
+
+The one mechanism that changes the physical memory available to the buddy allocator at runtime is memory hotplug: adding new DIMM slots or removing existing ones on capable hardware. This extends (or shrinks) `memblock.memory` and the buddy allocator's managed range. See the memory hotplug documentation for details on `add_memory()`, `remove_memory()`, and the `MEMBLOCK_HOTPLUG` flag.
+
+---
+
+## ZONE_MOVABLE and movable_node
+
+Beyond hard reservations, the kernel supports a softer form of memory isolation: ensuring that a zone or an entire NUMA node's memory is placed in `ZONE_MOVABLE`. Pages in `ZONE_MOVABLE` can only be satisfied by movable allocations, which guarantees they can be migrated out, making the zone suitable for memory offlining and hotplug.
+
+The `movable_node` kernel command line parameter enables this behavior. It is handled by `cmdline_parse_movable_node()` in `mm/memory_hotplug.c`:
+
+```c
+static int __init cmdline_parse_movable_node(char *p)
+{
+    movable_node_enabled = true;
+    return 0;
+}
+early_param("movable_node", cmdline_parse_movable_node);
+```
+
+When `movable_node_is_enabled()` returns true, `mm_init.c` iterates over memblock regions flagged `MEMBLOCK_HOTPLUG` and places their PFN range into `ZONE_MOVABLE` rather than `ZONE_NORMAL`. This prevents the kernel from placing non-migratable allocations (kernel code, pinned memory) on that node, enabling the entire node to be offlined and removed.
+
+```
+zone_movable_pfn[nid] = min(usable_startpfn, zone_movable_pfn[nid]);
+```
+
+`ZONE_MOVABLE` is also used without `movable_node` through the `kernelcore=` and `movablecore=` parameters, which split a portion of each node's memory into the movable zone.
+
+!!! note "Memory tiering"
+    `movable_node` is also used in CXL memory tiering configurations to mark slow-memory nodes as fully movable, enabling the kernel's tiered memory promotion/demotion machinery to move pages between fast (local DRAM) and slow (CXL-attached) tiers. See the CXL memory tiering documentation for details.
+
+---
+
+## Summary: reservation mechanisms at a glance
+
+```
+Boot time                          Runtime
+─────────────────────────────────────────────────────────────
+memblock_reserve()                 alloc_pages() + hold
+  └─ reserves arbitrary range      └─ allocate and never free
+  └─ buddy allocator never sees it
+
+memblock_reserve_kern()            memory hotplug
+  └─ like above + RSRV_KERN flag   └─ adds/removes whole regions
+
+memblock_phys_alloc()
+  └─ allocates AND reserves
+
+memblock_mark_nomap()
+  └─ reserves + excludes from
+     kernel direct map
+
+ZONE_MOVABLE / movable_node
+  └─ soft reservation: isolates
+     zone for movable allocs only
+─────────────────────────────────────────────────────────────
+Visible in:
+  /proc/iomem                      (resource tree, always)
+  /sys/kernel/debug/memblock/reserved  (if CONFIG_DEBUG_FS)
+  dmesg | grep -i reserved
+```

--- a/docs/mm/numa-acpi-srat.md
+++ b/docs/mm/numa-acpi-srat.md
@@ -1,0 +1,393 @@
+# NUMA Topology Discovery: ACPI SRAT and SLIT
+
+> How the kernel reads firmware tables to learn which memory belongs to which node — and how far apart those nodes are
+
+On NUMA systems, the kernel cannot detect the physical memory topology on its own. It relies on firmware to describe which CPUs and memory ranges share a proximity domain and how far apart those domains are from each other. On x86 and ARM64 platforms this information lives in two ACPI tables: the **SRAT** (System Resource Affinity Table) and the **SLIT** (System Locality Information Table).
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| [`drivers/acpi/numa/srat.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/acpi/numa/srat.c) | Core SRAT/SLIT parsing: `acpi_numa_init()`, `acpi_parse_slit()` |
+| [`arch/x86/mm/srat.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/srat.c) | x86 entry point (`x86_acpi_numa_init()`) and CPU affinity callbacks |
+| [`arch/x86/mm/numa.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/numa.c) | x86 NUMA initialization orchestration, `dummy_numa_init()` |
+| [`mm/numa_memblks.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/numa_memblks.c) | `numa_add_memblk()`, `numa_set_distance()`, NUMA distance table |
+| [`include/acpi/actbl3.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/acpi/actbl3.h) | SRAT and SLIT C struct definitions |
+
+## What Are SRAT and SLIT?
+
+SRAT and SLIT are ACPI firmware tables that together describe the physical memory topology of a NUMA system.
+
+**SRAT** answers: *which CPUs and which memory ranges belong to which proximity domain?*
+
+**SLIT** answers: *how far apart are the proximity domains from each other?*
+
+A **proximity domain** (PXM) is firmware's opaque identifier for a NUMA locality group. The kernel maps each PXM to a Linux node number during boot; after that, PXM values are only used internally by the ACPI parsing code.
+
+```
+Firmware view (SRAT/SLIT)           Linux kernel view
+─────────────────────────           ─────────────────
+PXM 0  →  CPU 0-7, 0x00000000-0x3FFFFFFFFF    →  node 0
+PXM 1  →  CPU 8-15, 0x4000000000-0x7FFFFFFFFF →  node 1
+
+SLIT distances:
+  PXM 0 → PXM 0: 10 (local)          node_distance(0,0) = 10
+  PXM 0 → PXM 1: 21 (remote)         node_distance(0,1) = 21
+  PXM 1 → PXM 0: 21 (remote)         node_distance(1,0) = 21
+  PXM 1 → PXM 1: 10 (local)          node_distance(1,1) = 10
+```
+
+## SRAT Table Format
+
+The SRAT is a variable-length ACPI table. It starts with a standard header followed by a sequence of subtable entries, each describing one CPU or one memory range.
+
+### Table Header
+
+```c
+/* include/acpi/actbl3.h */
+struct acpi_table_srat {
+    struct acpi_table_header header;  /* "SRAT" signature, length, revision */
+    u32 table_revision;               /* Must be 1 */
+    u64 reserved;                     /* Reserved, must be zero */
+};
+```
+
+The `header.revision` field is significant: SRAT revision 1 uses only the low 8 bits of `proximity_domain` in CPU affinity entries. Revision 2 and later use the full 32-bit value.
+
+### Memory Affinity Subtable
+
+Each memory range gets one `acpi_srat_mem_affinity` entry:
+
+```c
+/* include/acpi/actbl3.h */
+struct acpi_srat_mem_affinity {
+    struct acpi_subtable_header header;  /* type=1 (ACPI_SRAT_TYPE_MEMORY_AFFINITY), length */
+    u32 proximity_domain;                /* Which PXM this memory belongs to */
+    u16 reserved;
+    u64 base_address;                    /* Physical start address */
+    u64 length;                          /* Size in bytes */
+    u32 reserved1;
+    u32 flags;
+    u64 reserved2;
+};
+
+/* Relevant flags */
+#define ACPI_SRAT_MEM_ENABLED       (1)      /* Entry is valid and should be used */
+#define ACPI_SRAT_MEM_HOT_PLUGGABLE (1 << 1) /* Range is hot-pluggable */
+#define ACPI_SRAT_MEM_NON_VOLATILE  (1 << 2) /* Range is non-volatile (NVDIMM) */
+#define ACPI_SRAT_MEM_SPEC_PURPOSE  (1 << 3) /* Reserved for specific purpose */
+```
+
+The kernel skips any entry where `ACPI_SRAT_MEM_ENABLED` is not set. Hot-pluggable ranges are registered with memblock as hotplug regions so the memory hotplug subsystem can manage them correctly.
+
+### CPU Affinity Subtables
+
+Two subtable types handle CPUs depending on whether the system uses the legacy local APIC or x2APIC:
+
+```c
+/* Legacy APIC CPUs (SRAT type 0) */
+struct acpi_srat_cpu_affinity {
+    struct acpi_subtable_header header;
+    u8  proximity_domain_lo;    /* Low 8 bits of PXM (SRAT rev 1 only uses this) */
+    u8  apic_id;                /* Local APIC ID */
+    u32 flags;                  /* ACPI_SRAT_CPU_ENABLED = 1 */
+    u8  local_sapic_eid;        /* SAPIC extended ID (for Itanium, rarely used) */
+    u8  proximity_domain_hi[3]; /* High 24 bits of PXM (SRAT rev >= 2) */
+    u32 clock_domain;
+};
+
+/* x2APIC CPUs (SRAT type 2, ACPI 4.0+) */
+struct acpi_srat_x2apic_cpu_affinity {
+    struct acpi_subtable_header header;
+    u16 reserved;
+    u32 proximity_domain;       /* Full 32-bit PXM */
+    u32 apic_id;                /* x2APIC ID */
+    u32 flags;                  /* ACPI_SRAT_CPU_ENABLED = 1 */
+    u32 clock_domain;
+    u32 reserved2;
+};
+
+#define ACPI_SRAT_CPU_ENABLED  (1)  /* Entry is valid */
+```
+
+ARM64 systems use `acpi_srat_gicc_affinity` (SRAT type 3) instead of the APIC-based structures.
+
+## SLIT Table Format
+
+The SLIT encodes the relative memory access latency between every pair of proximity domains as a flat byte matrix:
+
+```c
+/* include/acpi/actbl3.h */
+struct acpi_table_slit {
+    struct acpi_table_header header;  /* "SLIT" signature */
+    u64 locality_count;               /* Number of proximity domains (N) */
+    u8  entry[];                      /* N*N byte matrix, row-major */
+};
+```
+
+The distance from PXM `i` to PXM `j` is:
+
+```
+distance = slit->entry[i * locality_count + j]
+```
+
+Defined reference values (from `include/linux/topology.h`):
+
+| Value | Meaning |
+|-------|---------|
+| `10` (`LOCAL_DISTANCE`) | Local node access |
+| `20` (`REMOTE_DISTANCE`) | Default remote distance when no SLIT |
+| > 10 | Higher = further away |
+
+The diagonal (`i == j`) must always be `LOCAL_DISTANCE` (10). Off-diagonal values must be strictly greater than 10. The kernel validates this in `slit_valid()` before using the table — if the SLIT fails validation it is silently discarded and default distances are used.
+
+## Kernel Parsing Path
+
+### Entry Points
+
+On x86, NUMA initialization is orchestrated from `x86_numa_init()` in `arch/x86/mm/numa.c`. It tries each initialization method in order until one succeeds:
+
+```
+x86_numa_init()
+  └─ numa_init(x86_acpi_numa_init)         [CONFIG_ACPI_NUMA]
+       └─ x86_acpi_numa_init()              arch/x86/mm/srat.c
+            └─ acpi_numa_init()             drivers/acpi/numa/srat.c
+                 ├─ parse SRAT table
+                 └─ parse SLIT table
+  └─ numa_init(amd_numa_init)              [CONFIG_AMD_NUMA, fallback]
+  └─ numa_init(of_numa_init)              [Device Tree, acpi_disabled]
+  └─ numa_init(dummy_numa_init)           [last resort: single node 0]
+```
+
+### SRAT Parsing in acpi_numa_init()
+
+`acpi_numa_init()` in `drivers/acpi/numa/srat.c` drives the full SRAT/SLIT parsing sequence:
+
+```c
+int __init acpi_numa_init(void)
+{
+    /* Parse SRAT table header, then iterate all subtable types */
+    if (!acpi_table_parse(ACPI_SIG_SRAT, acpi_parse_srat)) {
+        struct acpi_subtable_proc srat_proc[5];
+
+        /* CPU affinity subtables are processed first */
+        srat_proc[0].id = ACPI_SRAT_TYPE_CPU_AFFINITY;
+        srat_proc[0].handler = acpi_parse_processor_affinity;
+        srat_proc[1].id = ACPI_SRAT_TYPE_X2APIC_CPU_AFFINITY;
+        srat_proc[1].handler = acpi_parse_x2apic_affinity;
+        srat_proc[2].id = ACPI_SRAT_TYPE_GICC_AFFINITY;   /* ARM64 */
+        srat_proc[2].handler = acpi_parse_gicc_affinity;
+        /* ... */
+        acpi_table_parse_entries_array(ACPI_SIG_SRAT, ...);
+
+        /* Then memory affinity subtables */
+        cnt = acpi_table_parse_srat(ACPI_SRAT_TYPE_MEMORY_AFFINITY,
+                                    acpi_parse_memory_affinity, 0);
+    }
+
+    /* Parse SLIT */
+    acpi_table_parse(ACPI_SIG_SLIT, acpi_parse_slit);
+    /* ... */
+}
+```
+
+### CPU Entry Processing
+
+For each CPU affinity subtable, `acpi_numa_processor_affinity_init()` (in `arch/x86/mm/srat.c`) is called:
+
+1. Check `ACPI_SRAT_CPU_ENABLED` flag — skip disabled entries.
+2. Extract the proximity domain, accounting for SRAT revision (rev 1 uses only `proximity_domain_lo`).
+3. Call `acpi_map_pxm_to_node(pxm)` to get or allocate a Linux node number for this PXM.
+4. Record the APIC ID → node mapping in `__apicid_to_node[]`.
+
+### Memory Entry Processing
+
+For each memory affinity subtable, `acpi_parse_memory_affinity()` is called:
+
+1. Check `ACPI_SRAT_MEM_ENABLED` — skip disabled entries.
+2. Extract `base_address` and `length` to form the physical range `[start, end)`.
+3. Extract `proximity_domain` (masked to 8 bits for SRAT rev ≤ 1).
+4. Call `acpi_map_pxm_to_node(pxm)` to get the Linux node number.
+5. Call `numa_add_memblk(node, start, end)` to register the range.
+
+### PXM to Node Mapping
+
+The mapping between firmware PXM values and Linux node numbers is maintained by two arrays in `drivers/acpi/numa/srat.c`:
+
+```c
+static int pxm_to_node_map[MAX_PXM_DOMAINS];  /* PXM → node */
+static int node_to_pxm_map[MAX_NUMNODES];      /* node → PXM */
+```
+
+Two public functions expose this mapping:
+
+```c
+int pxm_to_node(int pxm);   /* Returns NUMA_NO_NODE if PXM unknown */
+int node_to_pxm(int node);  /* Returns PXM_INVAL if no mapping */
+```
+
+`acpi_map_pxm_to_node(pxm)` is the internal function that allocates a new node number the first time a PXM is encountered. It uses `first_unset_node(nodes_found_map)` to find the next available slot. This is how sparse PXM values (e.g., PXMs 0, 5, 100) get compacted into consecutive Linux node numbers (0, 1, 2).
+
+### SLIT Parsing
+
+`acpi_parse_slit()` iterates over the SLIT matrix after SRAT parsing is complete, so that all PXM→node mappings are already established:
+
+```c
+for (i = 0; i < slit->locality_count; i++) {
+    int from_node = pxm_to_node(i);
+    if (from_node == NUMA_NO_NODE)
+        continue;  /* PXM with no memory or CPU in SRAT */
+
+    for (j = 0; j < slit->locality_count; j++) {
+        int to_node = pxm_to_node(j);
+        if (to_node == NUMA_NO_NODE)
+            continue;
+
+        numa_set_distance(from_node, to_node,
+            slit->entry[slit->locality_count * i + j]);
+    }
+}
+```
+
+PXMs that appear in the SLIT but have no corresponding SRAT entry (no CPUs or memory) are silently skipped.
+
+## From Proximity Domains to the Memory Subsystem
+
+After SRAT parsing, the topology information is held in two structures that feed into the rest of the kernel.
+
+### numa_memblks and memblock
+
+`numa_add_memblk()` records `[start, end)` → `node` mappings in an internal `numa_meminfo` structure (in `mm/numa_memblks.c`). Later, `numa_memblks_init()` calls `memblock_set_node()` to tag every `memblock.memory` region with its NUMA node number. This is how the buddy allocator's per-node free lists are populated correctly at boot.
+
+See [memblock: The Boot-Time Memory Allocator](memblock.md) for how `memblock` tracks these regions and hands them to the buddy allocator.
+
+### NUMA Distance Matrix
+
+`numa_set_distance(from, to, distance)` writes into a flat `u8` array allocated from memblock:
+
+```c
+/* mm/numa_memblks.c */
+numa_distance[from * numa_distance_cnt + to] = distance;
+```
+
+At runtime, `node_distance(from, to)` (and its underlying `__node_distance()`) reads from this array to answer scheduler and page-allocator queries about topology proximity. The scheduler uses distance to prefer local memory allocation; the page allocator uses it to choose fallback nodes when the local node is exhausted.
+
+```
+SRAT parsing          SLIT parsing
+     │                     │
+     ▼                     ▼
+numa_add_memblk()    numa_set_distance()
+     │                     │
+     ▼                     ▼
+numa_meminfo{}       numa_distance[]
+     │                     │
+     ▼                     ▼
+memblock_set_node()  __node_distance()
+     │                     │
+     ▼                     ▼
+buddy allocator      scheduler / page alloc
+per-node free lists  fallback node selection
+```
+
+## Common Firmware Bugs
+
+!!! warning "Broken SRAT: memory silently assigned to node 0"
+    If the SRAT is missing memory entries, the kernel falls through to `numa_fill_memblks()`, which assigns unclaimed physical ranges to node 0. On a 4-socket system this means all 3 remote nodes' memory appears as node 0. The system boots but NUMA is completely broken: no remote memory is accessible from the correct node, and `numactl -H` will show a single huge node.
+
+    Detection: `numactl -H` reports one enormous node instead of several balanced ones. Boot log will show `SRAT: Node 0 PXM 0 [mem ...]` for all memory.
+
+!!! warning "Broken SLIT: all distances reported as 10"
+    Some firmware incorrectly fills the entire SLIT matrix — including off-diagonal entries — with the value 10 (`LOCAL_DISTANCE`). This means the firmware claims all nodes are equidistant from each other, which is false.
+
+    The kernel catches this in `slit_valid()`, which checks that diagonal entries equal `LOCAL_DISTANCE` and off-diagonal entries are strictly greater. A SLIT that fails this check is rejected with the message:
+
+    ```
+    SLIT table looks invalid. Not used.
+    ```
+
+    When the SLIT is rejected, the kernel falls back to default distances: `LOCAL_DISTANCE` (10) for same-node and `REMOTE_DISTANCE` (20) for all cross-node pairs. The scheduler and page allocator still function but cannot make topology-aware decisions beyond the two-level local/remote distinction.
+
+!!! warning "Sparse or non-contiguous PXM values"
+    The ACPI specification allows PXM values to be sparse — a system might have PXMs 0, 5, and 100 with no PXMs in between. The kernel handles this via `acpi_map_pxm_to_node()`, which allocates consecutive Linux node numbers regardless of PXM gaps. However, a SLIT for such a system must be sized `101 × 101` (for PXMs 0 through 100), and entries for non-existent PXMs must still be present.
+
+    Firmware that sizes the SLIT matrix incorrectly — for example, using `3 × 3` instead of `101 × 101` — will cause the kernel to read past the end of the table when translating distances. The kernel will either silently use garbage distance values or reject the SLIT as invalid.
+
+!!! warning "SRAT revision mismatch"
+    SRAT revision 1 packs the proximity domain into only the low 8 bits of the `proximity_domain_lo` field of CPU affinity entries. Starting with revision 2, the full 32-bit `proximity_domain` is used. Firmware that sets `header.revision = 1` but writes 32-bit PXMs will have its high bits silently masked off (`pxm &= 0xff`). CPUs and memory that share a PXM > 255 will appear to belong to PXM `pxm & 0xff`, breaking node assignments.
+
+## Validating NUMA Topology
+
+### Runtime Tools
+
+```bash
+# Show node sizes, CPUs per node, and the distance matrix
+numactl --hardware
+
+# Example output on a 2-node system:
+# available: 2 nodes (0-1)
+# node 0 cpus: 0 1 2 3 4 5 6 7
+# node 0 size: 65536 MB
+# node 0 free: 61234 MB
+# node 1 cpus: 8 9 10 11 12 13 14 15
+# node 1 size: 65536 MB
+# node 1 free: 60987 MB
+# node distances:
+# node   0   1
+#   0:  10  21
+#   1:  21  10
+
+# Read distance for a specific pair
+cat /sys/devices/system/node/node0/distance
+# 10 21   (distance from node 0 to node 0, then node 0 to node 1)
+```
+
+### Boot Log
+
+During early boot, the ACPI NUMA code logs each SRAT entry it accepts:
+
+```bash
+dmesg | grep -i "SRAT"
+# ACPI: SRAT: Node 0 PXM 0 [mem 0x00000000-0x3fffffffff]
+# ACPI: SRAT: Node 1 PXM 1 [mem 0x4000000000-0x7fffffffff]
+# ACPI: SRAT: Node 0 PXM 0 [mem 0x100000000-0x3fffffffff] hotplug
+```
+
+Missing expected nodes here is a clear sign of a broken SRAT.
+
+### Decoding the Raw Tables
+
+For deep inspection, decode the raw ACPI tables with the standard toolchain:
+
+```bash
+# Dump all ACPI tables to binary files
+acpidump -o acpi.dat
+acpixtract acpi.dat
+
+# Disassemble SRAT and SLIT
+iasl -d SRAT.dat
+iasl -d SLIT.dat
+# Produces SRAT.dsl and SLIT.dsl — human-readable text
+
+# Check for hotplug memory regions
+grep -i "hot" SRAT.dsl
+```
+
+## Non-ACPI Systems
+
+ACPI-based SRAT/SLIT parsing is used on x86 and ARM64. Other platforms discover NUMA topology differently:
+
+**Device Tree (ARM, RISC-V)**: Topology is described by the `numa-node-id` property in DT nodes. `of_numa_init()` reads these and calls `numa_add_memblk()` with the same interface that the SRAT parser uses. See [memblock: The Boot-Time Memory Allocator](memblock.md) for context on how Device Tree memory regions flow into memblock.
+
+**AMD without ACPI (`amd_numa_init()`)**: On older AMD systems where ACPI NUMA support is broken or absent, the kernel probes the AMD northbridge directly for memory topology. This is a fallback that runs only when `x86_acpi_numa_init()` fails.
+
+**No NUMA firmware (`dummy_numa_init()`)**: When all other methods fail (or when `numa=off` is passed on the kernel command line), `dummy_numa_init()` creates a single fake node 0 that covers the entire physical address space. The system runs as if it were a UMA machine regardless of the actual hardware topology.
+
+```c
+/* arch/x86/mm/numa.c */
+static int __init dummy_numa_init(void)
+{
+    node_set(0, numa_nodes_parsed);
+    numa_add_memblk(0, 0, PFN_PHYS(max_pfn));
+    return 0;
+}
+```

--- a/docs/mm/pci-bar-mapping.md
+++ b/docs/mm/pci-bar-mapping.md
@@ -1,0 +1,374 @@
+# PCI BAR Memory Mapping
+
+> How the kernel discovers, claims, and maps PCI device memory regions into kernel virtual address space
+
+## What Are PCI BARs?
+
+Every PCI and PCIe device exposes up to six **Base Address Registers** (BARs), numbered BAR0 through BAR5, in its configuration space. These registers tell the operating system where the device's memory-mapped I/O (MMIO) regions live in the physical address space.
+
+BARs live at offsets `0x10` through `0x24` in the standard PCI configuration header, defined in [`include/uapi/linux/pci_regs.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/pci_regs.h):
+
+```c
+#define PCI_BASE_ADDRESS_0  0x10  /* 32 bits */
+#define PCI_BASE_ADDRESS_1  0x14  /* 32 bits */
+#define PCI_BASE_ADDRESS_2  0x18  /* 32 bits */
+#define PCI_BASE_ADDRESS_3  0x1c  /* 32 bits */
+#define PCI_BASE_ADDRESS_4  0x20  /* 32 bits */
+#define PCI_BASE_ADDRESS_5  0x24  /* 32 bits */
+```
+
+The maximum number of standard BARs is defined as `PCI_STD_NUM_BARS = 6` in [`include/uapi/linux/pci_regs.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/pci_regs.h).
+
+### How BAR Size Is Determined
+
+The firmware or OS discovers the size of a BAR region using a hardware protocol: write all-1s (`0xFFFFFFFF`) to the BAR register, read the value back, mask off the type bits, and invert. The result is the size minus one. This is called **BAR sizing** and is performed by `pci_read_bases()` in [`drivers/pci/probe.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/probe.c), called from `pci_setup_device()` during bus enumeration.
+
+```
+Write: 0xFFFFFFFF → BAR register
+Read back: 0xFFFFF000  (device decodes 12 address bits → 4 KB region)
+Mask type bits, invert: size = 4096 bytes
+```
+
+The device decodes only the bits it responds to; the rest read back as zero. The lower bits hold type information and are masked before the inversion.
+
+## BAR Types
+
+The lower bits of each BAR register encode the region's type:
+
+```c
+#define PCI_BASE_ADDRESS_SPACE         0x01  /* 0 = memory, 1 = I/O */
+#define PCI_BASE_ADDRESS_SPACE_IO      0x01
+#define PCI_BASE_ADDRESS_SPACE_MEMORY  0x00
+#define PCI_BASE_ADDRESS_MEM_TYPE_MASK 0x06
+#define PCI_BASE_ADDRESS_MEM_TYPE_32   0x00  /* 32-bit address */
+#define PCI_BASE_ADDRESS_MEM_TYPE_1M   0x02  /* Below 1M (obsolete) */
+#define PCI_BASE_ADDRESS_MEM_TYPE_64   0x04  /* 64-bit address */
+#define PCI_BASE_ADDRESS_MEM_PREFETCH  0x08  /* prefetchable? */
+```
+
+### Memory BARs (`PCI_BASE_ADDRESS_SPACE_MEMORY`)
+
+The common case. The BAR describes a window of physical address space that maps directly to device registers or device-local memory. CPU accesses to this window go out on the PCIe bus and reach the device. The kernel maps these regions using `ioremap()` or one of its variants.
+
+### I/O BARs (`PCI_BASE_ADDRESS_SPACE_IO`)
+
+A legacy type specific to x86. The device occupies a range in the x86 I/O port address space, accessed via `inb()`/`outb()` instructions rather than normal memory loads and stores. Modern devices rarely use I/O BARs; PCIe firmware often assigns them but devices may not actually need them. `pci_iomap()` handles both types transparently.
+
+### Prefetchable BARs (`PCI_BASE_ADDRESS_MEM_PREFETCH`)
+
+A memory BAR with a guarantee that reads have no side effects and the CPU or PCIe fabric can safely prefetch data and combine writes. This is set only for regions like GPU framebuffers where sequential writes benefit from write-combining. Non-prefetchable BARs must not be speculatively read -- side effects (like clearing a status register on read) would be triggered incorrectly.
+
+### 64-bit BARs (`PCI_BASE_ADDRESS_MEM_TYPE_64`)
+
+A 64-bit memory BAR uses **two consecutive BAR slots** to store the full 64-bit base address: the lower 32 bits in BAR `n` and the upper 32 bits in BAR `n+1`. This means a device can have at most three 64-bit BARs (using all six slots in pairs), and accessing the resource via `pci_resource_start(dev, n)` gives the full 64-bit physical address correctly -- the kernel handles the two-register assembly transparently during `pci_read_bases()`.
+
+```
+BAR Layout for a device with one 64-bit BAR at BAR0:
+
+  BAR0  [0x10]: lower 32 bits of address + type bits
+  BAR1  [0x14]: upper 32 bits of address
+  BAR2  [0x18]: next independent BAR (e.g., another memory region)
+```
+
+## Linux BAR Enumeration
+
+During PCI bus enumeration, the kernel calls `pci_setup_device()` → `pci_read_bases()` for every device found. This function reads and sizes all BARs, then stores the results in `dev->resource[]` -- an array of `struct resource` indexed 0 through 5 (for the standard BARs), with entry 6 reserved for the expansion ROM.
+
+After enumeration, three macros in [`include/linux/pci.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/pci.h) give drivers everything they need:
+
+```c
+pci_resource_start(dev, bar)  /* physical base address of the BAR */
+pci_resource_len(dev, bar)    /* size of the BAR region in bytes  */
+pci_resource_flags(dev, bar)  /* type and attribute flags          */
+```
+
+The flags use the `IORESOURCE_*` constants from [`include/linux/ioport.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/ioport.h):
+
+| Flag | Value | Meaning |
+|------|-------|---------|
+| `IORESOURCE_IO` | `0x00000100` | I/O port BAR |
+| `IORESOURCE_MEM` | `0x00000200` | Memory BAR |
+| `IORESOURCE_PREFETCH` | `0x00002000` | Prefetchable memory |
+| `IORESOURCE_MEM_64` | `0x00100000` | 64-bit address BAR |
+
+## Requesting and Mapping a BAR
+
+A driver must follow three steps in order: enable the device, claim the BAR region from the kernel resource tree, and map the BAR into kernel virtual address space. All three functions live in [`drivers/pci/pci.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/pci.c) and [`drivers/pci/iomap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/iomap.c).
+
+### The Standard Driver Pattern
+
+```c
+static int my_driver_probe(struct pci_dev *pdev,
+                           const struct pci_device_id *id)
+{
+    void __iomem *base;
+    int err;
+
+    /* 1. Enable the device (powers on, enables bus mastering) */
+    err = pci_enable_device(pdev);
+    if (err)
+        return err;
+
+    /* 2. Claim BAR 0 — prevents other drivers from touching it.
+     *    pci_request_regions() claims all BARs at once. */
+    err = pci_request_region(pdev, 0, "my_driver");
+    if (err)
+        goto err_disable;
+
+    /* 3. Map BAR 0 into kernel virtual address space.
+     *    Pass 0 as maxlen to map the full BAR. */
+    base = pci_iomap(pdev, 0, 0);
+    if (!base) {
+        err = -ENOMEM;
+        goto err_release;
+    }
+
+    /* 4. Access the device using ioread*/iowrite* — never
+     *    dereference the pointer directly. */
+    u32 version = ioread32(base + REG_VERSION);
+    iowrite32(CTRL_ENABLE, base + REG_CONTROL);
+
+    pci_set_drvdata(pdev, base);
+    return 0;
+
+err_release:
+    pci_release_region(pdev, 0);
+err_disable:
+    pci_disable_device(pdev);
+    return err;
+}
+
+static void my_driver_remove(struct pci_dev *pdev)
+{
+    void __iomem *base = pci_get_drvdata(pdev);
+
+    pci_iounmap(pdev, base);
+    pci_release_region(pdev, 0);
+    pci_disable_device(pdev);
+}
+```
+
+### Function Reference
+
+**`pci_request_region(pdev, bar, name)`** / **`pci_request_regions(pdev, name)`**
+
+Claims one BAR (or all BARs) by inserting entries into the kernel's `iomem` or `ioport` resource tree. Returns `-EBUSY` if another driver already owns the region. This is the software lock that prevents two drivers from simultaneously mapping the same hardware registers. Defined in [`drivers/pci/pci.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/pci.c).
+
+**`pci_iomap(pdev, bar, maxlen)`**
+
+Maps the BAR into kernel virtual address space and returns a `void __iomem *` cookie. Internally calls `ioremap()` for memory BARs or `__pci_ioport_map()` for I/O BARs. If `maxlen` is 0, the entire BAR is mapped. Defined in [`drivers/pci/iomap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/iomap.c).
+
+**`ioread32(addr)` / `iowrite32(val, addr)`**
+
+The correct way to access MMIO. These functions handle any required memory barriers and work correctly regardless of whether the underlying mapping is true MMIO or an I/O port range. Do **not** dereference the `__iomem` pointer directly -- the compiler will allow it but it bypasses the barriers and will break on some architectures.
+
+**`pci_iounmap(pdev, addr)` / `pci_release_regions(pdev)`**
+
+Teardown pair for the mapping and claim. Always call them in driver `remove()`.
+
+### Managed Variant: `pcim_iomap()`
+
+For drivers that want automatic cleanup on driver detach, the devres-managed variant `pcim_iomap()` is available. It requires `pcim_enable_device()` instead of `pci_enable_device()`. The mapping is automatically released when the driver unbinds. Defined in [`drivers/pci/devres.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/devres.c).
+
+```c
+err = pcim_enable_device(pdev);
+if (err)
+    return err;
+
+base = pcim_iomap(pdev, 0, 0);
+if (!base)
+    return -ENOMEM;
+/* No explicit cleanup needed in remove() */
+```
+
+## Memory Types for BAR Mappings
+
+How the CPU accesses MMIO depends on the **page attribute** applied when the virtual mapping is created. The choice has large performance implications. On x86, this is controlled by the **Page Attribute Table (PAT)**, implemented in [`arch/x86/mm/pat/memtype.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/pat/memtype.c).
+
+### Uncached (UC) — Non-Prefetchable BARs
+
+`ioremap()` (called internally by `pci_iomap()`) maps the region as **UC-minus** (uncacheable, write-posted). Every read and write goes directly to the device; no data is held in any CPU cache. This is mandatory for control registers where each read may have side effects and writes must be visible to the device immediately.
+
+```c
+/* ioremap() is the default -- UC-minus caching */
+void __iomem *ioremap(resource_size_t phys_addr, unsigned long size);
+```
+
+### Write-Combining (WC) — Prefetchable BARs
+
+`ioremap_wc()` maps the region with **write-combining** enabled. The CPU may buffer multiple writes and send them to the device in a single burst, dramatically improving throughput for sequential writes. Reads still go to the device but there is no read prefetching. This is the correct choice for framebuffers, PCIe peer-to-peer memory, and any large, streaming-write workload.
+
+```c
+/* ioremap_wc() -- write-combining for prefetchable BARs */
+void __iomem *ioremap_wc(resource_size_t phys_addr, unsigned long size);
+```
+
+The PCI subsystem provides a wrapper for the write-combining case, defined in [`drivers/pci/iomap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/iomap.c):
+
+```c
+/* Maps a BAR with write-combining (prefetchable BARs only) */
+void __iomem *pci_iomap_wc(struct pci_dev *dev, int bar,
+                            unsigned long maxlen);
+```
+
+`pci_iomap_wc()` returns `NULL` for I/O BARs (write-combining makes no sense for port I/O) and calls `ioremap_wc()` for memory BARs.
+
+### Choosing the Right Mapping
+
+```c
+unsigned long flags = pci_resource_flags(pdev, bar);
+
+if (flags & IORESOURCE_PREFETCH) {
+    /* Safe to use write-combining */
+    base = pci_iomap_wc(pdev, bar, 0);
+} else {
+    /* Non-prefetchable: use uncached */
+    base = pci_iomap(pdev, bar, 0);
+}
+```
+
+!!! warning "Performance impact"
+    Mapping a 256 MB framebuffer as UC instead of WC can reduce sequential write throughput by an order of magnitude. GPU drivers are careful to use `pci_iomap_wc()` for VRAM BARs and `pci_iomap()` for register BARs even on the same device.
+
+## IOMMU and BAR Access
+
+The IOMMU translates device-issued DMA addresses (device → RAM direction). BAR accesses travel in the **opposite direction** (CPU → device) and bypass the IOMMU entirely. The CPU issues a physical memory transaction on the PCIe bus; the device responds directly.
+
+```
+DMA (device → RAM):
+  Device --[DMA addr]--> IOMMU --[phys addr]--> RAM
+
+MMIO (CPU → device):
+  CPU --[phys addr]--> PCIe --[reaches device, not RAM]
+```
+
+The IOMMU is not involved in MMIO reads or writes. However, during BAR assignment the firmware (and optionally the kernel) must ensure BAR physical addresses do not overlap with installed RAM. On x86 this is enforced by the memory map in `E820`, and the PCI subsystem checks `iomem_resource` before accepting BAR assignments.
+
+## 64-Bit BARs and Address Space Conflicts
+
+On systems with more than 4 GB of RAM, 32-bit BARs (which can only describe addresses below 4 GB) can conflict with installed memory. On most modern x86 systems, firmware handles this by reserving a region below 4 GB (sometimes called the **PCI hole** or **TOLUD** -- Top Of Low Usable DRAM) where BARs are placed without conflict. However, this shrinks the effective addressable low memory.
+
+To check whether a BAR uses 64-bit addressing from driver code:
+
+```c
+if (pci_resource_flags(pdev, bar) & IORESOURCE_MEM_64) {
+    /* BAR uses a 64-bit address; bar+1 is consumed for the high bits */
+    pr_info("64-bit BAR at %pa, size %pa\n",
+            &pci_resource_start(pdev, bar),
+            &pci_resource_len(pdev, bar));
+}
+```
+
+Modern NVMe drives, CXL memory devices, and high-end GPUs routinely use 64-bit BARs larger than 4 GB (e.g., a 16 GB VRAM BAR) placed above the 4 GB boundary. The kernel places these via `pci_reassign_resource()` in [`drivers/pci/setup-res.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/setup-res.c) when firmware leaves BARs unassigned or assigns them suboptimally.
+
+!!! note "Firmware vs. kernel BAR assignment"
+    Most x86 systems have firmware assign all BARs before the kernel boots. The kernel then reads and trusts those assignments. On embedded systems or when `pci=realloc` is passed on the kernel command line, the kernel may reassign BARs itself.
+
+## Debugging BAR Mappings
+
+### `lspci -v`
+
+Shows all BARs assigned to a device, including their physical addresses, sizes, and types:
+
+```
+$ lspci -v -s 03:00.0
+03:00.0 VGA compatible controller: NVIDIA Corporation ...
+        Memory at f6000000 (32-bit, non-prefetchable) [size=16M]
+        Memory at e0000000 (64-bit, prefetchable) [size=256M]
+        Memory at f0000000 (64-bit, prefetchable) [size=32M]
+        I/O ports at e000 [size=128]
+```
+
+The lines after the device description are the BARs. `prefetchable` indicates `IORESOURCE_PREFETCH` is set.
+
+### `/proc/iomem`
+
+Shows how BARs occupy the physical address space alongside RAM and other resources:
+
+```
+$ cat /proc/iomem
+00000000-00000fff : Reserved
+...
+e0000000-efffffff : PCI Bus 0000:03
+  e0000000-efffffff : 0000:03:00.0
+    e0000000-efffffff : nvidia
+f6000000-f6ffffff : 0000:03:00.0
+  f6000000-f6ffffff : nvidia
+```
+
+Entries are indented to show the resource hierarchy: bus window → device BAR → driver claim.
+
+### `/sys/bus/pci/devices/BBDF/resource`
+
+Each PCI device has a `resource` file showing all six BARs plus the expansion ROM, one per line, as three hex fields: start, end, flags.
+
+```
+$ cat /sys/bus/pci/devices/0000:03:00.0/resource
+0x00000000f6000000 0x00000000f6ffffff 0x0000000000040200
+0x00000000e0000000 0x00000000efffffff 0x000000000014220c
+0x00000000f0000000 0x00000000f1ffffff 0x000000000014220c
+0x000000000000e000 0x000000000000e07f 0x0000000000040101
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+```
+
+The third column is the `IORESOURCE_*` flags. `0x200` is `IORESOURCE_MEM`; `0x2000` is `IORESOURCE_PREFETCH`; `0x100000` is `IORESOURCE_MEM_64`.
+
+### `/sys/bus/pci/devices/BBDF/resource0` through `resource5`
+
+These files are `mmap()`-able from userspace (when the BAR is not marked exclusive). A userspace tool can map a BAR directly without a kernel driver:
+
+```c
+int fd = open("/sys/bus/pci/devices/0000:03:00.0/resource0", O_RDWR);
+size_t len = /* from resource file or lspci */ 16 * 1024 * 1024;
+void *mmio = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+uint32_t val = *(volatile uint32_t *)mmio;  /* direct access from userspace */
+```
+
+This is how tools like `nvtop` and GPU compute debuggers access device memory without a kernel driver. Note that `pci_request_regions_exclusive()` prevents this by setting `IORESOURCE_EXCLUSIVE`, blocking the sysfs mmap path.
+
+### Checking BAR assignments at boot
+
+```bash
+# All PCI-related messages during bus enumeration
+dmesg | grep -i pci | grep -i BAR
+
+# Check a specific device's resources from sysfs
+cat /sys/bus/pci/devices/0000:03:00.0/resource
+
+# Show the full iomem map
+cat /proc/iomem | grep -A2 "PCI Bus"
+```
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| [`drivers/pci/iomap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/iomap.c) | `pci_iomap()`, `pci_iomap_wc()`, `pci_iomap_range()`, `pci_iounmap()` |
+| [`drivers/pci/pci.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/pci.c) | `pci_request_region()`, `pci_request_regions()`, `pci_release_regions()` |
+| [`drivers/pci/probe.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/probe.c) | `pci_setup_device()`, `pci_read_bases()` — BAR sizing and enumeration |
+| [`drivers/pci/devres.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/devres.c) | `pcim_iomap()`, `pcim_enable_device()` — managed (devres) variants |
+| [`drivers/pci/setup-res.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/setup-res.c) | `pci_reassign_resource()` — BAR relocation |
+| [`include/linux/pci.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/pci.h) | `pci_resource_start()`, `pci_resource_len()`, `pci_resource_flags()` |
+| [`include/uapi/linux/pci_regs.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/pci_regs.h) | `PCI_BASE_ADDRESS_*` constants, `PCI_STD_NUM_BARS` |
+| [`include/linux/ioport.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/ioport.h) | `IORESOURCE_MEM`, `IORESOURCE_PREFETCH`, `IORESOURCE_MEM_64` |
+| [`arch/x86/mm/ioremap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/ioremap.c) | `ioremap()`, `ioremap_wc()`, `ioremap_uc()` on x86 |
+| [`arch/x86/mm/pat/memtype.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/pat/memtype.c) | PAT — page attribute table controlling cache modes |
+
+---
+
+## References
+
+### Further Reading
+
+- [Kernel documentation: Device I/O](https://docs.kernel.org/driver-api/device-io.html) — authoritative guide to MMIO access functions
+- [PCI Local Bus Specification, rev 3.0](https://pcisig.com/) — defines BAR layout, sizing protocol, and type bits
+- [LWN: PCI resource management](https://lwn.net/Articles/51834/) — early overview of how Linux manages PCI resources
+- [LWN: Write-combining mappings](https://lwn.net/Articles/252029/) — PAT and write-combining performance on x86
+
+### Related Pages
+
+- [DMA Memory Allocation](dma.md) — how devices transfer data to/from RAM (distinct from MMIO)
+- [vmalloc](vmalloc.md) — kernel virtual address space that `ioremap()` carves from
+- [Page Tables](page-tables.md) — how `ioremap()` mappings appear in the kernel page table
+- [CXL Memory Tiering](cxl-memory-tiering.md) — CXL devices expose large 64-bit BARs for memory expansion

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,8 +119,13 @@ nav:
       - Copy-on-Write: mm/cow.md
     - Boot & Subsystems:
       - memblock: mm/memblock.md
+      - Memory Reservation: mm/memory-reservation.md
+      - Boot Page Tables: mm/boot-page-tables.md
+      - NUMA Topology (ACPI SRAT/SLIT): mm/numa-acpi-srat.md
       - CMA: mm/cma.md
       - DMA: mm/dma.md
+      - Device Coherency: mm/device-coherency.md
+      - PCI BAR Mapping: mm/pci-bar-mapping.md
       - hugetlbfs vs THP: mm/hugetlbfs-vs-thp.md
     - Tuning:
       - PSI: mm/psi.md


### PR DESCRIPTION
## Summary

- **numa-acpi-srat.md**: ACPI SRAT/SLIT table structures from `actbl3.h`, parsing path `x86_numa_init()` → `acpi_numa_init()`, `pxm_to_node()` proximity domain mapping, `slit_valid()`, firmware bug patterns (missing entries, all-10 distances), validation with `numactl`/`acpidump`.
- **memory-reservation.md**: `memblock_reserve()`/`memblock_reserve_kern()`, `early_reserve_memory()` for kernel text/ACPI/initrd, `MEMBLOCK_NOMAP` vs reserved semantics, crashkernel range syntax, `movable_node`, `/proc/iomem` and debugfs inspection.
- **boot-page-tables.md**: `early_top_pgt`/`init_top_pgt` (`swapper_pg_dir`), `__startup_64()` in `map_kernel.c`, `early_dynamic_pgts`, 5-level paging via `check_la57_support()`, `kernel_randomize_memory()` KASLR for `page_offset_base`/`vmalloc_base`/`vmemmap_base`, `/sys/kernel/debug/page_tables/kernel`. x86_64-specific.
- **device-coherency.md**: `dma_alloc_coherent()`/`dma_map_single()`/`dma_sync_*`, `DMA_TO_DEVICE`/`DMA_FROM_DEVICE` enum, `ioremap()`/`ioremap_wc()`/`ioremap_uc()`, ARM64 `dcache_clean_poc()`/`dcache_inval_poc()`, PAT memory types.
- **pci-bar-mapping.md**: `PCI_STD_NUM_BARS=6`, `pci_resource_start()`/`pci_resource_len()`/`pci_resource_flags()`, `IORESOURCE_MEM`/`IORESOURCE_PREFETCH`/`IORESOURCE_MEM_64`, `pci_request_regions()`/`pci_iomap()`/`pci_iomap_wc()`/`pci_iounmap()`, `ioread32()`/`iowrite32()`, debugging via lspci/`/proc/iomem`/sysfs.

Closes #214, #29, #28, #33, #34