### PR TITLE
Add networking fundamentals docs

### DIFF
--- a/docs/net/napi.md
+++ b/docs/net/napi.md
@@ -1,0 +1,230 @@
+# Network Device and NAPI
+
+> How the kernel receives packets from hardware: interrupt mitigation and polling
+
+## The problem NAPI solves
+
+Before NAPI (New API), each arriving packet triggered a hardware interrupt. At low traffic rates, this works fine. Under high load — say, 10 Gbps with 64-byte packets — the NIC fires hundreds of thousands of interrupts per second. The kernel spends more time handling interrupts than processing packets: **interrupt livelock**.
+
+NAPI solves this by switching to a polling model when traffic is high:
+
+1. A packet arrives → NIC fires interrupt
+2. Kernel disables further NIC interrupts
+3. Kernel polls the NIC ring buffer for more packets
+4. After processing a budget of packets, re-enable interrupts
+
+This batches work and dramatically reduces interrupt overhead at high packet rates.
+
+## struct napi_struct
+
+Each network device (or each queue on a multi-queue NIC) has one `napi_struct`:
+
+```c
+// include/linux/netdevice.h
+struct napi_struct {
+    struct list_head    poll_list;    // on this CPU's softirq poll list
+    unsigned long       state;        // NAPI_STATE_SCHED, NAPI_STATE_DISABLE, ...
+    int                 weight;       // max packets per poll() call (budget)
+    int                 (*poll)(struct napi_struct *, int);  // driver's poll function
+
+    struct net_device   *dev;
+    struct hrtimer      timer;        // for threaded NAPI or deferred processing
+
+    u32                 napi_id;      // unique ID for busy polling
+    int                 index;        // queue index on the device
+
+    // GRO (Generic Receive Offload) state
+    struct gro_node     gro;
+};
+```
+
+## The NAPI receive flow
+
+```
+1. Packet arrives in NIC ring buffer
+2. NIC raises interrupt
+        ↓
+3. Hard IRQ handler (driver's irq_handler):
+   - napi_schedule(&napi)    → sets NAPI_STATE_SCHED
+   - disable NIC interrupt    (no more hardware interrupts)
+   - return IRQ_HANDLED
+        ↓
+4. Soft IRQ (NET_RX_SOFTIRQ) runs on the same CPU:
+   - net_rx_action() polls all scheduled NAPI instances
+        ↓
+5. Driver's poll() function:
+   for each packet (up to budget):
+       skb = napi_build_skb(rx_buf, headroom)
+       __netif_receive_skb(skb)  → route up the stack
+   if (processed < budget):
+       napi_complete_done(&napi, processed)  → re-enable interrupt
+   else:
+       return budget  → more work, stay scheduled
+```
+
+## Driver implementation pattern
+
+```c
+// Interrupt handler
+static irqreturn_t my_nic_interrupt(int irq, void *dev_id)
+{
+    struct my_nic *nic = dev_id;
+    // Disable interrupts for this NIC queue
+    my_nic_disable_irq(nic);
+    // Schedule NAPI poll
+    napi_schedule(&nic->napi);
+    return IRQ_HANDLED;
+}
+
+// NAPI poll function
+static int my_nic_poll(struct napi_struct *napi, int budget)
+{
+    struct my_nic *nic = container_of(napi, struct my_nic, napi);
+    int processed = 0;
+
+    while (processed < budget) {
+        struct sk_buff *skb = my_nic_receive_one(nic);
+        if (!skb)
+            break;
+        napi_gro_receive(napi, skb);  // pass to GRO + network stack
+        processed++;
+    }
+
+    if (processed < budget) {
+        // No more packets: exit polling mode, re-enable interrupts
+        napi_complete_done(napi, processed);
+        my_nic_enable_irq(nic);
+    }
+
+    return processed;
+}
+```
+
+## NAPI budget
+
+The budget (default: 64 packets per poll call) is a fairness mechanism — one heavily-loaded NIC can't monopolize the softirq CPU. After 64 packets, the softirq handler yields and lets other work run.
+
+```bash
+# Adjust NAPI budget (per device)
+ethtool -G eth0 rx 4096  # increase ring buffer size
+
+# The global budget is in /proc/sys/net/core/netdev_budget
+cat /proc/sys/net/core/netdev_budget  # default: 300
+echo 600 > /proc/sys/net/core/netdev_budget  # for high-throughput workloads
+
+# Time limit for a single poll cycle
+cat /proc/sys/net/core/netdev_budget_usecs  # default: 2000 (2ms)
+```
+
+## GRO: Generic Receive Offload
+
+GRO merges multiple small TCP segments into a single large `sk_buff` before passing up the stack, reducing per-packet overhead:
+
+```c
+// Driver calls napi_gro_receive() instead of netif_receive_skb()
+// GRO accumulates segments from the same TCP flow
+// When done, delivers a large merged skb up the stack
+napi_gro_receive(napi, skb);
+```
+
+```bash
+# Check GRO is enabled
+ethtool -k eth0 | grep generic-receive-offload
+# generic-receive-offload: on
+
+# Disable GRO (for debugging or when GRO adds latency)
+ethtool -K eth0 gro off
+```
+
+## struct net_device
+
+```c
+// include/linux/netdevice.h (key fields)
+struct net_device {
+    char            name[IFNAMSIZ];  // "eth0", "lo", etc.
+    unsigned long   state;           // __LINK_STATE_START, etc.
+    struct netdev_queue *_tx;        // transmit queues (array)
+    struct Qdisc    *qdisc;          // traffic control qdisc
+
+    const struct net_device_ops *netdev_ops;  // driver operations
+
+    unsigned int    flags;           // IFF_UP, IFF_BROADCAST, IFF_PROMISC, ...
+    unsigned int    mtu;             // maximum transmission unit
+
+    // Stats
+    struct net_device_stats stats;   // rx/tx packets, bytes, errors
+    // ...
+};
+```
+
+## Threaded NAPI
+
+For workloads that need predictable latency, NAPI can run in a kernel thread instead of a softirq:
+
+```bash
+# Enable threaded NAPI for all NICs
+echo 1 > /sys/class/net/eth0/threaded
+
+# The kernel creates "napi/eth0-0" etc. kthreads
+# These can be pinned to CPUs for better cache locality
+taskset -cp 4 $(pgrep "napi/eth0-0")
+```
+
+Threaded NAPI allows the poll function to sleep (e.g., for GRO flush timers) and gives the scheduler full control over poll CPU placement.
+
+## Busy polling
+
+For ultra-low-latency applications, busy polling bypasses softirq and polls the NIC directly from user context:
+
+```bash
+# Enable busy polling
+echo 50 > /proc/sys/net/core/busy_poll    # poll for 50µs
+echo 50 > /proc/sys/net/core/busy_read    # also on recv()
+
+# Per-socket (SO_BUSY_POLL option)
+setsockopt(fd, SOL_SOCKET, SO_BUSY_POLL, &timeout_us, sizeof(timeout_us));
+```
+
+This trades CPU cycles for latency — the application spins polling the NIC instead of sleeping and being woken by softirq.
+
+## RPS/RFS: multi-CPU receive scaling
+
+A single-queue NIC delivers all packets to one CPU. **RPS (Receive Packet Steering)** distributes packets across CPUs in software:
+
+```bash
+# Distribute receive processing across CPUs 0-7
+echo ff > /sys/class/net/eth0/queues/rx-0/rps_cpus
+
+# RFS (Receive Flow Steering): steer packets to the CPU where the
+# application is running (improves cache locality)
+echo 32768 > /proc/sys/net/core/rps_sock_flow_entries
+echo 2048  > /sys/class/net/eth0/queues/rx-0/rps_flow_cnt
+```
+
+Modern multi-queue NICs with RSS (Receive Side Scaling) do this in hardware, distributing flows across hardware queues — one NAPI instance per queue.
+
+## Diagnosing receive performance
+
+```bash
+# RX drop counters
+ethtool -S eth0 | grep -i drop
+
+# Softirq statistics (NET_RX_SOFTIRQ overruns)
+cat /proc/net/softnet_stat
+# Columns: total, dropped, time_squeeze, [cpu_collision], [received_rps], [flow_limit_count]
+# time_squeeze: poll ran out of budget (consider increasing netdev_budget)
+# dropped: packet dropped due to backlog overflow
+
+# Interrupts per CPU
+cat /proc/interrupts | grep eth0
+
+# Check GRO merging stats
+ethtool -S eth0 | grep gro
+```
+
+## Further reading
+
+- [sk_buff](sk-buff.md) — The packet structure built during receive
+- [Life of a Packet (receive)](life-of-packet-rx.md) — Full receive path beyond NAPI
+- [Socket Layer Overview](socket-layer.md) — Where packets go after network layer processing
+- [XDP](xdp.md) — Processing packets even earlier, before sk_buff allocation

--- a/docs/net/network-stack-overview.md
+++ b/docs/net/network-stack-overview.md
@@ -1,0 +1,144 @@
+# Why Is the Network Stack So Complex?
+
+> A mental model for the Linux networking subsystem
+
+## The fundamental challenge
+
+Networking is not a single problem — it's dozens of layered problems that must compose cleanly:
+
+- Different hardware (Ethernet, WiFi, InfiniBand, loopback)
+- Different address families (IPv4, IPv6, AF_UNIX, AF_PACKET)
+- Different transport protocols (TCP, UDP, SCTP, DCCP)
+- Different use cases (web servers, databases, real-time systems, containers)
+- Hard requirements: correctness, performance, security, extensibility
+
+The Linux network stack is complex because it solves all of these simultaneously, and has evolved over 30 years as each requirement was added.
+
+## The layer model
+
+The stack mirrors the OSI/IP model, but in kernel terms:
+
+```
+Application (userspace)
+    │  read/write/send/recv  (system calls)
+    ▼
+Socket layer          struct socket, struct sock, proto_ops
+    │  sendmsg/recvmsg
+    ▼
+Transport layer       TCP (net/ipv4/tcp.c), UDP (net/ipv4/udp.c)
+    │  ip_queue_xmit / udp_rcv
+    ▼
+Network layer (IP)    net/ipv4/ip_output.c, net/ipv4/ip_input.c
+    │  routing, fragmentation, NAT (via Netfilter hooks)
+    ▼
+Link layer            net/core/dev.c, driver-specific
+    │  __netif_receive_skb (RX) / dev_queue_xmit (TX)
+    ▼
+Hardware              NIC driver, NAPI, DMA ring buffers
+```
+
+Each layer adds/strips headers using the same `sk_buff` structure, pushing and pulling data pointers. **No data is copied between layers** — the same buffer passes through the entire stack.
+
+## The receive path in one picture
+
+```
+NIC DMA → ring buffer
+    ↓ interrupt (or polling)
+NAPI poll (NET_RX_SOFTIRQ)
+    ↓ skb = napi_build_skb()
+__netif_receive_skb()
+    ↓ protocol demux (Ethernet type)
+    ├── XDP programs (if attached)  ← early drop/redirect
+    ├── Packet sockets (tcpdump)
+    ├── Netfilter (PREROUTING hook)
+    ↓
+ip_rcv() → ip_rcv_finish()
+    ↓ routing decision
+    ├── Forward: ip_forward() → Netfilter (FORWARD) → ip_output()
+    └── Local: ip_local_deliver()
+              ↓ Netfilter (INPUT hook)
+              ↓ transport demux (proto = TCP/UDP/ICMP)
+              tcp_v4_rcv() / udp_rcv()
+              ↓ socket lookup (hash table)
+              sk->sk_receive_queue.push(skb)
+              sk->sk_data_ready(sk) → wake up reader
+```
+
+## The transmit path in one picture
+
+```
+write()/sendmsg()
+    ↓ tcp_sendmsg() / udp_sendmsg()
+    ↓ sk_buff allocation + data copy
+tcp_transmit_skb() / udp_send_skb()
+    ↓ IP header construction
+ip_queue_xmit() → ip_output()
+    ↓ Netfilter (OUTPUT hook)
+    ↓ routing: dst_output() → ip_finish_output()
+    ↓ fragmentation if needed
+    ↓ Netfilter (POSTROUTING hook)
+    ↓ neigh_output() → ARP resolution
+dev_queue_xmit()
+    ↓ qdisc (traffic control, rate limiting)
+    ↓ driver's ndo_start_xmit()
+    ↓ DMA to NIC
+```
+
+## Why multiple abstraction layers?
+
+### 1. Flexibility without copying
+
+Each layer operates on the same `sk_buff`. TCP adds a TCP header by calling `skb_push()` — moving the `data` pointer back 20 bytes and writing the header there. IP does the same for its header. Ethernet does the same for its header. **Zero copies across layers** for the headers.
+
+### 2. Protocol independence
+
+The socket layer doesn't know if the underlying transport is TCP or UDP. `proto_ops->sendmsg()` dispatches to the right implementation. Adding a new protocol (SCTP, QUIC in kernel, etc.) requires only implementing the right interfaces.
+
+### 3. Extensibility via hooks
+
+**Netfilter** provides hooks at fixed points in the IP stack (PREROUTING, INPUT, FORWARD, OUTPUT, POSTROUTING). Firewalls, NAT, connection tracking, and packet mangling all attach at these hooks — without modifying the core stack.
+
+**XDP** hooks even earlier, before `sk_buff` allocation, for maximum performance.
+
+**eBPF socket programs** hook at the socket level for per-flow policy.
+
+### 4. NAPI for high-throughput
+
+The interrupt-driven receive model doesn't scale. NAPI switches to polling under load, processing packets in batches in softirq context. GRO merges segments. RSS distributes across CPUs. All of this is layered on top of the core receive path.
+
+## Key data structures at a glance
+
+| Structure | Where | Purpose |
+|-----------|-------|---------|
+| `sk_buff` | everywhere | The packet — moves through all layers |
+| `struct socket` | net/core | VFS-facing: fd → socket mapping |
+| `struct sock` | net/core | Protocol-facing: queues, state, callbacks |
+| `struct proto` | per-protocol | TCP/UDP implementation |
+| `struct net_device` | drivers | NIC abstraction |
+| `struct napi_struct` | drivers | Per-queue receive polling |
+| `struct dst_entry` | routing | Next-hop routing cache entry |
+| `struct nf_hook_ops` | netfilter | Firewall/NAT hook registration |
+
+## Complexity by design, not accident
+
+The stack's complexity reflects genuine requirements:
+
+- **TCP** must handle packet loss, reordering, congestion, flow control, and connection lifetime — it's inherently complex
+- **NAT** must track connection state to rewrite both directions — requires the conntrack subsystem
+- **Multi-queue NICs** with RSS, RPS, XPS, and IRQ affinity require per-CPU state at every layer
+- **Containers** with network namespaces require virtualizing the entire network stack
+- **Security** (nftables, seccomp, SELinux socket labels) requires hooks at multiple points
+
+Understanding any one part (TCP, routing, Netfilter, NAPI) is tractable. The stack as a whole is complex because it's many tractable parts that must compose perfectly.
+
+## Where to go next
+
+The best way to understand the stack is to follow a packet:
+
+- [Life of a Packet (receive)](life-of-packet-rx.md) — NIC to application, step by step
+- [Life of a Packet (transmit)](life-of-packet-tx.md) — Application to wire
+
+Or start with the key structures:
+- [sk_buff](sk-buff.md) — The packet structure used everywhere
+- [Socket Layer Overview](socket-layer.md) — The socket/sock/proto hierarchy
+- [Network Device and NAPI](napi.md) — The receive hardware interface

--- a/docs/net/sk-buff.md
+++ b/docs/net/sk-buff.md
@@ -1,0 +1,222 @@
+# sk_buff: The Network Buffer
+
+> The central data structure of the Linux network stack
+
+## What sk_buff is
+
+`struct sk_buff` (socket buffer) is how the kernel represents a network packet. Every packet — from the moment it arrives from hardware to the moment it's delivered to a socket — lives in an `sk_buff`.
+
+The structure has two parts:
+1. **Metadata header**: pointers, length fields, protocol info, timestamps
+2. **Data buffer**: the actual packet bytes (pointed to, not embedded)
+
+Understanding `sk_buff` is fundamental to understanding the entire network stack, since every layer operates on it.
+
+## Memory layout
+
+```
+sk_buff metadata:
+┌──────────────────────────────────────┐
+│ next, prev  (list linkage)           │
+│ sk          (owning socket)          │
+│ dev         (network device)         │
+│ len, data_len                        │
+│ protocol, cloned, ...                │
+│ head, data, tail, end (data ptrs)    │
+│ cb[48]      (layer-private scratch)  │
+│ ...                                  │
+└──────────────────────────────────────┘
+
+Packet data buffer (allocated separately):
+ ┌─────────────┬───────────────────────────────────────┬────────┐
+ │  headroom   │  packet data (data ... tail)           │  end   │
+ └─────────────┴───────────────────────────────────────┴────────┘
+ ↑ head        ↑ data                           ↑ tail           ↑ end
+
+As headers are added (push down the stack):
+  data moves left: skb_push()
+As headers are consumed (pop up the stack):
+  data moves right: skb_pull()
+```
+
+The `headroom` is reserved space before `data` — lower layers (ethernet, IP) push their headers into headroom as the packet goes down the stack. This avoids copying.
+
+## struct sk_buff key fields
+
+```c
+// include/linux/skbuff.h
+struct sk_buff {
+    // List linkage (in queues, hash chains)
+    struct sk_buff  *next;
+    struct sk_buff  *prev;
+
+    struct sock     *sk;        // owning socket (or NULL for forwarded packets)
+    struct net_device *dev;     // network device this packet arrived on / will go out
+
+    ktime_t         tstamp;     // packet timestamp
+
+    // Per-layer scratch space: each layer stores its own data here.
+    // Only valid while the packet is at that layer.
+    char            cb[48] __aligned(8);
+
+    unsigned int    len;        // total length (linear + paged data)
+    unsigned int    data_len;   // paged data length (scatter-gather)
+    __u16           mac_len;    // MAC header length
+    __u16           hdr_len;    // cloned header length
+
+    __u8            cloned:1;   // shares data with another skb
+    __u8            head_frag:1; // head is a page fragment (not kmalloc)
+    __u8            pp_recycle:1; // owned by page_pool
+
+    // Protocol info
+    __be16          protocol;   // Ethernet type (ETH_P_IP, ETH_P_IPV6, ...)
+    __u16           transport_header;  // offset to L4 header
+    __u16           network_header;    // offset to L3 header (IP)
+    __u16           mac_header;        // offset to L2 header (Ethernet)
+
+    // Data pointers
+    sk_buff_data_t  tail;       // end of linear data
+    sk_buff_data_t  end;        // end of buffer (hard limit)
+    unsigned char   *head;      // start of buffer
+    unsigned char   *data;      // start of valid data
+
+    unsigned int    truesize;   // total memory charged to socket
+
+    // Paged data (for large packets, scatter-gather)
+    skb_frag_t      frags[MAX_SKB_FRAGS]; // page fragments
+    // ...
+};
+```
+
+## Data pointer manipulation
+
+```c
+// Push data onto the front (add a header going down the stack)
+void *skb_push(struct sk_buff *skb, unsigned int len)
+{
+    skb->data -= len;
+    skb->len += len;
+    return skb->data;
+}
+
+// Pull data off the front (consume a header going up the stack)
+void *skb_pull(struct sk_buff *skb, unsigned int len)
+{
+    skb->data += len;
+    skb->len -= len;
+    return skb->data;
+}
+
+// Add data at the end
+void *skb_put(struct sk_buff *skb, unsigned int len)
+{
+    void *tmp = skb_tail_pointer(skb);
+    skb->tail += len;
+    skb->len += len;
+    return tmp;
+}
+```
+
+## Header access macros
+
+```c
+// Get pointer to L2/L3/L4 headers
+static inline struct ethhdr *eth_hdr(const struct sk_buff *skb)
+{
+    return (struct ethhdr *)skb_mac_header(skb);
+}
+
+static inline struct iphdr *ip_hdr(const struct sk_buff *skb)
+{
+    return (struct iphdr *)skb_network_header(skb);
+}
+
+static inline struct tcphdr *tcp_hdr(const struct sk_buff *skb)
+{
+    return (struct tcphdr *)skb_transport_header(skb);
+}
+
+// Example: reading the destination IP from a received packet
+struct iphdr *iph = ip_hdr(skb);
+__be32 dst = iph->daddr;
+```
+
+## The cb[] scratch area
+
+Each layer has 48 bytes of private storage in `cb[]`. This is a critical design — it avoids separate allocations for per-layer metadata:
+
+```c
+// TCP uses cb[] to store TCP-specific info
+struct tcp_skb_cb {
+    union {
+        struct inet_skb_parm    h4;
+        struct inet6_skb_parm   h6;
+    } header;
+    __u32   seq;            // Starting sequence number
+    __u32   end_seq;        // SEQ + FIN + SYN + datalen
+    __u8    tcp_flags;      // TCP header flags
+    __u8    sacked;         // State of sack bits
+    // ...
+};
+#define TCP_SKB_CB(__skb)    ((struct tcp_skb_cb *)&((__skb)->cb[0]))
+
+// Usage:
+TCP_SKB_CB(skb)->seq = tcp_seq;
+```
+
+## Cloning and sharing
+
+`skb_clone()` creates a new `sk_buff` that shares the same data buffer. The `cloned` bit is set on both. Useful for sending the same packet to multiple consumers (e.g., packet sockets + forwarding):
+
+```c
+struct sk_buff *clone = skb_clone(skb, GFP_ATOMIC);
+// clone->data and skb->data point to the same buffer
+// modifying headers requires skb_copy_expand() first
+```
+
+`skb_copy()` creates a full independent copy.
+
+## Fragmented packets (scatter-gather)
+
+For large packets (e.g., TCP offload), data may span multiple pages:
+
+```c
+struct sk_buff {
+    // Linear portion: head...tail
+    // Paged portion:
+    skb_frag_t frags[MAX_SKB_FRAGS];
+    // data_len = total length of paged portions
+    // len = linear + paged
+};
+
+// Total accessible data:
+// skb->data ... skb->tail  (linear)
+// + frags[0] ... frags[nr_frags-1]  (paged)
+```
+
+Functions like `skb_linearize()` collapse paged data into the linear portion when a driver doesn't support scatter-gather.
+
+## Allocation and freeing
+
+```c
+// Allocate a new sk_buff with headroom for headers
+struct sk_buff *alloc_skb(unsigned int size, gfp_t priority);
+
+// Allocate from network allocator (uses page_pool for RX paths)
+struct sk_buff *napi_alloc_skb(struct napi_struct *napi, unsigned int length);
+
+// Free the sk_buff (decrements refcount, frees when zero)
+void kfree_skb(struct sk_buff *skb);
+
+// Free without error accounting (normal path)
+void consume_skb(struct sk_buff *skb);
+```
+
+`truesize` is charged to the socket's receive buffer (`sk->sk_rmem_alloc`). If the socket buffer fills up, new packets are dropped.
+
+## Further reading
+
+- [Socket Layer Overview](socket-layer.md) — How sk_buff connects to sockets
+- [Network Device and NAPI](napi.md) — How sk_buffs are allocated during receive
+- [Life of a Packet (receive)](life-of-packet-rx.md) — Full receive path using sk_buff
+- [Life of a Packet (transmit)](life-of-packet-tx.md) — Full transmit path

--- a/docs/net/socket-layer.md
+++ b/docs/net/socket-layer.md
@@ -1,0 +1,211 @@
+# Socket Layer Overview
+
+> How the kernel maps userspace socket calls to protocol implementations
+
+## The socket abstraction
+
+A socket is a bidirectional communication endpoint. From userspace, it's just a file descriptor. Internally, it's a stack of three structures:
+
+```
+userspace:   fd (int)
+             ↓
+kernel VFS:  struct file → f_op = socket_file_ops
+             ↓
+socket:      struct socket (VFS view: state, type, proto_ops)
+             ↓
+sock:        struct sock (protocol view: receive queues, buffers, state machine)
+             ↓
+protocol:    struct proto (TCP/UDP/RAW-specific operations)
+```
+
+## struct socket — the VFS-facing layer
+
+```c
+// include/linux/net.h
+struct socket {
+    socket_state        state;   // SS_FREE, SS_UNCONNECTED, SS_CONNECTING,
+                                  // SS_CONNECTED, SS_DISCONNECTING
+    short               type;    // SOCK_STREAM, SOCK_DGRAM, SOCK_RAW, ...
+    unsigned long       flags;
+    struct file         *file;   // associated file (for fd → socket lookup)
+    struct sock         *sk;     // the protocol-level socket
+    const struct proto_ops *ops; // VFS-to-protocol dispatch table
+    struct socket_wq    wq;      // wait queue for poll/select
+};
+```
+
+`proto_ops` is the dispatch table mapping socket syscalls to protocol code:
+
+```c
+// include/linux/net.h
+struct proto_ops {
+    int family;
+    int (*bind)     (struct socket *, struct sockaddr *, int);
+    int (*connect)  (struct socket *, struct sockaddr *, int, int);
+    int (*accept)   (struct socket *, struct socket *, struct proto_accept_arg *);
+    int (*listen)   (struct socket *, int);
+    int (*sendmsg)  (struct socket *, struct msghdr *, size_t);
+    int (*recvmsg)  (struct socket *, struct msghdr *, size_t, int);
+    int (*setsockopt)(struct socket *, int, int, sockptr_t, unsigned int);
+    int (*getsockopt)(struct socket *, int, int, char __user *, int __user *);
+    int (*shutdown) (struct socket *, int);
+    // ...
+};
+```
+
+For TCP/IPv4, `proto_ops = inet_stream_ops`. For UDP, `proto_ops = inet_dgram_ops`. For AF_UNIX, `proto_ops = unix_stream_ops`.
+
+## struct sock — the protocol-facing layer
+
+```c
+// include/net/sock.h
+struct sock {
+    struct sock_common __sk_common; // address/port/family/state
+    // Common macros expose these fields:
+    // sk_daddr, sk_rcv_saddr  (IPv4 addresses)
+    // sk_dport, sk_num        (ports)
+    // sk_state                (TCP_ESTABLISHED, TCP_CLOSE_WAIT, ...)
+    // sk_prot                 (points to struct proto)
+
+    // Receive path
+    struct sk_buff_head sk_receive_queue; // received but not yet read
+    struct {
+        atomic_t rmem_alloc;
+        struct sk_buff *head, *tail;
+    } sk_backlog;               // packets arrived while lock was held
+
+    // Memory limits
+    int           sk_rcvbuf;    // receive buffer size limit
+    int           sk_sndbuf;    // send buffer size limit
+    atomic_t      sk_rmem_alloc; // currently allocated for receive
+    atomic_t      sk_wmem_alloc; // currently allocated for send
+
+    // Callbacks (set by protocol)
+    void    (*sk_data_ready)(struct sock *sk);    // data arrived
+    void    (*sk_write_space)(struct sock *sk);   // send buffer freed up
+    void    (*sk_state_change)(struct sock *sk);  // TCP state changed
+    void    (*sk_error_report)(struct sock *sk);  // error (ICMP, etc.)
+
+    // Protocol-specific extension (TCP uses tcp_sock, etc.)
+    // Accessed by container_of() from the protocol layer
+};
+```
+
+## struct proto — the protocol implementation
+
+Each protocol registers a `struct proto` that contains the actual work:
+
+```c
+// include/net/sock.h
+struct proto {
+    void  (*close)     (struct sock *, long timeout);
+    int   (*connect)   (struct sock *, struct sockaddr *, int);
+    int   (*disconnect)(struct sock *, int);
+    struct sock *(*accept)(struct sock *, struct proto_accept_arg *);
+    int   (*sendmsg)   (struct sock *, struct msghdr *, size_t);
+    int   (*recvmsg)   (struct sock *, struct msghdr *, size_t, int, int *);
+    int   (*backlog_rcv)(struct sock *, struct sk_buff *);  // process backlog
+    int   (*hash)      (struct sock *);   // add to protocol hash table
+    void  (*unhash)    (struct sock *);
+    int   (*get_port)  (struct sock *, unsigned short);     // port binding
+    char  name[32];   // "TCP", "UDP", "RAW"
+    // ...
+};
+```
+
+TCP: `struct proto tcp_prot` at `net/ipv4/tcp_ipv4.c`
+UDP: `struct proto udp_prot` at `net/ipv4/udp.c`
+
+## Creating a socket: socket(2)
+
+```
+socket(AF_INET, SOCK_STREAM, 0)
+    → sys_socket()
+        → sock_create()
+            → __sock_create()
+                → net_families[AF_INET]->create()  # = inet_create()
+                    → allocate struct socket + struct sock (tcp_sock)
+                    → set sock->sk_prot = &tcp_prot
+                    → set sock->ops = &inet_stream_ops
+                    → tcp_prot.init(sk)
+        → sock_map_fd()  # install in fd table
+```
+
+## The two dispatch levels
+
+The double-layer dispatch (proto_ops → proto) exists because:
+
+- `proto_ops` handles the **VFS interface** (file descriptor semantics, socket states, address family dispatch)
+- `proto` handles the **protocol implementation** (TCP state machine, UDP demux, etc.)
+
+A single layer can't serve both: `sendmsg()` on a TCP socket needs different behavior from `sendmsg()` on a UDP socket, but both go through the same VFS file operations.
+
+## Receive path: how data reaches the socket
+
+```
+NIC interrupt → NAPI poll → __netif_receive_skb()
+    → IP input → TCP/UDP demux → socket lookup
+        → sk->sk_receive_queue or sk->sk_backlog
+            → sk->sk_data_ready(sk)   # wake up reader
+                → sock_def_readable() → wake_up_interruptible(&sk->sk_wq)
+                    → read()/recv() returns data
+```
+
+The `sk_backlog` handles the case where a packet arrives while the socket lock is held (e.g., during another syscall). Packets are held in the backlog and processed when the lock is released.
+
+## Socket buffers and memory
+
+```bash
+# Default receive/send buffer sizes
+cat /proc/sys/net/core/rmem_default  # bytes
+cat /proc/sys/net/core/wmem_default
+
+# Maximum (upper bound for setsockopt SO_RCVBUF/SO_SNDBUF)
+cat /proc/sys/net/core/rmem_max
+cat /proc/sys/net/core/wmem_max
+
+# TCP-specific auto-tuning range [min, default, max]
+cat /proc/sys/net/ipv4/tcp_rmem
+cat /proc/sys/net/ipv4/tcp_wmem
+```
+
+`sk->sk_rmem_alloc` tracks memory currently held in `sk_receive_queue`. When it exceeds `sk_rcvbuf`, new packets are dropped (kernel silently drops them, returning 0 bytes to the application if it doesn't read fast enough).
+
+## Socket state machine (TCP)
+
+```
+                   connect()
+                      ↓
+    CLOSE → SYN_SENT → ESTABLISHED → FIN_WAIT_1 → FIN_WAIT_2 → TIME_WAIT → CLOSE
+                                  ↘ CLOSE_WAIT → LAST_ACK → CLOSE
+
+                                  accept() returns when: LISTEN → ESTABLISHED
+```
+
+`sk->sk_state` (accessed via `sk->__sk_common.skc_state`) tracks this. The TCP protocol implementation transitions these states and calls `sk->sk_state_change()` to notify waiting pollers.
+
+## Inspecting sockets
+
+```bash
+# List all TCP sockets
+ss -tnap
+
+# Show socket memory usage
+ss -tm
+
+# Show internal kernel state for a socket (Linux 5.1+)
+ss --diag
+
+# /proc/net/tcp shows socket table
+cat /proc/net/tcp  # hex: local_addr:port remote_addr:port state tx_queue rx_queue uid
+
+# Count sockets by state
+ss -tan | awk 'NR>1 {print $1}' | sort | uniq -c | sort -rn
+```
+
+## Further reading
+
+- [sk_buff](sk-buff.md) — The packet structure passed between layers
+- [Network Device and NAPI](napi.md) — How packets arrive from hardware
+- [Life of a Packet (receive)](life-of-packet-rx.md) — Full path from NIC to socket
+- [TCP Implementation](tcp.md) — TCP state machine and congestion control

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,3 +194,9 @@ nav:
       - Scheduler Statistics: sched/schedstat.md
       - Scheduler Tracing: sched/sched-tracing.md
       - Scheduler Tuning: sched/sched-tuning.md
+  - Networking:
+    - Fundamentals:
+      - "Why Is the Network Stack So Complex?": net/network-stack-overview.md
+      - "sk_buff: The Network Buffer": net/sk-buff.md
+      - Socket Layer Overview: net/socket-layer.md
+      - Network Device and NAPI: net/napi.md


### PR DESCRIPTION
Batch 6: networking fundamentals. Closes #105, #106, #107, #125.

## Pages added

- **Why Is the Network Stack So Complex?** — Mental model for the entire stack: receive/transmit paths as annotated diagrams, key data structures at a glance, why multiple abstraction layers are necessary, where to go next (#125)
- **sk_buff** — Memory layout diagram (headroom/data/tail/end), key struct fields, skb_push/pull/put mechanics, cb[] scratch area, cloning vs copying, GRO scatter-gather fragments, allocation and truesize accounting (#106)
- **Socket Layer Overview** — struct socket/sock/proto three-layer hierarchy, proto_ops dispatch table, socket() syscall path (sock_create → inet_create → tcp_prot), receive backlog handling, sk_data_ready wakeup, buffer sizing sysctls, TCP state machine overview (#105)
- **Network Device and NAPI** — NAPI polling flow (interrupt → schedule → poll → napi_complete), struct napi_struct, driver implementation pattern, GRO segment merging, budget tuning (netdev_budget), threaded NAPI, busy polling, RPS/RFS for single-queue NICs, softnet_stat diagnostics (#107)

## Depends on
PR #227 (add-sched-debugging)