### PR TITLE
Add TCP/IP internals docs

### DIFF
--- a/docs/net/ip-routing.md
+++ b/docs/net/ip-routing.md
@@ -1,0 +1,245 @@
+# IP Routing
+
+> How the kernel decides where packets go: routing tables, lookups, and the FIB
+
+## What routing does
+
+For every packet — inbound or outbound — the kernel asks: "where should this go?" The routing subsystem answers:
+
+- **Local delivery**: This packet is for us, send it up to a socket
+- **Forward**: This packet is for someone else, find the next hop and transmit
+- **Unreachable**: No route to destination, send ICMP unreachable
+
+The answer comes from the **FIB (Forwarding Information Base)** — the kernel's routing table.
+
+## The routing tables
+
+Linux supports multiple routing tables (for policy routing):
+
+```bash
+# Main table (table 254) — standard routes
+ip route show
+
+# All tables
+ip route show table all
+
+# Lookup a specific destination
+ip route get 8.8.8.8
+# → 8.8.8.8 via 192.168.1.1 dev eth0 src 192.168.1.100
+
+# Add a route
+ip route add 10.0.0.0/8 via 192.168.1.254 dev eth0
+
+# Policy rules: route by source IP, mark, or interface
+ip rule show
+```
+
+## FIB internals: LC-trie
+
+The kernel implements the FIB as an **LC-trie** (Level Compressed trie, a.k.a. Patricia trie) for efficient longest-prefix matching:
+
+```c
+// include/net/ip_fib.h
+struct fib_table {
+    struct hlist_node   tb_hlist;
+    u32                 tb_id;      // table ID (254 = main, 255 = local)
+    int                 tb_num_default;
+    struct rcu_head     rcu;
+    unsigned long       *tb_data;   // the trie
+};
+
+struct fib_result {
+    __be32          prefix;
+    unsigned char   prefixlen;
+    struct fib_info *fi;    // next-hop info: gateway, device, metrics
+    struct fib_nh_common *nhc; // selected next hop (for ECMP)
+    // ...
+};
+```
+
+Lookup is `fib_table_lookup()`:
+
+```c
+// net/ipv4/fib_trie.c:1420
+int fib_table_lookup(struct fib_table *tb, const struct flowi4 *flp,
+                     struct fib_result *res, int fib_flags)
+{
+    // Walk the LC-trie from root
+    // At each node, extract bits from the destination address
+    // Follow the matching child
+    // At a leaf: longest-prefix match found
+    // Fill res with the fib_info (gateway, interface, etc.)
+}
+```
+
+## Route lookup: ip_route_input_noref()
+
+On receive, routing is called from `ip_rcv_finish()`:
+
+```c
+// net/ipv4/route.c
+int ip_route_input_noref(struct sk_buff *skb, __be32 daddr, __be32 saddr,
+                          dscp_t dscp, struct net_device *dev)
+{
+    // 1. Check route cache (per-CPU)
+    if (rt_cache_valid(skb->dst))
+        return 0;
+
+    // 2. FIB lookup
+    err = fib_lookup(net, &fl4, &res, 0);
+
+    // 3. Determine input action
+    if (res.type == RTN_LOCAL) {
+        // Packet is for us
+        skb->dst = &ip_local_deliver;
+    } else if (res.type == RTN_UNICAST) {
+        // Packet should be forwarded
+        ip_route_input_slow(skb, daddr, saddr, ...);
+    } else {
+        // RTN_UNREACHABLE, RTN_BLACKHOLE, RTN_PROHIBIT
+        goto martian_destination;
+    }
+}
+```
+
+## Route cache: dst_entry
+
+Routing decisions are cached in `struct dst_entry`:
+
+```c
+// include/net/dst.h
+struct dst_entry {
+    struct net_device *dev;         // output device
+    struct  dst_ops   *ops;         // ip_dst_ops, etc.
+    void (*output)(struct net *, struct sock *, struct sk_buff *);
+    // → ip_output() for local, ip_forward() for forwarded
+
+    unsigned long     _metrics;     // MTU, RTT, etc.
+    unsigned long     expires;      // cache expiry
+};
+```
+
+On the transmit path, the route is cached in `sk->sk_dst_cache`:
+
+```c
+// ip_queue_xmit() checks this first:
+rt = (struct rtable *)__sk_dst_check(sk, 0);
+if (!rt) {
+    rt = ip_route_output_ports(net, fl4, sk, daddr, saddr, ...);
+    sk_setup_caps(sk, &rt->dst);  // cache it
+}
+```
+
+## Policy routing
+
+Linux supports multiple routing tables and **rules** that select which table to use:
+
+```bash
+# Add a rule: packets from 10.0.0.0/24 use table 100
+ip rule add from 10.0.0.0/24 table 100
+ip route add default via 192.168.2.1 table 100
+
+# Rules are evaluated in priority order
+ip rule show
+# 0:      from all lookup local   (local table: localhost, broadcast)
+# 32766:  from all lookup main    (main table: normal routes)
+# 32767:  from all lookup default (default table: usually empty)
+```
+
+Rules can match on:
+- Source address (`from`)
+- Destination address (`to`)
+- Incoming interface (`iif`)
+- Firewall mark (`fwmark`)
+- TOS/DSCP field
+
+## ECMP: Equal Cost Multipath
+
+Multiple routes to the same destination with equal metric = ECMP:
+
+```bash
+# Add two equal-cost routes (traffic split across eth0 and eth1)
+ip route add 10.0.0.0/8 nexthop via 192.168.1.1 dev eth0 weight 1 \
+                         nexthop via 192.168.2.1 dev eth1 weight 1
+
+# Default hash: 5-tuple (src/dst IP, src/dst port, protocol)
+# L4 hash ensures same flow always takes the same path
+```
+
+```bash
+# Check ECMP hashing algorithm
+cat /proc/sys/net/ipv4/fib_multipath_hash_policy
+# 0 = L3 (src+dst IP)
+# 1 = L4 (5-tuple)
+# 2 = L3+L4
+```
+
+## Neighbor subsystem: ARP
+
+IP routing resolves to a next-hop IP, but transmission requires a MAC address. The **neighbor subsystem** maps IP → MAC via ARP:
+
+```c
+// net/core/neighbour.c
+struct neighbour {
+    struct neighbour __rcu *next;
+    struct neigh_table  *tbl;       // arp_tbl for IPv4
+    struct neigh_parms  *parms;
+    unsigned long       confirmed;  // last time we confirmed reachability
+    u8                  flags;
+    u8                  nud_state;  // NUD_REACHABLE, NUD_STALE, NUD_PROBE, ...
+    u8                  ha[ALIGN(MAX_ADDR_LEN, sizeof(unsigned long))]; // MAC addr
+    struct hh_cache     hh;         // cached L2 header for fast path
+    int (*output)(struct neighbour *, struct sk_buff *);
+};
+```
+
+NUD (Neighbor Unreachability Detection) states:
+
+```
+INCOMPLETE → REACHABLE (ARP reply received)
+REACHABLE → STALE (no recent confirmation)
+STALE → PROBE (send unicast ARP probe)
+PROBE → REACHABLE (got reply) or FAILED (no reply)
+```
+
+```bash
+# View ARP table
+ip neigh show
+
+# Add static ARP entry
+ip neigh add 10.0.0.5 lladdr 52:54:00:12:34:56 dev eth0
+
+# Flush stale entries
+ip neigh flush dev eth0
+
+# Tune ARP cache lifetime
+cat /proc/sys/net/ipv4/neigh/default/gc_stale_time  # default: 60s
+```
+
+## Diagnosing routing issues
+
+```bash
+# Simulate routing decision
+ip route get 8.8.8.8
+
+# Watch routing table changes
+ip monitor route
+
+# Count route cache misses (if applicable)
+cat /proc/net/rt_cache_stat  # (removed in newer kernels)
+
+# FIB table statistics
+cat /proc/net/fib_triestat
+# Aver depth: how deep the trie is
+# Max depth: worst case lookup depth
+
+# ICMP unreachable messages (routing failures)
+netstat -s | grep "destination unreachable"
+```
+
+## Further reading
+
+- [Life of a Packet (receive)](life-of-packet-rx.md) — Where routing fits in ip_rcv_finish
+- [Life of a Packet (transmit)](life-of-packet-tx.md) — Where ip_queue_xmit uses routing
+- [Netfilter Architecture](netfilter.md) — Hooks run alongside routing decisions
+- [TCP Implementation](tcp.md) — How TCP uses routing for source IP selection

--- a/docs/net/tcp.md
+++ b/docs/net/tcp.md
@@ -1,0 +1,290 @@
+# TCP Implementation
+
+> How the kernel implements reliable, ordered, byte-stream delivery
+
+## TCP's guarantees
+
+TCP provides:
+1. **Reliability**: Lost packets are retransmitted
+2. **Ordering**: Out-of-order segments are reordered before delivery
+3. **Flow control**: The sender doesn't overwhelm the receiver
+4. **Congestion control**: The sender doesn't overwhelm the network
+
+The kernel implements all four simultaneously, which is why TCP is complex.
+
+## struct tcp_sock
+
+TCP state per connection is in `struct tcp_sock` (extends `struct sock`):
+
+```c
+// include/linux/tcp.h
+struct tcp_sock {
+    // Sequence numbers
+    u32  rcv_nxt;      // next sequence we expect to receive
+    u32  snd_nxt;      // next sequence we'll send
+    u32  snd_una;      // oldest unacknowledged byte (send window start)
+
+    // Congestion control
+    u32  snd_cwnd;     // congestion window (in MSS units)
+    u32  snd_ssthresh; // slow start threshold
+    u32  snd_cwnd_cnt; // linear increase counter
+
+    // RTT measurement
+    u32  srtt_us;      // smoothed RTT (SRTT) × 8, in microseconds
+    u32  mdev_us;      // mean deviation of RTT (for RTO)
+    u32  rttvar_us;    // RTT variance
+
+    // Receive window
+    u32  rcv_wnd;      // current receive window size
+    u32  rcv_ssthresh; // receive window size threshold (small socket buffer)
+    u32  window_clamp; // maximum window size
+
+    // SACK state
+    struct tcp_sack_block selective_acks[4];  // SACK blocks to advertise
+    struct tcp_sack_block recv_sack_cache[4]; // cached SACK received
+
+    // Retransmission
+    u32  high_seq;     // snd_nxt at onset of congestion
+    u32  undo_marker;  // snd_una upon a new recovery episode
+
+    // Congestion control private data
+    // Accessed via tcp_sk(sk)->inet_conn.icsk_ca_priv
+    // (64 bytes for algorithm-specific state, e.g., BBR bandwidth samples)
+    // ...
+};
+```
+
+## Sequence numbers and windows
+
+```
+Send side:
+  snd_una ─── snd_nxt
+     │            │
+     └── unacked ─┘  (in-flight, waiting for ACK)
+         ↑
+  snd_una + snd_cwnd = send window limit
+
+Receive side:
+  rcv_nxt = next expected byte
+  rcv_nxt + rcv_wnd = advertised window limit (flow control)
+```
+
+## Retransmission: RTO and timer
+
+The **Retransmission Timeout (RTO)** is calculated from RTT measurements:
+
+```
+SRTT = α × SRTT + (1 - α) × RTT_sample   (α = 7/8)
+RTTVAR = β × RTTVAR + (1 - β) × |SRTT - RTT|   (β = 3/4)
+RTO = SRTT + 4 × RTTVAR   (minimum: 200ms)
+```
+
+When a segment is transmitted, a retransmit timer is armed for RTO. If no ACK arrives within RTO:
+1. The segment is retransmitted
+2. RTO doubles (exponential backoff)
+3. `snd_cwnd` is reduced (congestion signal)
+
+```bash
+# View TCP retransmit counters
+netstat -s | grep retransmit
+cat /proc/net/snmp | grep ^Tcp
+# TcpRetransSegs: total retransmitted segments
+```
+
+## Fast retransmit and SACK
+
+When out-of-order segments arrive, the receiver sends **duplicate ACKs** (same `ack_seq` as before, with a SACK block noting what was received).
+
+Three duplicate ACKs → fast retransmit (before RTO expires):
+
+```c
+// net/ipv4/tcp_input.c
+static void tcp_fastretrans_alert(struct sock *sk, u32 prior_snd_una, ...)
+{
+    // 3 duplicate ACKs → enter LOSS recovery
+    if (tp->sacked_out >= tp->reordering) {
+        tcp_enter_recovery(sk, ...);
+        // Retransmit the lost segment immediately
+        tcp_retransmit_skb(sk, tcp_rtx_queue_head(sk), 1);
+    }
+}
+```
+
+With **SACK (Selective ACK)**, the receiver tells the sender exactly which segments were received out of order. The sender can retransmit only the gaps:
+
+```bash
+# SACK is enabled by default
+cat /proc/sys/net/ipv4/tcp_sack  # → 1
+```
+
+## Congestion control framework
+
+The kernel has a pluggable congestion control framework:
+
+```c
+// include/net/tcp.h
+struct tcp_congestion_ops {
+    // Classic response: update cwnd on ACK
+    void (*cong_avoid)(struct sock *sk, u32 ack, u32 acked);
+
+    // Custom control: full control over cwnd and pacing
+    void (*cong_control)(struct sock *sk, u32 ack, int flag,
+                         const struct rate_sample *rs);
+
+    // Called when loss is detected: return new ssthresh
+    u32  (*ssthresh)(struct sock *sk);
+
+    // Called after loss recovery: restore cwnd
+    u32  (*undo_cwnd)(struct sock *sk);
+
+    char name[TCP_CA_NAME_MAX];  // "cubic", "bbr", "reno", etc.
+};
+```
+
+### Available algorithms
+
+```bash
+# List available congestion control algorithms
+cat /proc/sys/net/ipv4/tcp_available_congestion_control
+# cubic reno bbr2 bbr
+
+# Current default
+cat /proc/sys/net/ipv4/tcp_congestion_control
+# cubic
+
+# Change globally
+echo bbr > /proc/sys/net/ipv4/tcp_congestion_control
+
+# Per-socket (requires CAP_NET_ADMIN for some algorithms)
+setsockopt(fd, IPPROTO_TCP, TCP_CONGESTION, "bbr", 4);
+```
+
+### CUBIC (default)
+
+CUBIC uses the cubic function of time since last congestion event to grow the congestion window:
+
+```
+W(t) = C × (t - K)³ + W_max
+
+Where:
+  W_max = cwnd at last congestion event
+  K = time for cwnd to return to W_max
+  C = scaling constant (0.4)
+```
+
+- **Slow start**: cwnd grows exponentially until ssthresh
+- **Congestion avoidance**: cwnd grows per the cubic function
+- **Loss detected**: ssthresh = 0.7 × cwnd; cwnd = ssthresh
+
+### BBR (Bottleneck Bandwidth and RTT)
+
+BBR (Bottleneck Bandwidth and RTT) models the network path — bandwidth and propagation delay — rather than reacting to loss:
+
+```
+delivery_rate = bytes_delivered / elapsed_time
+BtlBw = max delivery_rate over recent window
+RTprop = min RTT over recent window
+
+pacing_rate = 2.77 × BtlBw  (probe phase)
+              BtlBw          (drain/PROBE_BW phase)
+cwnd = BtlBw × RTprop × 2   (BDP × 2)
+```
+
+BBR sends at a **paced rate** matching the bottleneck bandwidth, avoiding buffer bloat that loss-based algorithms create:
+
+```bash
+# BBR requires fq qdisc for accurate pacing
+echo fq > /sys/class/net/eth0/queues/tx-0/tx_queue_len  # not quite right
+tc qdisc replace dev eth0 root fq
+echo bbr > /proc/sys/net/ipv4/tcp_congestion_control
+```
+
+## Flow control: receive window
+
+The receiver's `rcv_wnd` tells the sender how much space remains in the receive buffer. If `rcv_wnd = 0`, the sender stops (zero window probe situation):
+
+```c
+// net/ipv4/tcp_output.c
+static u16 tcp_select_window(struct sock *sk)
+{
+    u32 cur_win = tcp_receive_window(tp);
+    u32 new_win = __tcp_select_window(sk);
+
+    // Don't shrink the window (can confuse senders)
+    if (new_win < cur_win)
+        new_win = cur_win;
+
+    return new_win;
+}
+```
+
+**TCP window scaling** (RFC 1323) allows windows > 65535 bytes by using a shift factor negotiated in SYN/SYN-ACK:
+
+```bash
+cat /proc/sys/net/ipv4/tcp_window_scaling  # → 1 (enabled)
+```
+
+## Nagle algorithm and TCP_NODELAY
+
+By default, TCP delays small packets hoping to coalesce them (Nagle's algorithm). For latency-sensitive applications:
+
+```c
+// Disable Nagle: send immediately even if segment is small
+int flag = 1;
+setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+```
+
+```bash
+# Check if TCP_NODELAY is set
+ss -tni | grep nodelay
+```
+
+## Key TCP sysctls
+
+```bash
+# Initial congestion window (in MSS units, default 10 per RFC 6928)
+cat /proc/sys/net/ipv4/tcp_init_cwnd  # Linux uses 10 by default
+
+# Maximum retransmits before giving up
+cat /proc/sys/net/ipv4/tcp_retries2  # default: 15 (≈924s timeout)
+
+# TIME_WAIT sockets: allow fast reuse
+echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse  # reuse for new outgoing connections
+
+# Keep-alive probes
+cat /proc/sys/net/ipv4/tcp_keepalive_time     # 7200s (2h)
+cat /proc/sys/net/ipv4/tcp_keepalive_probes   # 9 probes
+cat /proc/sys/net/ipv4/tcp_keepalive_intvl    # 75s between probes
+
+# Buffer auto-tuning [min, default, max]
+cat /proc/sys/net/ipv4/tcp_rmem
+cat /proc/sys/net/ipv4/tcp_wmem
+```
+
+## Inspecting TCP connections
+
+```bash
+# Detailed TCP socket info (shows congestion state, cwnd, etc.)
+ss -tni
+
+# Example output:
+# State Recv-Q Send-Q  Local Address:Port  Peer Address:Port
+# ESTAB 0      0       10.0.0.1:22         10.0.0.2:54321
+#  cubic wscale:7,7 rto:208 rtt:4.5/0.75 ato:40 mss:1448 pmtu:1500
+#  rcvmss:931 advmss:1448 cwnd:10 ssthresh:2147483647 bytes_sent:12345
+#  segs_out:456 segs_in:234 data_segs_out:123 send 25.7Mbps
+#  lastrcv:100ms lastack:50ms pacing_rate 51.4Mbps delivery_rate 25.7Mbps
+
+# Per-connection retransmit info
+ss -tin | grep retrans
+
+# TCP statistics
+netstat -s | grep -E "connection|segment|retransmit"
+```
+
+## Further reading
+
+- [TCP Congestion Control Algorithms](tcp-congestion.md) — CUBIC and BBR in depth (see below)
+- [Life of a Packet (transmit)](life-of-packet-tx.md) — How tcp_write_xmit uses cwnd
+- [What Happens When You connect()](connect.md) — Handshake and initial window setup
+- [Socket Layer Overview](socket-layer.md) — The socket buffer that feeds tcp_sendmsg

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,3 +204,6 @@ nav:
       - Life of a Packet (receive): net/life-of-packet-rx.md
       - Life of a Packet (transmit): net/life-of-packet-tx.md
       - What Happens When You connect(): net/connect.md
+    - TCP/IP:
+      - TCP Implementation: net/tcp.md
+      - IP Routing: net/ip-routing.md


### PR DESCRIPTION
Batch 8: TCP/IP internals. Closes #111, #112, #113.

## Pages added

- **TCP Implementation** — struct tcp_sock key fields (cwnd, ssthresh, rcv_nxt/snd_nxt/snd_una, srtt_us), sequence number and window diagram, RTO calculation (SRTT/RTTVAR per Jacobson), fast retransmit with 3 dupACKs, SACK selective retransmit, `tcp_congestion_ops` pluggable interface, CUBIC cubic function formula and behavior, BBR bandwidth-delay model (BtlBw + RTprop, pacing), Nagle algorithm and TCP_NODELAY, key sysctls (tcp_rmem/wmem, tcp_retries2, TIME_WAIT), `ss -tni` output decoding (#111, #112)
- **IP Routing** — FIB LC-trie structure (fib_table, fib_result), `fib_table_lookup`, `ip_route_input_noref` local/forward/unreachable decision, `dst_entry` routing cache and sk->sk_dst_cache, policy routing with `ip rule` (source, fwmark, iif selectors), ECMP multipath and L3/L4 hash policy, neighbor/ARP subsystem (struct neighbour, NUD state machine: INCOMPLETE→REACHABLE→STALE→PROBE), ARP cache tuning, fib_triestat diagnostics (#113)

## Depends on
PR #229 (add-net-lifecycle)