### PR TITLE
Add scheduler resource control & topology docs

### DIFF
--- a/docs/sched/cpu-affinity.md
+++ b/docs/sched/cpu-affinity.md
@@ -1,0 +1,178 @@
+# CPU Affinity
+
+> Per-task CPU pinning: sched_setaffinity() and how it interacts with cpusets
+
+## What CPU affinity controls
+
+CPU affinity lets a task (or an admin) restrict which CPUs a specific task may run on. Unlike cpuset — which applies to an entire cgroup — affinity is **per-task**.
+
+Common uses:
+- **Cache locality**: Pin a task to CPUs sharing an L3 cache
+- **Interrupt binding**: Keep a task on the same CPU as the NIC interrupt it processes
+- **Benchmarking**: Eliminate CPU-to-CPU variation by pinning to one core
+- **Real-time**: Reserve cores for latency-sensitive tasks
+
+## The syscall
+
+```c
+// Restrict a task to specific CPUs
+int sched_setaffinity(pid_t pid, size_t cpusetsize, const cpu_set_t *mask);
+
+// Read a task's current affinity mask
+int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
+```
+
+From the command line:
+
+```bash
+# Run a command pinned to CPUs 0 and 1
+taskset -c 0,1 my_program
+
+# Pin an existing process
+taskset -cp 0,1 $PID
+
+# Show current affinity
+taskset -p $PID
+# → pid 1234's current affinity mask: f  (CPUs 0-3 on a 4-core system)
+```
+
+## Kernel implementation
+
+### The syscall path
+
+```c
+// kernel/sched/syscalls.c:1256
+SYSCALL_DEFINE3(sched_setaffinity, pid_t, pid, unsigned int, len,
+                unsigned long __user *, user_mask_ptr)
+{
+    cpumask_var_t new_mask;
+    get_user_cpu_mask(user_mask_ptr, len, new_mask);  // copy from userspace
+    return sched_setaffinity(pid, new_mask);
+}
+```
+
+`sched_setaffinity()` validates the mask, checks permissions, and calls `__sched_setaffinity()` which calls `set_cpus_allowed_ptr()`.
+
+### Affinity fields in task_struct
+
+```c
+// include/linux/sched.h
+struct task_struct {
+    // ...
+    int            nr_cpus_allowed;  // popcount of cpus_ptr
+    const cpumask_t *cpus_ptr;       // effective affinity (points to cpus_mask
+                                     // or a temporary mask during migration)
+    cpumask_t      *user_cpus_ptr;   // user-set affinity (NULL if not set)
+    cpumask_t       cpus_mask;       // storage for cpus_ptr (usually)
+    // ...
+};
+```
+
+- `cpus_ptr` is what the scheduler reads. It normally points to `cpus_mask`.
+- During temporary CPU restriction (e.g., migration helpers), `cpus_ptr` may point elsewhere.
+- `user_cpus_ptr` tracks the user's requested mask, separate from any cpuset-imposed restrictions.
+
+### Reading back affinity
+
+```c
+// kernel/sched/syscalls.c:1275
+long sched_getaffinity(pid_t pid, struct cpumask *mask)
+{
+    // ...
+    cpumask_and(mask, &p->cpus_mask, cpu_active_mask);
+    // Note: intersects with active CPUs, excluding offline/hotplugged-out CPUs
+}
+```
+
+The returned mask is always intersected with `cpu_active_mask` — offline CPUs are excluded even if they're in `cpus_mask`.
+
+## Affinity and cpuset intersection
+
+When a task is in a cpuset, the effective affinity is:
+
+```
+effective = user_affinity ∩ cpuset.effective_cpus
+```
+
+If you call `sched_setaffinity()` with a mask that includes CPUs outside the cpuset, those CPUs are silently excluded. The task cannot escape its cpuset through affinity.
+
+```bash
+# Example: task in a cpuset restricted to CPUs 4-7
+taskset -cp 0-7 $PID      # try to use all CPUs
+taskset -p $PID            # effective: only 4-7 (cpuset intersection)
+```
+
+The kernel stores both masks separately:
+- `user_cpus_ptr`: what the user asked for
+- `cpus_mask`: the intersection with cpuset (what's actually enforced)
+
+This separation lets the kernel recompute the effective mask if the cpuset changes, without losing the user's original intent.
+
+## Migration: what happens when affinity changes
+
+When `set_cpus_allowed_ptr()` is called:
+
+1. If the task's current CPU is still in the new mask → nothing changes immediately
+2. If the current CPU is excluded → the task is migrated to an allowed CPU
+3. Migration goes through `migration_cpu_stop()` — a stop-machine mechanism that runs on the target CPU to safely move the task
+
+```bash
+# Observe affinity-triggered migrations
+perf stat -e migrations ./my_program
+```
+
+## Kernel threads and affinity
+
+Kernel threads start with affinity set to all online CPUs (`cpu_all_mask`). You can restrict them:
+
+```bash
+# Pin kernel worker thread (e.g., kworker)
+taskset -cp 0 $(pgrep "kworker/0:1")
+```
+
+Some kernel threads explicitly set their own affinity (e.g., interrupt threads, per-CPU kthreads) and resist external changes. Check `/proc/PID/status` for `Cpus_allowed`.
+
+## NUMA-aware affinity
+
+On NUMA systems, pinning to specific CPUs also affects memory allocation:
+
+```bash
+# Pin to NUMA node 1's CPUs (assuming CPUs 4-7 are on node 1)
+taskset -c 4-7 ./my_program
+
+# Better: use numactl to set both CPU and memory affinity
+numactl --cpunodebind=1 --membind=1 ./my_program
+```
+
+`numactl` combines CPU affinity (`sched_setaffinity`) with NUMA memory policy (`set_mempolicy`). For NUMA-sensitive workloads, setting both is essential — pinning CPUs without pinning memory can still result in remote memory accesses.
+
+## Checking affinity in /proc
+
+```bash
+# CPU affinity as a hex bitmask
+cat /proc/$PID/status | grep Cpus_allowed
+# → Cpus_allowed: 000f  (CPUs 0-3)
+# → Cpus_allowed_list: 0-3  (human-readable)
+
+# For threads in a process
+for tid in /proc/$PID/task/*/; do
+    echo -n "TID $(basename $tid): "
+    cat ${tid}/status | grep Cpus_allowed_list
+done
+```
+
+## Affinity vs cpuset vs scheduling domains
+
+| Mechanism | Granularity | Scope | Hard limit? |
+|-----------|-------------|-------|-------------|
+| `sched_setaffinity` | Per-task | Selected CPUs | Yes — task never runs elsewhere |
+| cpuset | Per-cgroup | Group of CPUs | Yes — intersected with all tasks |
+| Sched domains | Global | Topology levels | No — affects load balancing preferences |
+| `nice`/priority | Per-task | CPU time share | No — just affects scheduling preference |
+
+## Further reading
+
+- [cpuset](cpuset.md) — Group-level CPU restriction; intersects with per-task affinity
+- [Scheduling Domains](sched-domains.md) — How load balancing respects topology
+- [CPU Bandwidth Control](cpu-bandwidth.md) — Hard CPU time limits via cgroup quota
+- [NUMA](../mm/numa.md) — Why NUMA node affinity matters alongside CPU affinity

--- a/docs/sched/cpu-bandwidth.md
+++ b/docs/sched/cpu-bandwidth.md
@@ -1,0 +1,232 @@
+# CPU Bandwidth Control
+
+> CFS bandwidth throttling: how the kernel enforces hard CPU limits
+
+## What bandwidth control does
+
+CPU weight (shares) controls the *proportion* of CPU a group gets when the system is busy. Bandwidth control caps the *absolute* amount — a group set to 50% will be throttled to 50% even if the other 99% of CPU is idle.
+
+This matters for:
+- **Predictable latency**: Ensure a group never monopolizes the CPU
+- **Multi-tenant isolation**: Prevent one tenant from starving others
+- **Resource accounting**: Know exactly how much CPU a container is using
+
+## How it's configured
+
+```bash
+# v2 interface (unified)
+# Format: "quota_us period_us" or "max period_us" for unlimited
+cat /sys/fs/cgroup/mygroup/cpu.max
+# 200000 100000  → 200ms every 100ms = 2 CPUs worth
+
+echo "50000 100000" > /sys/fs/cgroup/mygroup/cpu.max  # 50% of 1 CPU
+
+# v1 interface (separate files)
+echo 50000  > /sys/fs/cgroup/cpu/mygroup/cpu.cfs_quota_us
+echo 100000 > /sys/fs/cgroup/cpu/mygroup/cpu.cfs_period_us
+```
+
+The **bandwidth** is `quota / period`. For a quota of 200ms and period of 100ms, the group can use 2 CPUs concurrently (200% utilization). The quota is a wall-clock budget, not per-CPU.
+
+## The bandwidth pool: struct cfs_bandwidth
+
+Each cgroup has one global `cfs_bandwidth` pool:
+
+```c
+// kernel/sched/sched.h
+struct cfs_bandwidth {
+    raw_spinlock_t   lock;
+    ktime_t          period;          // e.g., 100ms
+    u64              quota;           // e.g., 50ms (in ns)
+    u64              runtime;         // remaining this period
+    u64              burst;           // burst allowance above quota
+
+    struct hrtimer   period_timer;    // refills runtime at period end
+    struct hrtimer   slack_timer;     // deferred unthrottle batching
+    struct list_head throttled_cfs_rq; // per-CPU rqs that are throttled
+
+    int nr_periods;
+    int nr_throttled;
+    u64 throttled_time;
+};
+```
+
+At the start of each period, `runtime` is reset to `quota`. As tasks run, `runtime` drains. When `runtime` hits zero, all CPUs running tasks from this group are throttled.
+
+## Distribution: pool → per-CPU slice
+
+Tasks don't drain the global pool directly. Instead, each CPU grabs a **slice** from the pool when needed:
+
+```c
+// kernel/sched/fair.c
+static u64 sched_cfs_bandwidth_slice(void)
+{
+    return (u64)sysctl_sched_cfs_bandwidth_slice * NSEC_PER_USEC;
+    // Default: 5ms (sysctl: /proc/sys/kernel/sched_cfs_bandwidth_slice_us)
+}
+```
+
+```mermaid
+flowchart LR
+    POOL["Global pool<br/>runtime = 50ms remaining"]
+    CPU0["CPU 0's cfs_rq<br/>local_runtime = 5ms"]
+    CPU1["CPU 1's cfs_rq<br/>local_runtime = 5ms"]
+    CPU2["CPU 2's cfs_rq<br/>exhausted → throttled"]
+
+    POOL -->|"assign 5ms slice"| CPU0
+    POOL -->|"assign 5ms slice"| CPU1
+    POOL -->|"pool empty"| CPU2
+```
+
+When a CPU's local runtime runs out, it calls `assign_cfs_rq_runtime()` to grab another slice. If the pool is empty, the CPU is throttled.
+
+### assign_cfs_rq_runtime()
+
+```c
+// kernel/sched/fair.c
+static void assign_cfs_rq_runtime(struct cfs_rq *cfs_rq)
+{
+    struct cfs_bandwidth *cfs_b = tg_cfs_bandwidth(cfs_rq->tg);
+
+    raw_spin_lock(&cfs_b->lock);
+    __assign_cfs_rq_runtime(cfs_b, cfs_rq, sched_cfs_bandwidth_slice());
+    raw_spin_unlock(&cfs_b->lock);
+}
+```
+
+## Throttling: throttle_cfs_rq()
+
+When a CPU's local runtime drains to zero and the global pool is empty:
+
+```c
+// kernel/sched/fair.c
+static bool throttle_cfs_rq(struct cfs_rq *cfs_rq)
+{
+    // Add to group's throttled list
+    list_add_tail_rcu(&cfs_rq->throttled_list,
+                      &cfs_b->throttled_cfs_rq);
+    cfs_rq->throttled = 1;
+
+    // Walk up the group scheduling hierarchy:
+    // dequeue the group's sched_entity from parent runqueues
+    // so tasks in this group can no longer be selected
+    walk_tg_tree_from(cfs_rq->tg, tg_throttle_down, ...);
+
+    return true;
+}
+```
+
+After throttling, the group's `sched_entity` is removed from the parent runqueue. `pick_next_task()` will never select a task from this group until it's unthrottled.
+
+## Refill: the period timer
+
+At the end of each period, `period_timer` fires and refills the pool:
+
+```c
+// kernel/sched/fair.c
+static void __refill_cfs_bandwidth_runtime(struct cfs_bandwidth *cfs_b)
+{
+    cfs_b->runtime += cfs_b->quota;
+
+    // Cap at quota + burst (prevent unbounded accumulation)
+    cfs_b->runtime = min(cfs_b->runtime, cfs_b->quota + cfs_b->burst);
+}
+```
+
+After refilling, `unthrottle_cfs_rq()` is called for each throttled CPU:
+
+```c
+// kernel/sched/fair.c
+static void unthrottle_cfs_rq(struct cfs_rq *cfs_rq)
+{
+    cfs_rq->throttled = 0;
+
+    // Re-enqueue the group's sched_entity
+    // back into parent runqueues
+    walk_tg_tree_from(cfs_rq->tg, tg_unthrottle_up, ...);
+
+    // Tasks can run again
+}
+```
+
+## Burst: absorbing transient spikes
+
+`cpu.max.burst` (v2) / `cpu.cfs_burst_us` (v1) allows a group to temporarily exceed its quota by consuming saved-up credit:
+
+```bash
+# Allow 20ms burst above the 50ms quota (max 70ms in a period)
+echo "50000 100000 20000" > /sys/fs/cgroup/mygroup/cpu.max.burst
+# v2 format: "quota period burst"
+```
+
+This helps workloads with bursty behavior (startup, GC pauses) avoid throttling while still maintaining average rate limits.
+
+## Slack timer: batching unthrottles
+
+Unthrottling each CPU individually as soon as runtime becomes available would cause many small lock acquisitions. The **slack timer** batches unthrottles:
+
+```c
+// When runtime is returned to the pool (e.g., task blocks before using its slice),
+// instead of unthrottling immediately, arm the slack timer for 5ms
+// and batch multiple unthrottles together.
+```
+
+This reduces lock contention on `cfs_b->lock` at the cost of up to 5ms extra throttle time.
+
+## Diagnosing throttling
+
+### Reading cpu.stat
+
+```bash
+cat /sys/fs/cgroup/mygroup/cpu.stat
+nr_periods      100    # bandwidth periods elapsed
+nr_throttled     23    # periods where group was throttled
+throttled_usec  450000 # total throttle time (450ms)
+nr_bursts         5    # periods where burst was used
+burst_usec      15000  # total burst time (15ms)
+```
+
+A high `nr_throttled / nr_periods` ratio (say, >10%) indicates the quota is too low for the workload.
+
+### Tracing bandwidth events
+
+```bash
+# Trace throttle/unthrottle events
+trace-cmd record -e sched:sched_stat_throttled \
+                 -e cgroup:cgroup_throttle_cfs_rq \
+                 sleep 10
+trace-cmd report
+```
+
+### Common causes of unexpected throttling
+
+**Multi-threaded workloads**: If a group has 4 threads all running simultaneously, they collectively consume 4x the per-thread rate. A quota of 100ms/100ms = 100% is only 1 CPU — 4 threads will consume it in 25ms and be throttled for 75ms.
+
+**Solution**: Set quota = `target_utilization × period × number_of_CPUs_you_want_to_use`.
+
+```bash
+# Allow 2 CPUs: 200ms quota / 100ms period = 2.0 CPUs
+echo "200000 100000" > /sys/fs/cgroup/mygroup/cpu.max
+```
+
+**Short-lived bursts**: Tasks that do heavy work for 50ms then sleep will hit throttling during the heavy phase. Burst budget can absorb this.
+
+## Bandwidth slice tuning
+
+The default 5ms slice is a trade-off between:
+- **Too small** (< 1ms): High lock contention on `cfs_b->lock`
+- **Too large** (> 10ms): CPU gets 10ms of budget it may never use; throttle response is slow
+
+```bash
+# Default: 5000 µs
+cat /proc/sys/kernel/sched_cfs_bandwidth_slice_us
+
+# For latency-sensitive workloads, reduce to 1ms:
+echo 1000 > /proc/sys/kernel/sched_cfs_bandwidth_slice_us
+```
+
+## Further reading
+
+- [CPU cgroup v1 vs v2](cpu-cgroup.md) — The cgroup interface for bandwidth and weight
+- [cpuset](cpuset.md) — Restrict which CPUs bandwidth is counted against
+- [CFS](cfs.md) — The fair scheduler that bandwidth control wraps around

--- a/docs/sched/cpu-cgroup.md
+++ b/docs/sched/cpu-cgroup.md
@@ -1,0 +1,225 @@
+# CPU cgroup: v1 vs v2
+
+> Controlling CPU allocation with cgroups — shares, weights, and bandwidth
+
+## What CPU cgroups control
+
+CPU cgroups give you two independent controls:
+
+1. **Weight** (proportional share): "This group gets 2x more CPU than that group when both are busy"
+2. **Bandwidth** (hard limit): "This group can use at most 50% of one CPU per period"
+
+These are orthogonal. A group with high weight still gets throttled if it hits its bandwidth limit.
+
+## The interface difference
+
+cgroup v1 and v2 expose the same underlying mechanisms with different interfaces:
+
+| Control | v1 file | v2 file | Default |
+|---------|---------|---------|---------|
+| Weight | `cpu.shares` | `cpu.weight` | 1024 / 100 |
+| Bandwidth quota | `cpu.cfs_quota_us` | `cpu.max` (first field) | -1 (unlimited) |
+| Bandwidth period | `cpu.cfs_period_us` | `cpu.max` (second field) | 100000 µs |
+| Stats | `cpuacct.stat` + `cpu.stat` | `cpu.stat` | — |
+
+### Weight: shares vs weight
+
+v1 `cpu.shares` and v2 `cpu.weight` differ in scale but map to the same kernel concept:
+
+```
+v2 weight = (v1 shares × 100) / 1024
+v1 shares = (v2 weight × 1024) / 100
+```
+
+- v1 default: **1024 shares**
+- v2 default: **100 weight** (range: 1–10000)
+
+Internally both set `task_group->shares` — the kernel always works in the v1 shares unit.
+
+```bash
+# v1: give group A twice the CPU of group B when both are busy
+echo 2048 > /sys/fs/cgroup/cpu/groupA/cpu.shares
+echo 1024 > /sys/fs/cgroup/cpu/groupB/cpu.shares
+
+# v2: same, using weight
+echo 200 > /sys/fs/cgroup/groupA/cpu.weight
+echo 100 > /sys/fs/cgroup/groupB/cpu.weight
+```
+
+### Bandwidth: quota/period vs cpu.max
+
+v1 exposes quota and period as separate files; v2 combines them:
+
+```bash
+# v1: limit to 50% of one CPU (50ms every 100ms)
+echo 50000  > /sys/fs/cgroup/cpu/mygroup/cpu.cfs_quota_us
+echo 100000 > /sys/fs/cgroup/cpu/mygroup/cpu.cfs_period_us
+
+# v2: same
+echo "50000 100000" > /sys/fs/cgroup/mygroup/cpu.max
+# format: "quota period"
+# "max 100000" means unlimited (default)
+```
+
+## The kernel structures
+
+### struct task_group
+
+Every cgroup maps to a `task_group` in the kernel:
+
+```c
+// kernel/sched/sched.h
+struct task_group {
+    struct cgroup_subsys_state css;
+
+    // One sched_entity and cfs_rq per CPU
+    struct sched_entity     **se;      // array[NR_CPUS]
+    struct cfs_rq           **cfs_rq;  // array[NR_CPUS]
+    unsigned long             shares;  // weight (cpu.shares value)
+
+    // RT group scheduling (CONFIG_RT_GROUP_SCHED)
+    struct sched_rt_entity  **rt_se;
+    struct rt_rq            **rt_rq;
+
+    struct task_group       *parent;
+
+    // CFS bandwidth (CONFIG_CFS_BANDWIDTH)
+    struct cfs_bandwidth      cfs_bandwidth;
+};
+```
+
+Each CPU has its own `sched_entity` representing the group in that CPU's CFS runqueue. This allows the group to be scheduled as a single unit relative to other groups and tasks on that CPU, then internally distribute time among its members.
+
+### struct cfs_bandwidth
+
+```c
+// kernel/sched/sched.h
+struct cfs_bandwidth {
+    raw_spinlock_t  lock;
+    ktime_t         period;         // bandwidth period
+    u64             quota;          // quota per period (ns)
+    u64             runtime;        // remaining runtime this period
+    u64             burst;          // allowed burst above quota
+    s64             hierarchical_quota;
+
+    struct hrtimer  period_timer;   // fires at period end to refill
+    struct hrtimer  slack_timer;    // deferred unthrottle
+    struct list_head throttled_cfs_rq; // throttled per-CPU runqueues
+
+    // Statistics
+    int             nr_periods;
+    int             nr_throttled;
+    u64             throttled_time;
+};
+```
+
+## How bandwidth throttling works
+
+```mermaid
+flowchart TB
+    A["Task runs on CPU"]
+    B["update_curr() decrements cfs_rq->runtime"]
+    C{Runtime exhausted?}
+    D["throttle_cfs_rq()<br/>Task can't run — dequeued"]
+    E["period_timer fires<br/>__refill_cfs_bandwidth_runtime()"]
+    F["unthrottle_cfs_rq()<br/>Runtime refilled — re-enqueue"]
+    G["Task resumes"]
+
+    A --> B --> C
+    C -->|No| A
+    C -->|Yes| D --> E --> F --> G --> A
+```
+
+### Distribution to CPUs
+
+The global `cfs_b->runtime` budget is distributed to individual CPUs in slices:
+
+```c
+// kernel/sched/fair.c
+static void assign_cfs_rq_runtime(struct cfs_rq *cfs_rq)
+{
+    // Request a slice from the global pool
+    __assign_cfs_rq_runtime(cfs_b, cfs_rq,
+                             sched_cfs_bandwidth_slice());
+    // Default slice: 5ms (sysctl_sched_cfs_bandwidth_slice)
+}
+```
+
+A CPU grabs a 5ms slice from the global pool. When the slice runs out, it requests another. If the global pool is exhausted (quota used up for this period), the CPU is throttled.
+
+### Viewing throttling stats
+
+```bash
+# Per-group bandwidth stats
+cat /sys/fs/cgroup/mygroup/cpu.stat
+# nr_periods         - how many bandwidth periods elapsed
+# nr_throttled       - how many periods were throttled
+# throttled_usec     - total time throttled (microseconds)
+# nr_bursts          - burst periods used
+# burst_usec         - total burst time
+
+# Detect throttling in real time
+watch -n 1 'cat /sys/fs/cgroup/mycontainer/cpu.stat | grep throttled'
+```
+
+## Group scheduling hierarchy
+
+With `CONFIG_FAIR_GROUP_SCHED`, CFS builds a two-level hierarchy:
+
+```
+Top-level CFS runqueue
+├── group A's sched_entity  (weight=2000)
+│   └── A's cfs_rq
+│       ├── task1 (weight=1024)
+│       └── task2 (weight=512)
+└── group B's sched_entity  (weight=1000)
+    └── B's cfs_rq
+        └── task3 (weight=1024)
+```
+
+Group A gets 2000/(2000+1000) = 67% of CPU. Within A, task1 gets 2/3 and task2 gets 1/3 of A's share.
+
+This nesting allows containers to have isolated CPU allocations while tasks within a container compete fairly among themselves.
+
+## v1 vs v2: key behavioral differences
+
+**Hierarchical bandwidth (v2 only)**: In v2, a child cgroup's effective quota is the minimum of its own quota and its ancestors' quotas. In v1, cgroup bandwidth is per-cgroup, not inherited.
+
+**Unified controller (v2)**: v2 uses a single unified hierarchy — you can't mount cpu and cpuacct separately. Both are always enabled together.
+
+**Weight range**: v1 shares: 2–262144. v2 weight: 1–10000. The effective range is the same proportionally.
+
+## Practical examples
+
+### Container CPU limits (v2)
+
+```bash
+# Create a cgroup for a container
+mkdir /sys/fs/cgroup/containers/mycontainer
+
+# Give it 2 CPUs worth of quota (200ms every 100ms)
+echo "200000 100000" > /sys/fs/cgroup/containers/mycontainer/cpu.max
+
+# Give it weight 200 (2x default)
+echo 200 > /sys/fs/cgroup/containers/mycontainer/cpu.weight
+
+# Add a process
+echo $PID > /sys/fs/cgroup/containers/mycontainer/cgroup.procs
+```
+
+### Detecting CPU throttling
+
+```bash
+# Check if your container is being throttled
+cat /sys/fs/cgroup/$(cat /proc/self/cgroup | grep cpu | cut -d: -f3)/cpu.stat | \
+    awk '/throttled/ {print $0}'
+
+# With cgroup v1
+cat /sys/fs/cgroup/cpu/$(cat /proc/self/cgroup | grep ^7 | cut -d: -f3)/cpu.stat
+```
+
+## Further reading
+
+- [CPU Bandwidth Control](cpu-bandwidth.md) — Deep dive into CFS bandwidth mechanics
+- [cpuset](cpuset.md) — Restricting which CPUs and NUMA nodes a cgroup can use
+- [Scheduler Classes](scheduler-classes.md) — How group scheduling fits into the class hierarchy

--- a/docs/sched/cpuset.md
+++ b/docs/sched/cpuset.md
@@ -1,0 +1,202 @@
+# cpuset: CPU and Memory Pinning
+
+> How cgroups restrict which CPUs and NUMA nodes tasks can use
+
+## What cpuset controls
+
+`cpuset` is a cgroup subsystem that restricts which CPUs and NUMA memory nodes a group of tasks can use. It operates independently from CPU bandwidth and weight:
+
+- **Bandwidth** (cpu.max): How much CPU time a group gets
+- **Weight** (cpu.weight/shares): How CPU time is divided between groups
+- **cpuset**: Which CPUs are even eligible — tasks never run on excluded CPUs
+
+This matters for:
+- **NUMA locality**: Pin tasks to CPUs close to their memory
+- **Core isolation**: Reserve specific cores for latency-sensitive workloads
+- **Hardware partitioning**: Assign CPUs to dedicated containers
+
+## Interface
+
+```bash
+# v2 (unified hierarchy)
+ls /sys/fs/cgroup/mygroup/
+# cpuset.cpus              - requested CPU list
+# cpuset.mems              - requested NUMA node list
+# cpuset.cpus.effective    - actual CPUs after intersection with parent
+# cpuset.mems.effective    - actual NUMA nodes after intersection with parent
+# cpuset.cpus.exclusive    - CPUs exclusively reserved for this cgroup
+# cpuset.cpus.partition    - partition root control (member/root/isolated)
+
+# Pin a cgroup to CPUs 0-3 and NUMA node 0
+echo "0-3" > /sys/fs/cgroup/mygroup/cpuset.cpus
+echo "0"   > /sys/fs/cgroup/mygroup/cpuset.mems
+
+# v1 (separate mount)
+echo "0-3" > /sys/fs/cgroup/cpuset/mygroup/cpus
+echo "0"   > /sys/fs/cgroup/cpuset/mygroup/mems
+```
+
+## struct cpuset
+
+Each cgroup maps to a `cpuset` in `kernel/cgroup/cpuset-internal.h`:
+
+```c
+// kernel/cgroup/cpuset-internal.h
+struct cpuset {
+    struct cgroup_subsys_state css;  // embedded cgroup state
+
+    unsigned long flags;             // CS_CPU_EXCLUSIVE, CS_MEM_EXCLUSIVE, etc.
+
+    // User-configured masks (written via control files)
+    cpumask_var_t cpus_allowed;
+    nodemask_t    mems_allowed;
+
+    // Effective masks (actual limits applied to tasks)
+    // effective = configured & parent's effective
+    cpumask_var_t effective_cpus;
+    nodemask_t    effective_mems;
+
+    // Exclusive CPUs (v2 partition support)
+    cpumask_var_t effective_xcpus;  // effective exclusive CPUs granted
+    cpumask_var_t exclusive_cpus;   // user-requested exclusive CPUs
+
+    int partition_root_state;       // PRS_MEMBER/ROOT/ISOLATED or negative = invalid
+    int nr_deadline_tasks;          // SCHED_DEADLINE tasks in this cpuset
+
+    // ...
+};
+```
+
+### Flags
+
+```c
+typedef enum {
+    CS_CPU_EXCLUSIVE,      // No sibling cgroup can overlap these CPUs
+    CS_MEM_EXCLUSIVE,      // No sibling cgroup can overlap these NUMA nodes
+    CS_MEM_HARDWALL,       // User allocations cannot use other nodes (even as fallback)
+    CS_MEMORY_MIGRATE,     // Migrate pages when mems_allowed changes
+    CS_SCHED_LOAD_BALANCE, // Enable load balancing across cpuset CPUs
+    CS_SPREAD_PAGE,        // Spread page cache across all allowed nodes
+    CS_SPREAD_SLAB,        // Spread slab cache across all allowed nodes
+} cpuset_flagbits_t;
+```
+
+## Effective masks: intersection with parent
+
+The key cpuset invariant: a child's **effective_cpus** can only be a subset of its parent's **effective_cpus**. If you write a CPU list that includes CPUs not in the parent's effective set, those CPUs are silently excluded.
+
+```
+root cpuset: effective_cpus = {0,1,2,3,4,5,6,7}
+    └── mygroup: cpus_allowed = {4,5,6,7,8,9}
+                 effective_cpus = {4,5,6,7}  ← intersection with parent
+```
+
+```c
+// kernel/cgroup/cpuset.c (simplified)
+static void cpuset_cpus_allowed(struct task_struct *p, struct cpumask *pmask)
+{
+    struct cpuset *cs = task_cs(p);
+    // Walk up the hierarchy until we find a non-empty intersection
+    while (!cpumask_intersects(cs->effective_cpus, pmask))
+        cs = parent_cs(cs);
+    cpumask_and(pmask, pmask, cs->effective_cpus);
+}
+```
+
+## How tasks are constrained
+
+When a task is added to a cgroup (`cgroup.procs`), or when the cpuset's effective_cpus changes, the kernel updates the task's affinity:
+
+1. `cpuset_change_task_nodemask()` — updates NUMA node policy
+2. `set_cpus_allowed_ptr()` — restricts the task to `effective_cpus`
+3. If the task is currently running on an excluded CPU, it gets migrated
+
+Tasks in a cpuset can still set their own affinity (via `sched_setaffinity()`), but the result is always **intersected** with the cpuset's effective_cpus. You can't escape the cpuset through affinity.
+
+## Partition roots (v2)
+
+v2 cpusets support **partition roots** — a mechanism to carve CPUs out of the parent's scheduling domain entirely:
+
+```bash
+# Create a partition: take CPUs 4-7 exclusively
+echo "4-7" > /sys/fs/cgroup/mygroup/cpuset.cpus
+echo "root" > /sys/fs/cgroup/mygroup/cpuset.cpus.partition
+# CPUs 4-7 are now removed from the parent's scheduling domain
+# and form an isolated domain for mygroup
+
+# Isolated partition: no load balancing within the partition either
+echo "isolated" > /sys/fs/cgroup/mygroup/cpuset.cpus.partition
+```
+
+Partition states:
+- `member` (default): Normal cpuset, shares parent's scheduling domain
+- `root`: Carves out CPUs into a dedicated scheduling domain
+- `isolated`: Like root, but also disables load balancing within the partition
+
+## cpuset and scheduler domains
+
+When a partition root is created or CPUs are assigned exclusively, the kernel **rebuilds the scheduling domains**:
+
+```c
+// kernel/cgroup/cpuset.c
+// After effective_cpus changes:
+rebuild_sched_domains();  // or rebuild_sched_domains_locked()
+```
+
+This is expensive — each rebuild tears down and reconstructs per-CPU scheduler domain hierarchies. Avoid frequent cpuset CPU changes in production.
+
+## NUMA: mems_allowed
+
+`effective_mems` controls which NUMA nodes memory allocations can use:
+
+```bash
+# Restrict to node 0 only
+echo "0" > /sys/fs/cgroup/mygroup/cpuset.mems
+
+# Allow nodes 0 and 1
+echo "0-1" > /sys/fs/cgroup/mygroup/cpuset.mems
+```
+
+With `CS_MEM_HARDWALL` set, tasks cannot fall back to other nodes even if their allowed nodes are full. Without it, the kernel may allocate from other nodes under memory pressure.
+
+With `CS_MEMORY_MIGRATE` set, existing pages are migrated to the new node set when `mems_allowed` changes.
+
+## Diagnosing cpuset constraints
+
+```bash
+# See a task's cpuset
+cat /proc/$PID/cpuset
+# → /mygroup/container1
+
+# Effective CPUs for a cgroup
+cat /sys/fs/cgroup/mygroup/cpuset.cpus.effective
+
+# Check if a task's affinity is being constrained by cpuset
+taskset -p $PID  # shows the intersection of user affinity and cpuset
+
+# Monitor cpuset events (cpu hotplug, partition changes)
+cat /sys/kernel/debug/tracing/events/cpuset/
+```
+
+```bash
+# Common mistake: writing CPUs not in parent's effective set
+echo "0-7" > /sys/fs/cgroup/nested/cpuset.cpus
+cat /sys/fs/cgroup/nested/cpuset.cpus.effective
+# → 0-3   (silently clamped to parent's range)
+```
+
+## cpuset vs sched_setaffinity
+
+| Mechanism | Who controls | Scope | Inheritable |
+|-----------|-------------|-------|-------------|
+| cpuset | cgroup admin | All tasks in cgroup | Yes — children inherit |
+| sched_setaffinity | Process (CAP_SYS_NICE for others) | One task | No |
+
+The effective affinity is always `user_affinity ∩ cpuset.effective_cpus`. If either restricts a CPU, the task cannot run there.
+
+## Further reading
+
+- [CPU cgroup: v1 vs v2](cpu-cgroup.md) — CPU bandwidth and weight controls
+- [Scheduling Domains](sched-domains.md) — How cpuset partition roots affect load balancing
+- [CPU Affinity](cpu-affinity.md) — Per-task CPU restrictions via sched_setaffinity
+- [NUMA](../mm/numa.md) — Why NUMA node pinning matters for performance

--- a/docs/sched/sched-domains.md
+++ b/docs/sched/sched-domains.md
@@ -1,0 +1,211 @@
+# Scheduling Domains
+
+> How the kernel organizes CPUs into a hierarchy for load balancing
+
+## What scheduling domains are
+
+The Linux scheduler doesn't just balance load between individual CPUs — it uses a hierarchical topology that reflects the hardware: SMT siblings, CPU cores, NUMA sockets. This hierarchy is called the **scheduling domain tree**.
+
+Each level in the tree is a `sched_domain` spanning a set of CPUs. When load balancing runs, it works domain by domain, from narrowest (SMT) to widest (NUMA), respecting topology boundaries.
+
+This matters because:
+- Moving a task between SMT siblings is cheap (shared L1/L2 cache)
+- Moving between NUMA sockets is expensive (remote memory access)
+- The scheduler should balance aggressively at the cheap levels and conservatively at the expensive ones
+
+## struct sched_domain
+
+```c
+// include/linux/sched/topology.h
+struct sched_domain {
+    struct sched_domain __rcu *parent;   // broader domain (e.g., NUMA above MC)
+    struct sched_domain __rcu *child;    // narrower domain (e.g., SMT below MC)
+    struct sched_group *groups;          // circular list of sched_groups in this domain
+
+    unsigned long min_interval;          // minimum balance interval (ms)
+    unsigned long max_interval;          // maximum balance interval (ms)
+    unsigned int  imbalance_pct;         // tolerate up to X% imbalance before balancing
+    unsigned int  cache_nice_tries;      // leave hot tasks alone for this many tries
+
+    int flags;                           // SD_* flags controlling balance behavior
+    int level;                           // 0=SMT, 1=MC, 2=PKG, 3=NUMA, ...
+
+    unsigned long last_balance;          // last time balance ran (jiffies)
+    unsigned int  balance_interval;      // current adaptive interval
+
+    // per-CPU pointer (accessed via rcu)
+    // ...
+};
+```
+
+### SD_* flags
+
+Flags control what load balancing is enabled at each domain level:
+
+```c
+// include/linux/sched/sd_flags.h
+SD_LOAD_BALANCE     // Enable load balancing at this level
+SD_BALANCE_NEWIDLE  // Balance when a CPU goes idle
+SD_BALANCE_EXEC     // Balance when exec() is called (new task)
+SD_BALANCE_FORK     // Balance when fork() creates a task
+SD_WAKE_AFFINE      // Keep recently woken tasks on wake-up CPU
+SD_ASYM_CPUCAPACITY // Domain spans CPUs of different capacity (big.LITTLE)
+SD_SHARE_PKG_RESOURCES  // CPUs share last-level cache
+SD_NUMA             // Domain crosses NUMA node boundary
+SD_OVERLAP          // Domain can overlap with siblings (NUMA)
+```
+
+## The topology hierarchy
+
+The default topology levels (from narrowest to broadest):
+
+```
+NUMA (node 0)  ←────────────────────────────┐
+│                                           │
+└── PKG (socket 0)       PKG (socket 1) ───┘
+    │                    │
+    └── MC (core 0-3)    └── MC (core 4-7)
+        │
+        └── SMT (core 0: cpu0, cpu1)
+```
+
+Per-CPU pointers give quick access to specific levels:
+
+```c
+// kernel/sched/topology.c
+DEFINE_PER_CPU(struct sched_domain __rcu *, sd_llc);      // Last Level Cache domain
+DEFINE_PER_CPU(struct sched_domain_shared __rcu *, sd_llc_shared);
+DEFINE_PER_CPU(struct sched_domain __rcu *, sd_numa);     // NUMA domain
+DEFINE_PER_CPU(struct sched_domain __rcu *, sd_asym_packing);
+DEFINE_PER_CPU(struct sched_domain __rcu *, sd_asym_cpucapacity);
+```
+
+### struct sched_domain_topology_level
+
+Architecture code defines topology by providing a list of levels:
+
+```c
+// kernel/sched/topology.c
+static struct sched_domain_topology_level default_topology[] = {
+#ifdef CONFIG_SCHED_SMT
+    SDTL_INIT(tl_smt_mask, cpu_smt_flags, SMT),   // Hyperthreading siblings
+#endif
+#ifdef CONFIG_SCHED_CLUSTER
+    SDTL_INIT(tl_cls_mask, cpu_cluster_flags, CLS), // CPU cluster (e.g., ARM DSU)
+#endif
+#ifdef CONFIG_SCHED_MC
+    SDTL_INIT(tl_mc_mask, cpu_core_flags, MC),     // Cores sharing L2/L3
+#endif
+    SDTL_INIT(tl_pkg_mask, NULL, PKG),             // Physical socket/package
+    { NULL, },
+};
+```
+
+NUMA levels are added on top by `sched_init_numa()` based on ACPI SRAT data.
+
+## Building domains: build_sched_domains()
+
+When topology changes (boot, CPU hotplug, cpuset partition), the kernel rebuilds the domain tree:
+
+```c
+// kernel/sched/topology.c
+static int build_sched_domains(const struct cpumask *cpu_map,
+                                struct sched_domain_attr *attr)
+{
+    // For each CPU in cpu_map:
+    //   for each topology level:
+    //     sd_init() — allocate and initialize a sched_domain
+    //     connect parent/child pointers
+    //     assign to per-CPU sd pointer
+    // Then:
+    //   build_sched_groups() — connect CPUs into sched_groups per domain
+    //   cpu_attach_domain() — install new domains (RCU-swap old ones)
+}
+```
+
+This is called via `rebuild_sched_domains()`, which is triggered by:
+- `sched_domain_sysctl` changes
+- CPU hotplug events
+- cpuset partition root changes
+
+## Load balancing: sched_balance_rq()
+
+Load balancing happens in `sched_balance_rq()` (previously `load_balance()`), called periodically by the scheduler tick and when a CPU goes idle:
+
+```
+Idle CPU → sched_balance_rq()
+    Walk from narrowest domain to broadest:
+    ├── SMT domain: too few tasks? steal from sibling HT
+    ├── MC domain: unbalanced across cores? pull tasks
+    ├── PKG domain: cross-socket imbalance? migrate tasks
+    └── NUMA domain: large imbalance across nodes? migrate
+```
+
+Key principle: **start at the narrowest domain first**. If there's enough work within the MC domain, don't cross the PKG boundary. NUMA migrations are last resort.
+
+### Idle load balancing
+
+When a CPU runs out of work, it enters `newidle_balance()`:
+
+```c
+// kernel/sched/fair.c
+static int newidle_balance(struct rq *this_rq, struct rq_flags *rf)
+{
+    // Walk domains from narrowest outward
+    for_each_domain(this_cpu, sd) {
+        if (!(sd->flags & SD_BALANCE_NEWIDLE))
+            continue;
+
+        pulled_tasks = sched_balance_rq(this_rq, rf, sd,
+                                         CPU_NEWLY_IDLE, &continue_balancing);
+        if (pulled_tasks)
+            break;  // Found work at this level, stop
+    }
+}
+```
+
+### Periodic balancing
+
+The scheduler tick triggers `sched_balance_softirq()` every `balance_interval` jiffies. The interval adapts: if recent balancing found no imbalance, `balance_interval` doubles (up to `max_interval`) to reduce overhead. When imbalance is found, it resets to `min_interval`.
+
+## Viewing domain topology
+
+```bash
+# /proc/schedstat shows per-domain statistics (requires CONFIG_SCHEDSTATS)
+cat /proc/schedstat
+
+# sched_debug shows the full domain tree
+cat /proc/sched_debug | grep -A 20 "domain"
+
+# Per-CPU domain info
+cat /sys/kernel/debug/sched/domains/cpu0/domain0/name   # "MC"
+cat /sys/kernel/debug/sched/domains/cpu0/domain0/flags
+cat /sys/kernel/debug/sched/domains/cpu0/domain1/name   # "PKG"
+```
+
+## Domain isolation with cpuset
+
+cpuset partition roots **break** the scheduling domain tree. When you create a partition root with CPUs 4-7:
+
+1. Those CPUs are removed from the parent's domain
+2. `rebuild_sched_domains()` is called
+3. A new isolated domain tree is built for CPUs 4-7
+4. Load balancing no longer crosses the partition boundary
+
+This is how container runtimes pin VMs or containers to exclusive CPU sets with no interference from the host scheduler.
+
+## Asymmetric CPU capacity (big.LITTLE)
+
+On ARM systems with heterogeneous CPUs (Cortex-A55 + Cortex-A78), the `SD_ASYM_CPUCAPACITY` flag marks domains spanning CPUs of different compute capacity. The scheduler tracks CPU capacity via `cpu_capacity` and uses Energy Aware Scheduling (EAS) to prefer placing tasks on appropriately-sized CPUs.
+
+```bash
+# View per-CPU capacity (normalized, 1024 = maximum)
+cat /sys/devices/system/cpu/cpu*/cpu_capacity
+```
+
+## Further reading
+
+- [cpuset](cpuset.md) — How cpuset partition roots interact with sched domains
+- [CPU Affinity](cpu-affinity.md) — Per-task affinity and its relationship to domains
+- [CFS](cfs.md) — The fair scheduler that load balancing serves
+- [NUMA](../mm/numa.md) — Why cross-node migrations are expensive

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,3 +184,9 @@ nav:
       - RT Scheduler: sched/rt-scheduler.md
       - SCHED_DEADLINE: sched/deadline.md
       - Priority Inversion & PI Mutexes: sched/pi-mutexes.md
+    - Resource Control & Topology:
+      - CPU cgroup (v1 vs v2): sched/cpu-cgroup.md
+      - CPU Bandwidth Control: sched/cpu-bandwidth.md
+      - cpuset: sched/cpuset.md
+      - Scheduling Domains: sched/sched-domains.md
+      - CPU Affinity: sched/cpu-affinity.md


### PR DESCRIPTION
Batch 4 of the scheduler documentation series. Closes #96, #97, #98, #99, #100.

## Pages added

- **CPU cgroup (v1 vs v2)** — cpu.shares vs cpu.weight conversion, struct task_group, bandwidth throttling flowchart, v1 vs v2 behavioral differences
- **CPU Bandwidth Control** — CFS bandwidth pool, 5ms per-CPU slice distribution, throttle_cfs_rq/unthrottle mechanics, burst config, slack timer, cpu.stat diagnostics
- **cpuset** — struct cpuset fields, effective_cpus intersection with parent, partition roots (member/root/isolated), NUMA mems_allowed, cpuset vs sched_setaffinity comparison table
- **Scheduling Domains** — struct sched_domain, SD_* flags, default topology levels (SMT/CLS/MC/PKG/NUMA), build_sched_domains(), idle and periodic load balancing, cpuset partition isolation
- **CPU Affinity** — sched_setaffinity syscall path, cpus_ptr/user_cpus_ptr/cpus_mask in task_struct, cpuset intersection semantics, migration on affinity change, NUMA-aware pinning

## Depends on
PR #225 (add-sched-realtime)