### PR TITLE
Add networking debugging and observability documentation

### DIFF
--- a/docs/net/net-buffer-tuning.md
+++ b/docs/net/net-buffer-tuning.md
@@ -1,0 +1,244 @@
+# Network Buffer Tuning
+
+> Tuning socket buffers, ring buffers, and backpressure for high-throughput networking
+
+## The buffer hierarchy
+
+Network data flows through several buffering layers, each of which can be a bottleneck:
+
+```
+Application
+    ↓ write()
+Socket send buffer  (sk->sk_sndbuf)
+    ↓ tcp_sendmsg
+TCP write queue     (segments not yet sent or ACK'd)
+    ↓ ip_queue_xmit
+qdisc queue         (dev_queue_xmit)
+    ↓ ndo_start_xmit
+NIC TX ring buffer  (driver)
+    ↓ DMA
+Wire
+
+Wire
+    ↓ DMA
+NIC RX ring buffer  (driver)
+    ↓ NAPI
+Softnet backlog     (sd->input_pkt_queue)
+    ↓ __netif_receive_skb
+Socket receive buffer (sk->sk_receive_queue)
+    ↓ tcp_recvmsg
+Application
+```
+
+## Socket buffer tuning
+
+### TCP auto-tuning
+
+By default, TCP auto-tunes socket buffers based on observed bandwidth-delay product:
+
+```bash
+# TCP buffer auto-tuning (recommended: leave on)
+cat /proc/sys/net/ipv4/tcp_moderate_rcvbuf  # default: 1 (enabled)
+
+# Auto-tuning range [min, default, max] in bytes
+cat /proc/sys/net/ipv4/tcp_rmem  # → 4096 131072 6291456
+cat /proc/sys/net/ipv4/tcp_wmem  # → 4096 16384 4194304
+
+# For high-bandwidth, high-latency paths (e.g., 10Gbps, 50ms RTT)
+# BDP = 10Gbps × 50ms = 62.5 MB → need buffers ≥ 64MB
+echo "4096 87380 67108864" > /proc/sys/net/ipv4/tcp_rmem
+echo "4096 65536 67108864" > /proc/sys/net/ipv4/tcp_wmem
+```
+
+### Manual buffer sizing
+
+```bash
+# Global maximum (setsockopt cannot exceed this)
+cat /proc/sys/net/core/rmem_max  # default: 212992 (208KB)
+cat /proc/sys/net/core/wmem_max
+
+# Increase for large buffer sockets
+echo 67108864 > /proc/sys/net/core/rmem_max  # 64MB
+echo 67108864 > /proc/sys/net/core/wmem_max
+
+# Per-socket (application can set up to rmem_max/2 due to kernel doubling)
+setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
+setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size));
+
+# Check effective buffer size
+getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &actual, &len);
+# actual = 2 × requested (kernel doubles for bookkeeping)
+```
+
+### UDP buffer sizing
+
+UDP has no flow control — if the application reads slowly, packets are dropped:
+
+```bash
+# Increase UDP socket receive buffer for high-rate senders
+cat /proc/sys/net/core/rmem_default  # default receive buffer for all sockets
+echo 26214400 > /proc/sys/net/core/rmem_default  # 25MB
+
+# Application: increase buffer before binding
+int buf_size = 25 * 1024 * 1024;
+setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buf_size, sizeof(buf_size));
+```
+
+## NIC ring buffer tuning
+
+The NIC maintains DMA ring buffers for TX and RX. If they fill up, packets are dropped before they reach the kernel:
+
+```bash
+# Show current ring buffer sizes
+ethtool -g eth0
+# Ring parameters for eth0:
+# Pre-set maximums:
+# RX: 4096  TX: 4096
+# Current hardware settings:
+# RX: 256   TX: 256  ← often too small for high traffic
+
+# Increase ring buffers (critical for high-throughput workloads)
+ethtool -G eth0 rx 4096 tx 4096
+
+# Verify changes
+ethtool -g eth0
+```
+
+Ring buffer drops are visible in:
+
+```bash
+ethtool -S eth0 | grep -i "drop\|miss\|discard"
+# rx_missed_errors: number of packets NIC dropped because RX ring was full
+```
+
+## Softnet backlog
+
+The kernel's per-CPU receive backlog (`sd->input_pkt_queue`) sits between NAPI and protocol processing. If it fills, packets are dropped:
+
+```bash
+# Backlog queue length (per CPU)
+cat /proc/sys/net/core/netdev_max_backlog  # default: 1000
+
+# Increase for high packet rates
+echo 10000 > /proc/sys/net/core/netdev_max_backlog
+
+# Check for drops (column 2 = dropped, column 3 = time_squeeze)
+cat /proc/net/softnet_stat
+# format: total dropped time_squeeze 0 0 0 0 0 0 cpu_collision received_rps flow_limit_count
+```
+
+### softnet_stat columns explained
+
+```bash
+# Show per-CPU softnet stats with labels
+awk 'BEGIN{OFS="\t"; print "CPU","total","dropped","time_squeeze"}
+     {print NR-1, strtonum("0x"$1), strtonum("0x"$2), strtonum("0x"$3)}
+     ' /proc/net/softnet_stat | head -10
+```
+
+| Column | Meaning | Fix |
+|--------|---------|-----|
+| total | Total packets processed by softirq | Normal |
+| dropped | Packets dropped (backlog full) | Increase `netdev_max_backlog` |
+| time_squeeze | poll() ran out of budget | Increase `netdev_budget` |
+| cpu_collision | Multiple CPUs contending for CPU queue | Enable RPS/RSS |
+
+## TCP memory pressure
+
+The kernel limits total memory used by TCP sockets:
+
+```bash
+# TCP memory limits [pages at which pressure starts, hard limit, max]
+cat /proc/sys/net/ipv4/tcp_mem
+# → 94011 125349 188022 (in pages of 4KB = ~368MB total max)
+
+# Current usage
+cat /proc/net/sockstat | grep TCP
+# TCP: inuse 234 orphan 0 tw 12 alloc 248 mem 45
+
+# If mem approaches tcp_mem[2]: "TCP: out of memory" in dmesg
+# Fix: increase tcp_mem (or fix memory leaks/reduce connections)
+echo "768432 1024576 1536864" > /proc/sys/net/ipv4/tcp_mem
+```
+
+## Diagnosing buffer issues
+
+### RX bottleneck (application reads slowly)
+
+```bash
+# Large Recv-Q in ss means data is waiting for the application
+ss -tn | awk '$2 > 10000 {print $2, $5}'
+
+# Monitor socket memory usage
+cat /proc/net/sockstat
+
+# Check UDP drops
+netstat -s | grep "receive buffer"
+# "X packets pruned from receive queue because of socket buffer overrun"
+```
+
+### TX bottleneck (send buffer full)
+
+```bash
+# Large Send-Q means data is waiting to be sent (network slow or receiver window full)
+ss -tn | awk '$3 > 0'
+
+# Check if receiver window is limiting (zero window probes)
+netstat -s | grep "zero window"
+```
+
+### NIC ring buffer drops
+
+```bash
+# Check for NIC-level drops
+ethtool -S eth0 | grep -i drop
+watch -n 5 'ethtool -S eth0 | grep -i "drop\|miss" | awk "$2>0"'
+```
+
+### qdisc drops (TX queue too small)
+
+```bash
+# Check qdisc drops
+tc -s qdisc show dev eth0
+# If "dropped" is non-zero, qdisc is dropping packets
+
+# Increase qdisc queue length
+ip link set dev eth0 txqueuelen 10000  # default 1000
+```
+
+## Complete performance checklist
+
+For high-throughput servers (10G+):
+
+```bash
+# 1. NIC ring buffers
+ethtool -G eth0 rx 4096 tx 4096
+
+# 2. Socket buffers
+echo 67108864 > /proc/sys/net/core/rmem_max
+echo 67108864 > /proc/sys/net/core/wmem_max
+echo "4096 87380 67108864" > /proc/sys/net/ipv4/tcp_rmem
+echo "4096 65536 67108864" > /proc/sys/net/ipv4/tcp_wmem
+
+# 3. Softnet backlog
+echo 30000 > /proc/sys/net/core/netdev_max_backlog
+echo 1000  > /proc/sys/net/core/netdev_budget
+echo 8000  > /proc/sys/net/core/netdev_budget_usecs
+
+# 4. Connection tracking (if using NAT)
+echo 1048576 > /proc/sys/net/netfilter/nf_conntrack_max
+
+# 5. TCP memory
+echo "768432 1024576 1536864" > /proc/sys/net/ipv4/tcp_mem
+
+# 6. Offloads (ensure enabled for high-throughput)
+ethtool -k eth0 | grep -E "scatter-gather|tcp-segmentation|generic-segmentation|generic-receive"
+# All should be "on" for throughput; disable for latency/debug
+```
+
+## Further reading
+
+- [Understanding /proc/net/snmp](proc-snmp.md) — Counters that reflect these drops
+- [Network Tracing](net-tracing.md) — How to diagnose drop location
+- [Network Device and NAPI](napi.md) — NAPI budget and softnet tuning
+- [TCP Implementation](tcp.md) — How TCP window and cwnd interact with buffers

--- a/docs/net/net-debugging.md
+++ b/docs/net/net-debugging.md
@@ -1,0 +1,209 @@
+# Network Debugging with ss and ip
+
+> Essential tools for inspecting network state without looking at source code
+
+## ss: socket statistics
+
+`ss` (socket statistics) is the modern replacement for `netstat`. It reads directly from kernel data structures instead of parsing `/proc/net/tcp`, making it significantly faster.
+
+### Basic usage
+
+```bash
+# All TCP sockets
+ss -tn
+
+# With process info
+ss -tnp
+
+# All socket types
+ss -a
+
+# Listening sockets only
+ss -tnl
+
+# UDP sockets
+ss -un
+
+# Unix domain sockets
+ss -x
+```
+
+### Filter by state and address
+
+```bash
+# Specific state
+ss -tn state established
+ss -tn state time-wait
+ss -tn state syn-sent
+
+# Multiple states
+ss -tn state established state close-wait
+
+# Filter by port
+ss -tn sport = :22         # source port 22
+ss -tn dport = :80         # destination port 80
+ss -tn '( dport = :443 or sport = :443 )'
+
+# Filter by address
+ss -tn dst 8.8.8.8
+ss -tn src 10.0.0.0/8
+
+# Count TIME_WAIT sockets (common performance issue)
+ss -tn state time-wait | wc -l
+```
+
+### Detailed socket info
+
+```bash
+# Show internal TCP info (congestion state, cwnd, RTT, etc.)
+ss -tni
+
+# Example output for an ESTABLISHED connection:
+# ESTAB 0 0 10.0.0.1:22 10.0.0.2:54321
+#  cubic wscale:7,7 rto:208 rtt:4.2/0.5 ato:40 mss:1448 pmtu:1500
+#  rcvmss:931 advmss:1448 cwnd:10 ssthresh:2147483647
+#  bytes_sent:12345 bytes_acked:12345 bytes_received:67890
+#  segs_out:456 segs_in:234
+#  send 27.6Mbps pacing_rate 55.2Mbps delivery_rate 27.6Mbps
+#  delivered:234 app_limited
+#  reord_seen:0 lost:0 retrans:0/0 dsack_dups:0
+#  rcv_rtt:4.2 rcv_space:14600 rcv_ssthresh:87380 minrtt:3.8
+
+# Key fields:
+#   rtt/rtt_var: smoothed RTT and variance
+#   cwnd: congestion window (segments)
+#   ssthresh: slow start threshold
+#   retrans: cumulative/current retransmissions
+#   delivery_rate: actual send rate
+```
+
+### Socket memory usage
+
+```bash
+# Show send/receive queue sizes and memory
+ss -tm
+
+# Output columns:
+# Recv-Q: bytes received but not read by application
+# Send-Q: bytes sent but not yet acknowledged
+
+# Large Recv-Q: application not reading fast enough
+# Large Send-Q: network is slow / receiver window is small
+```
+
+## ip: network configuration and state
+
+### Interface information
+
+```bash
+# Show all interfaces with statistics
+ip -s link show
+# → shows rx/tx packets, bytes, errors, drops per interface
+
+# Show a specific interface
+ip link show eth0
+
+# Show IP addresses
+ip addr show
+ip addr show dev eth0
+
+# Monitor interface events (link up/down, address changes)
+ip monitor link
+ip monitor address
+```
+
+### Route inspection
+
+```bash
+# Show routing table
+ip route show
+ip route show table all  # all routing tables
+
+# Routing lookup (simulate what the kernel would do)
+ip route get 8.8.8.8
+# → 8.8.8.8 via 192.168.1.1 dev eth0 src 192.168.1.100 uid 0
+
+# Watch route changes
+ip monitor route
+
+# Show cached routes
+ip route show cache
+```
+
+### ARP/neighbor table
+
+```bash
+# Show ARP table
+ip neigh show
+# → 192.168.1.1 dev eth0 lladdr 52:54:00:12:34:56 REACHABLE
+
+# Filter by state
+ip neigh show nud reachable  # only confirmed entries
+ip neigh show nud stale      # entries that need reconfirmation
+
+# Flush stale entries
+ip neigh flush dev eth0
+
+# Add static entry
+ip neigh add 10.0.0.5 lladdr 52:54:00:11:22:33 dev eth0
+
+# Watch ARP events
+ip monitor neigh
+```
+
+## /proc/net: reading socket tables
+
+```bash
+# TCP socket table (hex addresses)
+cat /proc/net/tcp
+# local_address rem_address state tx_queue rx_queue uid inode
+# 0101007F:0035 00000000:0000 0A ...  ← 127.0.0.1:53 listening
+# 010011AC:01BB 02010A0A:E76C 01 ...  ← ESTABLISHED
+
+# Convert hex address:port
+python3 -c "import socket; print(socket.inet_ntoa(bytes.fromhex('010011AC')[::-1]))"
+# → 172.17.0.1
+
+# UDP sockets
+cat /proc/net/udp
+
+# Network interface stats
+cat /proc/net/dev
+# eth0: 12345678 23456 0 0 0 0 0 0  98765432 12345 0 0 0 0 0 0
+#       ↑rx bytes ↑rx pkts ↑err     ↑tx bytes ↑tx pkts
+
+# ARP table
+cat /proc/net/arp
+```
+
+## Quick diagnostic patterns
+
+```bash
+# Count connections by state (overall health check)
+ss -tan | awk 'NR>1 {print $1}' | sort | uniq -c | sort -rn
+
+# Top 10 remote IPs by connection count
+ss -tn | awk '{print $5}' | grep -v Peer | sed 's/:[0-9]*$//' | sort | uniq -c | sort -rn | head
+
+# Find what's listening (with process names)
+ss -tnlp
+
+# Check if port is in use
+ss -tnlp | grep ':8080'
+
+# Monitor socket queue buildup in real time
+watch -n 1 'ss -tn | awk "NR==1 || \$2>0 || \$3>0"'
+
+# Sockets with large send queues (possible network issue)
+ss -tn | awk '$3 > 0'  # Send-Q > 0
+
+# Sockets with large receive queues (slow application)
+ss -tn | awk '$2 > 10000'  # Recv-Q > 10KB
+```
+
+## Further reading
+
+- [Understanding /proc/net/snmp](proc-snmp.md) — Protocol counters in depth
+- [Network Tracing](net-tracing.md) — ftrace and BPF for packet-level debugging
+- [TCP Implementation](tcp.md) — What the ss -tni fields mean internally
+- [Socket Layer Overview](socket-layer.md) — The socket structures ss reads

--- a/docs/net/net-tracing.md
+++ b/docs/net/net-tracing.md
@@ -1,0 +1,235 @@
+# Tracing the Network Stack
+
+> ftrace, perf, and BPF tools for packet-level network debugging
+
+## Network trace events
+
+The kernel emits tracepoints at key points in the network stack, accessible via ftrace and perf:
+
+```bash
+# List available network trace events
+ls /sys/kernel/debug/tracing/events/net/
+ls /sys/kernel/debug/tracing/events/tcp/
+ls /sys/kernel/debug/tracing/events/skb/
+
+# Key events:
+# net:net_dev_xmit           - packet transmitted by device
+# net:net_dev_queue          - packet queued for transmission
+# net:netif_rx               - packet received (old NAPI path)
+# net:netif_receive_skb      - packet processed by NAPI
+# skb:consume_skb            - sk_buff freed (normal path)
+# skb:kfree_skb              - sk_buff freed (drop path)
+# tcp:tcp_send_reset         - RST sent
+# tcp:tcp_rcv_space_adjust   - receive buffer resized
+# tcp:tcp_destroy_sock       - socket destroyed
+```
+
+## Tracing packet drops with kfree_skb
+
+`skb:kfree_skb` fires whenever an sk_buff is dropped. The `reason` field identifies why:
+
+```bash
+# Enable drop tracing
+echo 1 > /sys/kernel/debug/tracing/events/skb/kfree_skb/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+
+# Example output:
+# <irq>-0 [000] ..... 123.456789: kfree_skb: skbaddr=0xffff... location=0xffffffff... protocol=2048 reason=NETFILTER_DROP
+
+# Or with trace-cmd:
+trace-cmd record -e skb:kfree_skb sleep 5
+trace-cmd report | grep kfree_skb
+```
+
+### Drop reason codes (Linux 5.17+)
+
+The `reason` field was added to identify exact drop location:
+
+```bash
+# See all drop reasons
+grep -r "SKB_DROP_REASON" /usr/include/linux/ 2>/dev/null | head -20
+# SKB_DROP_REASON_NOT_SPECIFIED
+# SKB_DROP_REASON_NO_SOCKET
+# SKB_DROP_REASON_PKT_TOO_SMALL
+# SKB_DROP_REASON_TCP_CSUM
+# SKB_DROP_REASON_TCP_FILTER
+# SKB_DROP_REASON_UDP_CSUM
+# etc.
+```
+
+### Using dropwatch (BCC)
+
+```bash
+# dropwatch: show packet drop locations and rates
+# Requires BCC tools
+dropwatch -l kas  # kernel address symbols
+
+# Or with bpftrace:
+bpftrace -e '
+tracepoint:skb:kfree_skb {
+    @drops[kstack] = count();
+}
+interval:s:5 {
+    print(@drops);
+    clear(@drops);
+}'
+```
+
+## Tracing TCP events
+
+```bash
+# Trace TCP state changes and resets
+trace-cmd record -e tcp:tcp_send_reset \
+                 -e tcp:tcp_receive_reset \
+                 sleep 10
+
+# Watch for RST storms (connection resets)
+bpftrace -e '
+tracepoint:tcp:tcp_send_reset {
+    @resets[args->saddr, args->daddr] = count();
+}
+interval:s:5 { print(@resets); clear(@resets); }'
+
+# Trace retransmissions
+bpftrace -e '
+kprobe:tcp_retransmit_skb {
+    @retrans[comm] = count();
+}'
+```
+
+## perf for network events
+
+```bash
+# Count network events system-wide
+perf stat -e \
+    net:net_dev_xmit,\
+    net:netif_receive_skb,\
+    skb:kfree_skb \
+    -a sleep 10
+
+# Record and analyze packet flow
+perf record -e net:netif_receive_skb -ag sleep 5
+perf report
+
+# Overhead of network processing (CPU cycles)
+perf top -e net:net_dev_xmit
+```
+
+## bpftrace one-liners
+
+```bash
+# Show receive rate per device
+bpftrace -e '
+tracepoint:net:netif_receive_skb {
+    @pkts[args->dev_name] = count();
+    @bytes[args->dev_name] = sum(args->len);
+}
+interval:s:1 {
+    print(@pkts); print(@bytes);
+    clear(@pkts); clear(@bytes);
+}'
+
+# Trace packet latency from NIC receive to socket delivery
+bpftrace -e '
+tracepoint:net:netif_receive_skb { @ts[args->skbaddr] = nsecs; }
+kprobe:tcp_rcv_established {
+    $key = (uint64)arg1;
+    if (@ts[$key]) {
+        @lat = hist(nsecs - @ts[$key]);
+        delete(@ts[$key]);
+    }
+}'
+
+# Track which processes send UDP packets
+bpftrace -e '
+kprobe:udp_sendmsg {
+    @[comm, pid] = count();
+}'
+
+# Show TCP connection setup time
+bpftrace -e '
+kprobe:tcp_connect { @start[tid] = nsecs; }
+kretprobe:tcp_finish_connect {
+    @connect_ms = hist((nsecs - @start[tid]) / 1000000);
+    delete(@start[tid]);
+}'
+```
+
+## Wireshark / tcpdump
+
+For packet-level capture:
+
+```bash
+# Capture on interface
+tcpdump -i eth0 -n
+
+# Filter by host and port
+tcpdump -i eth0 -n host 8.8.8.8 and port 53
+
+# Save to file for Wireshark
+tcpdump -i eth0 -w /tmp/capture.pcap
+
+# Capture specific protocol
+tcpdump -i eth0 -n 'tcp[tcpflags] & tcp-syn != 0'  # only SYN packets
+tcpdump -i eth0 -n 'tcp[tcpflags] & tcp-rst != 0'  # only RST packets
+
+# Read from file
+tcpdump -r /tmp/capture.pcap -nn
+
+# Capture on any interface (including loopback)
+tcpdump -i any -n
+```
+
+### AF_PACKET sockets (what tcpdump uses)
+
+tcpdump uses AF_PACKET sockets, which receive a copy of every packet at the `__netif_receive_skb` level — before the packet is processed by the network stack. This is why tcpdump sees packets even if they're subsequently dropped by iptables.
+
+```bash
+# tcpdump can miss packets under high load: check for drops
+tcpdump -i eth0 -w /dev/null -v  # shows "X packets captured, Y dropped by kernel"
+
+# Increase capture buffer to reduce drops
+tcpdump -i eth0 -B 65536 -w /dev/null  # 65MB buffer
+```
+
+## Tracing with nftables/iptables
+
+For packet-level debugging of firewall rules:
+
+```bash
+# nftables: trace packets matching a specific rule
+nft add table inet debug
+nft add chain inet debug input { type filter hook input priority -200\; }
+nft add rule inet debug input ip saddr 10.0.0.1 meta nftrace set 1
+nft monitor trace
+
+# iptables: LOG target (goes to kernel log / syslog)
+iptables -I INPUT 1 -p tcp --dport 80 -j LOG --log-prefix "HTTP: " --log-level 4
+journalctl -k | grep "HTTP: "
+```
+
+## net_ratelimit and kernel log drops
+
+The kernel rate-limits some network messages to prevent log flooding. If you see messages like `net_ratelimit: X callbacks suppressed`, the kernel is dropping log messages:
+
+```bash
+# Increase logging rate limit
+echo 5000 > /proc/sys/net/core/message_burst  # burst
+echo 10 > /proc/sys/net/core/message_cost     # tokens per interval
+```
+
+## Systematic approach to network debugging
+
+1. **Check counters first**: `/proc/net/dev`, `ethtool -S eth0`, `/proc/net/snmp`
+2. **Identify drop location**: `skb:kfree_skb` tracepoint or `dropwatch`
+3. **Check socket queues**: `ss -tn | awk '$2>0 || $3>0'`
+4. **Check conntrack**: `conntrack -S`, `cat /proc/sys/net/netfilter/nf_conntrack_count`
+5. **Packet capture**: `tcpdump` for protocol-level analysis
+6. **Firewall trace**: nftables `meta nftrace` or iptables LOG
+
+## Further reading
+
+- [Network Debugging with ss and ip](net-debugging.md) — Socket and route inspection
+- [Understanding /proc/net/snmp](proc-snmp.md) — Protocol counters
+- [Netfilter Architecture](netfilter.md) — Where firewall drops happen
+- [Life of a Packet (receive)](life-of-packet-rx.md) — The full path where drops can occur

--- a/docs/net/proc-snmp.md
+++ b/docs/net/proc-snmp.md
@@ -1,0 +1,210 @@
+# Understanding /proc/net/snmp and netstat
+
+> Protocol-level counters for diagnosing TCP, UDP, and IP issues
+
+## /proc/net/snmp
+
+`/proc/net/snmp` exposes MIB (Management Information Base) counters from the SNMP RFC. Each counter tells you about a specific protocol event at the IP, TCP, or UDP level.
+
+```bash
+cat /proc/net/snmp
+# Ip: Forwarding DefaultTTL InReceives InHdrErrors ...
+# Ip: 2 64 1234567 0 ...        ← values
+# Icmp: InMsgs InErrors InCsumErrors ...
+# Icmp: 123 0 0 ...
+# Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens ...
+# Tcp: 1 200 120000 -1 5678 ...
+# Udp: InDatagrams NoPorts InErrors OutDatagrams ...
+# Udp: 12345 0 0 23456 ...
+```
+
+## Key IP counters
+
+```bash
+# Extract IP stats
+awk '/^Ip:/ && /[0-9]/' /proc/net/snmp | head -1
+
+# Important fields:
+# InReceives       - packets received by IP layer
+# InHdrErrors      - IP header checksum errors
+# InAddrErrors     - destination address invalid (no such IP on this host)
+# ForwDatagrams    - packets forwarded (router only)
+# InDiscards       - dropped despite valid header (buffer pressure)
+# InDelivers       - packets delivered to transport layer
+# OutRequests      - packets originated locally
+# OutDiscards      - packets dropped due to send queue overflow
+# OutNoRoutes      - packets dropped because no route to destination
+# ReasmOKs         - fragments reassembled successfully
+# ReasmFails       - fragment reassembly failures
+# FragOKs          - fragmented outbound packets
+# FragFails        - fragmentation failures (DF bit set but MTU exceeded)
+```
+
+```bash
+# One-liner: show IP counters with labels
+paste <(head -1 /proc/net/snmp | tr ' ' '\n') \
+      <(sed -n '2p' /proc/net/snmp | tr ' ' '\n') | grep -v "^Ip"
+```
+
+## Key TCP counters
+
+```bash
+# Extract TCP stats with labels (using python for clarity)
+python3 -c "
+data = open('/proc/net/snmp').read()
+lines = [l.split() for l in data.split('\n') if l.startswith('Tcp')]
+for k, v in zip(lines[0][1:], lines[1][1:]):
+    if int(v) > 0:
+        print(f'{k}: {v}')
+"
+```
+
+| Counter | What it means | Common cause |
+|---------|---------------|--------------|
+| `ActiveOpens` | TCP connections initiated (connect()) | Normal outbound |
+| `PassiveOpens` | TCP connections accepted (accept()) | Normal inbound |
+| `AttemptFails` | Connections that failed during setup | Refused connections, SYN timeouts |
+| `EstabResets` | ESTABLISHED connections reset | Application crash, network issue |
+| `CurrEstab` | Currently established connections | Current load |
+| `InSegs` | Total segments received | Traffic volume |
+| `OutSegs` | Total segments sent | Traffic volume |
+| `RetransSegs` | Retransmitted segments | **Network quality issue** |
+| `InErrs` | Segments received with errors (bad checksum) | Hardware/NIC issue |
+| `OutRsts` | RST segments sent | Connection rejections |
+| `InCsumErrors` | Checksum errors | NIC offload bug, hardware issue |
+
+A rising `RetransSegs/OutSegs` ratio (>1-2%) indicates network packet loss:
+
+```bash
+# Calculate retransmit ratio
+python3 -c "
+import re
+data = open('/proc/net/snmp').read()
+tcp = dict(zip(re.findall(r'Tcp: (.*)', data)[0].split(),
+               re.findall(r'Tcp: (.*)', data)[1].split()))
+ratio = int(tcp['RetransSegs']) / max(int(tcp['OutSegs']), 1) * 100
+print(f'Retransmit ratio: {ratio:.2f}%')
+print(f'RetransSegs: {tcp[\"RetransSegs\"]}')
+print(f'OutSegs: {tcp[\"OutSegs\"]}')
+"
+```
+
+## Key UDP counters
+
+| Counter | What it means |
+|---------|---------------|
+| `InDatagrams` | UDP datagrams received and delivered |
+| `NoPorts` | Received UDP with no socket listening → ICMP port unreachable sent |
+| `InErrors` | Buffer overflow, checksum errors |
+| `OutDatagrams` | UDP datagrams sent |
+| `RcvbufErrors` | Dropped because socket receive buffer was full |
+| `SndbufErrors` | Dropped because socket send buffer was full |
+
+High `NoPorts` means something is sending to UDP ports with no listener. High `RcvbufErrors` means applications aren't reading fast enough.
+
+## /proc/net/netstat: extended TCP stats
+
+More detailed TCP counters (not in SNMP MIB):
+
+```bash
+cat /proc/net/netstat
+# TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts ...
+```
+
+Key `TcpExt` counters:
+
+| Counter | What it means |
+|---------|---------------|
+| `SyncookiesSent` | SYN cookies sent (SYN queue was full) |
+| `SyncookiesRecv` | Valid SYN cookie ACKs received |
+| `SyncookiesFailed` | SYN cookies that were invalid (possible attack) |
+| `EmbryonicRsts` | RSTs sent to SYN_RECV connections |
+| `ListenDrops` | Connections dropped because accept queue was full |
+| `ListenOverflows` | Accept queue overflow count |
+| `TCPHPHits` | Header prediction hits (fast path for established conns) |
+| `TCPPureAcks` | Pure ACKs received |
+| `TCPHPAcks` | ACKs processed via header prediction fast path |
+| `TCPRenoRecovery` | Reno-style loss recovery episodes |
+| `TCPSackRecovery` | SACK loss recovery episodes |
+| `TCPFastRetrans` | Fast retransmits triggered |
+| `TCPTimeouts` | RTO timeouts (slow recovery) |
+| `TCPLostRetransmit` | Retransmitted segments lost again |
+| `TCPDSACKOldSent` | Duplicate SACKs for old data |
+| `TCPAbortOnTimeout` | Connections aborted due to retry limit |
+| `TCPAbortOnData` | Connections aborted because data arrived on closing connection |
+
+```bash
+# Watch for TCP issues in real time
+watch -n 2 'awk "/^TcpExt:/ && NR==4 {
+    split(\$0, a, \" \"); for(i=1;i<=NF;i++) print a[i]
+}" /proc/net/netstat | paste - <(
+awk "/^TcpExt:/ && NR==3 {
+    split(\$0, a, \" \"); for(i=1;i<=NF;i++) print a[i]
+}" /proc/net/netstat) | grep -v "^0"'
+```
+
+## netstat (the tool)
+
+`netstat` reads from `/proc/net/` and presents counters in a readable format:
+
+```bash
+# Protocol statistics (from /proc/net/snmp and /proc/net/netstat)
+netstat -s
+
+# Filter to TCP stats
+netstat -s | grep -i -E "retransmit|error|fail|drop|reset"
+
+# Active connections
+netstat -tn          # like ss -tn
+
+# Listen sockets
+netstat -tnl
+```
+
+`netstat` is deprecated in favor of `ss` for connection listing, but `netstat -s` remains useful for statistics.
+
+## Diagnosing with counters: common issues
+
+### Packet loss
+
+```bash
+# Rising RetransSegs indicates loss
+watch -n 5 'cat /proc/net/snmp | grep ^Tcp | awk "NR==2 {print \"Retrans:\", \$13, \"OutSegs:\", \$11}"'
+
+# Also check NIC drops
+ethtool -S eth0 | grep -i drop
+```
+
+### Accept queue overflow
+
+```bash
+# ListenOverflows: connections dropped because backlog was full
+netstat -s | grep "listen"
+# If non-zero:
+#   increase listen() backlog: listen(fd, 4096)
+#   increase /proc/sys/net/core/somaxconn
+```
+
+### SYN flood detection
+
+```bash
+# SyncookiesSent > 0 means SYN queue was full
+netstat -s | grep "syncookies"
+# Or watch for large SYN-RECV count:
+ss -tn state syn-recv | wc -l
+```
+
+### UDP buffer drops
+
+```bash
+# RcvbufErrors: application not reading fast enough
+netstat -s | grep "receive buffer"
+# Fix: increase socket buffer (SO_RCVBUF) or increase read frequency
+```
+
+## Further reading
+
+- [Network Debugging with ss and ip](net-debugging.md) — Per-connection inspection
+- [Network Tracing](net-tracing.md) — Event-based debugging
+- [TCP Implementation](tcp.md) — What these counters measure internally
+- [Network Buffer Tuning](net-buffer-tuning.md) — Fixing buffer overflow issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,3 +215,8 @@ nav:
       - XDP (eXpress Data Path): net/xdp.md
       - AF_XDP Sockets: net/af-xdp.md
       - TC and qdisc: net/tc-qdisc.md
+    - Debugging & Observability:
+      - Network Debugging with ss and ip: net/net-debugging.md
+      - Network Tracing: net/net-tracing.md
+      - Understanding /proc/net/snmp: net/proc-snmp.md
+      - Network Buffer Tuning: net/net-buffer-tuning.md


### PR DESCRIPTION
## Summary
- `net/net-debugging.md`: ss -tni output interpretation, ip route/neigh inspection, /proc/net socket tables, diagnostic one-liners
- `net/net-tracing.md`: kfree_skb tracepoint with drop reasons, dropwatch, perf network events, bpftrace one-liners, tcpdump/AF_PACKET, nftables nftrace
- `net/proc-snmp.md`: /proc/net/snmp IP/TCP/UDP counters, /proc/net/netstat TcpExt counters (ListenOverflows, SyncookiesSent, TCPFastRetrans, etc.), netstat -s
- `net/net-buffer-tuning.md`: buffer hierarchy diagram (NIC ring → softnet → socket → application), tcp_rmem/wmem auto-tuning for 10G links, netdev_max_backlog, TCP memory limits, complete performance checklist

Closes #120, #122, #123, #124

## Test plan
- [ ] `mkdocs build` passes without errors
- [ ] All cross-links between the four new files resolve correctly
- [ ] All `/proc/net/snmp` counter names match kernel source