### PR TITLE
Add networking filtering docs: Netfilter, nftables, conntrack

### DIFF
--- a/docs/net/conntrack.md
+++ b/docs/net/conntrack.md
@@ -1,0 +1,259 @@
+# Connection Tracking (conntrack)
+
+> How the kernel tracks the state of network connections for stateful firewalling and NAT
+
+## What conntrack does
+
+Connection tracking maintains a table of all active network flows. For every packet, the kernel looks up its flow in this table to determine its state (new, established, related, invalid). This enables:
+
+- **Stateful firewalling**: Accept replies to outbound connections without explicit rules
+- **NAT**: Track both directions of a rewritten connection
+- **Helper modules**: Track related connections (FTP data channel, SIP RTP, etc.)
+
+Conntrack is implemented in `net/netfilter/nf_conntrack_core.c` and hooks at PREROUTING and OUTPUT (before routing and before NAT).
+
+## struct nf_conn
+
+Each tracked connection is a `struct nf_conn`:
+
+```c
+// include/net/netfilter/nf_conntrack.h
+struct nf_conn {
+    struct nf_conntrack ct_general;  // reference count
+
+    u32 timeout;  // expiry time (jiffies32)
+
+    // Two tuples: how we see it in each direction
+    // For TCP connection: client 10.0.0.1:54321 → server 8.8.8.8:80
+    //   tuplehash[ORIGINAL]: src=10.0.0.1:54321 dst=8.8.8.8:80  proto=TCP
+    //   tuplehash[REPLY]:    src=8.8.8.8:80 dst=10.0.0.1:54321  proto=TCP
+    struct nf_conntrack_tuple_hash tuplehash[IP_CT_DIR_MAX];
+
+    unsigned long status;  // IPS_* bitmask
+
+    u_int32_t mark;    // connmark (can be set by iptables CONNMARK target)
+    u_int32_t secmark; // SELinux security mark
+
+    union nf_conntrack_proto proto;  // per-protocol state (TCP: state machine)
+};
+```
+
+### Connection status bits (IPS_*)
+
+```c
+IPS_EXPECTED      // was expected by a helper (e.g., FTP data)
+IPS_SEEN_REPLY    // seen traffic in both directions
+IPS_ASSURED       // will survive GC under memory pressure (long-lived)
+IPS_CONFIRMED     // inserted into hash table (survived packet processing)
+IPS_SRC_NAT       // source address was NATted
+IPS_DST_NAT       // destination address was NATted
+IPS_DYING         // being removed
+IPS_FIXED_TIMEOUT // timeout was explicitly set
+```
+
+### TCP-specific state
+
+```c
+// TCP state tracked per connection
+union nf_conntrack_proto {
+    struct nf_ct_tcp {
+        enum tcp_conntrack state;  // TCP_CONNTRACK_SYN_SENT, ESTABLISHED, etc.
+        enum tcp_conntrack last_dir;
+        u_int32_t seen[2];         // window info for both directions
+    } tcp;
+    // UDP, ICMP, SCTP state...
+};
+```
+
+## Conntrack tuple
+
+A **tuple** uniquely identifies a packet in one direction:
+
+```c
+struct nf_conntrack_tuple {
+    struct nf_conntrack_man {
+        union nf_inet_addr u3;    // src IP (IPv4 or IPv6)
+        union nf_conntrack_man_proto {
+            __be16 port;  // TCP/UDP source port
+            // ICMP id, etc.
+        } u;
+    } src;
+
+    struct {
+        union nf_inet_addr u3;    // dst IP
+        union {
+            __be16 port;           // TCP/UDP destination port
+        } u;
+        u_int8_t protonum;         // IPPROTO_TCP, IPPROTO_UDP, ...
+        u_int8_t dir;              // ORIGINAL or REPLY
+    } dst;
+};
+```
+
+Two tuples are stored per `nf_conn`: the original direction and the reply direction (which is the original reversed). This is how NAT works — NAT modifies one or both tuples, and conntrack uses the reply tuple to match return traffic.
+
+## Conntrack lifecycle
+
+### 1. First packet (NEW)
+
+```
+Packet arrives → PREROUTING hook → nf_conntrack_in()
+    → Lookup hash table by packet's tuple
+    → Not found: create new nf_conn (state = UNCONFIRMED)
+    → Hash table insertion deferred (to avoid early allocation)
+    → Attach nf_conn to skb->_nfct
+```
+
+### 2. Confirmed (after LOCAL_OUT or FORWARD)
+
+```
+nf_conntrack_confirm()
+    → Hash the tuple
+    → Insert both tuplehash entries into conntrack hash table
+    → Status: IPS_CONFIRMED
+```
+
+### 3. Subsequent packets (ESTABLISHED)
+
+```
+Packet arrives → lookup by tuple → nf_conn found
+    → Update state, refresh timeout
+    → Set IPS_SEEN_REPLY when reply direction seen
+    → Set IPS_ASSURED when connection is long-lived
+```
+
+### 4. Timeout and cleanup
+
+Connections time out if no packets are seen. Timeouts vary by protocol and state:
+
+```bash
+# TCP timeouts
+cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_established  # 432000s (5 days)
+cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_syn_sent      # 120s
+cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait     # 120s
+cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_close          # 10s
+
+# UDP timeout (no state, just expiry)
+cat /proc/sys/net/netfilter/nf_conntrack_udp_timeout                # 30s
+cat /proc/sys/net/netfilter/nf_conntrack_udp_timeout_stream         # 180s
+
+# ICMP
+cat /proc/sys/net/netfilter/nf_conntrack_icmp_timeout               # 30s
+```
+
+## Conntrack states for firewall rules
+
+States visible to iptables/nftables:
+
+| State | Meaning |
+|-------|---------|
+| `NEW` | First packet of a new connection (SYN for TCP) |
+| `ESTABLISHED` | Reply seen; connection is going both ways |
+| `RELATED` | New connection related to an existing one (FTP data, ICMP error) |
+| `INVALID` | Doesn't match any connection; could be malformed |
+| `UNTRACKED` | Explicitly bypassed via `NOTRACK`/`raw` table |
+
+```bash
+# iptables: accept established/related, drop invalid
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+iptables -A INPUT -m conntrack --ctstate INVALID -j DROP
+
+# nftables
+nft add rule inet filter input ct state established,related accept
+nft add rule inet filter input ct state invalid drop
+```
+
+## Conntrack helpers: tracking related connections
+
+Some protocols open secondary connections (FTP data channel, SIP RTP media). **Conntrack helpers** parse protocol messages to `EXPECT` these secondary connections:
+
+```bash
+# Load FTP helper
+modprobe nf_conntrack_ftp
+# Now FTP data connections are automatically RELATED and accepted
+```
+
+The helper creates an **expectation** — a placeholder that matches the expected secondary connection:
+
+```c
+// When FTP server sends "PORT x,x,x,x,a,b":
+// Helper creates expectation: src=server dst=client dport=(a*256+b)
+// When data connection arrives → matches expectation → state=RELATED
+```
+
+```bash
+# View current expectations
+cat /proc/net/nf_conntrack | grep RELATED
+conntrack -L expect
+```
+
+## Conntrack marks (connmark)
+
+Marks allow correlating firewall rules with routing or QoS:
+
+```bash
+# Mark all HTTP connections
+iptables -t mangle -A POSTROUTING -p tcp --dport 80 \
+    -j CONNMARK --set-mark 0x1
+
+# Restore mark from conntrack to packet mark (on subsequent packets)
+iptables -t mangle -A PREROUTING -j CONNMARK --restore-mark
+
+# Use mark in routing (policy routing table 100)
+ip rule add fwmark 0x1 table 100
+```
+
+## Monitoring and debugging
+
+```bash
+# List all connections
+conntrack -L
+conntrack -L --proto tcp --state ESTABLISHED
+
+# Count connections by state
+conntrack -L 2>/dev/null | awk '{print $4}' | sort | uniq -c
+
+# Watch events in real time
+conntrack -E
+
+# Statistics per CPU (count lookups, inserts, found, etc.)
+conntrack -S
+# or
+cat /proc/net/stat/nf_conntrack
+
+# Dump conntrack table size
+cat /proc/sys/net/netfilter/nf_conntrack_count
+cat /proc/sys/net/netfilter/nf_conntrack_max
+
+# Manual delete
+conntrack -D -p tcp --src 10.0.0.1 --sport 54321
+
+# Flush entire table (WARNING: drops all active connections' state)
+conntrack -F
+```
+
+## Tuning for high-connection-rate environments
+
+```bash
+# Increase table size (at the cost of memory)
+echo 1048576 > /proc/sys/net/netfilter/nf_conntrack_max
+# Memory per entry: ~300 bytes → 1M entries ≈ 300MB
+
+# Hash table size (set at module load time)
+# nf_conntrack hashsize = nf_conntrack_max / 8 (typical)
+modprobe nf_conntrack hashsize=131072
+
+# Reduce TIME_WAIT entries (major consumer on busy servers)
+echo 60 > /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait
+
+# For SYN floods: don't track half-open connections (raw table)
+iptables -t raw -A PREROUTING -p tcp --syn -j NOTRACK
+iptables -A INPUT -p tcp --syn -m conntrack --ctstate UNTRACKED -j ACCEPT
+```
+
+## Further reading
+
+- [Netfilter Architecture](netfilter.md) — The hook framework conntrack lives within
+- [nftables vs iptables](nftables-iptables.md) — How to write conntrack rules
+- [Life of a Packet (receive)](life-of-packet-rx.md) — Where conntrack runs in the receive path
+- [Network Debugging with ss and ip](net-debugging.md) — Tools for inspecting connections

--- a/docs/net/netfilter.md
+++ b/docs/net/netfilter.md
@@ -1,0 +1,250 @@
+# Netfilter Architecture
+
+> The kernel's packet filtering and NAT framework: hooks, tables, and connection tracking
+
+## What Netfilter is
+
+Netfilter is a framework of hooks embedded at fixed points in the IP stack. Every packet traversing the network passes through these hooks, where registered callbacks (from iptables, nftables, conntrack, etc.) can inspect and modify it.
+
+Netfilter itself is just the framework. The policy (firewall rules, NAT, etc.) is implemented by modules that register at these hooks.
+
+## The five hook points
+
+```
+                          Routing Decision
+                                │
+NIC → PREROUTING ──────────────→ FORWARD → POSTROUTING → NIC
+                   ↓                                 ↑
+                LOCAL IN                         LOCAL OUT
+                   ↓                                 ↑
+               Local Socket ────────────────────────┘
+```
+
+```c
+// include/uapi/linux/netfilter.h
+enum nf_inet_hooks {
+    NF_INET_PRE_ROUTING,   // After L2, before routing decision
+    NF_INET_LOCAL_IN,      // After routing, for locally destined packets
+    NF_INET_FORWARD,       // For forwarded packets (not for us)
+    NF_INET_LOCAL_OUT,     // Packets generated locally, before routing
+    NF_INET_POST_ROUTING,  // After routing, just before transmission
+};
+```
+
+| Hook | When | Common uses |
+|------|------|-------------|
+| PREROUTING | After NIC, before routing | DNAT (port forwarding), conntrack |
+| LOCAL_IN | Before socket delivery | INPUT chain (firewall) |
+| FORWARD | Between receive and transmit | FORWARD chain (router firewall) |
+| LOCAL_OUT | After socket, before routing | OUTPUT chain |
+| POSTROUTING | Before NIC transmit | SNAT (masquerade) |
+
+## struct nf_hook_ops: registering a hook
+
+Any module can register callbacks at these hooks:
+
+```c
+// include/linux/netfilter.h
+struct nf_hook_ops {
+    nf_hookfn    *hook;       // callback: (priv, skb, state) → verdict
+    struct net_device *dev;   // NULL = all devices, or specific device
+    void         *priv;       // private data passed to hook
+    u8           pf;          // protocol family: NFPROTO_IPV4, NFPROTO_IPV6
+    unsigned int hooknum;     // which hook: NF_INET_PRE_ROUTING, etc.
+    int          priority;    // order among multiple hooks at same point
+                              // NF_IP_PRI_CONNTRACK = -200
+                              // NF_IP_PRI_FILTER = 0
+                              // NF_IP_PRI_NAT_SRC = +100
+};
+```
+
+Hook verdicts:
+- `NF_ACCEPT` — continue processing
+- `NF_DROP` — drop the packet
+- `NF_STOLEN` — hook took ownership (no further processing)
+- `NF_QUEUE` — send to userspace (for NFQUEUE)
+- `NF_REPEAT` — call this hook again
+
+```c
+// Example: simple hook that logs all TCP SYN packets
+static unsigned int syn_log_hook(void *priv, struct sk_buff *skb,
+                                  const struct nf_hook_state *state)
+{
+    struct iphdr *iph = ip_hdr(skb);
+    if (iph->protocol == IPPROTO_TCP) {
+        struct tcphdr *th = tcp_hdr(skb);
+        if (th->syn && !th->ack)
+            pr_info("SYN from %pI4 to %pI4\n", &iph->saddr, &iph->daddr);
+    }
+    return NF_ACCEPT;
+}
+```
+
+## iptables vs nftables
+
+Both are userspace tools that install rules into Netfilter. They differ in the underlying kernel representation:
+
+| Aspect | iptables | nftables |
+|--------|----------|----------|
+| Kernel module | ip_tables | nf_tables |
+| Rule storage | Table/chain/rule lists | Sets and maps with bytecode |
+| Performance | Linear scan | Set lookups (hash/rbtree) |
+| IPv4/IPv6 | Separate (iptables/ip6tables) | Unified (nft) |
+| ARP | Separate (arptables) | Unified |
+| Atomic rule update | No (per-rule add) | Yes (transactions) |
+
+Both install their rules as Netfilter hook callbacks under the hood.
+
+### iptables chains and tables
+
+```bash
+# iptables organizes rules into tables and chains
+iptables -L -n -v              # List rules in filter table
+iptables -t nat -L -n -v      # NAT table
+iptables -t mangle -L -n -v   # mangle table (QoS marks)
+iptables -t raw -L -n -v      # raw table (conntrack bypass)
+
+# Tables and which hooks they operate at:
+# filter: INPUT, FORWARD, OUTPUT
+# nat:    PREROUTING (DNAT), POSTROUTING (SNAT), OUTPUT (local DNAT)
+# mangle: all five hooks
+# raw:    PREROUTING, OUTPUT (runs BEFORE conntrack)
+```
+
+### nftables equivalent
+
+```bash
+# nftables uses a unified command
+nft list ruleset
+
+# Create a table and chain
+nft add table inet myfilter
+nft add chain inet myfilter input { type filter hook input priority 0\; policy drop\; }
+nft add rule inet myfilter input tcp dport 22 accept
+
+# Efficient set-based matching (no linear scan)
+nft add set inet myfilter allowed_ips { type ipv4_addr\; }
+nft add element inet myfilter allowed_ips { 10.0.0.1, 10.0.0.2 }
+nft add rule inet myfilter input ip saddr @allowed_ips accept
+```
+
+## Connection tracking (conntrack)
+
+**Conntrack** is the stateful packet inspection layer. It tracks every connection through the kernel, enabling:
+- Stateful firewall rules (`-m state --state ESTABLISHED,RELATED`)
+- NAT (both DNAT and SNAT need to rewrite both directions)
+- Connection-aware applications (via NFQUEUE or nf_conntrack events)
+
+### struct nf_conn
+
+```c
+// include/net/netfilter/nf_conntrack.h
+struct nf_conn {
+    struct nf_conntrack ct_general;   // reference count
+
+    u32 timeout;                      // expiry (jiffies)
+
+    // Two tuples: original direction and reply direction
+    // For TCP 10.0.0.1:54321 → 8.8.8.8:80:
+    //   tuplehash[ORIGINAL]: src=10.0.0.1:54321 dst=8.8.8.8:80
+    //   tuplehash[REPLY]:    src=8.8.8.8:80 dst=10.0.0.1:54321
+    struct nf_conntrack_tuple_hash tuplehash[IP_CT_DIR_MAX];
+
+    unsigned long status;   // IPS_CONFIRMED, IPS_SEEN_REPLY, IPS_ASSURED, ...
+
+    u_int32_t mark;         // connmark (for firewall rules / routing)
+    u_int32_t secmark;      // SELinux security mark
+
+    union nf_conntrack_proto proto;  // TCP state, UDP timeout, etc.
+};
+```
+
+### Conntrack lifecycle
+
+```
+Packet arrives → PREROUTING → conntrack lookup
+    New packet: create nf_conn entry (state: NEW)
+    Known packet: update state (ESTABLISHED/RELATED)
+    ↓
+Filter hook: rule can match by state
+    -m conntrack --ctstate NEW,ESTABLISHED
+    ↓
+POSTROUTING → NAT rewrites src/dst if needed
+    → nf_conn stores the rewrite for the reply direction
+```
+
+### Viewing conntrack state
+
+```bash
+# List all tracked connections
+conntrack -L
+# tcp      6 431999 ESTABLISHED src=10.0.0.1 dst=8.8.8.8 sport=54321 dport=80
+#                               src=8.8.8.8 dst=10.0.0.1 sport=80 dport=54321
+
+# Count connections by state
+conntrack -L | awk '{print $4}' | sort | uniq -c | sort -rn
+
+# Watch conntrack events
+conntrack -E
+
+# Conntrack table statistics
+cat /proc/net/stat/nf_conntrack
+```
+
+### Conntrack tuning
+
+```bash
+# Maximum number of tracked connections
+cat /proc/sys/net/netfilter/nf_conntrack_max
+echo 524288 > /proc/sys/net/netfilter/nf_conntrack_max
+
+# Current usage
+cat /proc/sys/net/netfilter/nf_conntrack_count
+
+# TCP established timeout (default: 5 days!)
+cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_established
+echo 7200 > /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_established
+
+# For high-connection-rate servers: tune TIME_WAIT timeout
+cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait  # default: 120s
+```
+
+A full conntrack table causes new connections to be dropped. This is a common issue on busy NAT gateways or connection-heavy servers.
+
+## NAT: DNAT and SNAT
+
+NAT is implemented as Netfilter hooks that modify packets and store the rewrite in the conntrack entry:
+
+```bash
+# DNAT: redirect port 80 to internal server (PREROUTING)
+iptables -t nat -A PREROUTING -p tcp --dport 80 -j DNAT --to-destination 192.168.1.10:8080
+
+# SNAT: masquerade outbound traffic (POSTROUTING)
+iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+
+# With nftables:
+nft add rule inet nat prerouting tcp dport 80 dnat to 192.168.1.10:8080
+nft add rule inet nat postrouting oifname "eth0" masquerade
+```
+
+The conntrack entry stores both directions, so reply packets are automatically rewritten in the opposite direction (DNAT reply becomes SNAT, etc.) without needing explicit reverse rules.
+
+## NF_HOOK macro: how hooks are called
+
+At each hook point in the IP stack:
+
+```c
+// Example from ip_rcv() (net/ipv4/ip_input.c)
+return NF_HOOK(NFPROTO_IPV4, NF_INET_PRE_ROUTING,
+               net, NULL, skb, dev, NULL,
+               ip_rcv_finish);
+```
+
+`NF_HOOK` calls each registered hook in priority order. If all return `NF_ACCEPT`, `ip_rcv_finish` is called. Any `NF_DROP` stops processing immediately.
+
+## Further reading
+
+- [nftables vs iptables](nftables-iptables.md) — Rule syntax and migration
+- [Connection Tracking](conntrack.md) — conntrack internals in depth
+- [Life of a Packet (receive)](life-of-packet-rx.md) — Where Netfilter hooks appear in the receive path
+- [IP Routing](ip-routing.md) — How routing and Netfilter interact

--- a/docs/net/nftables-iptables.md
+++ b/docs/net/nftables-iptables.md
@@ -1,0 +1,231 @@
+# nftables vs iptables
+
+> The two Linux packet filtering frontends: differences, migration, and coexistence
+
+## The relationship to Netfilter
+
+Both `iptables` and `nftables` are **userspace tools** that install rules into the kernel's Netfilter framework. The difference is in which kernel module processes those rules:
+
+- **iptables** → `ip_tables` kernel module (legacy, per-table modules)
+- **nftables** → `nf_tables` kernel module (unified, modern)
+
+The underlying hook mechanism is the same. What changes is how rules are represented, matched, and applied.
+
+## Why nftables was created
+
+iptables accumulated significant technical debt:
+
+1. **Separate tools for each family**: `iptables` (IPv4), `ip6tables` (IPv6), `arptables`, `ebtables` — each with its own codebase
+2. **Linear rule scanning**: Every packet scans every rule in a chain
+3. **No atomic updates**: Adding a rule requires re-applying the entire ruleset via `iptables-restore`
+4. **Poor set support**: Matching against large IP lists requires thousands of rules or `ipset` extension
+
+nftables (merged in Linux 3.13) solves all of these with a single unified framework.
+
+## Side-by-side comparison
+
+### Basic syntax
+
+```bash
+# iptables: block SSH from a specific IP
+iptables -A INPUT -s 10.0.0.5 -p tcp --dport 22 -j DROP
+
+# nftables equivalent
+nft add rule inet filter input ip saddr 10.0.0.5 tcp dport 22 drop
+```
+
+### Tables and chains
+
+```bash
+# iptables: implicit tables (filter, nat, mangle, raw, security)
+# You can't create new tables
+
+# nftables: explicit table and chain creation
+nft add table inet myfilter
+nft add chain inet myfilter input { type filter hook input priority 0\; policy accept\; }
+
+# iptables tables correspond to nftables types:
+# filter table  → type filter
+# nat table     → type nat
+# mangle table  → type route (for mangle)
+```
+
+### Rule listing
+
+```bash
+# iptables
+iptables -L -n -v --line-numbers
+iptables -t nat -L -n -v
+
+# nftables
+nft list ruleset            # everything
+nft list table inet filter  # specific table
+nft list chain inet filter input  # specific chain
+```
+
+### Counters
+
+```bash
+# iptables: counters per rule (packets, bytes)
+iptables -L -n -v
+# → Chain INPUT: 12345 packets, 1234567 bytes
+
+# nftables: optional counters per rule
+nft add rule inet filter input ip protocol tcp counter
+nft list ruleset  # shows counter values inline
+```
+
+## Set-based matching
+
+This is where nftables shines — efficient matching against large sets:
+
+```bash
+# iptables: 10,000 IPs requires 10,000 rules (linear scan)
+# (or ipset extension)
+
+# nftables: hash set, O(1) lookup
+nft add set inet filter blocked_ips {
+    type ipv4_addr\;
+    flags dynamic, timeout\;
+    timeout 1h\;   # entries expire after 1 hour
+}
+
+nft add rule inet filter input ip saddr @blocked_ips drop
+
+# Add IPs to the set
+nft add element inet filter blocked_ips { 10.0.0.1, 10.0.0.2, 192.168.1.0/24 }
+
+# Named maps: match IP → action
+nft add map inet filter client_policy {
+    type ipv4_addr : verdict\;
+}
+nft add element inet filter client_policy { 10.0.0.1 : accept, 10.0.0.2 : drop }
+nft add rule inet filter input ip saddr vmap @client_policy
+```
+
+## Atomic rule updates
+
+```bash
+# iptables: non-atomic — race window between flush and reload
+iptables -F INPUT
+iptables-restore < /etc/iptables/rules.v4
+
+# nftables: atomic transactions
+nft -f /etc/nftables.conf  # applied atomically, or fails entirely
+
+# nftables.conf example:
+table inet filter {
+    chain input {
+        type filter hook input priority 0; policy drop;
+        ct state established,related accept
+        iif lo accept
+        tcp dport { 22, 80, 443 } accept
+    }
+}
+```
+
+## NAT with nftables
+
+```bash
+# DNAT: redirect port 80 to internal server
+nft add table ip nat
+nft add chain ip nat prerouting { type nat hook prerouting priority -100\; }
+nft add chain ip nat postrouting { type nat hook postrouting priority 100\; }
+
+nft add rule ip nat prerouting tcp dport 80 dnat to 192.168.1.10:8080
+nft add rule ip nat postrouting oifname "eth0" masquerade
+```
+
+## Conntrack integration
+
+```bash
+# iptables: -m conntrack (or -m state)
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# nftables: ct state expression
+nft add rule inet filter input ct state established,related accept
+nft add rule inet filter input ct state invalid drop
+
+# Match by connection mark
+nft add rule inet filter input ct mark 0x1 accept
+```
+
+## Priority values
+
+```bash
+# Hook priorities determine order when multiple rules/tables are at same hook
+# Lower number = earlier execution
+
+# Standard priorities:
+#  -400: NF_IP_PRI_CONNTRACK_DEFRAG (IP defragmentation)
+#  -300: NF_IP_PRI_RAW              (raw table)
+#  -200: NF_IP_PRI_CONNTRACK        (conntrack)
+#   -50: NF_IP_PRI_SELINUX_FIRST    (SELinux)
+#     0: NF_IP_PRI_FILTER           (filter table)
+#    50: NF_IP_PRI_SELINUX_LAST
+#   100: NF_IP_PRI_NAT_SRC          (SNAT in POSTROUTING)
+#   300: NF_IP_PRI_CONNTRACK_HELPER
+
+nft add chain inet myapp input { type filter hook input priority -50\; }
+# This chain runs before standard filter rules
+```
+
+## Coexistence and migration
+
+iptables and nftables can coexist on a system, but `iptables-nft` (available in modern distros) wraps iptables syntax while using the `nf_tables` backend:
+
+```bash
+# Check which backend iptables uses
+iptables --version
+# iptables v1.8.7 (nf_tables)  ← using nf_tables backend
+# iptables v1.8.7 (legacy)     ← using ip_tables backend
+
+# Translate iptables rules to nftables
+iptables-translate -A INPUT -p tcp --dport 22 -j ACCEPT
+# → nft add rule ip filter INPUT tcp dport 22 counter accept
+
+# Translate entire ruleset
+iptables-restore-translate -f /etc/iptables/rules.v4 > /etc/nftables.conf
+```
+
+## Debugging and logging
+
+```bash
+# nftables: log matching packets
+nft add rule inet filter input tcp dport 22 log prefix "SSH: " level info
+
+# Count packets matched by a rule (counter keyword)
+nft add rule inet filter input tcp dport 80 counter accept
+
+# Trace packet through rules (nftables 0.9.1+)
+nft add table inet trace_debug
+nft add chain inet trace_debug input { type filter hook input priority -200\; }
+nft add rule inet trace_debug input ip saddr 10.0.0.1 meta nftrace set 1
+nft monitor trace
+
+# iptables: LOG target
+iptables -A INPUT -p tcp --dport 22 -j LOG --log-prefix "SSH: " --log-level 4
+```
+
+## Performance comparison
+
+For simple cases (small rulesets), performance is similar. For large rulesets:
+
+- **iptables**: O(n) per packet where n = number of rules
+- **nftables with sets**: O(1) for set membership, O(log n) for interval sets
+
+```bash
+# ipset (iptables extension) vs nftables native sets
+# ipset can match 100k IPs in ~same time as 1 rule
+# nftables sets are integrated, no separate tool needed
+
+# For high-performance firewalling, also consider:
+# - XDP for early drop before kernel networking stack
+# - eBPF socket filters
+```
+
+## Further reading
+
+- [Netfilter Architecture](netfilter.md) — The hook framework underlying both tools
+- [Connection Tracking](conntrack.md) — The conntrack module both tools use
+- [XDP](xdp.md) — Pre-stack packet filtering for maximum performance

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,3 +207,7 @@ nav:
     - TCP/IP:
       - TCP Implementation: net/tcp.md
       - IP Routing: net/ip-routing.md
+    - Filtering:
+      - Netfilter Architecture: net/netfilter.md
+      - nftables vs iptables: net/nftables-iptables.md
+      - Connection Tracking: net/conntrack.md


### PR DESCRIPTION
Batch 9: packet filtering. Closes #114, #115, #116.

## Pages added

- **Netfilter Architecture** — 5 hook points with flow diagram (PREROUTING/LOCAL_IN/FORWARD/LOCAL_OUT/POSTROUTING), struct nf_hook_ops (hook function, priority, hooknum, pf), verdict codes (NF_ACCEPT/DROP/STOLEN/QUEUE/REPEAT), iptables vs nftables kernel module comparison table, NF_HOOK macro pattern in IP stack code (#114)
- **nftables vs iptables** — Side-by-side syntax for common operations, table/chain creation (explicit in nftables vs implicit), set-based O(1) matching with hash/interval sets and maps, atomic transactions vs per-rule iptables, NAT rules, hook priority values (conntrack -200, filter 0, SNAT +100), iptables-nft backend, iptables-translate migration tool (#115)
- **Connection Tracking** — struct nf_conn (tuplehash ORIGINAL/REPLY, IPS_* status flags, TCP proto state machine), connection lifecycle (NEW→CONFIRMED→ESTABLISHED), protocol timeouts, conntrack states for firewall rules (NEW/ESTABLISHED/RELATED/INVALID/UNTRACKED), helper modules for FTP data channels, connmark for policy routing, tuning for high connection rates (nf_conntrack_max, TIME_WAIT timeout reduction) (#116)

## Depends on
PR #230 (add-net-tcpip)