### PR TITLE
Add scheduler debugging & observability docs

### DIFF
--- a/docs/sched/sched-tracing.md
+++ b/docs/sched/sched-tracing.md
@@ -1,0 +1,235 @@
+# Scheduler Tracing
+
+> ftrace, perf, and BPF tools for observing scheduler behavior in real time
+
+## Scheduler trace events
+
+The kernel emits scheduler events through the tracepoint system (ftrace). These are defined in `include/trace/events/sched.h` and cover every significant scheduling decision.
+
+Key events:
+
+| Event | When it fires |
+|-------|---------------|
+| `sched:sched_switch` | Every context switch |
+| `sched:sched_wakeup` | Task transitions from sleeping to runnable |
+| `sched:sched_wakeup_new` | Newly created task becomes runnable |
+| `sched:sched_waking` | Task wakeup starts (before it's on a runqueue) |
+| `sched:sched_migrate_task` | Task moves between CPUs |
+| `sched:sched_process_fork` | fork() |
+| `sched:sched_process_exec` | exec() |
+| `sched:sched_process_exit` | Task exits |
+| `sched:sched_stat_sleep` | Task woke from voluntary sleep (CONFIG_SCHEDSTATS) |
+| `sched:sched_stat_wait` | Time spent waiting on runqueue (CONFIG_SCHEDSTATS) |
+| `sched:sched_stat_iowait` | Time spent in I/O wait (CONFIG_SCHEDSTATS) |
+
+## sched_switch: the most important event
+
+```c
+// include/trace/events/sched.h
+TRACE_EVENT(sched_switch,
+    TP_PROTO(bool preempt,
+             struct task_struct *prev,
+             struct task_struct *next,
+             unsigned int prev_state),
+    // Fields:
+    // prev_comm, prev_pid, prev_prio, prev_state
+    // next_comm, next_pid, next_prio
+    //
+    // prev_state uses TASK_REPORT flags:
+    //   R = running/runnable (preempted)
+    //   S = interruptible sleep
+    //   D = uninterruptible sleep (I/O)
+    //   T = stopped
+    //   Z = zombie
+);
+```
+
+A `prev_state=R` means the task was preempted (involuntary switch). `prev_state=S` means it voluntarily gave up the CPU.
+
+## Recording with ftrace
+
+```bash
+# Enable specific events and record for 5 seconds
+trace-cmd record -e sched:sched_switch \
+                 -e sched:sched_wakeup \
+                 -e sched:sched_migrate_task \
+                 sleep 5
+
+# View the recording
+trace-cmd report | head -50
+
+# Filter by PID
+trace-cmd record -e sched:sched_switch \
+                 --filter 'next_pid == 1234 || prev_pid == 1234' \
+                 sleep 5
+```
+
+### Direct ftrace interface
+
+```bash
+# Enable events via debugfs
+echo 1 > /sys/kernel/debug/tracing/events/sched/sched_switch/enable
+echo 1 > /sys/kernel/debug/tracing/events/sched/sched_wakeup/enable
+
+# Read the ring buffer
+cat /sys/kernel/debug/tracing/trace
+
+# Or stream it
+cat /sys/kernel/debug/tracing/trace_pipe &
+
+# Filter by comm (task name)
+echo 'next_comm == "myapp"' > \
+    /sys/kernel/debug/tracing/events/sched/sched_switch/filter
+
+# Clean up
+echo 0 > /sys/kernel/debug/tracing/events/sched/sched_switch/enable
+echo > /sys/kernel/debug/tracing/trace
+```
+
+## perf sched: high-level scheduling analysis
+
+`perf sched` records scheduling activity and produces latency reports:
+
+```bash
+# Record scheduling events for 10 seconds
+perf sched record -- sleep 10
+
+# Show latency report: per-task scheduling delay
+perf sched latency
+# Task                  |   Runtime ms  | Switches | Average delay ms | Maximum delay ms
+# myapp:(2)             |     4500.123  |     1042  |          0.234   |         12.456
+# kworker/0:1           |      123.456  |      567  |          0.012   |          0.234
+
+# Replay the recording to see exact scheduling order
+perf sched replay
+
+# Show all scheduling events in order
+perf sched script | head -20
+```
+
+### perf sched latency
+
+High "Maximum delay" for a task means it was occasionally stuck waiting for the CPU for a long time. Common causes:
+- CPU temporarily saturated
+- Lock contention in the scheduler (rare)
+- NUMA migration overhead
+- RT task monopolizing the CPU
+
+```bash
+# Show tasks with highest maximum latency
+perf sched latency --sort max
+```
+
+## perf stat for scheduling counters
+
+```bash
+# Count context switches and migrations
+perf stat -e context-switches,cpu-migrations ./workload
+
+# Count scheduler events system-wide
+perf stat -e sched:sched_switch,sched:sched_wakeup,sched:sched_migrate_task \
+          -a sleep 10
+
+# Compare voluntary vs involuntary switches (requires cs breakdowns)
+perf stat -e sched:sched_switch -a sleep 5
+```
+
+## BPF tracing with bpftrace
+
+```bash
+# Trace context switches: show who switched to whom
+bpftrace -e '
+tracepoint:sched:sched_switch {
+    printf("%s -> %s\n", args->prev_comm, args->next_comm);
+}'
+
+# Show tasks with the longest scheduler wait time (time in runqueue)
+bpftrace -e '
+tracepoint:sched:sched_wakeup { @start[args->pid] = nsecs; }
+tracepoint:sched:sched_switch {
+    if (@start[args->next_pid]) {
+        @wait_ns[args->next_comm] = hist(nsecs - @start[args->next_pid]);
+        delete(@start[args->next_pid]);
+    }
+}'
+
+# Count migrations per task
+bpftrace -e '
+tracepoint:sched:sched_migrate_task {
+    @[args->comm] = count();
+}'
+```
+
+## Wakeup latency: runqlat (BCC)
+
+`runqlat` (from the BCC toolkit) measures how long tasks wait in the runqueue before running:
+
+```bash
+# Show runqueue latency histogram system-wide
+runqlat
+
+# Per-PID histogram
+runqlat -p $PID
+
+# Example output:
+# usecs               : count     distribution
+# 0 -> 1              : 12345     |********************|
+# 2 -> 3              : 4567      |*******             |
+# 4 -> 7              : 234       |                    |
+# 8 -> 15             : 89        |                    |
+# 16 -> 31            : 45        |                    |
+# 32 -> 63            : 12        |                    |  ← latency spikes here
+```
+
+`runqlen` shows the distribution of runqueue lengths:
+
+```bash
+runqlen  # shows how many tasks are typically in the runqueue
+```
+
+## Wakeup tracing with ftrace function graph
+
+To trace the full wakeup path including kernel functions:
+
+```bash
+# Trace the wakeup path for a specific PID
+echo function_graph > /sys/kernel/debug/tracing/current_tracer
+echo $PID > /sys/kernel/debug/tracing/set_graph_function
+echo 1 > /sys/kernel/debug/tracing/tracing_on
+# ... run workload ...
+cat /sys/kernel/debug/tracing/trace > /tmp/wakeup_trace.txt
+echo 0 > /sys/kernel/debug/tracing/tracing_on
+echo nop > /sys/kernel/debug/tracing/current_tracer
+```
+
+Or use the built-in wakeup tracers:
+
+```bash
+# Trace latency from wakeup to first run (worst case)
+echo wakeup > /sys/kernel/debug/tracing/current_tracer
+# Finds the maximum wakeup latency in microseconds
+cat /sys/kernel/debug/tracing/tracing_max_latency
+```
+
+## Reading sched_switch output
+
+A typical `trace-cmd report` line:
+
+```
+myapp-1234 [002] 12345.678901: sched_switch: prev_comm=myapp prev_pid=1234
+    prev_prio=120 prev_state=S ==> next_comm=kworker/2:1 next_pid=5678 next_prio=120
+```
+
+Interpretation:
+- `myapp` (pid 1234) on CPU 2 switched to sleep (`prev_state=S`)
+- `kworker/2:1` (pid 5678) is now running on CPU 2
+- Both at priority 120 (nice 0)
+
+If `prev_state=R`, myapp was preempted — it wanted to keep running but something higher priority took over.
+
+## Further reading
+
+- [Scheduler Statistics](schedstat.md) — Cumulative per-task stats in /proc
+- [Scheduler Tuning](sched-tuning.md) — Knobs that affect the behavior you're observing
+- [Context Switch](context-switch.md) — What the kernel does on each sched_switch event
+- [Wakeup](wakeup.md) — The full wakeup path from hardware interrupt to task running

--- a/docs/sched/sched-tuning.md
+++ b/docs/sched/sched-tuning.md
@@ -1,0 +1,208 @@
+# Scheduler Tuning
+
+> sysctl knobs, SCHED_FEAT flags, and common tuning patterns
+
+## Scheduler sysctls
+
+All scheduler tuning knobs live under `/proc/sys/kernel/`:
+
+```bash
+ls /proc/sys/kernel/sched_*
+```
+
+### Core timing knobs
+
+```bash
+# Minimum scheduling granularity (ns)
+# Tasks run for at least this long before being preempted
+# Default: 750000 (750µs), scales with CPU count
+cat /proc/sys/kernel/sched_min_granularity_ns
+
+# Base scheduling slice (ns) — the target time per task per period
+# EEVDF uses this as the default slice per task
+# Default: 700000 (700µs)
+cat /proc/sys/kernel/sched_base_slice_ns
+
+# Wakeup preemption granularity (ns)
+# A waking task must be this much more "urgent" to preempt the current task
+# Default: 1000000 (1ms)
+cat /proc/sys/kernel/sched_wakeup_granularity_ns
+```
+
+The relationship: `sched_latency_ns ≥ nr_runnable × sched_min_granularity_ns` ensures each runnable task gets at least one slice per latency period.
+
+### Migration and balancing
+
+```bash
+# Task migration cost (ns)
+# If a task ran on its current CPU within this window, it's "cache hot"
+# and the load balancer avoids migrating it
+# Default: 500000 (500µs)
+cat /proc/sys/kernel/sched_migration_cost_ns
+
+# Max tasks to migrate in one load balance call
+# Default: 32
+cat /proc/sys/kernel/sched_nr_migrate
+
+# CFS bandwidth slice (µs)
+# Amount of quota a CPU grabs from the global bandwidth pool at once
+# Default: 5000 (5ms)
+cat /proc/sys/kernel/sched_cfs_bandwidth_slice_us
+```
+
+### RT throttling
+
+```bash
+# RT task period (µs): how often RT tasks' quota is refreshed
+# Default: 1000000 (1 second)
+cat /proc/sys/kernel/sched_rt_period_us
+
+# RT task runtime (µs): how much of the period RT tasks can consume
+# Default: 950000 (950ms = 95% of period)
+# -1 = unlimited (disables RT throttling — dangerous)
+cat /proc/sys/kernel/sched_rt_runtime_us
+```
+
+### Schedstat
+
+```bash
+# Enable per-task scheduling statistics (slight overhead)
+# Default: 0 (disabled)
+echo 1 > /proc/sys/kernel/sched_schedstats
+```
+
+## SCHED_FEAT: compile-time feature toggles
+
+`SCHED_FEAT` flags are booleans controlling specific scheduler behaviors. In a kernel with `CONFIG_SCHED_DEBUG`, they can be toggled at runtime:
+
+```bash
+# View all features and their current state
+cat /sys/kernel/debug/sched/features
+# PLACE_LAG PLACE_DEADLINE_INITIAL PLACE_REL_DEADLINE RUN_TO_PARITY
+# PREEMPT_SHORT PICK_BUDDY CACHE_HOT_BUDDY DELAY_DEQUEUE DELAY_ZERO
+# WAKEUP_PREEMPTION ...
+
+# Toggle a feature
+echo NO_WAKEUP_PREEMPTION > /sys/kernel/debug/sched/features  # disable
+echo WAKEUP_PREEMPTION > /sys/kernel/debug/sched/features      # enable
+```
+
+Key features:
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `WAKEUP_PREEMPTION` | on | Waking task can preempt the current task if it has an earlier deadline |
+| `PLACE_LAG` | on | Adjust woken task's vruntime based on its lag (how much CPU it's owed) |
+| `PLACE_DEADLINE_INITIAL` | on | Give newly enqueued tasks an initial deadline advantage |
+| `CACHE_HOT_BUDDY` | on | Don't preempt a cache-hot task just because it's been running |
+| `NEXT_BUDDY` | off | After preemption, try to run the task that just woke up |
+| `HRTICK` | off | Use high-resolution timers for scheduling (lower overhead than hrtimer for most workloads) |
+| `TTWU_QUEUE` | arch | Queue cross-CPU wakeups (reduces IPI storms) |
+| `RT_RUNTIME_SHARE` | off | Allow RT tasks to borrow runtime from sibling CPUs |
+| `LATENCY_WARN` | off | Warn when a task exceeds sysctl_sched_latency_warn_ms |
+
+## Common tuning scenarios
+
+### Latency-sensitive workloads (network, trading, audio)
+
+```bash
+# Reduce minimum granularity: tasks get smaller slices, lower max latency
+echo 500000 > /proc/sys/kernel/sched_min_granularity_ns     # 500µs (default 750µs)
+echo 700000 > /proc/sys/kernel/sched_base_slice_ns           # keep at default
+
+# Reduce wakeup granularity: waking tasks preempt more aggressively
+echo 500000 > /proc/sys/kernel/sched_wakeup_granularity_ns  # 500µs (default 1ms)
+
+# Reduce migration cost: allow more migration (less cache-hot protection)
+echo 250000 > /proc/sys/kernel/sched_migration_cost_ns      # 250µs (default 500µs)
+```
+
+### Throughput-oriented workloads (batch processing, HPC)
+
+```bash
+# Increase minimum granularity: tasks run longer before preemption
+echo 4000000 > /proc/sys/kernel/sched_min_granularity_ns   # 4ms
+
+# Increase migration cost: keep tasks cache-hot, fewer migrations
+echo 5000000 > /proc/sys/kernel/sched_migration_cost_ns    # 5ms
+
+# Allow more tasks to migrate per balance call
+echo 64 > /proc/sys/kernel/sched_nr_migrate
+```
+
+### Real-time workloads (SCHED_FIFO/RR tasks)
+
+```bash
+# Ensure RT tasks get priority over CFS (default: 95%)
+cat /proc/sys/kernel/sched_rt_runtime_us  # should be 950000
+
+# For isolated RT cores (combined with cpuset isolation):
+# Disable RT throttling on dedicated cores — RT tasks need guaranteed time
+# WARNING: only safe if RT tasks are well-behaved and CPU is fully dedicated
+echo -1 > /proc/sys/kernel/sched_rt_runtime_us  # disable throttling globally
+
+# Better: use per-cgroup RT limit
+echo "950000 1000000" > /sys/fs/cgroup/rt_group/cpu.rt_runtime_us
+```
+
+### Container/cgroup isolation
+
+```bash
+# Give a container 2 CPUs (200ms quota / 100ms period)
+echo "200000 100000" > /sys/fs/cgroup/containers/myapp/cpu.max
+
+# Reduce bandwidth slice for tighter throttle response (at cost of more lock contention)
+echo 1000 > /proc/sys/kernel/sched_cfs_bandwidth_slice_us  # 1ms (default 5ms)
+```
+
+## CPU isolation for RT/low-latency
+
+For truly latency-sensitive tasks, isolate CPUs from the kernel scheduler entirely:
+
+```bash
+# Boot parameter: remove CPUs 4-7 from general scheduling
+# Add to /etc/default/grub: GRUB_CMDLINE_LINUX="isolcpus=4-7 nohz_full=4-7 rcu_nocbs=4-7"
+
+# At runtime: pin tasks to isolated CPUs
+taskset -c 4 ./latency_sensitive_app
+
+# Check isolation status
+cat /sys/devices/system/cpu/isolated  # → 4-7
+cat /sys/devices/system/cpu/nohz_full # → 4-7
+```
+
+`isolcpus` removes CPUs from the load balancer. `nohz_full` disables the scheduler tick on those CPUs (tasks run without periodic interruption). `rcu_nocbs` offloads RCU callbacks to other CPUs.
+
+## Diagnosing tuning effects
+
+```bash
+# Measure scheduling latency before and after
+perf sched latency -- sleep 10
+
+# Count preemptions (involuntary switches)
+perf stat -e cs ./workload 2>&1 | grep "context-switches"
+
+# Watch runqueue length (high = tasks waiting)
+runqlen 10  # from BCC toolkit, sample every 10ms
+
+# Check if tasks are being throttled (CFS bandwidth)
+watch -n 1 'cat /sys/fs/cgroup/myapp/cpu.stat | grep throttled'
+```
+
+## Observability checklist
+
+Before tuning, establish a baseline:
+
+1. **Are tasks waiting long?** → `perf sched latency` or `runqlat`
+2. **Excessive migrations?** → `perf stat -e cpu-migrations` or `schedstat`
+3. **CFS bandwidth throttling?** → `cpu.stat nr_throttled/nr_periods`
+4. **RT task monopolizing CPU?** → `htop` or `perf top` showing high RT%
+5. **NUMA inefficiency?** → `numastat`, `perf stat -e cache-misses`
+
+## Further reading
+
+- [Scheduler Statistics](schedstat.md) — What to measure before tuning
+- [Scheduler Tracing](sched-tracing.md) — Real-time observation tools
+- [CPU Bandwidth Control](cpu-bandwidth.md) — CFS quota/throttle tuning
+- [cpuset](cpuset.md) — CPU isolation for low-latency workloads
+- [EEVDF](eevdf.md) — How the slice/deadline parameters affect task selection

--- a/docs/sched/schedstat.md
+++ b/docs/sched/schedstat.md
@@ -1,0 +1,201 @@
+# Scheduler Statistics
+
+> /proc/schedstat, /proc/PID/schedstat, and the sched_statistics structure
+
+## What schedstat tracks
+
+The kernel accumulates per-task and per-CPU scheduling statistics under `CONFIG_SCHEDSTATS`. These tell you how long tasks wait, how long they sleep, how often they migrate, and what's happening in the load balancer.
+
+Schedstat is the first place to look when diagnosing scheduling anomalies: excessive wait times, unexpected migrations, or load imbalance.
+
+## Enabling schedstat
+
+```bash
+# Check if enabled (runtime toggle since 4.6)
+cat /proc/sys/kernel/sched_schedstats
+# 0 = disabled (default — saves ~5% on scheduler overhead)
+# 1 = enabled
+
+# Enable at runtime
+echo 1 > /proc/sys/kernel/sched_schedstats
+
+# Or boot with schedstats=enable
+```
+
+Without `CONFIG_SCHEDSTATS`, the fields exist but are always zero. Most production kernels have `CONFIG_SCHEDSTATS` compiled in but disabled by default via the sysctl.
+
+## Per-task statistics: /proc/PID/schedstat
+
+```bash
+cat /proc/$PID/schedstat
+# Three space-separated fields:
+# 1. CPU time (ns): total time running on CPU
+# 2. Wait time (ns): total time runnable but waiting for CPU
+# 3. Timeslices: number of times the task was scheduled
+```
+
+Example:
+
+```bash
+cat /proc/$$/schedstat
+# 1234567890 98765432 1042
+# → ran 1.23s, waited 98.7ms, scheduled 1042 times
+```
+
+### The sched_statistics struct
+
+These statistics are stored in `struct sched_entity` (embedded in `task_struct`):
+
+```c
+// include/linux/sched.h (CONFIG_SCHEDSTATS)
+struct sched_statistics {
+    // Runqueue wait time
+    u64  wait_start;      // timestamp when task last entered runqueue
+    u64  wait_max;        // maximum wait time observed
+    u64  wait_count;      // number of times task waited on runqueue
+    u64  wait_sum;        // total wait time (ns)
+    u64  iowait_count;    // number of I/O waits
+    u64  iowait_sum;      // total I/O wait time (ns)
+
+    // Sleep time (voluntary block)
+    u64  sleep_start;
+    u64  sleep_max;
+    s64  sum_sleep_runtime;
+
+    // Block time (involuntary, e.g., page fault)
+    u64  block_start;
+    u64  block_max;
+    s64  sum_block_runtime;
+
+    // Scheduling slice stats
+    s64  exec_max;        // longest single execution burst (ns)
+    u64  slice_max;       // longest scheduler slice used
+
+    // Migration stats
+    u64  nr_migrations_cold;            // migrated but cache was cold
+    u64  nr_failed_migrations_affine;   // couldn't migrate due to affinity
+    u64  nr_failed_migrations_running;  // target was running
+    u64  nr_failed_migrations_hot;      // task was cache-hot, left alone
+    u64  nr_forced_migrations;          // affinity was overridden
+
+    // Wakeup stats
+    u64  nr_wakeups;
+    u64  nr_wakeups_sync;     // wakeup from WF_SYNC (producer-consumer)
+    u64  nr_wakeups_migrate;  // wakeup caused a migration
+    u64  nr_wakeups_local;    // woke up on local CPU
+    u64  nr_wakeups_remote;   // woke up on remote CPU
+    u64  nr_wakeups_affine;   // woke up on CPU due to affinity hint
+};
+```
+
+## Per-CPU statistics: /proc/schedstat
+
+```bash
+cat /proc/schedstat
+# version 15
+# timestamp 12345678901234
+# cpu0 0 0 0 0 0 0 123456789 987654321 42
+# cpu1 0 0 0 0 0 0 ...
+# domain0 00000003 0 0 0 0 0 0 ...
+```
+
+### CPU line fields (v15 format)
+
+```
+cpu<N> yld_count sched_count sched_goidle ttwu_count ttwu_local \
+       rq_cpu_time run_delay pcount
+```
+
+| Field | Description |
+|-------|-------------|
+| `yld_count` | Times sched_yield() was called |
+| `sched_count` | Times __schedule() was called |
+| `sched_goidle` | Times __schedule() went to idle |
+| `ttwu_count` | try_to_wake_up() calls |
+| `ttwu_local` | Wakeups on local CPU |
+| `rq_cpu_time` | Total time on runqueue (ns) |
+| `run_delay` | Total wait time before running (ns) |
+| `pcount` | Tasks scheduled |
+
+### Domain line fields
+
+Each `domain<N>` line shows load balancer statistics for that scheduling domain on that CPU:
+
+```
+domain<N> cpumask lb_count[idle] lb_count[busy] lb_count[newly_idle] \
+          lb_failed[...] lb_balanced[...] lb_imbalance[...] \
+          lb_gained[...] lb_hot_gained[...] lb_nobusyg[...] lb_nobusyq[...]
+          alb_count alb_failed alb_pushed
+          sbe_count sbe_balanced sbe_pushed
+          sbf_count sbf_balanced sbf_pushed
+          ttwu_wake_remote ttwu_move_affine ttwu_move_balance
+```
+
+These are the raw counters behind load balancing decisions — useful for diagnosing whether the load balancer is working.
+
+## /proc/PID/sched
+
+More detailed per-task stats (always available, not gated by schedstats):
+
+```bash
+cat /proc/$PID/sched
+# Task: myprocess (pid: 1234)
+# ...
+# se.exec_start                    :  1234567890.123456
+# se.vruntime                      :         456789.012
+# se.sum_exec_runtime              :       12345.678901
+# nr_switches                      :               1042
+# nr_voluntary_switches            :                998
+# nr_involuntary_switches          :                 44
+# se.load.weight                   :               1024
+# se.runnable_weight               :               1024
+# policy                           :                  0
+# prio                             :                120
+# clock-delta                      :                 42
+# mm->numa_scan_seq                :                  0
+```
+
+Key fields:
+
+| Field | Meaning |
+|-------|---------|
+| `se.vruntime` | Current virtual runtime (ns) |
+| `se.sum_exec_runtime` | Total CPU time consumed (ns) |
+| `nr_voluntary_switches` | Context switches initiated by the task (I/O, sleep) |
+| `nr_involuntary_switches` | Preemptions — scheduler forced the task off CPU |
+| `prio` | Effective priority (100=RT max, 120=nice 0, 139=nice 19) |
+
+A high `nr_involuntary_switches` relative to `nr_voluntary_switches` suggests the task is being preempted frequently — it may be using more CPU than its allocation allows, or competing with higher-priority tasks.
+
+## Interpreting wait time
+
+```bash
+# Script to show top tasks by scheduler wait time
+for pid in /proc/[0-9]*/schedstat; do
+    task=$(dirname $pid | xargs -I{} cat {}/comm 2>/dev/null)
+    read cpu_time wait_time slices < $pid
+    echo "$wait_time $task $pid"
+done | sort -rn | head -20
+```
+
+High `wait_time` relative to `cpu_time` means a task is often runnable but waiting for a CPU. Possible causes:
+- System is overloaded (more runnable tasks than CPUs)
+- Task has low priority (nice value or cgroup weight)
+- CPU affinity is too restrictive
+
+## perf and schedstat together
+
+```bash
+# Measure scheduler overhead for a workload
+perf stat -e context-switches,cpu-migrations,sched:sched_switch ./workload
+
+# Count involuntary context switches (preemptions)
+perf stat -e sched:sched_switch -a sleep 5 2>&1 | grep sched_switch
+```
+
+## Further reading
+
+- [Scheduler Tracing](sched-tracing.md) — ftrace events for real-time scheduling observation
+- [Scheduler Tuning](sched-tuning.md) — sysctl knobs to adjust scheduler behavior
+- [CFS](cfs.md) — How vruntime and virtual deadlines relate to scheduling decisions
+- [Runqueues & Task Selection](runqueues.md) — Where these statistics are updated

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,3 +190,7 @@ nav:
       - cpuset: sched/cpuset.md
       - Scheduling Domains: sched/sched-domains.md
       - CPU Affinity: sched/cpu-affinity.md
+    - Debugging & Observability:
+      - Scheduler Statistics: sched/schedstat.md
+      - Scheduler Tracing: sched/sched-tracing.md
+      - Scheduler Tuning: sched/sched-tuning.md


### PR DESCRIPTION
Batch 5 of the scheduler documentation series. Closes #101, #102, #104.

## Pages added

- **Scheduler Statistics** — struct sched_statistics fields, /proc/PID/schedstat format (3 fields: cpu time, wait time, slices), /proc/schedstat CPU and domain line interpretation, /proc/PID/sched detailed view, wait time analysis scripts
- **Scheduler Tracing** — scheduler tracepoints (sched_switch with field breakdown, sched_wakeup, sched_migrate_task), trace-cmd and ftrace recording with filters, perf sched latency/replay/script, bpftrace one-liners, BCC runqlat/runqlen, wakeup tracer for max latency
- **Scheduler Tuning** — sysctls (sched_min_granularity_ns, sched_base_slice_ns, sched_wakeup_granularity_ns, sched_migration_cost_ns, sched_nr_migrate, RT throttle), SCHED_FEAT flags with descriptions, tuning patterns for latency/throughput/RT/container workloads, CPU isolation with isolcpus/nohz_full/rcu_nocbs

## Depends on
PR #226 (add-sched-resources)