### PR TITLE
Fix mkdocs.yml YAML syntax for nav titles with colons

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,8 +163,8 @@ nav:
       - /proc/vmstat reference: mm/proc-vmstat.md
     - Bugs:
       - Bug Index: mm/bugs/README.md
-      - War Stories: Performance Regressions: mm/war-stories-regressions.md
-      - War Stories: CVE Case Studies: mm/war-stories-cves.md
-      - War Stories: Bug Incident Narratives: mm/war-stories-bugs.md
+      - "War Stories: Performance Regressions": mm/war-stories-regressions.md
+      - "War Stories: CVE Case Studies": mm/war-stories-cves.md
+      - "War Stories: Bug Incident Narratives": mm/war-stories-bugs.md
     - Reference:
       - Glossary: mm/glossary.md


### PR DESCRIPTION
Nav titles containing colons must be quoted in YAML. Fixes build failure introduced when war-stories nav entries were added.