### PR TITLE
Add XDP and TC networking docs

### DIFF
--- a/docs/net/af-xdp.md
+++ b/docs/net/af-xdp.md
@@ -1,0 +1,190 @@
+# AF_XDP Sockets
+
+> Sending and receiving packets directly to/from userspace with zero copies
+
+## What AF_XDP is
+
+AF_XDP is a socket address family that allows a userspace application to receive packets directly from an XDP program — bypassing the kernel network stack entirely for those packets. A BPF program running in XDP redirects matched packets to an AF_XDP socket, and the application reads them from a shared-memory ring buffer.
+
+This achieves near-DPDK performance while staying within the kernel security model (no kernel bypass, kernel still owns the hardware).
+
+## The architecture
+
+```
+NIC hardware → DMA → ring buffer
+    ↓ (NAPI poll)
+XDP program runs:
+    if packet matches: bpf_redirect_map(&xsk_map, queue_id, 0) → XDP_REDIRECT
+    else: XDP_PASS → normal kernel stack
+    ↓
+Shared UMEM (User Memory)
+    ↓
+AF_XDP socket (xsk) → userspace application reads/writes directly
+```
+
+No `sk_buff` is allocated. The packet DMA buffer is the same memory that userspace reads.
+
+## UMEM: the shared memory region
+
+AF_XDP is built around **UMEM** — a userspace-allocated memory region divided into fixed-size frames that both the kernel and userspace share:
+
+```
+UMEM:
+┌──────┬──────┬──────┬──────┬──────┬──────┐
+│frame0│frame1│frame2│frame3│frame4│frame5│ ...
+└──────┴──────┴──────┴──────┴──────┴──────┘
+Each frame: configurable size (default 4096 bytes)
+```
+
+Four ring buffers mediate ownership of frames between kernel and userspace:
+
+| Ring | Direction | Who produces | Who consumes |
+|------|-----------|--------------|--------------|
+| FILL | RX: give frames to kernel | Userspace | Kernel (DMA target) |
+| RX | RX: kernel delivers packets | Kernel | Userspace |
+| TX | TX: userspace sends packets | Userspace | Kernel |
+| COMPLETION | TX: kernel signals sent | Kernel | Userspace |
+
+## Setting up an AF_XDP socket
+
+```c
+// 1. Create UMEM (shared memory)
+int umem_size = 4096 * NUM_FRAMES;  // NUM_FRAMES of 4096 bytes each
+void *umem_area = mmap(NULL, umem_size, PROT_READ|PROT_WRITE,
+                       MAP_PRIVATE|MAP_ANONYMOUS|MAP_HUGETLB, -1, 0);
+
+struct xdp_umem_reg mr = {
+    .addr = (uint64_t)umem_area,
+    .len  = umem_size,
+    .chunk_size = 4096,
+    .headroom   = 0,
+};
+
+// 2. Create AF_XDP socket
+int xsk_fd = socket(AF_XDP, SOCK_RAW, 0);
+
+// 3. Register UMEM with socket
+setsockopt(xsk_fd, SOL_XDP, XDP_UMEM_REG, &mr, sizeof(mr));
+
+// 4. Set up ring sizes
+int ring_size = 2048;
+setsockopt(xsk_fd, SOL_XDP, XDP_RX_RING,   &ring_size, sizeof(ring_size));
+setsockopt(xsk_fd, SOL_XDP, XDP_TX_RING,   &ring_size, sizeof(ring_size));
+setsockopt(xsk_fd, SOL_XDP, XDP_UMEM_FILL_RING,      &ring_size, sizeof(ring_size));
+setsockopt(xsk_fd, SOL_XDP, XDP_UMEM_COMPLETION_RING,&ring_size, sizeof(ring_size));
+
+// 5. Map rings into userspace
+struct xdp_mmap_offsets off;
+getsockopt(xsk_fd, SOL_XDP, XDP_MMAP_OFFSETS, &off, &optlen);
+
+void *fill_ring = mmap(NULL, off.fr.desc + ring_size * sizeof(__u64),
+                       PROT_READ|PROT_WRITE, MAP_SHARED|MAP_POPULATE,
+                       xsk_fd, XDP_UMEM_PGOFF_FILL_RING);
+// Similar for rx_ring, tx_ring, completion_ring
+
+// 6. Bind to interface and queue
+struct sockaddr_xdp sxdp = {
+    .sxdp_family    = AF_XDP,
+    .sxdp_ifindex   = ifindex,
+    .sxdp_queue_id  = queue_id,
+    .sxdp_flags     = XDP_COPY,  // or XDP_ZEROCOPY for optimal performance
+};
+bind(xsk_fd, (struct sockaddr *)&sxdp, sizeof(sxdp));
+```
+
+## Zero-copy mode
+
+In **zero-copy** mode (`XDP_ZEROCOPY`), the NIC DMA-writes packets directly into the UMEM frames. No data copying occurs between NIC, kernel, and userspace. Requires:
+- Driver support (i40e, mlx5, ixgbe, etc.)
+- UMEM frames pinned in memory
+
+In **copy mode** (`XDP_COPY`), the kernel copies packet data from its internal buffers to UMEM. Works on any NIC but adds a copy.
+
+## Receiving packets (RX loop)
+
+```c
+// Fill ring with addresses of free frames (give to kernel for DMA)
+for (int i = 0; i < NUM_FRAMES; i++) {
+    fill_ring->addrs[fill_prod_idx % ring_size] = i * FRAME_SIZE;
+    fill_prod_idx++;
+}
+// Update fill ring producer index
+__atomic_store_n(fill_ring->producer, fill_prod_idx, __ATOMIC_RELEASE);
+
+// Poll for received packets
+struct pollfd pfd = { .fd = xsk_fd, .events = POLLIN };
+poll(&pfd, 1, -1);
+
+// Read from RX ring
+uint32_t rx_idx = *rx_ring->consumer;
+uint32_t avail  = *rx_ring->producer - rx_idx;
+
+for (uint32_t i = 0; i < avail; i++) {
+    struct xdp_desc *desc = &rx_ring->descs[(rx_idx + i) % ring_size];
+    void *pkt = umem_area + desc->addr;
+    uint32_t len = desc->len;
+    // Process packet at pkt[0..len-1]
+    // Then return the frame to fill ring
+}
+*rx_ring->consumer = rx_idx + avail;
+```
+
+## The XDP program (kernel side)
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_XSKMAP);
+    __uint(max_entries, 64);
+    __type(key, __u32);    // queue index
+    __type(value, __u32);  // xsk socket fd
+} xsk_map SEC(".maps");
+
+SEC("xdp")
+int xdp_redirect_to_xsk(struct xdp_md *ctx)
+{
+    // Redirect all packets on this queue to the AF_XDP socket
+    return bpf_redirect_map(&xsk_map, ctx->rx_queue_index, XDP_PASS);
+    // XDP_PASS as fallback: if no xsk registered for this queue, pass to stack
+}
+```
+
+```bash
+# Register xsk socket in the XSKMAP
+bpftool map update id <xskmap_id> key 0 value <xsk_fd>
+```
+
+## libxdp / libbpf helper library
+
+For production use, `libxdp` (part of xdp-tools) and `libbpf` provide abstractions that handle the ring management, UMEM setup, and XDP program loading:
+
+```c
+// With libxdp
+#include <xdp/xsk.h>
+
+struct xsk_socket_config cfg = {
+    .rx_size     = 2048,
+    .tx_size     = 2048,
+    .libxdp_flags = XSK_LIBXDP_FLAGS__INHIBIT_PROG_LOAD,
+    .xdp_flags   = XDP_FLAGS_UPDATE_IF_NOEXIST,
+    .bind_flags  = XDP_ZEROCOPY,
+};
+
+struct xsk_umem *umem;
+struct xsk_socket *xsk;
+
+xsk_umem__create(&umem, umem_area, umem_size, fill_ring, comp_ring, NULL);
+xsk_socket__create(&xsk, ifname, queue_id, umem, rx_ring, tx_ring, &cfg);
+```
+
+## Use cases
+
+- **Kernel bypass for application protocols**: Handle DNS/HTTP packet parsing in userspace at line rate
+- **Packet capture**: Zero-copy alternative to libpcap for high-rate captures
+- **Custom load balancers**: User-space decision logic with kernel-speed I/O
+- **Network function virtualization**: Virtual switches, firewalls without full DPDK
+
+## Further reading
+
+- [XDP](xdp.md) — The XDP framework that feeds AF_XDP sockets
+- [Network Device and NAPI](napi.md) — Where XDP programs hook into the driver
+- [TC and qdisc](tc-qdisc.md) — Alternative for post-stack packet steering

--- a/docs/net/tc-qdisc.md
+++ b/docs/net/tc-qdisc.md
@@ -1,0 +1,239 @@
+# TC (Traffic Control) and qdisc
+
+> How the kernel shapes, schedules, and polices outbound traffic
+
+## What TC does
+
+Traffic Control (TC) is the kernel's framework for controlling packet transmission. It sits between `dev_queue_xmit()` and the NIC driver, and handles:
+
+- **Shaping**: Rate-limit outbound traffic (TBF, HTB)
+- **Scheduling**: Control which packets go next (PRIO, FQ)
+- **Policing**: Drop packets exceeding a rate (policer)
+- **Classification**: Map packets to treatment classes
+
+TC only controls **egress** (outbound) by default. Ingress shaping requires redirect tricks (IFB device).
+
+## The qdisc hierarchy
+
+Every network device has a root **qdisc** (queuing discipline). When a packet is transmitted, it goes through the qdisc before reaching the driver:
+
+```
+dev_queue_xmit(skb)
+    → q->enqueue(skb, q)   // qdisc enqueue
+    → q->dequeue(q)         // qdisc selects next packet
+    → dev_hard_start_xmit() // driver DMA
+```
+
+Qdiscs can be hierarchical:
+
+```
+root qdisc (HTB)
+├── class 1:10 (rate 100Mbit)
+│   └── leaf qdisc (fq_codel)
+├── class 1:20 (rate 50Mbit)
+│   └── leaf qdisc (pfifo)
+└── class 1:30 (rate 10Mbit)  ← default
+    └── leaf qdisc (sfq)
+```
+
+## Viewing current qdisc
+
+```bash
+# Show qdisc on an interface
+tc qdisc show dev eth0
+
+# Default (most interfaces): pfifo_fast
+# → 3-band FIFO based on TOS bits
+# Handle "0:" is the root
+
+# Show full hierarchy
+tc qdisc show dev eth0
+tc class show dev eth0
+tc filter show dev eth0
+```
+
+## Common qdiscs
+
+### pfifo_fast (default)
+
+Three priority bands (0=high, 1=med, 2=low) based on the packet's DSCP/TOS field. Simple FIFO within each band. No rate limiting.
+
+```bash
+# Default on most interfaces
+tc qdisc show dev eth0
+# qdisc pfifo_fast 0: root refcnt 2 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
+```
+
+### fq_codel (modern default on Linux desktops)
+
+**Fair Queueing + Controlled Delay (CoDel)**. Combines fair per-flow scheduling with active queue management (AQM) to reduce bufferbloat:
+
+```bash
+tc qdisc add dev eth0 root fq_codel
+tc qdisc show dev eth0
+# qdisc fq_codel 8001: root refcnt 2 limit 10240p flows 1024
+#   quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn
+```
+
+Parameters:
+- `target`: acceptable minimum standing queue delay (default 5ms)
+- `interval`: control loop interval for CoDel (default 100ms)
+- `flows`: number of hash buckets for fair queueing (default 1024)
+- `ecn`: mark packets instead of dropping when possible
+
+### fq (Fair Queue — default for BBR)
+
+Per-flow fair queuing with pacing. Allows each flow to specify its desired send rate. Required for TCP BBR congestion control's accurate pacing:
+
+```bash
+tc qdisc replace dev eth0 root fq
+
+# After enabling BBR:
+echo bbr > /proc/sys/net/ipv4/tcp_congestion_control
+tc qdisc replace dev eth0 root fq  # fq enables accurate rate pacing
+```
+
+### TBF (Token Bucket Filter)
+
+Rate-limits traffic to a specific bandwidth with burst allowance:
+
+```bash
+# Limit to 1Mbit/s with 10KB burst
+tc qdisc add dev eth0 root tbf rate 1mbit burst 10k latency 50ms
+
+# Parameters:
+#   rate:    sustained rate
+#   burst:   maximum burst (traffic above rate drains tokens accumulated here)
+#   latency: maximum queuing latency (used to calculate queue size)
+```
+
+### HTB (Hierarchical Token Bucket)
+
+The standard choice for multi-class rate limiting. Supports a hierarchy of classes with guaranteed and ceiling rates:
+
+```bash
+# Root HTB qdisc
+tc qdisc add dev eth0 root handle 1: htb default 30
+
+# Classes: guaranteed rate + ceiling
+tc class add dev eth0 parent 1:  classid 1:1 htb rate 100mbit
+tc class add dev eth0 parent 1:1 classid 1:10 htb rate 80mbit ceil 100mbit
+tc class add dev eth0 parent 1:1 classid 1:20 htb rate 15mbit ceil 100mbit
+tc class add dev eth0 parent 1:1 classid 1:30 htb rate  5mbit ceil 100mbit
+
+# Leaf qdiscs for each class
+tc qdisc add dev eth0 parent 1:10 handle 10: fq_codel
+tc qdisc add dev eth0 parent 1:20 handle 20: fq_codel
+tc qdisc add dev eth0 parent 1:30 handle 30: fq_codel
+```
+
+When class 1:10 uses less than 80Mbit, its unused bandwidth can be borrowed by 1:20 and 1:30, up to their ceiling (100Mbit).
+
+## TC filters: classifying packets
+
+Filters determine which class a packet goes to:
+
+```bash
+# Match by destination port → class 1:10
+tc filter add dev eth0 parent 1: protocol ip prio 1 \
+    u32 match ip dport 80 0xffff flowid 1:10
+
+# Match by source IP
+tc filter add dev eth0 parent 1: protocol ip prio 2 \
+    u32 match ip src 10.0.0.0/8 flowid 1:20
+
+# Match by fwmark (from iptables MARK)
+tc filter add dev eth0 parent 1: protocol ip prio 3 \
+    handle 0x1 fw flowid 1:10
+
+# eBPF classifier (modern approach)
+tc filter add dev eth0 parent 1: bpf obj tc_prog.o sec tc flowid 1:10
+```
+
+## TC eBPF (TC-BPF)
+
+eBPF programs can be attached to TC as classifiers or actions. Unlike XDP, TC-BPF runs **after `sk_buff` allocation**, enabling full packet modification:
+
+```c
+// TC egress program: add VLAN tag
+SEC("tc")
+int tc_add_vlan(struct __sk_buff *skb)
+{
+    bpf_skb_vlan_push(skb, htons(ETH_P_8021Q), 100);  // VLAN 100
+    return TC_ACT_OK;
+}
+```
+
+```bash
+# Attach TC-BPF program to egress
+tc qdisc add dev eth0 clsact
+tc filter add dev eth0 egress bpf obj tc_prog.o sec tc direct-action
+
+# Can also attach to ingress (for shaping incoming traffic)
+tc filter add dev eth0 ingress bpf obj tc_ingress.o sec tc direct-action
+```
+
+TC-BPF verdicts:
+- `TC_ACT_OK` (= 0): pass to next stage
+- `TC_ACT_SHOT` (= 2): drop
+- `TC_ACT_REDIRECT` (= 7): redirect to another interface
+
+## Ingress shaping with IFB
+
+TC only shapes egress natively. For ingress shaping:
+
+```bash
+# Create IFB (Intermediate Functional Block) device
+modprobe ifb
+ip link set dev ifb0 up
+
+# Redirect all ingress traffic to IFB
+tc qdisc add dev eth0 ingress handle ffff:
+tc filter add dev eth0 parent ffff: protocol all u32 \
+    match u32 0 0 action mirred egress redirect dev ifb0
+
+# Now shape ifb0's egress (= eth0's ingress)
+tc qdisc add dev ifb0 root tbf rate 10mbit burst 20k latency 100ms
+```
+
+## netem: network emulation
+
+`netem` adds artificial delay, jitter, packet loss, and corruption — useful for testing:
+
+```bash
+# Add 100ms delay with 10ms jitter
+tc qdisc add dev eth0 root netem delay 100ms 10ms
+
+# Add 5% packet loss
+tc qdisc add dev eth0 root netem loss 5%
+
+# Combine: 50ms delay + 1% loss + 0.1% corruption
+tc qdisc add dev eth0 root netem delay 50ms loss 1% corrupt 0.1%
+
+# Remove
+tc qdisc del dev eth0 root
+```
+
+## Statistics
+
+```bash
+# Show qdisc statistics
+tc -s qdisc show dev eth0
+# qdisc fq_codel 8001: root ...
+#  Sent 12345 bytes 100 pkt (dropped 0, overlimits 0 requeues 0)
+#  backlog 0b 0p requeues 0
+#  maxpacket 1514 drop_overlimit 0 new_flow_count 50
+
+# Show class statistics (HTB)
+tc -s class show dev eth0
+
+# Watch in real time
+watch -n 1 'tc -s qdisc show dev eth0'
+```
+
+## Further reading
+
+- [XDP](xdp.md) — Pre-stack packet processing (higher performance than TC for drops)
+- [AF_XDP Sockets](af-xdp.md) — Userspace packet I/O without full kernel bypass
+- [Life of a Packet (transmit)](life-of-packet-tx.md) — Where TC fits in the transmit path
+- [CPU Bandwidth Control](../sched/cpu-bandwidth.md) — Analogous control for CPU time

--- a/docs/net/xdp.md
+++ b/docs/net/xdp.md
@@ -1,0 +1,256 @@
+# XDP (eXpress Data Path)
+
+> High-performance packet processing before the kernel network stack
+
+## What XDP is
+
+XDP is a programmable, high-performance packet processing framework that runs eBPF programs **before the kernel allocates `sk_buff`**. It's attached to a network device and invoked by the NIC driver (or the kernel) for every incoming packet.
+
+XDP eliminates the main overhead sources of traditional kernel packet processing:
+- **No `sk_buff` allocation**: Operates directly on DMA-mapped packet memory
+- **No per-packet memory allocation**: Uses pre-allocated per-CPU buffers
+- **No lock contention**: Each CPU processes its own RX queue independently
+
+This enables packet rates of tens of millions of packets per second on a single core.
+
+## XDP actions (return codes)
+
+An XDP program examines the packet and returns one of five actions:
+
+```c
+// include/uapi/linux/bpf.h
+enum xdp_action {
+    XDP_ABORTED = 0,  // BPF error: drop + trace event
+    XDP_DROP,         // Drop the packet immediately
+    XDP_PASS,         // Pass to normal kernel network stack
+    XDP_TX,           // Transmit back out the same NIC (hairpin)
+    XDP_REDIRECT,     // Redirect to another NIC, CPU, or AF_XDP socket
+};
+```
+
+## struct xdp_md — the BPF program's context
+
+XDP programs see the packet through `struct xdp_md`:
+
+```c
+// include/uapi/linux/bpf.h
+struct xdp_md {
+    __u32 data;           // pointer to packet start (cast to void*)
+    __u32 data_end;       // pointer to packet end
+    __u32 data_meta;      // pointer to metadata area (before data)
+    __u32 ingress_ifindex; // receiving interface index
+    __u32 rx_queue_index;  // RX queue number
+    __u32 egress_ifindex;  // for XDP_REDIRECT: target interface
+};
+```
+
+The underlying kernel structure is `struct xdp_buff`:
+
+```c
+// include/net/xdp.h
+struct xdp_buff {
+    void *data;           // packet start
+    void *data_end;       // packet end
+    void *data_meta;      // metadata area
+    void *data_hard_start; // start of DMA buffer (headroom before data)
+    struct xdp_rxq_info *rxq; // RX queue info (device, queue index)
+    u32   frame_sz;       // total frame size
+    u32   flags;
+};
+```
+
+## A minimal XDP program
+
+```c
+// Drop all UDP traffic
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/udp.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("xdp")
+int xdp_drop_udp(struct xdp_md *ctx)
+{
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+
+    struct ethhdr *eth = data;
+    if ((void*)(eth + 1) > data_end)
+        return XDP_PASS;
+
+    if (eth->h_proto != htons(ETH_P_IP))
+        return XDP_PASS;
+
+    struct iphdr *iph = (void*)(eth + 1);
+    if ((void*)(iph + 1) > data_end)
+        return XDP_PASS;
+
+    if (iph->protocol == IPPROTO_UDP)
+        return XDP_DROP;
+
+    return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";
+```
+
+## Attaching XDP programs
+
+```bash
+# Compile
+clang -O2 -target bpf -c xdp_drop_udp.c -o xdp_drop_udp.o
+
+# Attach to interface (native mode: highest performance)
+ip link set dev eth0 xdp obj xdp_drop_udp.o sec xdp
+
+# Check it's attached
+ip link show eth0
+# → link/ether ... xdp (id 42, flags <XDP_FLAGS_SKB_MODE>)
+
+# Remove
+ip link set dev eth0 xdp off
+
+# With bpftool
+bpftool net attach xdp id 42 dev eth0
+bpftool net show dev eth0
+```
+
+## XDP operation modes
+
+```bash
+# Native/driver mode (fastest): program runs in NIC driver's NAPI poll
+ip link set dev eth0 xdp obj prog.o
+
+# Generic/SKB mode (any NIC, slower): runs after sk_buff allocation
+ip link set dev eth0 xdpgeneric obj prog.o
+
+# Hardware offload (smartNICs: Netronome, etc.): runs on NIC hardware
+ip link set dev eth0 xdpoffload obj prog.o
+```
+
+| Mode | Performance | NIC requirement | When to use |
+|------|-------------|-----------------|-------------|
+| Native | Highest | Driver support | Production DDoS mitigation, load balancing |
+| Generic | Moderate | Any NIC | Development, NICs without XDP support |
+| HW Offload | Maximum | Smartcard NIC | Extreme performance (line-rate 100G) |
+
+## XDP_REDIRECT: steering to other destinations
+
+`XDP_REDIRECT` is the most powerful action, allowing redirection to:
+
+```c
+// Redirect to another NIC
+bpf_redirect(ifindex, 0);
+
+// Redirect to a CPU (via CPUMAP)
+bpf_redirect_map(&cpu_map, target_cpu, 0);
+
+// Redirect to AF_XDP socket (for userspace packet processing)
+bpf_redirect_map(&xsk_map, queue_id, 0);
+```
+
+### BPF maps for redirection
+
+```c
+// DEVMAP: redirect to another NIC
+struct {
+    __uint(type, BPF_MAP_TYPE_DEVMAP);
+    __uint(max_entries, 256);
+    __type(key, __u32);    // ifindex
+    __type(value, __u32);  // destination ifindex
+} tx_port SEC(".maps");
+
+// CPUMAP: send to a specific CPU's RX queue
+struct {
+    __uint(type, BPF_MAP_TYPE_CPUMAP);
+    __uint(max_entries, 16);
+    __type(key, __u32);     // CPU id
+    __type(value, struct bpf_cpumap_val); // queue size + optional XDP prog
+} cpu_map SEC(".maps");
+```
+
+## Common XDP use cases
+
+### DDoS mitigation
+
+```c
+// Drop packets from known attack sources (BPF map lookup)
+struct {
+    __uint(type, BPF_MAP_TYPE_LPM_TRIE);
+    __type(key, struct bpf_lpm_trie_key_u8);
+    __type(value, __u64);  // drop counter
+} blocklist SEC(".maps");
+
+SEC("xdp")
+int xdp_ddos_filter(struct xdp_md *ctx)
+{
+    struct iphdr *iph = parse_iphdr(ctx);
+    if (!iph) return XDP_PASS;
+
+    struct bpf_lpm_trie_key_u8 key = { .prefixlen = 32 };
+    *((__u32 *)key.data) = iph->saddr;
+
+    if (bpf_map_lookup_elem(&blocklist, &key))
+        return XDP_DROP;
+
+    return XDP_PASS;
+}
+```
+
+### Load balancing
+
+```c
+// XDP load balancer: forward to backend servers via XDP_TX
+// (used by Facebook's Katran, Cloudflare's layer4 load balancer)
+```
+
+### Packet sampling
+
+```c
+// Sample 1 in 1000 packets to userspace via perf ring buffer
+if (bpf_get_prandom_u32() % 1000 == 0) {
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
+                          data, data_end - data);
+}
+return XDP_PASS;
+```
+
+## Statistics and observability
+
+```bash
+# XDP program statistics
+bpftool prog show
+bpftool prog dump xlated id 42  # show XDP bytecode
+
+# Count XDP drops (per-CPU)
+bpftool map dump id <map_id>
+
+# ethtool XDP stats
+ethtool -S eth0 | grep xdp
+# rx_xdp_drop: 12345
+# rx_xdp_redirect: 0
+# rx_xdp_pass: 67890
+
+# Trace XDP events
+perf record -e xdp:xdp_exception -ag sleep 10
+trace-cmd record -e xdp:xdp_bulk_tx -e xdp:xdp_redirect_err
+```
+
+## Performance comparison
+
+At 40 Gbps with small packets:
+
+| Path | Mpps/core | Notes |
+|------|-----------|-------|
+| Kernel TCP stack | ~1-2 | Full stack processing |
+| DPDK (userspace) | ~20-30 | Kernel bypass |
+| XDP native | ~20-25 | In-kernel, no copy |
+| XDP HW offload | ~80+ | NIC handles it |
+
+## Further reading
+
+- [AF_XDP Sockets](af-xdp.md) — Sending XDP-processed packets to userspace
+- [Network Device and NAPI](napi.md) — Where XDP hooks into the driver
+- [TC and qdisc](tc-qdisc.md) — Alternative packet steering (post-stack)
+- [Netfilter Architecture](netfilter.md) — The older hook-based alternative

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -211,3 +211,7 @@ nav:
       - Netfilter Architecture: net/netfilter.md
       - nftables vs iptables: net/nftables-iptables.md
       - Connection Tracking: net/conntrack.md
+    - XDP & TC:
+      - XDP (eXpress Data Path): net/xdp.md
+      - AF_XDP Sockets: net/af-xdp.md
+      - TC and qdisc: net/tc-qdisc.md


### PR DESCRIPTION
Batch 10: XDP and traffic control. Closes #117, #118, #119.

## Pages added

- **XDP (eXpress Data Path)** — XDP actions (ABORTED/DROP/PASS/TX/REDIRECT), struct xdp_md (userspace view) and struct xdp_buff (kernel view), minimal eBPF XDP program with proper bounds checking, attaching via `ip link set xdp`, native/generic/HW-offload modes comparison table, XDP_REDIRECT with DEVMAP/CPUMAP/XSKMAP, DDoS mitigation with LPM_TRIE and packet sampling examples, ethtool XDP stats, performance comparison table (#117)
- **AF_XDP Sockets** — UMEM shared memory region, 4-ring ownership protocol (FILL/RX/TX/COMPLETION), zero-copy vs copy mode (XDP_ZEROCOPY vs XDP_COPY), socket setup code (mmap + bind), XDP program with XSKMAP redirect, userspace RX loop with ring pointers, libxdp/libbpf helper library usage, use cases (kernel bypass, packet capture, NVF) (#118)
- **TC and qdisc** — qdisc hierarchy (root → class → leaf), pfifo_fast/fq_codel/fq/TBF/HTB/netem qdiscs with examples, complete HTB multi-class rate limiting setup, TC filters (u32, fw/fwmark, eBPF classifier), TC-BPF with clsact + direct-action (egress and ingress), IFB for ingress shaping, netem for delay/jitter/loss testing, tc -s statistics interpretation (#119)

## Depends on
PR #231 (add-net-filtering)