### PR TITLE
Add locking fundamentals: spinlock, mutex, rwsem, RCU, seqlock

### DIFF
--- a/docs/locking/README.md
+++ b/docs/locking/README.md
@@ -1,0 +1,50 @@
+# Locking and Synchronization
+
+> How the Linux kernel serializes concurrent access to shared data
+
+## Why locking matters
+
+Linux runs on systems with hundreds of CPUs, all sharing kernel data structures. Without synchronization, two CPUs could simultaneously modify a linked list — corrupting its pointers, losing entries, or looping forever. Locking prevents this.
+
+The kernel provides a rich set of primitives, each with different performance characteristics and usage contexts:
+
+| Primitive | Sleeps? | IRQ-safe? | Use when |
+|-----------|---------|-----------|----------|
+| `raw_spinlock_t` | No | Yes | Must not sleep, IRQ context |
+| `spinlock_t` | No (RT: yes) | No | Process context, short critical sections |
+| `mutex_t` | Yes | No | Process context, longer critical sections |
+| `rw_semaphore` | Yes | No | Many readers, few writers |
+| `rwlock_t` | No | Yes | Many readers, IRQ context |
+| RCU | No (readers) | Yes (readers) | Read-heavy, pointer-based data |
+| `seqlock_t` | No | Yes | Small data, writers must not starve |
+
+## Contents
+
+### Fundamentals
+- [Spinlock and raw_spinlock](spinlock.md) — The atomic building block
+- [Mutex and rt_mutex](mutex.md) — Sleeping locks for process context
+- [rwlock and rwsem](rwlock-rwsem.md) — Reader-writer locking
+- [RCU (Read-Copy-Update)](rcu.md) — Lock-free reads via grace periods
+- [Seqlock](seqlock.md) — Sequence counters for small frequently-read data
+
+### Advanced
+- [Atomic operations and memory barriers](atomics.md) — The primitives beneath the primitives
+- [Per-CPU variables](percpu.md) — Eliminating shared state entirely
+- [Lockdep](lockdep.md) — The kernel's lock validator
+- [Lock contention debugging](lock-debugging.md) — Diagnosing lock hotspots
+- [Futex internals](futex.md) — How userspace locking works
+
+## The hierarchy: what can nest inside what
+
+```
+Hardware interrupts (NMI)
+    └── can only use: raw_spinlock (irqsave), atomic ops
+Hardware interrupts (IRQ)
+    └── can use: raw_spinlock (irqsave), rwlock (irqsave), seqlock
+Softirqs / tasklets
+    └── can use: spinlock (bh), rwlock (bh), RCU read side
+Process context (preemptible)
+    └── can use: everything, including mutex, semaphore, RCU
+```
+
+Never call a sleeping lock from interrupt context — the kernel will warn or deadlock.

--- a/docs/locking/mutex.md
+++ b/docs/locking/mutex.md
@@ -1,0 +1,165 @@
+# Mutex and rt_mutex
+
+> Sleeping locks for process context — the right tool when your critical section can block
+
+## What is a mutex?
+
+A mutex (mutual exclusion lock) is a sleeping lock. When a thread can't acquire a mutex, it goes to sleep and is woken up when the lock becomes available. This is unlike a spinlock, which busy-waits.
+
+Because acquiring a mutex may sleep, mutexes can only be used in **process context** — never in interrupt handlers, softirqs, or tasklets.
+
+## The mutex structure
+
+```c
+/* include/linux/mutex_types.h */
+struct mutex {
+    atomic_long_t   owner;      /* task_struct* of owner + flags in low bits */
+    raw_spinlock_t  wait_lock;  /* protects wait_list */
+    struct osq_lock osq;        /* optimistic spinning queue (MCS) */
+    struct list_head wait_list; /* list of waiting tasks */
+};
+```
+
+The `owner` field packs the owner pointer and status flags into a single atomic:
+
+```c
+/* kernel/locking/mutex.h */
+#define MUTEX_FLAG_WAITERS  0x01  /* there are waiters on wait_list */
+#define MUTEX_FLAG_HANDOFF  0x02  /* lock being handed off to first waiter */
+#define MUTEX_FLAG_PICKUP   0x04  /* lock being picked up by first waiter */
+#define MUTEX_FLAGS         0x07
+```
+
+The task pointer is stored in `owner & ~MUTEX_FLAGS` (safe because `task_struct` is aligned to at least 8 bytes, so the low 3 bits are always zero).
+
+## Basic API
+
+```c
+#include <linux/mutex.h>
+
+/* Static initialization */
+DEFINE_MUTEX(my_mutex);
+
+/* Dynamic initialization */
+struct mutex my_mutex;
+mutex_init(&my_mutex);
+
+/* Lock (may sleep) */
+mutex_lock(&my_mutex);
+/* critical section */
+mutex_unlock(&my_mutex);
+
+/* Interruptible lock (returns -EINTR if signal arrives) */
+if (mutex_lock_interruptible(&my_mutex))
+    return -ERESTARTSYS;
+/* critical section */
+mutex_unlock(&my_mutex);
+
+/* Killable lock (only interrupted by fatal signals) */
+if (mutex_lock_killable(&my_mutex))
+    return -EINTR;
+
+/* Non-blocking trylock (returns 1 on success, 0 if locked) */
+if (mutex_trylock(&my_mutex)) {
+    /* got it */
+    mutex_unlock(&my_mutex);
+}
+
+/* Check if locked (advisory, not synchronization) */
+mutex_is_locked(&my_mutex);
+```
+
+## Three acquisition strategies
+
+When `mutex_lock()` is called and the lock is held, the kernel tries three strategies in order:
+
+```
+1. Fastpath (no contention)
+   ─────────────────────────
+   atomic_long_try_cmpxchg(owner, 0, current)
+   → succeeds immediately, no waiting
+
+2. Midpath (owner is running on another CPU)
+   ──────────────────────────────────────────
+   Optimistic spinning via OSQ (MCS queue)
+   → spins briefly, hoping owner finishes quickly
+   → avoids the overhead of sleep/wake
+   → bails out if owner is preempted
+
+3. Slowpath (must sleep)
+   ──────────────────────
+   Add self to wait_list, set TASK_UNINTERRUPTIBLE, schedule()
+   → woken by mutex_unlock() when lock is released
+```
+
+This three-phase approach avoids sleeping when the lock will be released quickly (the common case on loaded multiprocessor systems).
+
+## Strict semantics
+
+Mutexes enforce strict ownership rules that spinlocks do not:
+
+- **Only the owner can unlock**: calling `mutex_unlock()` from a different task is a bug
+- **No recursive locking**: a task that holds a mutex must not call `mutex_lock()` again on the same mutex — it will deadlock
+- **No exit with lock held**: if a task exits while holding a mutex, the system detects this (with `CONFIG_DEBUG_MUTEXES`)
+- **No use in interrupt context**: the kernel will warn if you try
+
+```c
+/* DON'T: unlock from a different task */
+void thread_a(void) { mutex_lock(&m); /* hands off to thread_b */ }
+void thread_b(void) { mutex_unlock(&m); /* BUG: not the owner */ }
+
+/* DON'T: recursive locking */
+mutex_lock(&m);
+mutex_lock(&m);  /* DEADLOCK */
+```
+
+## rt_mutex: priority-inheritance mutex
+
+On PREEMPT_RT kernels, `spinlock_t` is implemented via `rt_mutex_t` so that high-priority RT tasks can preempt the lock holder. The `rt_mutex_t` is also available directly for cases where priority inheritance is explicitly needed.
+
+```c
+/* include/linux/rtmutex.h */
+struct rt_mutex_base {
+    raw_spinlock_t  wait_lock;
+    struct rb_root_cached waiters;  /* waiters sorted by priority */
+    struct task_struct *owner;
+};
+```
+
+The key difference: with an rt_mutex, if a high-priority task is waiting on the lock, the lock holder **inherits** that high priority until it releases the lock. This prevents **priority inversion** (a low-priority task blocking a high-priority one indefinitely).
+
+```
+Without PI:
+  RT task (prio=90)    waits on lock held by...
+  Normal task (prio=20)   ... but gets preempted by...
+  Medium task (prio=50)   ... which runs for a long time → RT task starves
+
+With rt_mutex:
+  RT task (prio=90)    waits on lock held by...
+  Normal task (prio=20)   ... is boosted to prio=90, runs immediately
+  → RT task gets the lock quickly
+```
+
+See [Priority Inversion & PI Mutexes](../sched/pi-mutexes.md) for the full story.
+
+## Choosing between mutex and spinlock
+
+```
+Use mutex when:
+  ✓ Critical section may block (e.g., kmalloc(GFP_KERNEL), copy_from_user)
+  ✓ Critical section is long (milliseconds)
+  ✓ You're in process context
+
+Use spinlock when:
+  ✓ Critical section never blocks
+  ✓ Critical section is very short (microseconds)
+  ✓ You're in interrupt context
+  ✓ You need IRQ protection (spin_lock_irqsave)
+```
+
+## Further reading
+
+- [Spinlock and raw_spinlock](spinlock.md) — The busy-wait alternative
+- [Lockdep](lockdep.md) — Detecting deadlocks and lock ordering violations
+- [Priority Inversion & PI Mutexes](../sched/pi-mutexes.md) — When rt_mutex matters
+- `Documentation/locking/mutex-design.rst` in the kernel tree

--- a/docs/locking/rcu.md
+++ b/docs/locking/rcu.md
@@ -1,0 +1,238 @@
+# RCU (Read-Copy-Update)
+
+> Lock-free reads through grace periods — the highest-performance synchronization in the kernel
+
+## The core idea
+
+RCU solves a specific problem: how do you allow many readers to access a data structure with zero synchronization overhead, while still allowing writers to modify it safely?
+
+The insight: **readers never modify the data**, so they can run truly concurrently as long as the writer doesn't free the old data until all readers that could see it have finished.
+
+```
+Writer algorithm:
+  1. Make a copy of the data
+  2. Modify the copy
+  3. Atomically publish the new version (pointer swap)
+  4. Wait for a "grace period" — until all readers that could
+     have seen the old version have finished
+  5. Free the old version
+
+Reader algorithm:
+  1. Enter RCU read-side critical section (very cheap)
+  2. Dereference the published pointer
+  3. Use the data
+  4. Exit RCU read-side critical section
+```
+
+The critical property: **readers pay almost nothing**. On non-preemptible kernels, `rcu_read_lock()` is literally a compiler barrier with preemption disabled — no atomic operations, no cache line bouncing.
+
+## The grace period
+
+A **grace period** is the time the writer waits after publishing the new pointer before freeing the old one. A grace period ends when every CPU has passed through a **quiescent state** — a point where no RCU read-side critical section can be in progress.
+
+Quiescent states include:
+- Context switch (the CPU was preempted)
+- Idle (the CPU has no work)
+- User mode execution
+
+```
+CPU 0: [reader using old data]──────────────────[end read]
+CPU 1:                         [context switch]
+CPU 2:                                    [context switch]
+                         ↑                           ↑
+                   grace period starts          grace period ends
+                                                (old data safe to free)
+```
+
+On a non-preemptible kernel, a grace period completes when every CPU has scheduled at least once. This is why context switches are RCU quiescent states.
+
+## API
+
+```c
+#include <linux/rcupdate.h>
+
+/* Read side: enter/exit critical section */
+rcu_read_lock();
+/* Access RCU-protected data. May NOT sleep (on !PREEMPT_RCU). */
+rcu_read_unlock();
+
+/* Read a pointer protected by RCU */
+struct my_data *p = rcu_dereference(rcu_ptr);
+/* rcu_dereference adds a data-dependency barrier — required! */
+
+/* Publish a new pointer (issues memory barrier before assignment) */
+rcu_assign_pointer(rcu_ptr, new_data);
+
+/* Wait for grace period to complete (blocking) */
+synchronize_rcu();
+
+/* Schedule callback for after grace period (non-blocking) */
+call_rcu(&old_data->rcu_head, my_free_callback);
+
+/* In the callback: */
+static void my_free_callback(struct rcu_head *head)
+{
+    struct my_data *data = container_of(head, struct my_data, rcu_head);
+    kfree(data);
+}
+```
+
+### Embedding rcu_head
+
+Any object freed via RCU must embed `struct rcu_head`:
+
+```c
+struct my_data {
+    int value;
+    char name[32];
+    struct rcu_head rcu;  /* for call_rcu / kfree_rcu */
+};
+
+/* Allocate and publish */
+struct my_data *new_data = kmalloc(sizeof(*new_data), GFP_KERNEL);
+new_data->value = 42;
+rcu_assign_pointer(global_ptr, new_data);
+
+/* Remove and free (writer side) */
+struct my_data *old = rcu_dereference_protected(global_ptr,
+                                                 lockdep_is_held(&my_lock));
+rcu_assign_pointer(global_ptr, NULL);
+synchronize_rcu();
+kfree(old);
+
+/* Or with call_rcu (async) */
+call_rcu(&old->rcu, my_free_callback);
+```
+
+### kfree_rcu shorthand
+
+For objects that just need `kfree()` after a grace period, `kfree_rcu()` is a shorthand that avoids writing a callback:
+
+```c
+/* Instead of call_rcu + callback that calls kfree: */
+kfree_rcu(old_data, rcu);  /* 'rcu' is the rcu_head field name */
+
+/* Zero-argument form (Linux 5.5+): no rcu_head needed */
+kfree_rcu(old_data);
+```
+
+## A complete example: RCU-protected lookup table
+
+```c
+/* Global pointer, updated rarely */
+static struct config __rcu *global_config;
+static DEFINE_SPINLOCK(config_lock);  /* protects writers */
+
+/* Reader: called frequently, must be fast */
+int get_timeout(void)
+{
+    int timeout;
+    rcu_read_lock();
+    timeout = rcu_dereference(global_config)->timeout;
+    rcu_read_unlock();
+    return timeout;
+}
+
+/* Writer: called rarely */
+int update_config(int new_timeout)
+{
+    struct config *new_cfg, *old_cfg;
+
+    new_cfg = kmalloc(sizeof(*new_cfg), GFP_KERNEL);
+    if (!new_cfg)
+        return -ENOMEM;
+
+    spin_lock(&config_lock);
+    old_cfg = rcu_dereference_protected(global_config,
+                                         lockdep_is_held(&config_lock));
+    new_cfg->timeout = new_timeout;
+    rcu_assign_pointer(global_config, new_cfg);
+    spin_unlock(&config_lock);
+
+    /* Wait until no reader can see old_cfg, then free it */
+    synchronize_rcu();
+    kfree(old_cfg);
+    return 0;
+}
+```
+
+## RCU-protected lists
+
+The kernel provides `rculist.h` for linked lists:
+
+```c
+#include <linux/rculist.h>
+
+/* Writer: add to list (must hold list lock) */
+spin_lock(&list_lock);
+list_add_rcu(&new->list, &my_list);
+spin_unlock(&list_lock);
+
+/* Writer: remove from list */
+spin_lock(&list_lock);
+list_del_rcu(&entry->list);
+spin_unlock(&list_lock);
+synchronize_rcu();  /* wait before freeing */
+kfree(entry);
+
+/* Reader: traverse list */
+rcu_read_lock();
+list_for_each_entry_rcu(entry, &my_list, list) {
+    /* use entry */
+}
+rcu_read_unlock();
+```
+
+## RCU flavors
+
+There are three main RCU flavors for different contexts:
+
+| Flavor | Read-side lock | Quiescent state | Use when |
+|--------|---------------|-----------------|----------|
+| `rcu` | `rcu_read_lock()` | context switch, idle, user mode | Most kernel code |
+| `rcu_bh` | `rcu_read_lock_bh()` | any BH-disabled region | Legacy, BH context |
+| `rcu_sched` | `rcu_read_lock_sched()` | preemption-disabled region | Scheduler internals |
+
+Since Linux 5.0, all three are unified — `synchronize_rcu()` waits for all three simultaneously.
+
+## SRCU: sleepable RCU
+
+Standard RCU read-side critical sections cannot sleep. SRCU (Sleepable RCU) lifts this restriction at the cost of higher read-side overhead:
+
+```c
+#include <linux/srcu.h>
+
+DEFINE_SRCU(my_srcu);  /* or DEFINE_STATIC_SRCU */
+
+/* Reader (may sleep) */
+int idx = srcu_read_lock(&my_srcu);
+/* ... may call schedule() here ... */
+srcu_read_unlock(&my_srcu, idx);
+
+/* Writer */
+synchronize_srcu(&my_srcu);
+```
+
+SRCU is used where readers need to sleep, such as notifier chains, filesystem operations, and BPF program invocation.
+
+## When to use RCU
+
+```
+RCU is ideal when:
+  ✓ Reads are much more frequent than writes
+  ✓ Read-side performance is critical (no atomic ops in read path)
+  ✓ The data is accessed via pointers
+  ✓ Writers can tolerate the cost of synchronize_rcu() or call_rcu()
+
+RCU is not suited for:
+  ✗ Write-heavy workloads (synchronize_rcu is expensive)
+  ✗ Data updated in-place (not pointer-based)
+  ✗ Small per-CPU data (use per-CPU variables instead)
+```
+
+## Further reading
+
+- [RCU in Memory Management](../mm/rcu-mm.md) — How RCU is used in the mm subsystem
+- [Spinlock](spinlock.md) — For write-heavy short critical sections
+- [rwsem](rwlock-rwsem.md) — For sleeping reader-writer locking
+- `Documentation/RCU/` in the kernel tree — Paul McKenney's extensive RCU docs

--- a/docs/locking/rwlock-rwsem.md
+++ b/docs/locking/rwlock-rwsem.md
@@ -1,0 +1,186 @@
+# rwlock and rwsem
+
+> Reader-writer locking — concurrent reads, exclusive writes
+
+## The reader-writer pattern
+
+Many kernel data structures are read far more often than they are written. A plain spinlock or mutex serializes all access, even concurrent reads that don't conflict. Reader-writer locks allow multiple simultaneous readers while ensuring writers have exclusive access:
+
+```
+Multiple readers: OK
+Reader + writer:  BLOCKED (writer waits)
+Two writers:      BLOCKED (second waits)
+```
+
+The kernel provides two reader-writer primitives:
+
+| Primitive | Sleeps? | IRQ-safe? | Use when |
+|-----------|---------|-----------|----------|
+| `rwlock_t` | No (spinlock) | Yes | Interrupt context, short critical sections |
+| `rw_semaphore` | Yes (sleeping) | No | Process context, longer critical sections |
+
+## rwlock_t: the spinning variant
+
+`rwlock_t` is a reader-writer spinlock. Readers and writers both spin rather than sleep.
+
+```c
+#include <linux/rwlock.h>
+
+/* Initialization */
+DEFINE_RWLOCK(my_rwlock);  /* static */
+rwlock_t my_rwlock;
+rwlock_init(&my_rwlock);   /* dynamic */
+
+/* Read side */
+read_lock(&my_rwlock);
+/* read critical section — concurrent with other readers */
+read_unlock(&my_rwlock);
+
+/* Write side */
+write_lock(&my_rwlock);
+/* write critical section — exclusive */
+write_unlock(&my_rwlock);
+
+/* IRQ-safe variants (if lock is also taken in IRQ handler) */
+unsigned long flags;
+read_lock_irqsave(&my_rwlock, flags);
+read_unlock_irqrestore(&my_rwlock, flags);
+
+write_lock_irqsave(&my_rwlock, flags);
+write_unlock_irqrestore(&my_rwlock, flags);
+
+/* BH variants */
+read_lock_bh(&my_rwlock);
+read_unlock_bh(&my_rwlock);
+```
+
+On PREEMPT_RT kernels, `rwlock_t` is implemented with `rwbase_rt` (sleeping), just like `spinlock_t` maps to `rt_mutex`.
+
+## rw_semaphore: the sleeping variant
+
+`rw_semaphore` is the sleeping counterpart to `rwlock_t`. Contended waiters go to sleep rather than spinning (after a brief optimistic spin phase, like mutex).
+
+```c
+/* include/linux/rwsem.h */
+struct rw_semaphore {
+    atomic_long_t count;   /* reader count + RWSEM_WRITER_LOCKED bit */
+    atomic_long_t owner;   /* writer task_struct* */
+    struct osq_lock osq;   /* optimistic spinners */
+    raw_spinlock_t wait_lock;
+    struct list_head wait_list;
+};
+```
+
+The `count` field encodes both the lock state and the reader count:
+
+```
+count = 0            → unlocked
+count = WRITER_LOCKED (bit 0) → held by writer
+count > 0            → held by N readers (count is reader count)
+```
+
+### API
+
+```c
+#include <linux/rwsem.h>
+
+/* Initialization */
+DECLARE_RWSEM(my_rwsem);       /* static */
+struct rw_semaphore my_rwsem;
+init_rwsem(&my_rwsem);         /* dynamic */
+
+/* Read side */
+down_read(&my_rwsem);          /* may sleep */
+/* read critical section */
+up_read(&my_rwsem);
+
+/* Interruptible read lock */
+if (down_read_interruptible(&my_rwsem))
+    return -ERESTARTSYS;
+up_read(&my_rwsem);
+
+/* Trylock (non-blocking) */
+if (down_read_trylock(&my_rwsem)) {
+    /* got it */
+    up_read(&my_rwsem);
+}
+
+/* Write side */
+down_write(&my_rwsem);         /* may sleep, exclusive */
+/* write critical section */
+up_write(&my_rwsem);
+
+/* Downgrade from write to read (without releasing) */
+downgrade_write(&my_rwsem);    /* demote exclusive → shared */
+/* now in read-side critical section */
+up_read(&my_rwsem);
+```
+
+### downgrade_write
+
+`downgrade_write()` atomically converts a write lock to a read lock. It's used when a writer has finished the write phase and wants to continue reading, while allowing other readers in:
+
+```c
+down_write(&mm->mmap_lock);
+/* modify vma list */
+downgrade_write(&mm->mmap_lock);
+/* now read-only, other readers can join */
+up_read(&mm->mmap_lock);
+```
+
+## Writer starvation
+
+A critical problem with naïve reader-writer locks: if readers arrive continuously, a writer may never get the lock. Linux's rwsem prevents this by queuing writers — once a writer is waiting, new readers are also queued (they don't jump ahead of the waiting writer).
+
+```
+Timeline:
+  R1 holds read lock
+  W1 requests write lock → queues
+  R2 requests read lock → also queues (behind W1)
+  R1 releases → W1 gets lock
+  W1 releases → R2 gets lock
+```
+
+## When to use rwlock vs rwsem vs plain mutex/spinlock
+
+```
+rwlock_t:
+  ✓ IRQ context readers or writers
+  ✓ Very short read/write critical sections
+  ✗ Don't use if write side is rare — consider just spinlock
+
+rw_semaphore:
+  ✓ Process context, long critical sections
+  ✓ Read-heavy workloads (many concurrent readers give real benefit)
+  ✗ Not worth it for very short critical sections (mutex overhead similar)
+
+Rule of thumb: if your reads are > 5x more frequent than writes,
+and reads are long enough to matter, rwsem is a win.
+The mm subsystem uses it heavily (mm->mmap_lock).
+```
+
+## Real-world usage: mmap_lock
+
+The VMA list in each process is protected by `mm->mmap_lock` (an `rw_semaphore`):
+
+```c
+/* Reading VMAs (e.g., during page fault) */
+mmap_read_lock(mm);      /* = down_read(&mm->mmap_lock) */
+vma = find_vma(mm, addr);
+/* use vma */
+mmap_read_unlock(mm);    /* = up_read(&mm->mmap_lock) */
+
+/* Modifying VMAs (e.g., mmap/munmap syscall) */
+mmap_write_lock(mm);     /* = down_write(&mm->mmap_lock) */
+/* add/remove/modify VMAs */
+mmap_write_unlock(mm);   /* = up_write(&mm->mmap_lock) */
+```
+
+This allows multiple threads in the same process to take page faults concurrently, while mmap/munmap operations are serialized.
+
+## Further reading
+
+- [Spinlock and raw_spinlock](spinlock.md) — The plain spinlock
+- [RCU](rcu.md) — Even more concurrent reads (no reader-side locking at all)
+- [Per-VMA Locks](../mm/per-vma-locks.md) — Fine-grained alternative to mmap_lock
+- `Documentation/locking/` in the kernel tree

--- a/docs/locking/seqlock.md
+++ b/docs/locking/seqlock.md
@@ -1,0 +1,182 @@
+# Seqlock
+
+> Sequence counters for lockless reads of small, frequently-updated data
+
+## The seqlock pattern
+
+A seqlock (sequence lock) solves a specific problem: how do you let readers access small data (like a timestamp or a counter) without taking any lock, while still detecting if a concurrent write happened?
+
+The writer increments a sequence counter before and after writing. A reader reads the counter before and after reading the data. If the counter changed (or is odd, meaning a write is in progress), the reader retries:
+
+```
+Writer:
+  seq++      (now odd → write in progress)
+  write data
+  seq++      (now even → write complete)
+
+Reader:
+  s1 = seq
+  if (s1 & 1) retry    ← write in progress
+  read data
+  s2 = seq
+  if (s1 != s2) retry  ← write happened during read
+  data is valid
+```
+
+This gives **zero-cost reads when there are no concurrent writes**, and cheap retries otherwise.
+
+## Two types: seqcount_t and seqlock_t
+
+```c
+/* seqcount_t: raw counter, no writer serialization built in.
+   You provide your own writer lock. */
+typedef struct seqcount {
+    unsigned sequence;
+} seqcount_t;
+
+/* seqlock_t: seqcount + embedded spinlock for writer serialization */
+typedef struct {
+    struct seqcount_spinlock seqcount;
+    spinlock_t lock;
+} seqlock_t;
+```
+
+`seqlock_t` is the complete package for most users. `seqcount_t` is used when the writer serialization is handled by some other mechanism (e.g., a mutex).
+
+## API
+
+### seqlock_t
+
+```c
+#include <linux/seqlock.h>
+
+/* Initialization */
+DEFINE_SEQLOCK(my_seqlock);    /* static */
+seqlock_t my_seqlock;
+seqlock_init(&my_seqlock);     /* dynamic */
+
+/* Writer side */
+write_seqlock(&my_seqlock);
+/* modify data */
+write_sequnlock(&my_seqlock);
+
+/* Writer + IRQ disable */
+write_seqlock_irqsave(&my_seqlock, flags);
+write_sequnlock_irqrestore(&my_seqlock, flags);
+
+/* Reader side: retry loop */
+unsigned seq;
+int value;
+do {
+    seq = read_seqbegin(&my_seqlock);
+    value = protected_value;
+} while (read_seqretry(&my_seqlock, seq));
+/* value is now consistent */
+```
+
+### seqcount_t
+
+```c
+#include <linux/seqlock.h>
+
+DEFINE_SEQCOUNT(my_seqcount);
+
+/* Writer: you serialize separately */
+spin_lock(&my_lock);
+write_seqcount_begin(&my_seqcount);
+/* modify data */
+write_seqcount_end(&my_seqcount);
+spin_unlock(&my_lock);
+
+/* Reader */
+unsigned seq;
+do {
+    seq = read_seqcount_begin(&my_seqcount);
+    /* read data */
+} while (read_seqcount_retry(&my_seqcount, seq));
+```
+
+## Real-world example: jiffies and time
+
+The kernel uses seqlocks extensively for time-related data that is updated on every timer tick but read from many places:
+
+```c
+/* kernel/time/timekeeping.c */
+/* Reading the current time */
+static inline u64 __ktime_get_fast_ns(void)
+{
+    struct tk_read_base *tkr = &tk_core.tkr_mono;
+    unsigned int seq;
+    u64 now;
+
+    do {
+        seq = raw_read_seqcount_latch(&tkr->seq);
+        now = tkr->base + clocksource_delta(tkr->clock, tkr->mask, tkr->mult, tkr->shift);
+    } while (raw_read_seqcount_latch_retry(&tkr->seq, seq));
+
+    return now;
+}
+```
+
+The `jiffies_64` counter is also protected by a seqlock on 32-bit systems (where a 64-bit read is non-atomic):
+
+```c
+/* include/linux/jiffies.h */
+extern seqlock_t jiffies_lock;
+extern u64 jiffies_64;
+
+static inline u64 get_jiffies_64(void)
+{
+    unsigned long seq;
+    u64 ret;
+    do {
+        seq = read_seqbegin(&jiffies_lock);
+        ret = jiffies_64;
+    } while (read_seqretry(&jiffies_lock, seq));
+    return ret;
+}
+```
+
+## Constraints
+
+Seqlocks have important limitations:
+
+1. **No pointers**: readers cannot follow pointers during the critical section. If the writer frees the old object between the reader's pointer dereference and its use, the reader has a dangling pointer. Use RCU instead for pointer-based data.
+
+2. **Small, bounded data**: the retry loop must be cheap and terminating. Don't protect megabytes of data or data with variable-length reads.
+
+3. **Writer progress**: writes complete quickly. If writes are frequent or long, readers will spin in the retry loop.
+
+4. **No blocking in reader**: the reader critical section must not sleep (the data could change while asleep).
+
+```
+Use seqlock when:
+  ✓ Data is small and fixed-size (integers, timestamps)
+  ✓ Reads are much more frequent than writes
+  ✓ Writers are quick and infrequent
+  ✓ No pointers in the protected data
+
+Use RCU when:
+  ✓ Data is pointer-based
+  ✓ Reads must see consistent snapshots of complex structures
+```
+
+## Seqlock vs rwlock
+
+Both allow concurrent readers, but:
+
+| | rwlock | seqlock |
+|---|--------|---------|
+| Reader overhead | atomic op (acquire) | non-atomic read + barrier |
+| Writer blocks readers? | Yes | No (readers retry) |
+| Writer starvation | No | Possible (but rare) |
+| Pointer data | Yes | No |
+| IRQ safe | Yes | Yes |
+
+Seqlock wins on read-heavy, write-rare workloads with non-pointer data.
+
+## Further reading
+
+- [rwlock and rwsem](rwlock-rwsem.md) — For pointer-based data or complex structures
+- [RCU](rcu.md) — Lock-free reads for pointer-based data
+- `Documentation/locking/seqlock.rst` in the kernel tree

--- a/docs/locking/spinlock.md
+++ b/docs/locking/spinlock.md
@@ -1,0 +1,197 @@
+# Spinlock and raw_spinlock
+
+> Busy-wait locks that don't sleep — the foundation of kernel synchronization
+
+## What is a spinlock?
+
+A spinlock is a lock that a thread holds by spinning in a tight loop until the lock becomes available. Unlike a mutex, it never puts the thread to sleep. This makes spinlocks usable in contexts where sleeping is forbidden — interrupt handlers, NMI handlers, and anywhere `in_interrupt()` is true.
+
+The cost: spinning wastes CPU cycles. Spinlocks should only protect very short critical sections (typically microseconds, not milliseconds).
+
+## Two spinlock types
+
+The kernel has two types that look similar but behave differently on PREEMPT_RT kernels:
+
+```c
+/* include/linux/spinlock_types.h */
+
+/* Non-RT kernels: spinlock_t wraps raw_spinlock_t */
+typedef struct spinlock {
+    union {
+        struct raw_spinlock rlock;
+    };
+} spinlock_t;
+
+/* raw_spinlock_t: always a real spinlock, never converted */
+typedef struct raw_spinlock {
+    arch_spinlock_t raw_lock;   /* arch-specific, e.g. queued spinlock */
+#ifdef CONFIG_DEBUG_LOCK_ALLOC
+    struct lockdep_map dep_map;
+#endif
+} raw_spinlock_t;
+```
+
+On a standard kernel (non-RT), `spinlock_t` and `raw_spinlock_t` behave identically.
+
+On a PREEMPT_RT kernel, `spinlock_t` becomes a sleeping lock (backed by `rt_mutex`) so that RT tasks can preempt the lock holder. `raw_spinlock_t` remains a true spinlock even on RT.
+
+**Rule**: use `spinlock_t` for most code. Use `raw_spinlock_t` only when you need a true spinlock even on RT kernels (e.g., the scheduler's runqueue lock, which cannot sleep because the scheduler itself is how sleeping works).
+
+## Basic API
+
+```c
+#include <linux/spinlock.h>
+
+/* Static initialization */
+DEFINE_SPINLOCK(my_lock);
+
+/* Dynamic initialization */
+spinlock_t my_lock;
+spin_lock_init(&my_lock);
+
+/* Lock / unlock (process context, preemption disabled) */
+spin_lock(&my_lock);
+/* critical section */
+spin_unlock(&my_lock);
+
+/* Lock/unlock + disable local interrupts */
+unsigned long flags;
+spin_lock_irqsave(&my_lock, flags);
+/* critical section — safe even if called from process context
+   where IRQ handler might also take this lock */
+spin_unlock_irqrestore(&my_lock, flags);
+
+/* Lock/unlock + disable only softirqs (bottom halves) */
+spin_lock_bh(&my_lock);
+spin_unlock_bh(&my_lock);
+
+/* Non-blocking trylock (returns 1 on success, 0 on failure) */
+if (spin_trylock(&my_lock)) {
+    /* got the lock */
+    spin_unlock(&my_lock);
+}
+```
+
+## When to use irqsave vs plain spin_lock
+
+The rule: you need `spin_lock_irqsave()` if the same lock is acquired from both process context and an interrupt handler.
+
+```c
+/* WRONG: process context takes lock, then IRQ fires and also
+   tries to take the same lock → deadlock */
+static spinlock_t counter_lock;
+static int counter;
+
+void update_counter(void)       /* process context */
+{
+    spin_lock(&counter_lock);   /* takes lock */
+    counter++;
+    spin_unlock(&counter_lock); /* releases lock */
+}
+
+irqreturn_t my_irq_handler(int irq, void *data)
+{
+    spin_lock(&counter_lock);   /* DEADLOCK: IRQ fires while process holds lock */
+    counter++;
+    spin_unlock(&counter_lock);
+    return IRQ_HANDLED;
+}
+
+/* CORRECT: disable IRQs while holding the lock */
+void update_counter(void)
+{
+    unsigned long flags;
+    spin_lock_irqsave(&counter_lock, flags);
+    counter++;
+    spin_unlock_irqrestore(&counter_lock, flags);
+}
+```
+
+If the lock is only used within a single IRQ handler (or only in process context where IRQs are already off), plain `spin_lock()` is sufficient.
+
+## How it works: queued spinlocks
+
+Modern x86 uses **queued spinlocks** (MCS-based, introduced in Linux 3.15). Instead of all waiters spinning on the same variable (causing cache line bouncing), each CPU spins on its own per-CPU node:
+
+```
+Lock structure:
+┌──────────────────────────────┐
+│ locked:1 | pending:1 | tail  │  ← 32-bit word
+└──────────────────────────────┘
+       ↑
+       Bit 0: is the lock held?
+            Bit 1: is there a waiter about to get it?
+                   Bits 2-31: index into MCS queue
+
+MCS queue node (per-CPU):
+┌────────────────────────────┐
+│ locked | next_cpu_ptr      │
+└────────────────────────────┘
+         ↑
+         Each waiter spins on its own node's 'locked' field.
+         No cache line bouncing.
+```
+
+When a CPU acquires the lock it clears `locked` in the next CPU's node, causing only that waiter to stop spinning. This scales to hundreds of CPUs.
+
+## raw_spinlock API
+
+`raw_spinlock_t` uses the same naming convention but with `raw_` prefix:
+
+```c
+raw_spinlock_t raw_lock = __RAW_SPIN_LOCK_UNLOCKED(raw_lock);
+
+raw_spin_lock(&raw_lock);
+raw_spin_unlock(&raw_lock);
+
+raw_spin_lock_irqsave(&raw_lock, flags);
+raw_spin_unlock_irqrestore(&raw_lock, flags);
+
+raw_spin_trylock(&raw_lock);       /* returns 1 on success */
+```
+
+## Debugging: lockdep catches misuse
+
+With `CONFIG_DEBUG_SPINLOCK` and `CONFIG_LOCKDEP`, the kernel detects:
+- Double-locking (taking a lock you already hold)
+- Unlocking from a different CPU than where you locked
+- Sleeping while holding a spinlock
+
+```
+BUG: spinlock already locked on CPU#1
+spin_lock() at include/linux/spinlock.h:186
+...
+```
+
+See [Lockdep](lockdep.md) for full details.
+
+## Common mistakes
+
+```c
+/* DON'T: hold a spinlock across sleeping calls */
+spin_lock(&lock);
+kmalloc(size, GFP_KERNEL);  /* may sleep — BUG */
+spin_unlock(&lock);
+
+/* DO: use GFP_ATOMIC when holding a spinlock */
+spin_lock(&lock);
+kmalloc(size, GFP_ATOMIC);  /* never sleeps */
+spin_unlock(&lock);
+
+/* DON'T: call spin_lock twice on the same lock (no recursion) */
+spin_lock(&lock);
+spin_lock(&lock);  /* DEADLOCK */
+
+/* DON'T: exit function without unlocking */
+spin_lock(&lock);
+if (error)
+    return -EINVAL;  /* leaked lock! */
+spin_unlock(&lock);
+```
+
+## Further reading
+
+- [Mutex and rt_mutex](mutex.md) — When you can afford to sleep
+- [Lockdep](lockdep.md) — How the kernel validates lock usage
+- [Atomic operations and memory barriers](atomics.md) — What spinlocks are built on
+- `Documentation/locking/spinlocks.rst` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,3 +220,11 @@ nav:
       - Network Tracing: net/net-tracing.md
       - Understanding /proc/net/snmp: net/proc-snmp.md
       - Network Buffer Tuning: net/net-buffer-tuning.md
+  - Locking:
+    - Getting Started: locking/README.md
+    - Fundamentals:
+      - Spinlock and raw_spinlock: locking/spinlock.md
+      - Mutex and rt_mutex: locking/mutex.md
+      - rwlock and rwsem: locking/rwlock-rwsem.md
+      - RCU (Read-Copy-Update): locking/rcu.md
+      - Seqlock: locking/seqlock.md


### PR DESCRIPTION
## Summary
- `locking/README.md`: Overview of locking primitives with comparison table and usage hierarchy
- `locking/spinlock.md`: spinlock_t vs raw_spinlock_t, queued spinlock internals, when to use irqsave vs plain, common mistakes
- `locking/mutex.md`: struct mutex layout, three acquisition strategies (fastpath/midpath/slowpath), strict ownership semantics, rt_mutex and priority inheritance
- `locking/rwlock-rwsem.md`: rwlock_t (spinning) vs rw_semaphore (sleeping), writer starvation prevention, downgrade_write, mmap_lock example
- `locking/rcu.md`: grace periods, quiescent states, rcu_read_lock/rcu_dereference/rcu_assign_pointer, call_rcu/kfree_rcu, RCU-protected lists, SRCU
- `locking/seqlock.md`: sequence counter pattern, seqcount_t vs seqlock_t, jiffies example, constraints (no pointers)

Closes #236, #237, #238, #239, #240

## Test plan
- [ ] mkdocs build passes without errors
- [ ] All cross-links resolve (spinlock ↔ mutex, rcu ↔ mm/rcu-mm)