### PR TITLE
Add advanced locking: atomics, per-CPU, lockdep, contention debugging, futex

### DIFF
--- a/docs/locking/atomics.md
+++ b/docs/locking/atomics.md
@@ -1,0 +1,239 @@
+# Atomic Operations and Memory Barriers
+
+> The primitives that all higher-level synchronization is built on
+
+## What problem do atomics solve?
+
+On modern CPUs, a simple `x++` compiles to three operations: load `x`, add 1, store `x`. If two CPUs run this simultaneously, both might load the same value and one increment is lost:
+
+```
+CPU 0:  load x (gets 5)                store x = 6
+CPU 1:              load x (gets 5)              store x = 6
+Result: x = 6 (should be 7)
+```
+
+Atomic operations are hardware instructions that perform a read-modify-write as a single indivisible unit. No other CPU can see an intermediate state.
+
+## atomic_t and atomic64_t
+
+```c
+/* include/linux/atomic.h */
+typedef struct { int counter; } atomic_t;
+typedef struct { s64 counter; } atomic64_t;
+
+/* Basic operations */
+atomic_t a = ATOMIC_INIT(0);
+
+atomic_read(&a);              /* read value */
+atomic_set(&a, 5);            /* set value */
+
+atomic_inc(&a);               /* a++ */
+atomic_dec(&a);               /* a-- */
+atomic_add(n, &a);            /* a += n */
+atomic_sub(n, &a);            /* a -= n */
+
+/* Return the new value */
+int v = atomic_inc_return(&a);   /* ++a */
+int v = atomic_dec_return(&a);   /* --a */
+int v = atomic_add_return(n, &a);
+int v = atomic_sub_return(n, &a);
+
+/* Return the old value */
+int old = atomic_fetch_add(n, &a);
+int old = atomic_fetch_sub(n, &a);
+
+/* Test and return */
+bool zero = atomic_dec_and_test(&a);  /* returns true if result == 0 */
+bool neg  = atomic_add_negative(n, &a); /* returns true if result < 0 */
+
+/* Bitwise */
+atomic_or(mask, &a);
+atomic_and(mask, &a);
+atomic_xor(mask, &a);
+int old = atomic_fetch_or(mask, &a);
+```
+
+## Compare-and-swap (cmpxchg)
+
+The most powerful atomic: atomically compare a value with expected, and swap if equal:
+
+```c
+/* Succeeds (returns old == expected) if *ptr == expected, sets *ptr = new */
+old = atomic_cmpxchg(&a, expected, new);
+
+/* Returns true if the swap happened */
+bool success = atomic_try_cmpxchg(&a, &expected, new);
+```
+
+This is the building block for lock-free data structures. For example, a non-blocking push:
+
+```c
+struct node {
+    struct node *next;
+    int value;
+};
+static atomic_long_t head;  /* really: struct node __rcu *head */
+
+void push(struct node *node)
+{
+    struct node *old_head;
+    do {
+        old_head = (struct node *)atomic_long_read(&head);
+        node->next = old_head;
+    } while (atomic_long_cmpxchg(&head,
+                                  (long)old_head,
+                                  (long)node) != (long)old_head);
+}
+```
+
+## atomic_long_t
+
+`atomic_long_t` is a pointer-sized atomic, useful for 64-bit values that need to fit in a pointer on all architectures:
+
+```c
+atomic_long_t v = ATOMIC_LONG_INIT(0);
+atomic_long_read(&v);
+atomic_long_set(&v, val);
+atomic_long_add(n, &v);
+atomic_long_cmpxchg(&v, old, new);
+```
+
+## READ_ONCE and WRITE_ONCE
+
+Two CPUs accessing a variable simultaneously is undefined behavior in C. `READ_ONCE` and `WRITE_ONCE` prevent the compiler from:
+- Tearing the access (splitting a word-sized read/write into multiple)
+- Merging or reordering accesses
+- Caching the value in a register across function calls
+
+```c
+/* Without READ_ONCE/WRITE_ONCE: compiler may cache, reorder, or tear */
+while (flag) { ... }  /* compiler might load flag once and loop forever */
+
+/* With READ_ONCE: fresh load every iteration */
+while (READ_ONCE(flag)) { ... }
+
+/* WRITE_ONCE: ensure the write is visible as a single operation */
+WRITE_ONCE(flag, 0);
+```
+
+These are the minimum necessary for any shared variable access. They don't provide ordering guarantees between CPUs — that's what memory barriers are for.
+
+## Memory barriers
+
+Modern CPUs and compilers reorder memory accesses for performance. On a single CPU this is invisible, but between CPUs it can break synchronization.
+
+There are three types of reordering to prevent:
+
+```
+Store-store: CPU may reorder two stores
+Load-load:   CPU may reorder two loads
+Store-load:  CPU may reorder a store followed by a load (most common)
+```
+
+### Barrier types
+
+```c
+/* Full barrier: no reordering across this point */
+smp_mb();
+
+/* Read barrier: no load reordering across this point */
+smp_rmb();
+
+/* Write barrier: no store reordering across this point */
+smp_wmb();
+
+/* Acquire: no loads/stores after this are moved before it */
+smp_load_acquire(ptr);   /* load + acquire barrier */
+
+/* Release: no loads/stores before this are moved after it */
+smp_store_release(ptr, val);  /* release barrier + store */
+```
+
+### Acquire-Release pattern
+
+The most common barrier pattern is acquire/release, used for passing data from producer to consumer:
+
+```c
+/* Producer */
+data = compute_result();        /* (1) prepare data */
+smp_store_release(&ready, 1);  /* (2) publish: data visible before ready=1 */
+
+/* Consumer */
+if (smp_load_acquire(&ready)) { /* (3) check: ready=1 before reading data */
+    use(data);                   /* (4) data is guaranteed visible here */
+}
+```
+
+The release barrier in (2) ensures (1) is ordered before (2). The acquire barrier in (3) ensures (3) is ordered before (4). Together they form a happens-before relationship.
+
+### Atomic ordering variants
+
+Atomic operations come in four ordering flavors:
+
+```c
+/* Relaxed: no ordering, just atomicity */
+atomic_add_relaxed(1, &counter);
+
+/* Acquire: loads after this see stores before the pairing release */
+atomic_add_acquire(1, &counter);
+
+/* Release: stores before this are visible before any pairing acquire */
+atomic_add_release(1, &counter);
+
+/* Full (default): both acquire and release semantics */
+atomic_add(1, &counter);
+```
+
+Use relaxed for counters where you don't need ordering. Use acquire/release for producer-consumer synchronization. The defaults (`atomic_add`, etc.) are full barriers, which is safe but potentially slower than needed.
+
+```c
+/* Around non-atomic operations: ensure ordering with respect to atomics */
+smp_mb__before_atomic();
+/* non-atomic operations */
+atomic_op();
+/* non-atomic operations */
+smp_mb__after_atomic();
+```
+
+## Common patterns
+
+### Reference counting (atomic_t)
+
+```c
+/* Simpler than kref for simple cases */
+static atomic_t refcount = ATOMIC_INIT(1);
+
+void get(void) { atomic_inc(&refcount); }
+void put(void) {
+    if (atomic_dec_and_test(&refcount))
+        free_object();
+}
+```
+
+The kernel provides `kref` (kernel reference counting) that wraps atomic operations with cleaner semantics.
+
+### Flags (atomic_t as bitfield)
+
+```c
+#define FLAG_BUSY    0
+#define FLAG_READY   1
+
+atomic_t flags = ATOMIC_INIT(0);
+
+/* Set a flag */
+atomic_or(BIT(FLAG_READY), &flags);
+
+/* Test and clear atomically */
+if (atomic_fetch_andnot(BIT(FLAG_BUSY), &flags) & BIT(FLAG_BUSY)) {
+    /* was busy, now cleared */
+}
+```
+
+For per-bit atomics, the kernel also provides `set_bit()`, `clear_bit()`, `test_and_set_bit()`, etc. on `unsigned long`.
+
+## Further reading
+
+- [Spinlock](spinlock.md) — Built on atomics and memory barriers
+- [Per-CPU variables](percpu.md) — Avoiding atomics entirely for per-CPU data
+- `Documentation/memory-barriers.txt` in the kernel tree — The definitive reference
+- `Documentation/atomic_t.txt` — atomic_t semantics

--- a/docs/locking/futex.md
+++ b/docs/locking/futex.md
@@ -1,0 +1,207 @@
+# Futex Internals
+
+> How userspace mutex and condition variable implementations work in the kernel
+
+## What is a futex?
+
+A **futex** (fast userspace mutex) is the kernel mechanism that allows userspace locking primitives (pthreads mutex, condition variables, semaphores) to be efficient. The key insight: in the common uncontended case, locking and unlocking should happen entirely in userspace with no kernel involvement. The kernel is only called when there's actual contention.
+
+The futex syscall (`futex(2)`) provides two core operations:
+- `FUTEX_WAIT`: sleep if the futex word has a given value
+- `FUTEX_WAKE`: wake one or more waiters
+
+## The uncontended fast path
+
+A pthread mutex, for example, is implemented over a 32-bit integer in userspace memory:
+
+```c
+/* Simplified pthread mutex */
+int mutex_word = 0;  /* 0 = unlocked, 1 = locked, 2 = locked with waiters */
+
+void pthread_mutex_lock(int *mutex_word)
+{
+    /* Fast path: try to take the lock with an atomic CAS */
+    if (atomic_cmpxchg(mutex_word, 0, 1) == 0)
+        return;  /* got it, no kernel call */
+
+    /* Slow path: there's contention, call into the kernel */
+    do {
+        /* Mark that there are waiters */
+        atomic_set(mutex_word, 2);
+        /* Sleep until value != 2 */
+        futex(mutex_word, FUTEX_WAIT, 2, NULL, NULL, 0);
+    } while (atomic_cmpxchg(mutex_word, 0, 2) != 0);
+}
+
+void pthread_mutex_unlock(int *mutex_word)
+{
+    /* Fast path: no waiters */
+    if (atomic_xchg(mutex_word, 0) == 1)
+        return;  /* just clear, no kernel call */
+
+    /* Slow path: there are waiters, wake one */
+    futex(mutex_word, FUTEX_WAKE, 1, NULL, NULL, 0);
+}
+```
+
+The kernel is called only when:
+1. Locking: the lock is already held (someone needs to sleep)
+2. Unlocking: there are waiters that need to be woken
+
+For a lightly-contended mutex, most lock/unlock operations complete entirely in userspace with two atomic instructions.
+
+## Kernel-side data structures
+
+```c
+/* kernel/futex/futex.h */
+
+/* Identifies a specific futex (where in memory it is) */
+union futex_key {
+    struct {
+        u64 ptr;          /* for private futexes: mm pointer */
+        unsigned long word;  /* page offset + word offset */
+    } private;
+    struct {
+        u64 ptr;          /* for shared futexes: mapping pointer */
+        unsigned long pgoff; /* page offset in file */
+        unsigned int offset;
+    } shared;
+    struct {
+        u64 ptr;
+        unsigned long word;
+    } both;
+};
+
+/* One entry per sleeping waiter */
+struct futex_q {
+    struct plist_node list;       /* sorted by priority in hash bucket */
+    struct task_struct *task;     /* the sleeping task */
+    spinlock_t *lock_ptr;         /* hash bucket lock */
+    union futex_key key;          /* what futex we're waiting on */
+    struct futex_pi_state *pi_state; /* priority inheritance state */
+    u32 bitset;                   /* for FUTEX_WAIT_BITSET */
+};
+
+/* Hash table bucket: all futexes with the same hash share a bucket */
+struct futex_hash_bucket {
+    atomic_t waiters;
+    spinlock_t lock;
+    struct plist_head chain;      /* list of futex_q entries */
+} ____cacheline_aligned_in_smp;
+```
+
+The hash table has `1 << CONFIG_FUTEX_HASHBITS` buckets (default 256 on most configs). Multiple futexes may share a bucket — the key is used to identify the specific futex when waking.
+
+## Private vs shared futexes
+
+```c
+/* Private futex (process-private, default in glibc) */
+futex(&word, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, expected, timeout, NULL, 0);
+
+/* Shared futex (can be in shared memory, accessible cross-process) */
+futex(&word, FUTEX_WAIT, expected, timeout, NULL, 0);
+```
+
+Private futexes are slightly faster because the key is just the virtual address — no page table walk needed. Shared futexes use the underlying page's physical address (via `page->mapping` + offset) so multiple processes mapping the same page see the same futex.
+
+## FUTEX_WAIT: going to sleep
+
+```c
+/* Simplified kernel FUTEX_WAIT implementation */
+int futex_wait(u32 __user *uaddr, u32 val, ...)
+{
+    struct futex_q q;
+    struct futex_hash_bucket *hb;
+
+    /* 1. Compute the key */
+    ret = get_futex_key(uaddr, &q.key);
+
+    /* 2. Lock the hash bucket */
+    hb = hash_futex(&q.key);
+    spin_lock(&hb->lock);
+
+    /* 3. Check the value under the bucket lock */
+    ret = get_user(uval, uaddr);
+    if (uval != val) {
+        /* Value changed before we got here: return without sleeping */
+        spin_unlock(&hb->lock);
+        return -EAGAIN;
+    }
+
+    /* 4. Queue ourselves */
+    plist_add(&q.list, &hb->chain);
+    spin_unlock(&hb->lock);
+
+    /* 5. Sleep */
+    set_current_state(TASK_INTERRUPTIBLE);
+    schedule();
+
+    /* 6. Woke up: remove from queue */
+    return 0;
+}
+```
+
+The crucial step is checking the value **under the hash bucket lock** (step 3). This prevents a race where:
+- Userspace sees the lock is contended and calls FUTEX_WAIT
+- The lock holder unlocks and calls FUTEX_WAKE before we've queued
+- We'd sleep forever without the lock check
+
+## FUTEX_WAKE: waking sleepers
+
+```c
+int futex_wake(u32 __user *uaddr, int nr_wake)
+{
+    struct futex_hash_bucket *hb;
+    struct futex_key key;
+    struct futex_q *q;
+
+    get_futex_key(uaddr, &key);
+    hb = hash_futex(&key);
+
+    spin_lock(&hb->lock);
+    /* Find waiters with matching key and wake them */
+    plist_for_each_entry_safe(q, ..., &hb->chain, list) {
+        if (futex_match(&q->key, &key)) {
+            wake_up_process(q->task);
+            if (--nr_wake == 0)
+                break;
+        }
+    }
+    spin_unlock(&hb->lock);
+}
+```
+
+## PI futexes
+
+Priority-inheritance futexes (`FUTEX_LOCK_PI`, `FUTEX_UNLOCK_PI`) implement the priority inheritance protocol for userspace mutexes. When a high-priority task blocks on a PI futex held by a low-priority task, the low-priority task's effective priority is boosted.
+
+The kernel maintains a `futex_pi_state` struct that connects the `futex_q` to an `rt_mutex` — the same priority-inheritance machinery used by `rt_mutex_t` in the kernel.
+
+```c
+/* Userspace PI mutex (simplified) */
+void pi_mutex_lock(int *uaddr)
+{
+    /* Try to take: set word to our TID */
+    int zero = 0;
+    if (cmpxchg(uaddr, 0, gettid()) == 0)
+        return;  /* got it */
+    /* Block: kernel will boost owner's priority */
+    futex(uaddr, FUTEX_LOCK_PI, 0, timeout, NULL, 0);
+}
+```
+
+## Condition variables (FUTEX_WAIT + FUTEX_WAKE)
+
+`pthread_cond_wait` is implemented as:
+1. Release the associated mutex (userspace atomic)
+2. `FUTEX_WAIT` on the condition variable word
+3. On wake: re-acquire the mutex
+
+`pthread_cond_signal` / `pthread_cond_broadcast` use `FUTEX_WAKE` (signal) or `FUTEX_REQUEUE` (broadcast, to efficiently move waiters to the mutex's queue without waking them all).
+
+## Further reading
+
+- [Mutex and rt_mutex](mutex.md) — Kernel-side sleeping locks
+- [Priority Inversion & PI Mutexes](../sched/pi-mutexes.md) — The rt_mutex PI mechanism
+- `man 2 futex` — Syscall interface
+- `Documentation/locking/` in the kernel tree

--- a/docs/locking/lock-debugging.md
+++ b/docs/locking/lock-debugging.md
@@ -1,0 +1,233 @@
+# Lock Contention Debugging
+
+> Finding and fixing lock hotspots in the kernel
+
+## Identifying the problem
+
+Lock contention manifests as CPUs burning time waiting rather than doing useful work. Symptoms:
+- High CPU utilization but low throughput
+- `perf top` shows `_raw_spin_lock` or `mutex_lock` near the top
+- `sar -u` shows high `%sys` with low actual work rate
+- `perf stat` shows many `lock:contention_begin` events
+
+## /proc/lock_stat
+
+Requires `CONFIG_LOCK_STAT=y`. Provides per-lock-class contention statistics:
+
+```bash
+# Enable lock stats collection
+echo 1 > /proc/sys/kernel/lock_stat
+
+# View stats (reset on read if you use >)
+cat /proc/lock_stat
+
+# Reset counters
+echo 0 > /proc/lock_stat
+```
+
+Output format:
+```
+class name    con-bounces  contentions  waittime-min  waittime-max  waittime-total  acq-bounces  acquisitions  holdtime-min  holdtime-max  holdtime-total
+&rq->lock:
+                   234567       234567          0.20       4567.89    12345678.90       345678      23456789          0.10        234.56    23456789.12
+```
+
+Key columns:
+- **contentions**: number of times a caller had to wait (lock was already held)
+- **waittime-max**: worst-case wait time (µs) — your tail latency
+- **holdtime-total**: total time the lock was held — high means long critical sections
+- **con-bounces**: contentions where the previous holder was on a different CPU (cross-CPU bouncing)
+
+```bash
+# Find the most contended locks
+cat /proc/lock_stat | sort -k2 -rn | head -20
+
+# Focus on high wait times
+awk '$5 > 1000' /proc/lock_stat  # waittime-max > 1ms
+```
+
+## perf lock
+
+`perf lock` traces lock events with timestamps:
+
+```bash
+# Record lock events (requires perf with lock support)
+perf lock record -a sleep 10
+
+# Analyze: show most contended locks
+perf lock report
+
+# Summary view
+perf lock report --key acquired
+```
+
+Output:
+```
+                Name   acquired  contended  avg wait (ns)  total wait (ns)
+        &rq->__lock:    1234567      45678          12345      12345678901
+  &mm->mmap_lock(W):      23456       1234         234567       1234567890
+```
+
+## perf top for lock hotspots
+
+```bash
+# Find which functions spend most time waiting on locks
+perf top -e lock:contention_begin,lock:contention_end
+
+# Profile lock acquisition overhead
+perf record -e lock:contention_begin -ag sleep 10
+perf report --stdio
+```
+
+## bpftrace for lock analysis
+
+```bash
+# Track lock wait time per lock and call site
+bpftrace -e '
+kprobe:mutex_lock {
+    @ts[tid] = nsecs;
+    @caller[tid] = kstack;
+}
+kretprobe:mutex_lock /@ts[tid]/ {
+    $wait = nsecs - @ts[tid];
+    if ($wait > 1000000) {  /* > 1ms */
+        printf("Long mutex wait: %lu ns\n  caller:\n%s\n",
+               $wait, @caller[tid]);
+    }
+    delete(@ts[tid]);
+    delete(@caller[tid]);
+}'
+
+# Histogram of spinlock hold times
+bpftrace -e '
+kprobe:_raw_spin_lock {
+    @start[tid] = nsecs;
+}
+kprobe:_raw_spin_unlock /@start[tid]/ {
+    @hold_ns = hist(nsecs - @start[tid]);
+    delete(@start[tid]);
+}'
+
+# Find which locks have the most contention (spin loops)
+bpftrace -e '
+kprobe:__pv_queued_spin_lock_slowpath {
+    @[kstack] = count();
+}
+interval:s:5 {
+    print(@); clear(@);
+}'
+```
+
+## Lockdep contention tracking
+
+```bash
+# With CONFIG_LOCK_STAT and CONFIG_LOCKDEP, check /proc/lockdep_stats
+cat /proc/lockdep_stats
+# lock-classes: 2341
+# direct dependencies: 8234
+# chain cache misses: 123
+# hardirq-safe locks:  456
+# softirq-safe locks:  789
+```
+
+## ftrace: tracing specific lock points
+
+```bash
+# Trace all mutex_lock calls with stack
+echo mutex_lock > /sys/kernel/debug/tracing/set_ftrace_filter
+echo function_graph > /sys/kernel/debug/tracing/current_tracer
+echo 1 > /sys/kernel/debug/tracing/tracing_on
+# ... reproduce the issue ...
+echo 0 > /sys/kernel/debug/tracing/tracing_on
+cat /sys/kernel/debug/tracing/trace | head -100
+```
+
+## Common lock contention patterns and fixes
+
+### 1. Fine-grained locking
+
+Replace one coarse lock with many per-bucket or per-object locks:
+
+```c
+/* Before: one global lock */
+static DEFINE_SPINLOCK(hash_lock);
+static struct hlist_head hash_table[HASH_SIZE];
+
+/* After: per-bucket locks */
+struct hash_bucket {
+    spinlock_t lock;
+    struct hlist_head head;
+} ____cacheline_aligned;
+static struct hash_bucket hash_table[HASH_SIZE];
+```
+
+The `____cacheline_aligned` attribute prevents false sharing between adjacent buckets.
+
+### 2. Read-write splitting
+
+If most access is read-only, use rwsem or RCU:
+
+```c
+/* Before: spinlock serializes readers and writers */
+spin_lock(&config_lock);
+val = config->value;
+spin_unlock(&config_lock);
+
+/* After: RCU allows concurrent reads */
+rcu_read_lock();
+cfg = rcu_dereference(config);
+val = cfg->value;
+rcu_read_unlock();
+```
+
+### 3. Per-CPU sharding
+
+For counters and stats, use per-CPU variables:
+
+```c
+/* Before: atomic increment on shared counter */
+atomic_inc(&event_count);
+
+/* After: per-CPU counter, no synchronization needed */
+this_cpu_inc(event_count);
+```
+
+### 4. Lock elision / trylock patterns
+
+In some cases, falling back to a slower path avoids contention:
+
+```c
+/* Try to acquire, fall back to queuing work if busy */
+if (!spin_trylock(&cache_lock)) {
+    schedule_work(&cache_work);  /* retry later */
+    return;
+}
+/* fast path */
+spin_unlock(&cache_lock);
+```
+
+### 5. Batching
+
+Reduce lock granularity by batching multiple updates into one critical section:
+
+```c
+/* Before: one lock per item */
+for (item in items) {
+    spin_lock(&list_lock);
+    list_add(&item->node, &list);
+    spin_unlock(&list_lock);
+}
+
+/* After: batch */
+spin_lock(&list_lock);
+for (item in items)
+    list_add(&item->node, &list);
+spin_unlock(&list_lock);
+```
+
+## Further reading
+
+- [Lockdep](lockdep.md) — Detecting circular dependencies
+- [Spinlock](spinlock.md) — When spinlocks make sense
+- [RCU](rcu.md) — For read-heavy workloads
+- [Per-CPU variables](percpu.md) — Eliminating shared counters

--- a/docs/locking/lockdep.md
+++ b/docs/locking/lockdep.md
@@ -1,0 +1,185 @@
+# Lockdep: Lock Dependency Validator
+
+> The kernel's runtime lock correctness checker
+
+## What lockdep does
+
+Lockdep is a kernel subsystem (enabled by `CONFIG_PROVE_LOCKING`) that tracks lock acquisition order at runtime and detects potential deadlocks before they actually happen. It catches:
+
+- **Circular lock dependencies**: A → B → A (classic deadlock)
+- **Lock inversion**: taking A then B in some code paths, B then A in others
+- **Bad IRQ context**: sleeping lock taken in interrupt context
+- **Recursive locking**: taking the same lock twice without releasing
+- **Missing annotations**: lock ordering that depends on subclasses
+
+Lockdep reports a "possible deadlock" the first time it sees a new lock ordering that could lead to deadlock — even if no actual deadlock has occurred yet. This is much better than waiting for a real deadlock to happen in production.
+
+## Lock classes
+
+Lockdep tracks **lock classes**, not individual lock instances. A class represents "all locks initialized with this key". For example, all `mutex` instances of type `struct inode->i_mutex` belong to the same class, even though there are millions of inodes.
+
+```c
+/* Each statically initialized lock gets its own class automatically */
+DEFINE_MUTEX(my_mutex);  /* class key = address of my_mutex */
+
+/* Dynamic locks: a static key must be provided */
+struct my_struct {
+    struct mutex lock;
+};
+
+void init_my_struct(struct my_struct *s)
+{
+    /* All my_struct::lock instances share one class key */
+    static struct lock_class_key my_lock_key;
+    mutex_init(&s->lock);
+    /* Or with explicit class annotation: */
+    lockdep_set_class(&s->lock, &my_lock_key);
+}
+```
+
+## Dependency graph
+
+Every time a lock is acquired while another lock is already held, lockdep adds an edge A → B to its directed graph. A circular dependency (A → B → A) means a potential deadlock.
+
+```
+Scenario:
+  Thread 1: lock(A), lock(B)    → adds edge A→B
+  Thread 2: lock(B), lock(A)    → adds edge B→A
+                                 → CIRCULAR! lockdep reports a warning
+```
+
+The warning appears the moment Thread 2's pattern is first observed, even if Threads 1 and 2 never actually run concurrently.
+
+## Reading a lockdep warning
+
+```
+======================================================
+WARNING: possible circular locking dependency detected
+6.5.0 #1 Not tainted
+------------------------------------------------------
+thread/1234 is trying to acquire lock:
+ffffffff82345678 (&a_lock){+.+.}-{3:3}, at: func_a+0x12/0x34
+
+but task is already holding:
+ffffffff82345690 (&b_lock){+.+.}-{3:3}, at: func_b+0x56/0x78
+
+which lock already depends on the new lock.
+
+the existing dependency chain (in reverse order) is:
+-> #1 (&b_lock){+.+.}-{3:3}:
+       lock_acquire at kernel/locking/lockdep.c:5543
+       _raw_spin_lock at kernel/locking/spinlock.c:151
+       func_b+0x56/0x78
+-> #0 (&a_lock){+.+.}-{3:3}:
+       lock_acquire at kernel/locking/lockdep.c:5543
+       _raw_spin_lock at kernel/locking/spinlock.c:151
+       func_a+0x12/0x34
+```
+
+Key fields:
+- The lock type annotation `{+.+.}` shows where it's used: `+` = used with IRQs enabled, `-` = used with IRQs disabled, `.` = not used in that context
+- The dependency chain shows the exact call path that created the dependency
+
+## Lock annotations
+
+Lockdep provides annotations to use in your code:
+
+```c
+/* Assert that a lock is held (WARN if not) */
+lockdep_assert_held(&my_mutex);
+
+/* Assert held for read */
+lockdep_assert_held_read(&my_rwsem);
+
+/* Assert held for write */
+lockdep_assert_held_write(&my_rwsem);
+
+/* Assert that NO lock is held (for sleeping functions) */
+might_sleep();    /* warns if in atomic context */
+
+/* Mark code that must not sleep */
+cant_sleep();
+
+/* Mark that we're in RCU read-side critical section */
+lockdep_assert_in_rcu_read_lock();
+```
+
+These are no-ops when lockdep is disabled (`CONFIG_PROVE_LOCKING=n`), so they're safe to leave in production code.
+
+## Subclasses for nested locks
+
+When you legitimately take two locks of the same class in order (e.g., locking a parent then a child in a tree traversal), lockdep needs a subclass annotation to understand this is intentional and not a deadlock:
+
+```c
+/* A tree where each node has its own lock of the same class */
+struct tree_node {
+    struct mutex lock;
+    struct tree_node *child;
+};
+
+void lock_parent_then_child(struct tree_node *parent,
+                             struct tree_node *child)
+{
+    /* Without subclass: lockdep would flag this as circular */
+    mutex_lock(&parent->lock);
+    mutex_lock_nested(&child->lock, 1);  /* subclass=1 = child level */
+    /* ... */
+    mutex_unlock(&child->lock);
+    mutex_unlock(&parent->lock);
+}
+```
+
+The `_nested` variants (`mutex_lock_nested`, `spin_lock_nested`, `down_read_nested`, etc.) take a subclass argument that lockdep uses to distinguish lock orderings at different tree depths.
+
+## /proc/lockdep
+
+When lockdep is active, it exposes its data:
+
+```bash
+# All known lock classes
+cat /proc/lockdep
+
+# Dependency graph
+cat /proc/lockdep_chains
+
+# Statistics (lock classes used, dependency chains, etc.)
+cat /proc/lockdep_stats
+# lock-classes: 2341
+# direct dependencies: 8234
+# indirect dependencies: 12456
+# all direct dependencies: 23456
+```
+
+## Lock stats (/proc/lock_stat)
+
+With `CONFIG_LOCK_STAT`, the kernel tracks contention per lock class:
+
+```bash
+cat /proc/lock_stat
+# class name    con-bounces   contentions   waittime-min   waittime-max   waittime-total  acq-bounces   acquisitions  holdtime-min   holdtime-max   holdtime-total
+# &mm->mmap_lock:
+#                      5623        5623              0.26        1234.56       123456.78      234567         2345678          0.12         456.78       23456789.12
+```
+
+Columns:
+- `contentions`: times the lock was already held when taken
+- `waittime-*`: how long callers waited (microseconds)
+- `acquisitions`: total lock acquisitions
+- `holdtime-*`: how long the lock was held
+
+High `contentions` and `waittime-max` indicate a lock hotspot.
+
+## Performance impact
+
+Lockdep is expensive — it keeps a complete dependency graph in memory and validates every lock acquisition. It's intended for development/testing kernels, not production:
+
+- Memory: ~60MB for the lock class data structures
+- CPU: each lock acquire/release goes through lockdep validation
+
+For production, compile with `CONFIG_PROVE_LOCKING=n`. The `lockdep_assert_held()` annotations remain as no-ops.
+
+## Further reading
+
+- [Lock contention debugging](lock-debugging.md) — Using lock_stat and perf to find hotspots
+- [Spinlock](spinlock.md) — What lockdep validates
+- `Documentation/locking/lockdep-design.rst` — Lockdep internals

--- a/docs/locking/percpu.md
+++ b/docs/locking/percpu.md
@@ -1,0 +1,163 @@
+# Per-CPU Variables
+
+> Eliminating shared state by giving each CPU its own copy
+
+## The core idea
+
+Many kernel subsystems maintain per-CPU counters or state — a count of context switches, cache statistics, a runqueue pointer. The obvious approach is a global variable with a lock. But the per-CPU approach is better: give each CPU its own copy.
+
+Benefits:
+- **No synchronization needed for CPU-local access**: reading/writing your own CPU's copy requires no locks
+- **No cache line bouncing**: each CPU touches only its own data, no false sharing
+- **Naturally scalable**: performance doesn't degrade as CPU count increases
+
+The tradeoff: reading the system-wide total requires summing all CPUs' copies.
+
+## How it works
+
+The kernel allocates a contiguous per-CPU area for each CPU at boot. A per-CPU variable is an offset into this area. To access CPU N's copy, you compute `base[N] + offset`:
+
+```
+Per-CPU memory layout:
+
+CPU 0 area:  [var_a] [var_b] [counter] [...]
+CPU 1 area:  [var_a] [var_b] [counter] [...]
+CPU 2 area:  [var_a] [var_b] [counter] [...]
+                      ↑
+                      same offset, different base address per CPU
+```
+
+## Declaring and using per-CPU variables
+
+```c
+#include <linux/percpu.h>
+#include <linux/percpu-defs.h>
+
+/* Declare a per-CPU variable (one copy per CPU) */
+DEFINE_PER_CPU(int, my_counter);
+DEFINE_PER_CPU(struct my_stats, cpu_stats);
+
+/* Declare in header: */
+DECLARE_PER_CPU(int, my_counter);
+
+/* Access your own CPU's copy */
+/* get_cpu_var: disables preemption, returns reference */
+int val = get_cpu_var(my_counter);
+get_cpu_var(my_counter)++;
+put_cpu_var(my_counter);  /* re-enables preemption */
+
+/* this_cpu_*: low-overhead variant, you must ensure no migration */
+this_cpu_inc(my_counter);
+this_cpu_add(my_counter, 5);
+int v = this_cpu_read(my_counter);
+this_cpu_write(my_counter, 0);
+```
+
+The difference between `get_cpu_var` and `this_cpu_*`:
+- `get_cpu_var` disables preemption — safe even if code can be preempted
+- `this_cpu_*` does NOT disable preemption — caller must guarantee they won't migrate (e.g., already in a preemption-disabled section, or in a per-CPU context)
+
+## Accessing another CPU's data
+
+```c
+/* Read CPU N's copy (observer only, no lock needed for reading) */
+int val = per_cpu(my_counter, cpu_id);
+
+/* Get a pointer to CPU N's copy */
+int *ptr = per_cpu_ptr(&my_counter, cpu_id);
+```
+
+For writes to another CPU's variable, you typically need either a lock or to use an IPI (inter-processor interrupt) to run code on that CPU.
+
+## Summing all CPUs
+
+```c
+/* Sum a per-CPU integer across all CPUs */
+long total = 0;
+int cpu;
+for_each_possible_cpu(cpu)
+    total += per_cpu(my_counter, cpu);
+
+/* Or using the convenience helper for percpu_counter: */
+s64 sum = percpu_counter_sum(&my_percpu_counter);
+```
+
+## percpu_counter: the ready-made solution
+
+For simple counters, `percpu_counter` provides a complete implementation that batches updates to a central counter:
+
+```c
+#include <linux/percpu_counter.h>
+
+struct percpu_counter my_counter;
+percpu_counter_init(&my_counter, 0, GFP_KERNEL);
+
+/* Fast: update this CPU's local count */
+percpu_counter_add(&my_counter, 1);
+percpu_counter_inc(&my_counter);
+percpu_counter_dec(&my_counter);
+
+/* Approximate: fast sum (may be slightly off) */
+s64 approx = percpu_counter_read(&my_counter);
+
+/* Exact: sums all CPUs (slower) */
+s64 exact = percpu_counter_sum(&my_counter);
+
+percpu_counter_destroy(&my_counter);
+```
+
+`percpu_counter` batches updates: each CPU accumulates up to `batch` (default 32) local changes before flushing to the global counter. This makes increments O(1) with no atomic operations in the fast path.
+
+## When NOT to use per-CPU variables
+
+Per-CPU is not always the answer:
+
+```
+Use per-CPU when:
+  ✓ Data is primarily updated by the owning CPU
+  ✓ Global aggregates can be approximate (stats, counters)
+  ✓ Per-CPU state makes semantic sense (runqueues, CPU-local caches)
+
+Don't use per-CPU when:
+  ✗ Any CPU can update the data equally often
+  ✗ The global total must always be exact and consistent
+  ✗ The data is inherently global (a single flag, a single pointer)
+```
+
+## Real-world usage: VM stats
+
+The mm subsystem uses per-CPU variables for page counters:
+
+```c
+/* mm/vmstat.c */
+DEFINE_PER_CPU(struct vm_event_state, vm_event_states);
+
+/* Increment a VM event counter (e.g., number of page faults) */
+static inline void count_vm_event(enum vm_event_item item)
+{
+    this_cpu_inc(vm_event_states.event[item]);
+}
+
+/* Read the global total */
+unsigned long global_node_page_state(enum node_stat_item item)
+{
+    long x = atomic_long_read(&vm_node_stat[item]);
+    return x;
+}
+```
+
+And the scheduler uses per-CPU runqueues:
+
+```c
+/* kernel/sched/core.c */
+DEFINE_PER_CPU_SHARED_ALIGNED(struct rq, runqueues);
+
+#define cpu_rq(cpu) (&per_cpu(runqueues, (cpu)))
+#define this_rq()   this_cpu_ptr(&runqueues)
+```
+
+## Further reading
+
+- [Atomic operations](atomics.md) — When you do need synchronization
+- [Spinlock](spinlock.md) — Protecting truly shared data
+- `Documentation/core-api/per-cpu.rst` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -228,3 +228,9 @@ nav:
       - rwlock and rwsem: locking/rwlock-rwsem.md
       - RCU (Read-Copy-Update): locking/rcu.md
       - Seqlock: locking/seqlock.md
+    - Advanced:
+      - Atomic Operations and Memory Barriers: locking/atomics.md
+      - Per-CPU Variables: locking/percpu.md
+      - Lockdep: locking/lockdep.md
+      - Lock Contention Debugging: locking/lock-debugging.md
+      - Futex Internals: locking/futex.md


### PR DESCRIPTION
## Summary
- `locking/atomics.md`: atomic_t/atomic64_t API, compare-and-swap, READ_ONCE/WRITE_ONCE, memory barrier types (smp_mb/rmb/wmb, acquire/release), ordering variants
- `locking/percpu.md`: DEFINE_PER_CPU, get_cpu_var vs this_cpu_*, per_cpu_ptr, percpu_counter, runqueue/vmstat examples
- `locking/lockdep.md`: lock classes, dependency graph, reading lockdep warnings, _nested subclasses, lockdep_assert_held annotations, /proc/lock_stat
- `locking/lock-debugging.md`: /proc/lock_stat, perf lock report, bpftrace for lock latency histograms, fine-grained locking/RCU/per-CPU fix patterns
- `locking/futex.md`: fast path (no kernel), hash table, futex_key, futex_q, FUTEX_WAIT check-under-lock race prevention, PI futexes, condition variable implementation

Closes #241, #242, #243, #244, #245

## Test plan
- [ ] mkdocs build passes without errors
- [ ] Cross-links to sched/pi-mutexes and mm/rcu-mm resolve