### PR TITLE
Add networking lifecycle docs: receive, transmit, connect

### DIFF
--- a/docs/net/connect.md
+++ b/docs/net/connect.md
@@ -1,0 +1,278 @@
+# What Happens When You connect()
+
+> The TCP three-way handshake from a kernel perspective
+
+## Overview
+
+When a client calls `connect()`, the kernel initiates a TCP three-way handshake. The call may block until the connection is established (or timeout/error). The full sequence:
+
+```
+Client                                    Server
+  │                                          │
+connect() →                                  │ (listening on accept())
+  tcp_v4_connect()                           │
+  → route lookup                             │
+  → ephemeral port selection                 │
+  → TCP state: SYN_SENT                      │
+  → send SYN packet                          │
+  │────────────── SYN ─────────────────────→ │
+  │                                     tcp_v4_rcv()
+  │                                     tcp_rcv_state_process()
+  │                                     TCP state: SYN_RECEIVED
+  │                                     send SYN-ACK
+  │ ←──────────── SYN-ACK ─────────────── │
+tcp_v4_rcv()                                 │
+tcp_rcv_synsent_state_process()              │
+→ TCP state: ESTABLISHED                     │
+→ wake up connect()                          │
+→ send ACK                                   │
+  │────────────── ACK ─────────────────────→ │
+  │                                     TCP state: ESTABLISHED
+  │                                     sk queued on listen backlog
+  │                                     accept() returns new socket
+```
+
+## Phase 1: connect() syscall → tcp_v4_connect()
+
+```c
+// Userspace
+int fd = socket(AF_INET, SOCK_STREAM, 0);
+connect(fd, (struct sockaddr *)&addr, sizeof(addr));
+```
+
+The syscall path:
+
+```
+connect()
+  → inet_stream_connect()       [af_inet.c]
+    → __inet_stream_connect()
+      → sk->sk_prot->connect()  = tcp_v4_connect()
+```
+
+## Phase 2: tcp_v4_connect()
+
+```c
+// net/ipv4/tcp_ipv4.c:222
+int tcp_v4_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
+{
+    struct sockaddr_in *usin = (struct sockaddr_in *)uaddr;
+
+    // 1. Route lookup: find how to reach the destination
+    rt = ip_route_connect(fl4, daddr, inet->inet_saddr, ...);
+
+    // 2. Source IP selection (if not bound)
+    // fl4->saddr is filled in by the routing subsystem
+
+    // 3. Ephemeral port selection (if not bound)
+    err = inet_hash_connect(&tcp_death_row, sk);
+    // Picks a source port from ip_local_port_range, checks for conflicts
+
+    // 4. Transition to SYN_SENT state
+    tcp_set_state(sk, TCP_SYN_SENT);
+
+    // 5. Start the connect timer (retransmission)
+    inet->inet_id = get_random_u16();
+
+    // 6. Send SYN
+    err = tcp_connect(sk);
+}
+```
+
+## Phase 3: tcp_connect() — sending the SYN
+
+```c
+// net/ipv4/tcp_output.c:4296
+int tcp_connect(struct sock *sk)
+{
+    struct tcp_sock *tp = tcp_sk(sk);
+
+    // Initialize sequence number (random for security)
+    tp->write_seq = secure_tcp_seq(inet->inet_saddr, inet->inet_daddr,
+                                   inet->inet_sport, inet->inet_dport);
+
+    // Allocate SYN sk_buff
+    buff = sk_stream_alloc_skb(sk, 0, sk->sk_allocation, true);
+
+    // Set up SYN packet
+    tcp_init_nondata_skb(buff, tp->write_seq++, TCPHDR_SYN);
+
+    // TCP Fast Open: attach data to SYN if requested
+    if (tp->fastopen_req)
+        err = tcp_send_syn_data(sk, buff);
+    else
+        tcp_transmit_skb(sk, buff, 1, sk->sk_allocation);
+
+    // Start retransmit timer
+    inet_csk_reset_xmit_timer(sk, ICSK_TIME_RETRANS, inet_csk(sk)->icsk_rto, ...);
+
+    return 0;
+}
+```
+
+SYN options set in the SYN packet:
+- **MSS** (Maximum Segment Size): tells the server the max segment we'll accept
+- **WSCALE**: window scaling factor for large windows
+- **SACK_PERM**: we support Selective ACK
+- **Timestamp**: for RTT measurement and PAWS (Protection Against Wrapped Sequences)
+
+## Phase 4: Server processes SYN → tcp_rcv_state_process()
+
+On the server side:
+
+```c
+// net/ipv4/tcp_input.c
+int tcp_rcv_state_process(struct sock *sk, struct sk_buff *skb)
+{
+    // Server in LISTEN state receives SYN:
+    case TCP_LISTEN:
+        if (th->syn) {
+            // Create a request socket (lightweight, not a full sock yet)
+            req = inet_reqsk_alloc(rsk_ops, sk, !want_cookie);
+
+            // Record client's ISN, MSS, options
+            tcp_parse_options(net, skb, &opt_rx, ...);
+
+            // Start SYN timeout timer (handles half-open connections)
+            inet_csk_reqsk_queue_hash_add(sk, req, TCP_TIMEOUT_INIT);
+
+            // Send SYN-ACK
+            af_ops->send_synack(sk, dst, &fl, req, ...);
+            // → tcp_send_synack() → tcp_transmit_skb()
+        }
+}
+```
+
+The server creates a **request socket** (`struct request_sock`) — a lightweight half-open connection entry. The full `struct sock` is only allocated when the third ACK arrives.
+
+## Phase 5: Client processes SYN-ACK → ESTABLISHED
+
+```c
+// net/ipv4/tcp_input.c
+static int tcp_rcv_synsent_state_process(struct sock *sk, struct sk_buff *skb, ...)
+{
+    // Client in SYN_SENT receives SYN-ACK:
+    if (th->ack) {
+        // Validate ACK number: must ACK our SYN
+        if (TCP_SKB_CB(skb)->ack_seq != tp->snd_nxt)
+            goto reset_and_undo;
+
+        // Accept server's ISN
+        tp->rcv_nxt = TCP_SKB_CB(skb)->seq + 1;
+
+        // Record server's MSS, window scale, SACK support
+        tcp_process_options(...);
+
+        // Transition to ESTABLISHED
+        tcp_set_state(sk, TCP_ESTABLISHED);
+
+        // Initialize congestion control
+        tcp_init_congestion_control(sk);
+
+        // Send ACK (completes the 3-way handshake)
+        tcp_send_ack(sk);
+
+        // Wake up connect() — it can return now
+        sk->sk_state_change(sk);
+        // → wake_up_interruptible(sk->sk_wq)
+    }
+}
+```
+
+`connect()` unblocks and returns 0.
+
+## Phase 6: Server processes ACK → accept() returns
+
+```c
+// Server receives the final ACK:
+// tcp_rcv_state_process() → TCP_SYN_RECV case
+//   → inet_csk(sk)->icsk_af_ops->syn_recv_sock()
+//       → tcp_v4_syn_recv_sock()
+//           → allocate full struct sock for the new connection
+//           → move from request_sock queue to accept queue
+//   → sk_acceptq_added()  (increments accept queue length)
+
+// accept() on the server:
+accept(listenfd, &addr, &addrlen)
+  → inet_accept()
+    → sk->sk_prot->accept()  = inet_csk_accept()
+      → wait for connection in accept queue
+      → dequeue and return new sock
+```
+
+## SYN backlog and accept queue
+
+The server maintains two queues:
+
+```
+SYN queue (incomplete connections):
+  SYN received → request_sock added
+  SYN-ACK sent
+  ACK received → moved to accept queue
+
+Accept queue (complete connections):
+  accept() dequeues from here
+```
+
+Controlled by:
+
+```bash
+# Maximum accept queue depth (SOMAXCONN)
+cat /proc/sys/net/core/somaxconn  # default: 4096
+
+# TCP SYN backlog
+cat /proc/sys/net/ipv4/tcp_max_syn_backlog  # default: 512
+
+# listen() second argument sets per-socket accept queue limit
+listen(fd, backlog);  # capped at somaxconn
+```
+
+A full accept queue → new ACKs are dropped → client retries (appears as connection slowness, not error). A full SYN queue → SYN cookies or SYN drop.
+
+## SYN cookies
+
+Under SYN flood attack, the SYN queue fills. SYN cookies encode connection state in the ISN, avoiding SYN queue entries:
+
+```bash
+# Enable SYN cookies (auto-activates under SYN flood)
+cat /proc/sys/net/ipv4/tcp_syncookies  # 1 = enabled (default)
+```
+
+With SYN cookies, the server doesn't create a request_sock on SYN receipt. Instead, it encodes the connection parameters in the SYN-ACK's sequence number. When the ACK arrives with the valid cookie, the connection is established without ever having been in the SYN queue.
+
+## Ephemeral port selection
+
+```bash
+# Range for ephemeral (outbound) ports
+cat /proc/sys/net/ipv4/ip_local_port_range
+# → 32768 60999  (default)
+
+# Count ports in use
+ss -tn | wc -l
+
+# If running out of ports: expand range or use SO_REUSEPORT
+echo "1024 65535" > /proc/sys/net/ipv4/ip_local_port_range
+```
+
+## Observing the connection
+
+```bash
+# See connections in all TCP states
+ss -tn state syn-sent
+ss -tn state syn-recv  # on server: half-open connections
+
+# Count connections by state
+ss -tan | awk 'NR>1 {print $1}' | sort | uniq -c | sort -rn
+
+# Trace the handshake
+trace-cmd record -e tcp:tcp_rcv_state_process \
+                 -e tcp:tcp_send_syn \
+                 -e tcp:tcp_send_synack \
+                 sleep 5
+```
+
+## Further reading
+
+- [Life of a Packet (transmit)](life-of-packet-tx.md) — How the SYN packet is transmitted
+- [Life of a Packet (receive)](life-of-packet-rx.md) — How the SYN-ACK is received
+- [TCP Implementation](tcp.md) — Congestion control, flow control, retransmission
+- [Socket Layer Overview](socket-layer.md) — Socket state machine

--- a/docs/net/life-of-packet-rx.md
+++ b/docs/net/life-of-packet-rx.md
@@ -1,0 +1,282 @@
+# Life of a Packet (Receive Path)
+
+> From NIC DMA to application read(), step by step
+
+## Overview
+
+A TCP packet arriving at a server traverses roughly 8 distinct phases before the application receives the data. Each phase is handled by a different kernel subsystem, and the same `sk_buff` passes through all of them without data copying.
+
+```
+NIC hardware
+    ↓ DMA
+Ring buffer
+    ↓ interrupt / NAPI poll
+sk_buff allocation
+    ↓
+Ethernet demux (__netif_receive_skb)
+    ↓
+IP input (ip_rcv)
+    ↓ Netfilter: PREROUTING
+    ↓ routing decision
+    ↓ Netfilter: INPUT
+TCP input (tcp_v4_rcv)
+    ↓ socket lookup
+    ↓ TCP state machine
+Socket receive queue
+    ↓ data_ready wakeup
+Application: read() / recv()
+```
+
+## Phase 1: NIC DMA and interrupt
+
+The NIC places received packets into a pre-allocated **ring buffer** via DMA. Each ring entry (descriptor) points to a kernel buffer:
+
+```c
+// Driver pre-allocates buffers (RX ring setup)
+for each ring slot:
+    buf = page_pool_alloc_pages(pool, GFP_ATOMIC);
+    ring->desc[i].dma_addr = dma_map_page(dev, buf, ...);
+```
+
+When a packet arrives:
+1. NIC writes packet data to the DMA buffer
+2. NIC sets the "done" bit on the ring descriptor
+3. NIC raises a hardware interrupt
+
+## Phase 2: NAPI polling
+
+The hard IRQ handler disables further NIC interrupts and schedules NAPI:
+
+```c
+// Driver interrupt handler
+static irqreturn_t my_nic_irq(int irq, void *data)
+{
+    napi_schedule(&nic->napi);   // schedule softirq poll
+    my_nic_mask_irq(nic);        // disable NIC interrupt
+    return IRQ_HANDLED;
+}
+```
+
+The `NET_RX_SOFTIRQ` softirq fires (on the same CPU) and calls `net_rx_action()`:
+
+```c
+// net/core/dev.c
+static __latent_entropy void net_rx_action(void)
+{
+    // For each scheduled napi on this CPU:
+    while (!list_empty(&sd->poll_list)) {
+        napi->poll(napi, budget);  // driver's poll function
+    }
+}
+```
+
+The driver's poll function builds `sk_buff`s from ring buffer entries:
+
+```c
+static int my_nic_poll(struct napi_struct *napi, int budget)
+{
+    while (pkts < budget && ring has packets) {
+        skb = napi_build_skb(rx_buf, headroom);
+        skb->protocol = eth_type_trans(skb, dev); // set Ethernet type
+        napi_gro_receive(napi, skb);              // pass to GRO → stack
+    }
+    if (pkts < budget)
+        napi_complete_done(napi, pkts);  // re-enable interrupt
+    return pkts;
+}
+```
+
+## Phase 3: Ethernet demux — __netif_receive_skb()
+
+`napi_gro_receive()` either merges the packet with an existing GRO flow or delivers it to `__netif_receive_skb()`:
+
+```c
+// net/core/dev.c
+static int __netif_receive_skb_core(struct sk_buff *skb, ...)
+{
+    // 1. Deliver to packet sockets (tcpdump, AF_PACKET)
+    list_for_each_entry_rcu(ptype, &ptype_all, list)
+        ptype->func(skb, ...);
+
+    // 2. XDP (if attached to this device) — early drop/redirect
+    // [handled before this point in NAPI]
+
+    // 3. Protocol demux based on skb->protocol
+    ptype = __netif_get_rx_handler(skb);
+    // For IP: ip_rcv()
+    // For ARP: arp_rcv()
+    // etc.
+    ptype->func(skb, ...);
+}
+```
+
+## Phase 4: IP input — ip_rcv()
+
+```c
+// net/ipv4/ip_input.c:564
+int ip_rcv(struct sk_buff *skb, struct net_device *dev, ...)
+{
+    // Validate IP header: checksum, version, min length
+    iph = ip_hdr(skb);
+    if (ip_fast_csum((u8 *)iph, iph->ihl))
+        goto drop;  // bad checksum
+
+    // Pull IP header, expose transport header
+    skb_pull(skb, iph->ihl * 4);
+
+    // Netfilter: NF_INET_PRE_ROUTING hook
+    // (conntrack, DNAT happens here)
+    return NF_HOOK(NFPROTO_IPV4, NF_INET_PRE_ROUTING, ..., ip_rcv_finish);
+}
+
+static int ip_rcv_finish(struct sk_buff *skb)
+{
+    // Route: is this for us or should we forward?
+    ip_route_input_noref(skb, iph->daddr, iph->saddr, iph->tos, dev);
+
+    // dst decides: local delivery or forward
+    return dst_input(skb);
+    // → ip_local_deliver() for local packets
+    // → ip_forward() for forwarded packets
+}
+```
+
+## Phase 5: Netfilter INPUT hook and local delivery
+
+```c
+// net/ipv4/ip_input.c
+int ip_local_deliver(struct sk_buff *skb)
+{
+    // Netfilter: NF_INET_LOCAL_IN hook
+    // (iptables INPUT rules, firewall, etc.)
+    return NF_HOOK(NFPROTO_IPV4, NF_INET_LOCAL_IN, ..., ip_local_deliver_finish);
+}
+
+static int ip_local_deliver_finish(struct sk_buff *skb)
+{
+    // Transport protocol demux
+    // iph->protocol = IPPROTO_TCP (6), IPPROTO_UDP (17), etc.
+    ipprot = rcu_dereference(inet_protos[iph->protocol]);
+    ipprot->handler(skb);
+    // → tcp_v4_rcv() for TCP
+    // → udp_rcv() for UDP
+}
+```
+
+## Phase 6: TCP receive — tcp_v4_rcv()
+
+```c
+// net/ipv4/tcp_ipv4.c:2147
+int tcp_v4_rcv(struct sk_buff *skb)
+{
+    // 1. Validate TCP header
+    th = tcp_hdr(skb);
+    if (skb->len < th->doff * 4)
+        goto drop;
+
+    // 2. Socket lookup: find the sock matching (src IP, src port, dst IP, dst port)
+    sk = __inet_lookup_skb(&tcp_hashinfo, skb, th->source, th->dest, ...);
+    if (!sk)
+        goto no_tcp_socket;  // send RST
+
+    // 3. If socket lock is held, queue to backlog
+    if (!sock_owned_by_user(sk)) {
+        tcp_v4_do_rcv(sk, skb);
+    } else {
+        sk_add_backlog(sk, skb, ...);
+    }
+}
+
+static int tcp_v4_do_rcv(struct sock *sk, struct sk_buff *skb)
+{
+    // TCP state machine: handles SYN, ACK, data, FIN, RST
+    // For ESTABLISHED state:
+    tcp_rcv_established(sk, skb);
+}
+```
+
+## Phase 7: TCP state machine and socket queue
+
+For an ESTABLISHED connection receiving data:
+
+```c
+// net/ipv4/tcp_input.c (simplified)
+static void tcp_rcv_established(struct sock *sk, struct sk_buff *skb)
+{
+    // Fast path: expected sequence number, no options
+    // Slow path: reordering, SACKs, urgent data, options
+
+    // 1. Sequence number validation
+    // 2. Data delivery to receive queue
+    eaten = tcp_queue_rcv(sk, skb, &fragstolen);
+
+    // 3. Send ACK (may be delayed)
+    tcp_event_data_recv(sk, skb);
+
+    // 4. Wake up reader
+    sk->sk_data_ready(sk);  // = sock_def_readable()
+}
+
+static int tcp_queue_rcv(struct sock *sk, struct sk_buff *skb, bool *fragstolen)
+{
+    // Add to sk->sk_receive_queue
+    __skb_queue_tail(&sk->sk_receive_queue, skb);
+    sk_mem_charge(sk, skb->truesize);  // charge against sk_rcvbuf
+}
+```
+
+## Phase 8: Application read()
+
+The application calls `read()` or `recv()`. If `sk_receive_queue` is empty, it blocks (TASK_INTERRUPTIBLE). When `sk_data_ready()` fires, the task wakes:
+
+```c
+// net/ipv4/tcp.c
+int tcp_recvmsg(struct sock *sk, struct msghdr *msg, size_t len, int flags, int *addr_len)
+{
+    // Lock the socket
+    lock_sock(sk);
+
+    while (len > 0) {
+        // Dequeue from sk_receive_queue
+        skb = skb_peek(&sk->sk_receive_queue);
+        if (!skb) {
+            // Nothing: wait
+            sk_wait_data(sk, &timeo, last);
+            continue;
+        }
+
+        // Copy data to userspace (msg->msg_iter)
+        copied = skb_copy_datagram_msg(skb, offset, msg, chunk);
+        // Advance offset, release consumed skbs
+    }
+
+    // Process backlog accumulated while we held the lock
+    release_sock(sk);
+}
+```
+
+`release_sock()` processes the backlog: packets that arrived while the socket was locked are now handled by `tcp_v4_do_rcv()`.
+
+## Key counters to watch
+
+```bash
+# Drop counters at each stage
+ethtool -S eth0 | grep -i drop   # NIC ring drops
+cat /proc/net/softnet_stat        # softirq backlog drops (column 2)
+ss -s                             # socket buffer drops
+cat /proc/net/snmp | grep -E "Tcp|Ip"  # IP/TCP protocol counters
+
+# Specific TCP counters
+netstat -s | grep -E "segments|retransmit|error"
+
+# Socket receive queue depth (RX-Q column)
+ss -tn  # non-zero RX-Q means unread data in socket buffer
+```
+
+## Further reading
+
+- [sk_buff](sk-buff.md) — The packet structure used throughout this path
+- [Network Device and NAPI](napi.md) — Phases 1-2 in depth
+- [Socket Layer Overview](socket-layer.md) — struct sock and the receive queue
+- [Life of a Packet (transmit)](life-of-packet-tx.md) — The outbound path
+- [TCP Implementation](tcp.md) — TCP state machine and congestion control

--- a/docs/net/life-of-packet-tx.md
+++ b/docs/net/life-of-packet-tx.md
@@ -1,0 +1,312 @@
+# Life of a Packet (Transmit Path)
+
+> From application write() to NIC DMA, step by step
+
+## Overview
+
+When an application writes data to a TCP socket, the kernel turns that data into one or more IP packets and transmits them. The path from `write()` to wire:
+
+```
+Application: write() / send()
+    ↓
+tcp_sendmsg()         copy data into sk_buff chain
+    ↓
+tcp_write_xmit()      TCP segmentation, window check
+    ↓
+tcp_transmit_skb()    build TCP header
+    ↓
+ip_queue_xmit()       build IP header, routing lookup
+    ↓ Netfilter: OUTPUT
+    ↓ Netfilter: POSTROUTING
+neigh_output()        ARP resolution → Ethernet header
+    ↓
+dev_queue_xmit()      qdisc (traffic control)
+    ↓
+driver ndo_start_xmit() DMA to NIC
+    ↓
+NIC transmits packet
+```
+
+## Phase 1: tcp_sendmsg() — data from userspace
+
+```c
+// net/ipv4/tcp.c:1460
+int tcp_sendmsg(struct sock *sk, struct msghdr *msg, size_t size)
+{
+    lock_sock(sk);
+    err = tcp_sendmsg_locked(sk, msg, size);
+    release_sock(sk);
+    return err;
+}
+
+int tcp_sendmsg_locked(struct sock *sk, struct msghdr *msg, size_t size)
+{
+    while (msg_data_left(msg)) {
+        // Get or allocate a send sk_buff
+        skb = tcp_write_queue_tail(sk);
+        if (!skb || skb_tailroom(skb) == 0) {
+            skb = sk_stream_alloc_skb(sk, 0, sk->sk_allocation, ...);
+            tcp_add_write_queue_tail(sk, skb);
+        }
+
+        // Copy data from userspace into skb
+        // Uses copy_from_iter() — zero-copy for MSG_ZEROCOPY if configured
+        copy = skb_copy_to_page_nocache(sk, &msg->msg_iter, skb, ...);
+        copied += copy;
+    }
+
+    // Try to send immediately
+    tcp_push(sk, flags, mss_now, ...);
+}
+```
+
+Data is held in `sk->sk_write_queue` until TCP decides to send it.
+
+## Phase 2: TCP write: tcp_write_xmit()
+
+TCP decides *when* to send based on:
+- Congestion window (`tp->snd_cwnd`)
+- Receive window advertised by peer (`tp->snd_wnd`)
+- Nagle algorithm (delay small packets)
+- Send buffer availability
+
+```c
+// net/ipv4/tcp_output.c
+static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, ...)
+{
+    while ((skb = tcp_send_head(sk))) {
+        // Check congestion window
+        cwnd_quota = tcp_cwnd_test(tp, skb);
+        if (!cwnd_quota)
+            break;
+
+        // Check receive window
+        if (!tcp_snd_wnd_test(tp, skb, mss_now))
+            break;
+
+        // Segment if skb is larger than MSS
+        if (skb->len > mss_now)
+            tcp_mtu_probe(sk) || tcp_fragment(sk, skb, mss_now, ...);
+
+        tcp_transmit_skb(sk, skb, 1, GFP_ATOMIC);
+    }
+}
+```
+
+## Phase 3: Build TCP header — tcp_transmit_skb()
+
+```c
+// net/ipv4/tcp_output.c
+static int tcp_transmit_skb(struct sock *sk, struct sk_buff *skb, int clone_it, ...)
+{
+    // Clone the skb (original stays in write queue for retransmit)
+    if (clone_it)
+        skb = skb_clone(skb, gfp_mask);
+
+    // Make room for TCP header
+    skb_push(skb, tcp_header_size);
+    skb_reset_transport_header(skb);
+
+    // Fill TCP header
+    th = tcp_hdr(skb);
+    th->source = inet->inet_sport;
+    th->dest   = inet->inet_dport;
+    th->seq    = htonl(tcb->seq);
+    th->ack_seq = htonl(tp->rcv_nxt);
+    th->doff   = tcp_header_size >> 2;
+    th->window = htons(tcp_select_window(sk));
+    // ... options (SACK, timestamp, etc.)
+
+    // Compute checksum (or leave for hardware offload)
+    tcp_set_skb_tso_segs(skb, mss_now);
+
+    // Hand to IP layer
+    icsk->icsk_af_ops->queue_xmit(sk, skb, &inet->cork.fl);
+    // → ip_queue_xmit()
+}
+```
+
+## Phase 4: IP layer — ip_queue_xmit()
+
+```c
+// net/ipv4/ip_output.c:546
+int ip_queue_xmit(struct sock *sk, struct sk_buff *skb, struct flowi *fl)
+{
+    // Route lookup (cached in sk->sk_dst_cache)
+    rt = (struct rtable *)__sk_dst_check(sk, 0);
+    if (!rt) {
+        rt = ip_route_output_ports(net, fl4, sk, ...);
+        sk_setup_caps(sk, &rt->dst);
+    }
+    skb_dst_set_noref(skb, &rt->dst);
+
+    // Build IP header
+    skb_push(skb, sizeof(struct iphdr));
+    skb_reset_network_header(skb);
+    iph = ip_hdr(skb);
+    iph->version  = 4;
+    iph->ihl      = 5;
+    iph->tos      = inet->tos;
+    iph->tot_len  = htons(skb->len);
+    iph->id       = htons(inet->inet_id++);
+    iph->ttl      = ip_select_ttl(inet, &rt->dst);
+    iph->protocol = sk->sk_protocol;
+    iph->saddr    = fl4->saddr;
+    iph->daddr    = fl4->daddr;
+    ip_send_check(iph);  // compute checksum
+
+    // Netfilter: NF_INET_LOCAL_OUT hook (OUTPUT chain)
+    return NF_HOOK(NFPROTO_IPV4, NF_INET_LOCAL_OUT, sk, skb, NULL,
+                   rt->dst.dev, dst_output);
+}
+```
+
+## Phase 5: Netfilter OUTPUT and routing
+
+`dst_output()` calls `ip_output()`:
+
+```c
+// net/ipv4/ip_output.c:428
+int ip_output(struct net *net, struct sock *sk, struct sk_buff *skb)
+{
+    struct net_device *dev = skb_dst(skb)->dev;
+    skb->dev = dev;
+    skb->protocol = htons(ETH_P_IP);
+
+    // Netfilter: NF_INET_POST_ROUTING hook (POSTROUTING chain)
+    // (SNAT happens here)
+    return NF_HOOK_COND(NFPROTO_IPV4, NF_INET_POST_ROUTING, sk, skb,
+                        NULL, dev, ip_finish_output, ...);
+}
+
+static int ip_finish_output(struct net *net, struct sock *sk, struct sk_buff *skb)
+{
+    // Fragmentation if needed (skb->len > dev->mtu)
+    if (skb->len > ip_skb_dst_mtu(sk, skb))
+        return ip_fragment(net, sk, skb, mtu, ip_finish_output2);
+
+    return ip_finish_output2(net, sk, skb);
+}
+```
+
+## Phase 6: ARP and Ethernet — neigh_output()
+
+`ip_finish_output2()` resolves the next-hop MAC address:
+
+```c
+// net/ipv4/ip_output.c
+static int ip_finish_output2(struct net *net, struct sock *sk, struct sk_buff *skb)
+{
+    struct neighbour *neigh;
+
+    // Neighbour lookup (ARP table)
+    neigh = ip_neigh_for_gw(rt, skb, &is_v6gw);
+    if (!neigh) {
+        // ARP resolution: send ARP request, queue packet
+        neigh_output(neigh, skb, is_v6gw);
+    }
+
+    // neigh->output = neigh_hh_output() if MAC known
+    // → adds Ethernet header and calls dev_queue_xmit()
+    return neigh_output(neigh, skb, is_v6gw);
+}
+```
+
+If the ARP entry doesn't exist, an ARP request is sent and the packet is queued until the reply arrives.
+
+## Phase 7: Traffic control — dev_queue_xmit()
+
+```c
+// net/core/dev.c
+int dev_queue_xmit(struct sk_buff *skb)
+{
+    struct net_device *dev = skb->dev;
+    struct netdev_queue *txq;
+
+    // Select transmit queue (XPS: Transmit Packet Steering)
+    txq = netdev_core_pick_tx(dev, skb, ...);
+
+    // Pass through qdisc (traffic control, rate limiting)
+    // Default: pfifo_fast (priority FIFO)
+    // Custom: tbf, htb, fq_codel, etc.
+    rc = __dev_xmit_skb(skb, q, dev, txq);
+    // q->enqueue() → q->dequeue() → dev_hard_start_xmit()
+}
+```
+
+The qdisc can:
+- Drop packets (rate limiting via TBF, policing)
+- Reorder packets (FQ scheduling)
+- Delay packets (netem for testing)
+- Shape traffic (HTB, TBF)
+
+## Phase 8: Driver DMA — ndo_start_xmit()
+
+```c
+// Driver implementation
+static netdev_tx_t my_nic_xmit(struct sk_buff *skb, struct net_device *dev)
+{
+    // Map skb data for DMA
+    dma_addr = dma_map_single(dev, skb->data, skb->len, DMA_TO_DEVICE);
+
+    // Write descriptor to TX ring
+    ring->desc[tail].dma_addr = dma_addr;
+    ring->desc[tail].len = skb->len;
+    ring->desc[tail].cmd = CMD_EOP | CMD_IFCS;  // end of packet, insert FCS
+
+    // Advance ring tail
+    ring->tail = (tail + 1) % ring->size;
+
+    // Ring doorbell: notify NIC of new descriptor
+    writel(ring->tail, ring->tail_reg);
+
+    return NETDEV_TX_OK;
+}
+```
+
+After the NIC transmits the packet, it generates a TX completion interrupt. The driver then calls `dev_consume_skb_any(skb)` to free the `sk_buff`.
+
+## TX completion and write space wakeup
+
+```c
+// TX completion interrupt handler
+static void my_nic_tx_clean(struct my_nic_ring *ring)
+{
+    while (ring->next_to_clean != ring->next_to_use) {
+        skb = ring->tx_buf[ring->next_to_clean].skb;
+        dma_unmap_single(...);
+        dev_consume_skb_any(skb);  // free sk_buff
+        ring->next_to_clean++;
+    }
+    // If socket send buffer freed up, wake the writer
+    netif_wake_queue(ring->dev);
+}
+```
+
+`netif_wake_queue()` eventually calls `sk->sk_write_space(sk)`, waking any task blocked in `sendmsg()` waiting for send buffer space.
+
+## Send buffer and backpressure
+
+The kernel won't copy more data than the send buffer allows:
+
+```bash
+# Default TCP send buffer sizes [min, default, max]
+cat /proc/sys/net/ipv4/tcp_wmem
+# → 4096 16384 4194304
+
+# Per-socket override
+setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size));
+
+# Check current usage (Send-Q column)
+ss -tn  # non-zero Send-Q = data in send buffer, waiting to be transmitted
+```
+
+If `sk->sk_wmem_alloc >= sk->sk_sndbuf`, `tcp_sendmsg()` blocks until TX completions free up space.
+
+## Further reading
+
+- [sk_buff](sk-buff.md) — The packet structure built in tcp_sendmsg
+- [Life of a Packet (receive)](life-of-packet-rx.md) — The inbound path
+- [TCP Implementation](tcp.md) — Congestion control and window management
+- [Socket Layer Overview](socket-layer.md) — The sendmsg dispatch chain
+- [TC and qdisc](tc-qdisc.md) — Traffic control in Phase 7

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,3 +200,7 @@ nav:
       - "sk_buff: The Network Buffer": net/sk-buff.md
       - Socket Layer Overview: net/socket-layer.md
       - Network Device and NAPI: net/napi.md
+    - Lifecycle:
+      - Life of a Packet (receive): net/life-of-packet-rx.md
+      - Life of a Packet (transmit): net/life-of-packet-tx.md
+      - What Happens When You connect(): net/connect.md


### PR DESCRIPTION
Batch 7: networking lifecycle. Closes #108, #109, #110.

## Pages added

- **Life of a Packet (receive)** — 8-phase annotated path from NIC DMA ring buffer through NAPI poll, `__netif_receive_skb` Ethernet demux, `ip_rcv` + Netfilter PREROUTING/INPUT hooks, `tcp_v4_rcv` socket hash lookup and backlog handling, `tcp_rcv_established` sequence validation and `sk_receive_queue`, `sk_data_ready` wakeup, and `tcp_recvmsg` data copy to userspace (#108)
- **Life of a Packet (transmit)** — 8-phase path from `tcp_sendmsg` data copy into write queue, `tcp_write_xmit` congestion window / receive window check, `tcp_transmit_skb` TCP header build with options, `ip_queue_xmit` IP header + routing, Netfilter OUTPUT/POSTROUTING hooks, `neigh_output` ARP resolution + Ethernet header, `dev_queue_xmit` qdisc, `ndo_start_xmit` DMA, and TX completion write-space wakeup (#109)
- **What Happens When You connect()** — Full TCP 3-way handshake: `tcp_v4_connect` route lookup + port selection + SYN_SENT, `tcp_connect` ISN + SYN options (MSS/WSCALE/SACK/timestamp), server `request_sock` half-open tracking + SYN-ACK, client `tcp_rcv_synsent_state_process` ESTABLISHED transition + final ACK, server accept queue delivery. Includes SYN backlog, SYN cookies, and ephemeral port range tuning (#110)

## Depends on
PR #228 (add-net-fundamentals)