### PR TITLE
Add interrupts and async processing documentation

### DIFF
--- a/docs/interrupts/README.md
+++ b/docs/interrupts/README.md
@@ -1,0 +1,52 @@
+# Interrupts and Async Processing
+
+> How hardware events reach kernel code, and how deferred work gets done
+
+## The interrupt problem
+
+Hardware devices need to tell the CPU that something happened — a network packet arrived, a disk read completed, a timer expired. The CPU can't poll everything constantly, so hardware uses **interrupts**: a signal that stops whatever the CPU is doing and runs an interrupt handler.
+
+But interrupt handlers must be fast — they run with interrupts (partially) disabled, blocking all other interrupts. So kernel design divides work into two halves:
+
+```
+Hardware interrupt
+    │
+    ▼
+Top half (hardirq)     ← runs immediately, must be fast
+  - Acknowledge interrupt
+  - Copy data from device
+  - Schedule bottom half
+
+Bottom half            ← deferred, runs with interrupts enabled
+  - Process the data
+  - Complete the work
+  - May sleep (workqueues only)
+```
+
+## Contents
+
+### Fundamentals
+- [Interrupt Handling Overview](interrupts.md) — From hardware to handler
+- [IRQ Descriptor and irq_chip](irq-desc.md) — The kernel's interrupt abstraction
+- [request_irq and free_irq](request-irq.md) — Registering interrupt handlers
+- [Threaded IRQs](threaded-irq.md) — Moving work out of hardirq context
+
+### Deferred Work (Bottom Halves)
+- [Softirqs](softirq.md) — The lowest-level deferral mechanism
+- [Tasklets](tasklets.md) — Per-CPU serialized softirq consumers
+- [Workqueues](workqueues.md) — Process-context deferred work
+- [Timers and hrtimers](timers.md) — Deferred work at a specific time
+
+## Execution contexts
+
+Understanding which context code runs in is critical for choosing the right locking:
+
+| Context | `in_interrupt()` | May sleep? | Preemptible? |
+|---------|-----------------|------------|--------------|
+| Process context | false | Yes | Yes |
+| Softirq | true | No | No |
+| Hardirq | true | No | No |
+| Threaded IRQ | false | Yes | Yes |
+| Workqueue | false | Yes | Yes |
+
+`in_interrupt()` returns true in both softirq and hardirq context. Use `in_irq()` for hardirq-only, `in_softirq()` for softirq-only.

--- a/docs/interrupts/interrupts.md
+++ b/docs/interrupts/interrupts.md
@@ -1,0 +1,181 @@
+# Interrupt Handling Overview
+
+> From hardware signal to kernel handler: the complete path
+
+## What happens when hardware sends an interrupt
+
+On x86, the interrupt flow:
+
+```
+Hardware device asserts IRQ line
+    ↓
+Interrupt Controller (APIC/PIC)
+  Identifies interrupt source, routes to CPU
+    ↓
+CPU finishes current instruction
+  Saves: RIP, RFLAGS, RSP, CS, SS to kernel stack
+  Clears IF (disables hardware interrupts)
+  Looks up handler in IDT (Interrupt Descriptor Table)
+    ↓
+common_interrupt() (arch/x86/kernel/irq.c)
+  irq_enter_rcu()    ← marks hardirq context
+  handle_irq()       ← calls the high-level handler
+  irq_exit_rcu()     ← exits hardirq context, runs pending softirqs
+    ↓
+irq_exit_rcu() checks if softirqs are pending
+  If yes: invoke_softirq() → __do_softirq()
+```
+
+## The IDT and interrupt vectors
+
+The x86 Interrupt Descriptor Table (IDT) has 256 entries, each pointing to a handler:
+
+```
+Vectors 0-31:   CPU exceptions (divide by zero, page fault, etc.)
+Vectors 32-127: Hardware IRQs (mapped by APIC)
+Vector 128:     System call (int 0x80, legacy)
+Vectors 129-255: Other IPIs, local APIC, MSI
+```
+
+Each IDT entry specifies privilege level, segment, and handler address. When an interrupt fires, the CPU indexes into the IDT to find the handler.
+
+## Interrupt entry: irq_enter and irq_exit
+
+The kernel tracks whether it's in interrupt context with per-CPU counters in `preempt_count`:
+
+```c
+/* include/linux/preempt.h */
+#define HARDIRQ_SHIFT   (PREEMPT_SHIFT + PREEMPT_BITS)
+#define SOFTIRQ_SHIFT   (HARDIRQ_SHIFT + HARDIRQ_BITS)
+
+/* preempt_count layout:
+   bits 0-7:  preempt count
+   bits 8-15: softirq count
+   bits 16-19: hardirq count
+   bit 20+: NMI count
+*/
+
+#define in_irq()      (hardirq_count())  /* in hardirq handler */
+#define in_softirq()  (softirq_count())  /* in softirq handler */
+#define in_interrupt() (irq_count())     /* in any interrupt context */
+```
+
+`irq_enter()` increments the hardirq count; `irq_exit()` decrements it and runs pending softirqs if we're returning to process context:
+
+```c
+/* kernel/softirq.c (simplified) */
+void irq_exit_rcu(void)
+{
+    /* Decrement hardirq nesting count */
+    preempt_count_sub(HARDIRQ_OFFSET);
+
+    /* Run softirqs if we're back in process context */
+    if (!in_interrupt() && local_softirq_pending())
+        invoke_softirq();
+
+    tick_irq_exit();
+    rcu_irq_exit();
+    trace_hardirq_exit();
+}
+```
+
+## The irq_desc lookup
+
+From the interrupt vector, the kernel finds the `irq_desc` (interrupt descriptor):
+
+```c
+/* arch/x86/kernel/irq.c (simplified) */
+__visible void __irq_entry common_interrupt(struct pt_regs *regs, u64 vector)
+{
+    struct irq_desc *desc;
+
+    irq_enter_rcu();
+
+    /* Convert CPU vector → Linux IRQ number → irq_desc */
+    desc = __this_cpu_read(vector_irq[vector]);
+    if (likely(!IS_ERR_OR_NULL(desc)))
+        handle_irq(desc, regs);
+
+    irq_exit_rcu();
+}
+```
+
+## Interrupt context restrictions
+
+Code running in hardirq context must follow strict rules:
+
+```c
+/* DON'T: sleep in interrupt context */
+irqreturn_t my_handler(int irq, void *dev)
+{
+    msleep(1);           /* BUG: may sleep */
+    kmalloc(sz, GFP_KERNEL);  /* BUG: may sleep */
+    mutex_lock(&m);      /* BUG: may sleep */
+    return IRQ_HANDLED;
+}
+
+/* DO: use non-sleeping alternatives */
+irqreturn_t my_handler(int irq, void *dev)
+{
+    kmalloc(sz, GFP_ATOMIC);  /* never sleeps */
+    spin_lock(&s);             /* doesn't sleep */
+    /* ... */
+    spin_unlock(&s);
+    return IRQ_HANDLED;
+}
+```
+
+Hardware interrupts are disabled on the current CPU for the duration of the hardirq handler (the CPU cleared `IF` on entry). Interrupts on other CPUs are not affected.
+
+## /proc/interrupts
+
+```bash
+cat /proc/interrupts
+#            CPU0       CPU1       CPU2       CPU3
+#   0:         21          0          0          0  IR-IO-APIC    2-edge      timer
+#   1:          2          0          0          1  IR-IO-APIC    1-edge      i8042
+#  16:          0          0          0          0  IR-IO-APIC   16-level     uhci_hcd:usb3
+#  24:          0          0          0          0  IR-PCI-MSI 524288-edge      xhci_hcd
+# LOC:     198432     197654     196543     198123   Local timer interrupts
+# SPU:          0          0          0          0   Spurious interrupts
+# PMI:          0          0          0          0   Performance monitoring interrupts
+# RES:       1234       1567       1234       1345   Rescheduling interrupts
+# CAL:        234        234        234        234   Function call interrupts
+```
+
+- First column: IRQ number (or name for special interrupts)
+- CPU columns: per-CPU interrupt count since boot
+- Controller: interrupt controller and routing
+- Name: driver name from `request_irq()`
+
+```bash
+# Watch interrupt rates
+watch -d -n 1 'cat /proc/interrupts'
+
+# IRQs per second
+awk 'NR>1 {for(i=2;i<=NF-2;i++) if($i+0>0) {print $0; next}}' /proc/interrupts
+```
+
+## IRQ affinity
+
+Each IRQ can be steered to specific CPUs:
+
+```bash
+# Show IRQ affinity (bitmask)
+cat /proc/irq/24/smp_affinity      # hex bitmask
+cat /proc/irq/24/smp_affinity_list # human-readable CPU list
+
+# Pin IRQ 24 to CPUs 0-3
+echo "f" > /proc/irq/24/smp_affinity   # hex f = CPUs 0-3
+echo "0-3" > /proc/irq/24/smp_affinity_list
+
+# irqbalance daemon automatically balances IRQ affinity
+systemctl status irqbalance
+```
+
+## Further reading
+
+- [IRQ Descriptor and irq_chip](irq-desc.md) — The irq_desc data structures
+- [request_irq and free_irq](request-irq.md) — Registering handlers
+- [Softirqs](softirq.md) — What irq_exit runs when pending
+- `Documentation/core-api/genericirq.rst` — Generic IRQ subsystem docs

--- a/docs/interrupts/irq-desc.md
+++ b/docs/interrupts/irq-desc.md
@@ -1,0 +1,168 @@
+# IRQ Descriptor and irq_chip
+
+> The kernel's abstraction over interrupt hardware
+
+## The three-layer interrupt abstraction
+
+The Linux interrupt subsystem uses three structures to abstract over wildly different interrupt controllers (APIC, GIC, IOAPIC, MSI, GPIO controllers...):
+
+```
+Linux IRQ number
+    ↓
+struct irq_desc        ← per-IRQ kernel state (handlers, counters, flags)
+    │
+    ├── struct irq_data      ← chip-level data (controller, chip-specific)
+    │       │
+    │       └── struct irq_chip   ← controller operations (mask, unmask, ack, eoi)
+    │
+    └── struct irqaction     ← linked list of registered handlers
+```
+
+## struct irq_desc
+
+One `irq_desc` exists for each Linux IRQ number. It's the central object that ties together the hardware abstraction and the software handlers:
+
+```c
+/* include/linux/irqdesc.h */
+struct irq_desc {
+    struct irq_common_data irq_common_data;  /* shared irq/chip data */
+    struct irq_data        irq_data;         /* chip-level data */
+    struct irqstat __percpu *kstat_irqs;     /* per-CPU interrupt count */
+    irq_flow_handler_t     handle_irq;       /* high-level handler */
+    struct irqaction       *action;          /* handler chain */
+    unsigned int           depth;            /* nested disable count */
+    unsigned int           irq_count;        /* for stall detection */
+    unsigned int           irqs_unhandled;   /* spurious count */
+    raw_spinlock_t         lock;             /* protects this struct */
+    struct cpumask         *percpu_enabled;  /* per-CPU enable state */
+    const char             *name;
+};
+```
+
+Key fields:
+- `handle_irq`: the **flow handler** — decides how to run the action chain (edge-triggered, level-triggered, per-CPU, etc.)
+- `action`: linked list of `irqaction` structs, one per registered handler
+- `depth`: incremented by `disable_irq()`, decremented by `enable_irq()` — only 0 means actually enabled
+
+## struct irqaction
+
+One `irqaction` per `request_irq()` call. Multiple drivers can share an IRQ line, each with its own `irqaction`:
+
+```c
+/* include/linux/interrupt.h */
+struct irqaction {
+    irq_handler_t    handler;     /* the interrupt handler function */
+    void             *dev_id;     /* passed to handler, identifies the device */
+    struct irqaction *next;       /* next handler sharing this IRQ */
+    irq_handler_t    thread_fn;   /* threaded handler (if IRQF_ONESHOT) */
+    struct task_struct *thread;   /* kernel thread for threaded handler */
+    unsigned int     irq;         /* IRQ number */
+    unsigned int     flags;       /* IRQF_* flags */
+    const char       *name;       /* appears in /proc/interrupts */
+};
+```
+
+When a shared IRQ fires, the kernel walks the `irqaction` chain calling each handler in turn. Each handler returns `IRQ_HANDLED` if it handled the interrupt, or `IRQ_NONE` if it wasn't its device.
+
+## struct irq_chip
+
+The `irq_chip` provides operations for controlling the interrupt controller hardware. Each controller (APIC, ARM GIC, etc.) implements this interface:
+
+```c
+/* include/linux/irq.h */
+struct irq_chip {
+    const char *name;           /* appears in /proc/interrupts */
+
+    /* Basic control */
+    void (*irq_mask)(struct irq_data *data);    /* disable at controller */
+    void (*irq_unmask)(struct irq_data *data);  /* enable at controller */
+    void (*irq_enable)(struct irq_data *data);  /* enable (may = unmask) */
+    void (*irq_disable)(struct irq_data *data); /* disable */
+    void (*irq_ack)(struct irq_data *data);     /* acknowledge (edge) */
+    void (*irq_eoi)(struct irq_data *data);     /* end-of-interrupt (level) */
+
+    /* Affinity */
+    int  (*irq_set_affinity)(struct irq_data *data,
+                              const struct cpumask *dest, bool force);
+
+    /* Trigger type */
+    int  (*irq_set_type)(struct irq_data *data, unsigned int flow_type);
+
+    /* Wakeup */
+    int  (*irq_set_wake)(struct irq_data *data, unsigned int on);
+};
+```
+
+Drivers typically don't call `irq_chip` operations directly — the generic IRQ layer calls them at the right time.
+
+## IRQ domains
+
+Modern systems have hierarchical interrupt controllers (e.g., GPIO expander → GIC → CPU). **IRQ domains** map hardware interrupt numbers to Linux IRQ numbers:
+
+```
+Hardware interrupt 47 (on GPIO expander)
+    ↓ irq_domain (gpio chip)
+Linux IRQ 234
+    ↓ irq_domain (GIC)
+Hardware interrupt 58 (at GIC)
+    ↓
+CPU interrupt vector
+```
+
+```c
+/* Creating an IRQ domain (driver code) */
+struct irq_domain *domain = irq_domain_add_linear(
+    node,           /* device tree node */
+    num_irqs,       /* number of hardware IRQs */
+    &my_domain_ops, /* translate hw → linux IRQ */
+    host_data       /* driver private data */
+);
+
+/* In the domain ops: map HW IRQ to Linux IRQ */
+static int my_irq_domain_map(struct irq_domain *d,
+                              unsigned int virq, irq_hw_number_t hwirq)
+{
+    irq_set_chip_and_handler(virq, &my_chip, handle_level_irq);
+    irq_set_chip_data(virq, d->host_data);
+    return 0;
+}
+```
+
+## Flow handlers
+
+The flow handler (`handle_irq` in `irq_desc`) determines how interrupt delivery works:
+
+| Handler | Usage |
+|---------|-------|
+| `handle_edge_irq` | Edge-triggered: ack before calling action chain |
+| `handle_level_irq` | Level-triggered: mask, run actions, unmask |
+| `handle_fasteoi_irq` | Modern level (with EOI): most ARM/x86 MSI |
+| `handle_percpu_irq` | Per-CPU interrupts (local timer, IPI) |
+| `handle_simple_irq` | No mask/ack, just run actions |
+
+The difference between edge and level matters:
+- **Edge**: interrupt fires once when signal transitions. If missed, it won't fire again.
+- **Level**: interrupt fires as long as signal is asserted. Must be masked during handling.
+
+## Observing IRQ state
+
+```bash
+# Full IRQ table with controller info
+cat /proc/interrupts
+
+# Per-IRQ information
+ls /proc/irq/24/
+# affinity_hint  node  smp_affinity  smp_affinity_list  spread_affinity
+
+# Current affinity
+cat /proc/irq/24/smp_affinity_list  # e.g., "0-3"
+
+# IRQ chip name and handler
+cat /sys/kernel/debug/irq/irqs/24  # (requires debugfs)
+```
+
+## Further reading
+
+- [Interrupt Handling Overview](interrupts.md) — The hardware interrupt flow
+- [request_irq and free_irq](request-irq.md) — Registering irqactions
+- `Documentation/core-api/genericirq.rst` — Generic IRQ subsystem design

--- a/docs/interrupts/request-irq.md
+++ b/docs/interrupts/request-irq.md
@@ -1,0 +1,195 @@
+# request_irq and free_irq
+
+> Registering interrupt handlers with the kernel
+
+## The basic API
+
+```c
+#include <linux/interrupt.h>
+
+/* Register an interrupt handler */
+int request_irq(unsigned int irq,
+                irq_handler_t handler,
+                unsigned long flags,
+                const char *name,
+                void *dev_id);
+
+/* Returns 0 on success, negative errno on failure */
+
+/* Unregister: dev_id must match what was passed to request_irq */
+void free_irq(unsigned int irq, void *dev_id);
+
+/* Managed version: automatically freed when device is removed */
+int devm_request_irq(struct device *dev, unsigned int irq,
+                     irq_handler_t handler, unsigned long flags,
+                     const char *name, void *dev_id);
+```
+
+## Handler return values
+
+```c
+typedef irqreturn_t (*irq_handler_t)(int irq, void *dev_id);
+
+#define IRQ_NONE      (0)            /* not my interrupt */
+#define IRQ_HANDLED   (1)            /* handled the interrupt */
+#define IRQ_WAKE_THREAD (2)          /* wake the threaded handler */
+```
+
+- Return `IRQ_NONE` if the interrupt wasn't from your device (important for shared IRQs)
+- Return `IRQ_HANDLED` when you've handled it
+- Return `IRQ_WAKE_THREAD` to wake the threaded handler (see [Threaded IRQs](threaded-irq.md))
+
+## IRQF flags
+
+```c
+/* Trigger type (usually already configured by firmware/devicetree) */
+IRQF_TRIGGER_RISING   /* edge: low → high */
+IRQF_TRIGGER_FALLING  /* edge: high → low */
+IRQF_TRIGGER_HIGH     /* level: active high */
+IRQF_TRIGGER_LOW      /* level: active low */
+
+/* Sharing */
+IRQF_SHARED           /* interrupt line shared with other devices */
+
+/* Threading */
+IRQF_ONESHOT          /* disable IRQ line until thread handler completes */
+IRQF_NO_THREAD        /* force non-threaded even if requested */
+
+/* Power management */
+IRQF_NO_SUSPEND       /* don't disable during suspend */
+IRQF_FORCE_RESUME     /* force-enable on resume even if disabled */
+
+/* Misc */
+IRQF_NOBALANCING      /* exclude from IRQ balancing */
+IRQF_PERCPU           /* per-CPU interrupt */
+```
+
+## A minimal driver example
+
+```c
+#include <linux/interrupt.h>
+#include <linux/module.h>
+
+struct my_device {
+    int irq;
+    void __iomem *regs;
+    /* ... */
+};
+
+static irqreturn_t my_irq_handler(int irq, void *dev_id)
+{
+    struct my_device *dev = dev_id;
+    u32 status;
+
+    /* Read interrupt status register */
+    status = readl(dev->regs + STATUS_REG);
+
+    /* Check if this is our interrupt */
+    if (!(status & MY_IRQ_BIT))
+        return IRQ_NONE;
+
+    /* Acknowledge (clear) the interrupt */
+    writel(MY_IRQ_BIT, dev->regs + STATUS_CLEAR_REG);
+
+    /* Do minimal work here — queue deferred processing */
+    schedule_work(&dev->work);
+
+    return IRQ_HANDLED;
+}
+
+static int my_driver_probe(struct platform_device *pdev)
+{
+    struct my_device *dev;
+    int ret;
+
+    dev = devm_kzalloc(&pdev->dev, sizeof(*dev), GFP_KERNEL);
+
+    dev->irq = platform_get_irq(pdev, 0);
+    dev->regs = devm_ioremap_resource(&pdev->dev, res);
+
+    INIT_WORK(&dev->work, my_work_handler);
+
+    /* devm_request_irq: automatically freed when device is removed */
+    ret = devm_request_irq(&pdev->dev, dev->irq, my_irq_handler,
+                           0, dev_name(&pdev->dev), dev);
+    if (ret) {
+        dev_err(&pdev->dev, "Failed to request IRQ %d\n", dev->irq);
+        return ret;
+    }
+
+    return 0;
+}
+```
+
+## Shared IRQs
+
+On legacy systems (e.g., PCI INTx), multiple devices share a single IRQ line. Each registers with `IRQF_SHARED`:
+
+```c
+/* Both devices register on the same IRQ */
+request_irq(irq, handler_a, IRQF_SHARED, "device-a", dev_a);
+request_irq(irq, handler_b, IRQF_SHARED, "device-b", dev_b);
+
+/* When the IRQ fires, both handlers are called in sequence:
+   kernel calls handler_a(irq, dev_a), then handler_b(irq, dev_b)
+   Each must check its own hardware status register and return IRQ_NONE
+   if not its interrupt */
+```
+
+Requirements for shared IRQs:
+1. `IRQF_SHARED` must be set by all sharing drivers
+2. `dev_id` must be unique (typically the device struct pointer)
+3. Each handler must be able to determine if it was its device
+
+## disable_irq / enable_irq
+
+```c
+/* Disable an IRQ and wait for any running handler to complete */
+disable_irq(irq);          /* sleeps until handler done */
+disable_irq_nosync(irq);   /* returns immediately */
+
+/* Re-enable */
+enable_irq(irq);
+
+/* Balanced: nested calls (depth counter) */
+disable_irq(irq);  /* depth=1 */
+disable_irq(irq);  /* depth=2 */
+enable_irq(irq);   /* depth=1, still disabled */
+enable_irq(irq);   /* depth=0, now enabled */
+```
+
+`disable_irq()` increments `irq_desc->depth`. The IRQ is only physically disabled when `depth` goes from 1 to 0.
+
+## synchronize_irq
+
+After calling `free_irq()`, you may need to wait for any currently-running handler to complete:
+
+```c
+free_irq(dev->irq, dev);
+synchronize_irq(dev->irq);  /* wait for in-flight handlers */
+/* now safe to free dev */
+```
+
+`devm_request_irq()` handles this automatically at device removal, so prefer it over manual `request_irq()` + `free_irq()`.
+
+## Getting the IRQ number
+
+```c
+/* From platform resources */
+irq = platform_get_irq(pdev, 0);
+
+/* From device tree */
+irq = of_irq_get(np, 0);
+
+/* From PCI */
+irq = pci_irq_vector(pdev, 0);  /* MSI or legacy */
+
+/* From GPIO */
+irq = gpiod_to_irq(gpio);
+```
+
+## Further reading
+
+- [IRQ Descriptor and irq_chip](irq-desc.md) — What's registered under the hood
+- [Threaded IRQs](threaded-irq.md) — Moving work out of hardirq context
+- [Workqueues](workqueues.md) — For deferred work from interrupt handlers

--- a/docs/interrupts/softirq.md
+++ b/docs/interrupts/softirq.md
@@ -1,0 +1,156 @@
+# Softirqs
+
+> The kernel's high-priority deferred work mechanism
+
+## What are softirqs?
+
+Softirqs (software interrupts) are the lowest-level deferred execution mechanism in the kernel. Unlike hardirq handlers that run with interrupts disabled, softirqs run with interrupts **enabled** — they're preemptible by hardirqs but not by other softirqs on the same CPU.
+
+Softirqs are statically defined: there are exactly 10 softirq types, registered at boot. New types cannot be added dynamically. Drivers don't use softirqs directly — they use [tasklets](tasklets.md) or [workqueues](workqueues.md) instead.
+
+## The 10 softirq types
+
+```c
+/* include/linux/interrupt.h */
+enum {
+    HI_SOFTIRQ      = 0,  /* high-priority tasklets */
+    TIMER_SOFTIRQ   = 1,  /* timer wheel expiry */
+    NET_TX_SOFTIRQ  = 2,  /* network transmit */
+    NET_RX_SOFTIRQ  = 3,  /* network receive (NAPI) */
+    BLOCK_SOFTIRQ   = 4,  /* block layer completions */
+    IRQ_POLL_SOFTIRQ= 5,  /* IRQ poll (blk-mq) */
+    TASKLET_SOFTIRQ = 6,  /* normal-priority tasklets */
+    SCHED_SOFTIRQ   = 7,  /* scheduler (load balancing) */
+    HRTIMER_SOFTIRQ = 8,  /* high-resolution timer */
+    RCU_SOFTIRQ     = 9,  /* RCU callbacks */
+    NR_SOFTIRQS
+};
+```
+
+The number is the **priority** — lower number runs first. `HI_SOFTIRQ` (priority 0) for high-priority tasklets always preempts `TASKLET_SOFTIRQ` (priority 6) for normal tasklets.
+
+## How softirqs are triggered
+
+A softirq is raised by calling `raise_softirq()`, which sets a bit in the per-CPU `__softirq_pending` bitmask:
+
+```c
+/* Raise a softirq (can call from hardirq context) */
+raise_softirq(NET_RX_SOFTIRQ);
+
+/* Variant for use when IRQs are already disabled */
+raise_softirq_irqoff(NET_TX_SOFTIRQ);
+```
+
+## When softirqs run
+
+Softirqs are processed at three points:
+
+1. **After a hardirq handler returns** (`irq_exit_rcu()`)
+2. **In ksoftirqd threads** when softirqs are too frequent
+3. **Explicitly** in `local_bh_enable()` when bottom halves are re-enabled
+
+The `__do_softirq()` → `handle_softirqs()` loop:
+
+```c
+/* kernel/softirq.c (simplified) */
+static void handle_softirqs(bool ksirqd)
+{
+    __u32 pending = local_softirq_pending();
+
+    /* Enable IRQs (softirqs run with interrupts enabled) */
+    local_irq_enable();
+
+    /* Process each pending softirq in priority order */
+    while ((softirq_bit = ffs(pending))) {
+        h = &softirq_vec[softirq_bit - 1];
+        h->action();    /* call the registered handler */
+        pending >>= softirq_bit;
+    }
+
+    local_irq_disable();
+
+    /* If more softirqs pending and time allows, restart */
+    if (pending) {
+        if (time_before(jiffies, end) && !need_resched() && --max_restart)
+            goto restart;
+        /* Otherwise, wake ksoftirqd */
+        wakeup_softirqd();
+    }
+}
+```
+
+The loop limits to `MAX_SOFTIRQ_RESTART` (10) iterations before waking `ksoftirqd`, preventing softirqs from starving processes indefinitely.
+
+## ksoftirqd
+
+When softirqs are too frequent (high network load, many timers), the loop would run too long. Instead, the kernel wakes `ksoftirqd/N` — one per CPU — which is a kernel thread at `SCHED_NORMAL` priority that drains pending softirqs:
+
+```bash
+# ksoftirqd threads: one per CPU
+ps aux | grep ksoftirqd
+# root         9  0.0  0.0      0     0 ?   S    10:00   0:01 [ksoftirqd/0]
+# root        18  0.0  0.0      0     0 ?   S    10:00   0:00 [ksoftirqd/1]
+```
+
+Since `ksoftirqd` is a normal process, it can be preempted by user tasks, preventing livelock. High CPU usage by `ksoftirqd` indicates the system is processing many interrupts.
+
+## Checking softirq activity
+
+```bash
+# Per-CPU softirq counts
+cat /proc/softirqs
+#                     CPU0       CPU1       CPU2       CPU3
+#           HI:          1          1          1          1
+#        TIMER:    1234567    1234456    1234123    1234234
+#       NET_TX:       1234       1567       1123       1345
+#       NET_RX:    2345678    2345234    2345123    2345456
+#        BLOCK:      23456      23234      23123      23345
+#     IRQ_POLL:          0          0          0          0
+#      TASKLET:       1234       1234       1234       1234
+#        SCHED:    3456789    3456234    3456123    3456456
+#      HRTIMER:      12345      12234      12123      12234
+#          RCU:    4567890    4567234    4567123    4567456
+
+# NET_RX high = heavy network receive
+# TASKLET high = many driver tasklets
+# RCU high = many RCU callbacks being processed
+```
+
+## Registering a softirq handler (kernel subsystems only)
+
+```c
+/* At boot time only (not from drivers) */
+open_softirq(MY_SOFTIRQ_NR, my_softirq_action);
+
+/* The handler signature */
+static void my_softirq_action(void)
+{
+    /* Process work for this CPU */
+    /* Runs with IRQs enabled, preemptible by hardirqs */
+    /* Cannot sleep */
+}
+```
+
+Drivers should use tasklets or workqueues instead — never add a new softirq type.
+
+## local_bh_disable / local_bh_enable
+
+Code that shares data with softirq handlers must disable softirqs on the local CPU while accessing the data:
+
+```c
+/* Disable softirqs (and tasklets) on this CPU */
+local_bh_disable();
+/* Access data shared with softirq handler */
+local_bh_enable();  /* re-enables, runs pending softirqs */
+
+/* spin_lock_bh: spinlock + local_bh_disable in one call */
+spin_lock_bh(&my_lock);
+/* safe to access data that softirq also touches */
+spin_unlock_bh(&my_lock);
+```
+
+## Further reading
+
+- [Tasklets](tasklets.md) — The driver-accessible wrapper around softirqs
+- [Workqueues](workqueues.md) — When you need to sleep in deferred work
+- [Network Device and NAPI](../net/napi.md) — NET_RX_SOFTIRQ in practice

--- a/docs/interrupts/tasklets.md
+++ b/docs/interrupts/tasklets.md
@@ -1,0 +1,145 @@
+# Tasklets
+
+> Serialized, per-CPU deferred work built on softirqs
+
+## What are tasklets?
+
+Tasklets are a driver-accessible deferral mechanism built on top of softirqs (`TASKLET_SOFTIRQ` and `HI_SOFTIRQ`). They provide two properties that raw softirqs don't:
+
+1. **Serialization**: a given tasklet runs on only one CPU at a time — even on SMP systems, the same tasklet function is never called concurrently
+2. **Dynamic registration**: drivers can register their own tasklets without defining a new softirq type
+
+Tasklets cannot sleep (they run in softirq context). For deferred work that needs to sleep, use [workqueues](workqueues.md).
+
+## The tasklet_struct
+
+```c
+/* include/linux/interrupt.h */
+struct tasklet_struct {
+    struct tasklet_struct *next;  /* pending list link */
+    unsigned long state;          /* TASKLET_STATE_SCHED, TASKLET_STATE_RUN */
+    atomic_t count;               /* 0 = enabled, >0 = disabled */
+    void (*callback)(struct tasklet_struct *t);  /* modern API */
+    unsigned long data;           /* legacy: passed to old-style func */
+};
+```
+
+## API
+
+```c
+#include <linux/interrupt.h>
+
+/* Modern API: callback receives the tasklet pointer */
+void my_tasklet_handler(struct tasklet_struct *t)
+{
+    struct my_device *dev = from_tasklet(dev, t, tasklet);
+    /* process work */
+}
+
+/* Declare (static) */
+DECLARE_TASKLET(my_tasklet, my_tasklet_handler);
+
+/* Or initialize dynamically */
+struct tasklet_struct my_tasklet;
+tasklet_setup(&my_tasklet, my_tasklet_handler);
+
+/* Schedule (can call from IRQ handler) */
+tasklet_schedule(&my_tasklet);    /* normal priority (TASKLET_SOFTIRQ) */
+tasklet_hi_schedule(&my_tasklet); /* high priority (HI_SOFTIRQ) */
+
+/* Disable/enable */
+tasklet_disable(&my_tasklet);   /* wait for running, then disable */
+tasklet_disable_nosync(&my_tasklet);  /* disable without waiting */
+tasklet_enable(&my_tasklet);    /* re-enable, schedule if was pending */
+
+/* Wait for tasklet to finish and kill it */
+tasklet_kill(&my_tasklet);
+```
+
+## from_tasklet: accessing device context
+
+The modern callback receives a `struct tasklet_struct *`. Use `from_tasklet()` to get the containing device struct:
+
+```c
+struct my_device {
+    struct tasklet_struct rx_tasklet;
+    void *rx_buffer;
+    int rx_len;
+};
+
+static void my_rx_tasklet(struct tasklet_struct *t)
+{
+    struct my_device *dev = from_tasklet(dev, t, rx_tasklet);
+    /* process dev->rx_buffer[0..dev->rx_len-1] */
+}
+
+static irqreturn_t my_irq_handler(int irq, void *data)
+{
+    struct my_device *dev = data;
+
+    /* Copy data from hardware to buffer */
+    dev->rx_len = readl(dev->regs + RX_LEN);
+    memcpy_fromio(dev->rx_buffer, dev->regs + RX_DATA, dev->rx_len);
+
+    /* Defer processing to tasklet */
+    tasklet_schedule(&dev->rx_tasklet);
+    return IRQ_HANDLED;
+}
+```
+
+## Serialization guarantee
+
+If `tasklet_schedule()` is called while the tasklet is already running on another CPU, the tasklet will run again after it finishes. But it will never run concurrently:
+
+```
+CPU 0: tasklet running...
+CPU 1: tasklet_schedule() → sets SCHED bit
+
+After CPU 0 finishes: sees SCHED bit, runs tasklet again
+→ tasklet function never runs simultaneously on two CPUs
+```
+
+This is the key advantage over raw softirqs, where the same handler can run on multiple CPUs simultaneously.
+
+## Tasklets are deprecated for new code
+
+Since Linux 5.10+, tasklets are considered deprecated for new code. The reasons:
+- Softirq context means no sleeping, limited functionality
+- Serialization is too coarse for modern hardware
+- Workqueues provide similar functionality with more flexibility
+
+New drivers should use `workqueue` (or `threaded IRQ`) instead of tasklets.
+
+```c
+/* Instead of tasklet, use work_struct */
+struct my_device {
+    struct work_struct rx_work;  /* instead of tasklet */
+};
+
+static void my_rx_work(struct work_struct *work)
+{
+    struct my_device *dev = container_of(work, struct my_device, rx_work);
+    /* can sleep, take mutexes, etc. */
+}
+
+/* Schedule from IRQ handler */
+schedule_work(&dev->rx_work);
+```
+
+## Observing tasklet activity
+
+```bash
+# Tasklet softirq counts
+cat /proc/softirqs | grep -E "TASKLET|HI"
+#     HI:        4        2        1        3
+# TASKLET:    12345    12234    12123    12234
+
+# High TASKLET counts indicate heavy tasklet usage
+# Consider migrating to workqueues if causing scheduling issues
+```
+
+## Further reading
+
+- [Softirqs](softirq.md) — What tasklets are built on
+- [Workqueues](workqueues.md) — The recommended modern alternative
+- [Threaded IRQs](threaded-irq.md) — Another modern alternative for driver IRQ handling

--- a/docs/interrupts/threaded-irq.md
+++ b/docs/interrupts/threaded-irq.md
@@ -1,0 +1,156 @@
+# Threaded IRQs
+
+> Moving interrupt work into process context for longer processing
+
+## The problem with hardirq handlers
+
+Hardware interrupt handlers (hardirq) run with interrupts disabled on the current CPU. This means:
+- They cannot sleep
+- They cannot acquire sleeping locks (mutex, semaphore)
+- They block other interrupts on the same CPU
+- Latency for other high-priority interrupts is added
+
+For complex devices (I2C buses, SPI controllers, touchscreens), the interrupt handler needs to do I2C/SPI register reads that can take milliseconds. That's far too long for a hardirq handler.
+
+**Threaded IRQs** solve this by moving the heavy lifting to a dedicated kernel thread that runs in process context.
+
+## request_threaded_irq
+
+```c
+int request_threaded_irq(unsigned int irq,
+                         irq_handler_t handler,     /* hardirq handler (primary) */
+                         irq_handler_t thread_fn,   /* threaded handler (secondary) */
+                         unsigned long irqflags,
+                         const char *devname,
+                         void *dev_id);
+```
+
+When a threaded IRQ fires:
+1. `handler` (the primary) runs in hardirq context
+   - Must return `IRQ_WAKE_THREAD` to wake the thread, or `IRQ_HANDLED` / `IRQ_NONE`
+2. The IRQ thread (named `irq/N-name`) runs `thread_fn` in process context
+   - May sleep, take mutexes, do I2C reads, etc.
+   - `IRQF_ONESHOT` keeps the IRQ line masked until `thread_fn` returns
+
+## The IRQF_ONESHOT requirement
+
+For threaded IRQs with level-triggered interrupts, you **must** use `IRQF_ONESHOT`. Here's why:
+
+Without `IRQF_ONESHOT`:
+1. Interrupt fires → hardirq runs → IRQ line unmasked → interrupt fires again
+2. The thread is woken, but the interrupt fires again before the thread reads the register
+3. The IRQ line never quiets → interrupt storm
+
+With `IRQF_ONESHOT`:
+1. Interrupt fires → hardirq runs → IRQ line **remains masked**
+2. Thread runs → reads register, clears interrupt source
+3. Thread completes → IRQ line is **unmasked** by the kernel
+4. Now the line is quiet
+
+```c
+/* Always use IRQF_ONESHOT with level-triggered threaded IRQs */
+request_threaded_irq(irq, primary_handler, thread_fn,
+                     IRQF_ONESHOT | IRQF_TRIGGER_LOW, "my-device", dev);
+```
+
+## A complete threaded IRQ example
+
+```c
+/* Primary handler: runs in hardirq context */
+static irqreturn_t my_primary_handler(int irq, void *dev_id)
+{
+    struct my_device *dev = dev_id;
+
+    /* Minimal work: check it's our interrupt */
+    if (!(readl(dev->regs + STATUS) & MY_BIT))
+        return IRQ_NONE;
+
+    /* Disable the interrupt source (device-side) to prevent re-firing */
+    writel(0, dev->regs + IRQ_ENABLE);
+
+    /* Wake the thread to do the real work */
+    return IRQ_WAKE_THREAD;
+}
+
+/* Thread handler: runs in process context */
+static irqreturn_t my_thread_handler(int irq, void *dev_id)
+{
+    struct my_device *dev = dev_id;
+
+    /* Can sleep, take mutexes, do I2C reads, etc. */
+    i2c_smbus_read_byte_data(dev->client, REG_DATA);
+
+    /* Process data */
+    input_report_key(dev->input, KEY_ENTER, 1);
+    input_sync(dev->input);
+
+    /* Re-enable device-side interrupt */
+    writel(MY_BIT, dev->regs + IRQ_ENABLE);
+
+    return IRQ_HANDLED;
+}
+
+static int my_probe(struct i2c_client *client)
+{
+    /* ... */
+    return devm_request_threaded_irq(&client->dev, client->irq,
+                                     my_primary_handler,
+                                     my_thread_handler,
+                                     IRQF_ONESHOT | IRQF_TRIGGER_LOW,
+                                     "my-touchscreen", dev);
+}
+```
+
+## NULL primary handler
+
+If all the work can go to the thread and you don't need to make a "is this my interrupt?" decision in hardirq context, you can pass `NULL` as the primary handler:
+
+```c
+/* NULL primary: kernel provides a default that always returns IRQ_WAKE_THREAD */
+request_threaded_irq(irq, NULL, my_thread_fn,
+                     IRQF_ONESHOT | IRQF_TRIGGER_RISING, "my-sensor", dev);
+```
+
+The kernel's default primary handler acknowledges the interrupt and wakes the thread.
+
+## The IRQ thread
+
+The kernel creates one kernel thread per threaded IRQ, named `irq/N-name` where N is the IRQ number:
+
+```bash
+# List IRQ threads
+ps aux | grep "irq/"
+# root     1234  0.0  0.0      0     0 ?   S    10:00   0:00 [irq/45-eth0]
+# root     1235  0.0  0.0      0     0 ?   S    10:00   0:00 [irq/46-spi0]
+
+# IRQ threads run at SCHED_FIFO priority 50 by default
+chrt -p 1234  # shows scheduling policy and priority
+```
+
+IRQ threads can have their priority adjusted:
+
+```bash
+# Set IRQ 45 thread to SCHED_FIFO priority 90 (for RT workloads)
+chrt -f -p 90 $(pgrep -f "irq/45")
+```
+
+## When to use threaded IRQs
+
+```
+Use threaded IRQs when:
+  ✓ Handler needs to do I2C/SPI communication (sleeps)
+  ✓ Handler needs to acquire a mutex
+  ✓ Handler does complex processing that takes > a few µs
+  ✓ Level-triggered interrupt (IRQF_ONESHOT prevents storm)
+
+Keep in hardirq when:
+  ✓ Very simple: read register, copy data, ack
+  ✓ Network packet receive (NAPI handles deferral differently)
+  ✓ Hard real-time requirements (avoid thread scheduling latency)
+```
+
+## Further reading
+
+- [request_irq and free_irq](request-irq.md) — The non-threaded version
+- [Workqueues](workqueues.md) — Another way to defer work to process context
+- [Softirqs](softirq.md) — For deferred work that must stay in softirq context

--- a/docs/interrupts/timers.md
+++ b/docs/interrupts/timers.md
@@ -1,0 +1,203 @@
+# Timers and hrtimers
+
+> Scheduling kernel work at a specific time
+
+## Two timer subsystems
+
+The kernel has two independent timer mechanisms:
+
+| | timer_list | hrtimer |
+|---|-----------|---------|
+| Resolution | jiffies (1ms–10ms) | nanoseconds |
+| Data structure | hash table (timer wheel) | red-black tree |
+| Callback context | softirq (TIMER_SOFTIRQ) | softirq or hardirq |
+| Use for | Coarse timeouts, watchdogs | High-precision, audio/video, userspace sleep |
+
+## timer_list: jiffies-based timers
+
+`timer_list` is the traditional timer API. Timers expire on a jiffies boundary (typically 1ms–10ms depending on `HZ`).
+
+```c
+/* include/linux/timer.h */
+struct timer_list {
+    struct hlist_node entry;     /* timer wheel position */
+    unsigned long expires;       /* expiry time in jiffies */
+    void (*function)(struct timer_list *);
+    u32 flags;
+};
+```
+
+### API
+
+```c
+#include <linux/timer.h>
+
+struct my_device {
+    struct timer_list watchdog;
+};
+
+static void my_watchdog_handler(struct timer_list *t)
+{
+    struct my_device *dev = from_timer(dev, t, watchdog);
+    /* runs in TIMER_SOFTIRQ context: no sleeping */
+    if (device_stuck(dev))
+        recover_device(dev);
+    /* Restart timer */
+    mod_timer(&dev->watchdog, jiffies + HZ * 5);  /* 5 seconds */
+}
+
+/* Initialize */
+timer_setup(&dev->watchdog, my_watchdog_handler, 0);
+
+/* Start timer: expire in 5 seconds */
+mod_timer(&dev->watchdog, jiffies + HZ * 5);
+
+/* Check if pending */
+if (timer_pending(&dev->watchdog)) { ... }
+
+/* Cancel (non-synchronous: may still fire) */
+del_timer(&dev->watchdog);
+
+/* Cancel and wait for in-flight handler to complete */
+del_timer_sync(&dev->watchdog);
+
+/* Restart timer to new expiry (or arm if not pending) */
+mod_timer(&dev->watchdog, jiffies + HZ);
+```
+
+### Time conversion helpers
+
+```c
+jiffies + HZ           /* 1 second */
+jiffies + HZ / 2       /* 500ms */
+jiffies + msecs_to_jiffies(250)  /* 250ms */
+jiffies + usecs_to_jiffies(500)  /* 500µs */
+
+/* Remaining time */
+long remaining = timer->expires - jiffies;
+```
+
+### The timer wheel
+
+Timers are stored in a hierarchical hash table called the **timer wheel**. The wheel has multiple levels of 64 slots each, covering different time ranges:
+
+```
+Level 0: 64 slots × 1 jiffie   = 64 jiffies (~64ms at HZ=1000)
+Level 1: 64 slots × 64 jiffies = ~4 seconds
+Level 2: 64 slots × 4096 jiffies = ~4.5 minutes
+Level 3: 64 slots × 262144 jiffies = ~4.8 hours
+```
+
+On each timer tick, the wheel advances. Timers in the current slot are fired. Timers at higher levels are "cascaded" down as needed.
+
+## hrtimer: high-resolution timers
+
+hrtimers use `ktime_t` (nanosecond resolution) and a red-black tree ordered by expiry time. The closest expiry sets the hardware timer interrupt.
+
+```c
+/* include/linux/hrtimer.h */
+struct hrtimer {
+    struct timerqueue_node node;   /* rb-tree node, stores expiry */
+    ktime_t _softexpires;          /* earliest possible expiry */
+    enum hrtimer_restart (*function)(struct hrtimer *);
+    struct hrtimer_clock_base *base;
+    u8 state;
+    u8 is_rel;    /* relative time? */
+    u8 is_soft;   /* softirq delivery? */
+    u8 is_hard;   /* hardirq delivery? */
+};
+```
+
+### API
+
+```c
+#include <linux/hrtimer.h>
+
+struct my_device {
+    struct hrtimer timer;
+};
+
+static enum hrtimer_restart my_hrtimer_handler(struct hrtimer *timer)
+{
+    struct my_device *dev = container_of(timer, struct my_device, timer);
+
+    /* Process work */
+    do_periodic_work(dev);
+
+    /* Restart: advance by 10ms */
+    hrtimer_forward_now(timer, ms_to_ktime(10));
+    return HRTIMER_RESTART;
+
+    /* Or: don't restart */
+    /* return HRTIMER_NORESTART; */
+}
+
+/* Initialize */
+hrtimer_setup(&dev->timer, my_hrtimer_handler,
+              CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+
+/* Start: fire in 10ms */
+hrtimer_start(&dev->timer, ms_to_ktime(10), HRTIMER_MODE_REL);
+
+/* Start with absolute time */
+hrtimer_start(&dev->timer, ktime_get() + ms_to_ktime(100),
+              HRTIMER_MODE_ABS);
+
+/* Cancel */
+hrtimer_cancel(&dev->timer);         /* cancel, wait if firing */
+hrtimer_try_to_cancel(&dev->timer);  /* cancel only if not firing */
+
+/* Check if active */
+if (hrtimer_active(&dev->timer)) { ... }
+```
+
+### Clock sources
+
+```c
+CLOCK_MONOTONIC     /* always-increasing, not affected by settimeofday */
+CLOCK_REALTIME      /* wall-clock time, can jump */
+CLOCK_BOOTTIME      /* like MONOTONIC but includes suspend time */
+CLOCK_TAI           /* international atomic time */
+```
+
+Use `CLOCK_MONOTONIC` for most kernel timers. Use `CLOCK_REALTIME` only when the timer must track wall-clock time.
+
+### Delivery modes
+
+```c
+/* Soft mode: callback in HRTIMER_SOFTIRQ (default on non-RT) */
+HRTIMER_MODE_REL_SOFT
+
+/* Hard mode: callback in hardirq context (lower latency, more restrictions) */
+HRTIMER_MODE_REL_HARD
+
+/* Pinned: timer stays on current CPU */
+HRTIMER_MODE_REL_PINNED
+```
+
+## Userspace sleep: hrtimer under the hood
+
+The kernel's `nanosleep()` syscall and `usleep()` in glibc are implemented via hrtimers. When a process calls `nanosleep(10ms)`:
+
+1. `hrtimer_start()` arms a timer 10ms in the future
+2. Process goes to `TASK_INTERRUPTIBLE` sleep
+3. Timer fires → callback wakes the process
+4. Process returns from `nanosleep()`
+
+The precision of `usleep(1)` (1µs sleep) depends on whether `CONFIG_HZ_HIGH` is set and whether the hardware supports high-resolution timer mode.
+
+```bash
+# Check if high-resolution timers are active
+cat /sys/devices/system/clocksource/clocksource0/available_clocksource
+# tsc hpet acpi_pm
+
+# Current clocksource
+cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+# tsc
+```
+
+## Further reading
+
+- [Softirqs](softirq.md) — Where TIMER_SOFTIRQ and HRTIMER_SOFTIRQ run
+- [Workqueues](workqueues.md) — For work deferred by a timer that needs to sleep
+- `Documentation/timers/timers-howto.rst` — Which timer to use when

--- a/docs/interrupts/workqueues.md
+++ b/docs/interrupts/workqueues.md
@@ -1,0 +1,188 @@
+# Workqueues
+
+> Process-context deferred work — the right choice for most drivers
+
+## What are workqueues?
+
+Workqueues are the most flexible deferred work mechanism in the kernel. Unlike softirqs and tasklets, workqueue handlers run in **process context** — they can sleep, take mutexes, do memory allocation with `GFP_KERNEL`, and perform any operation that's valid in a kernel thread.
+
+The kernel automatically manages a pool of worker threads. Each work item is queued and run when a worker becomes available.
+
+## Work items and initialization
+
+```c
+#include <linux/workqueue.h>
+
+/* Define a work item and its handler */
+struct my_device {
+    struct work_struct  work;      /* one-shot work */
+    struct delayed_work dwork;     /* delayed work */
+};
+
+/* Work handler: runs in process context */
+static void my_work_handler(struct work_struct *work)
+{
+    struct my_device *dev = container_of(work, struct my_device, work);
+    /* Can sleep, take mutexes, allocate memory with GFP_KERNEL */
+    mutex_lock(&dev->lock);
+    process_data(dev);
+    mutex_unlock(&dev->lock);
+}
+
+static void my_delayed_work_handler(struct work_struct *work)
+{
+    struct delayed_work *dwork = to_delayed_work(work);
+    struct my_device *dev = container_of(dwork, struct my_device, dwork);
+    /* ... */
+}
+
+/* Initialize */
+INIT_WORK(&dev->work, my_work_handler);
+INIT_DELAYED_WORK(&dev->dwork, my_delayed_work_handler);
+```
+
+## Scheduling work
+
+```c
+/* Queue on the system workqueue (runs as soon as worker is free) */
+schedule_work(&dev->work);
+
+/* Queue with a delay */
+schedule_delayed_work(&dev->dwork, msecs_to_jiffies(100));  /* 100ms delay */
+
+/* Cancel a pending delayed work */
+cancel_delayed_work_sync(&dev->dwork);  /* wait for running handler */
+cancel_delayed_work(&dev->dwork);       /* don't wait */
+
+/* Cancel a non-delayed work */
+cancel_work_sync(&dev->work);
+```
+
+`schedule_work()` is idempotent: if the work is already pending, calling it again does nothing. The work will run exactly once.
+
+## System workqueues
+
+The kernel provides several pre-built workqueues for different priorities and behaviors:
+
+```c
+/* include/linux/workqueue.h */
+extern struct workqueue_struct *system_wq;           /* general purpose */
+extern struct workqueue_struct *system_highpri_wq;   /* high priority */
+extern struct workqueue_struct *system_long_wq;      /* for long-running work */
+extern struct workqueue_struct *system_unbound_wq;   /* not CPU-bound */
+extern struct workqueue_struct *system_freezable_wq; /* freezable for suspend */
+extern struct workqueue_struct *system_power_efficient_wq; /* optimized for power */
+
+/* Queue on a specific workqueue */
+queue_work(system_highpri_wq, &dev->work);
+queue_delayed_work(system_wq, &dev->dwork, delay);
+```
+
+For most drivers, `system_wq` (accessed via `schedule_work()`) is the right choice.
+
+## Creating a private workqueue
+
+For work that needs specific concurrency control or isolation from system work:
+
+```c
+/* alloc_workqueue(name, flags, max_active) */
+
+/* Bound: one worker per CPU, max 1 concurrent item */
+wq = alloc_workqueue("my-driver", WQ_MEM_RECLAIM, 1);
+
+/* Unbound: not tied to specific CPUs, good for CPU-intensive work */
+wq = alloc_workqueue("my-driver-unbound", WQ_UNBOUND, 0);
+
+/* High priority, unbound */
+wq = alloc_workqueue("my-driver-hp", WQ_UNBOUND | WQ_HIGHPRI, 0);
+
+/* Queue on private workqueue */
+queue_work(wq, &dev->work);
+
+/* Flush: wait for all pending work to complete */
+flush_workqueue(wq);
+drain_workqueue(wq);
+
+/* Destroy */
+destroy_workqueue(wq);
+```
+
+## WQ flags
+
+| Flag | Meaning |
+|------|---------|
+| `WQ_UNBOUND` | Workers not bound to specific CPUs — work runs anywhere |
+| `WQ_MEM_RECLAIM` | Reserves a rescue worker for memory pressure situations |
+| `WQ_HIGHPRI` | Workers run at elevated priority |
+| `WQ_FREEZABLE` | Work freezes during system suspend |
+| `WQ_SYSFS` | Expose workqueue in `/sys/bus/workqueue/devices/` |
+
+## Concurrency-managed workqueues (cmwq)
+
+Since Linux 2.6.36, the kernel uses **concurrency-managed workqueues** (cmwq). Instead of one thread per CPU, the kernel maintains a pool of workers and dynamically creates/destroys threads based on demand.
+
+The key property: **the kernel tries to keep exactly one runnable worker per CPU**. If a worker sleeps (waiting on I/O or a mutex), the kernel may create another worker to keep the CPU busy.
+
+```
+Worker pool state:
+  Worker A: running (doing work)
+  Worker B: sleeping on mutex
+                ↓
+  Kernel creates Worker C to handle next queued work
+  (because Worker B is blocked, Worker A is the only runner)
+
+When Worker B wakes:
+  Now two runnable workers → Worker B becomes idle
+```
+
+This avoids both CPU underutilization (when workers sleep) and thread explosion (cmwq reuses workers intelligently).
+
+## flush_work vs cancel_work
+
+```c
+/* Wait for a specific work item to finish */
+flush_work(&dev->work);          /* blocks until handler completes */
+flush_delayed_work(&dev->dwork); /* cancels delay if pending, then waits */
+
+/* Cancel and wait */
+cancel_work_sync(&dev->work);         /* cancel + wait for running handler */
+cancel_delayed_work_sync(&dev->dwork); /* cancel delayed + wait */
+```
+
+Always use `cancel_*_sync()` in driver teardown to prevent use-after-free:
+
+```c
+static void my_driver_remove(struct platform_device *pdev)
+{
+    struct my_device *dev = platform_get_drvdata(pdev);
+
+    /* IMPORTANT: cancel before freeing dev */
+    cancel_work_sync(&dev->work);
+    cancel_delayed_work_sync(&dev->dwork);
+
+    kfree(dev);
+}
+```
+
+## Observing workqueue activity
+
+```bash
+# List workqueues and worker thread counts
+cat /sys/bus/workqueue/devices/*/name 2>/dev/null
+
+# Worker threads
+ps aux | grep kworker
+# root  1234  0.0 [kworker/0:1-events]    ← CPU 0, events wq
+# root  1235  0.0 [kworker/1:2-mm_percpu_wq]
+# root  1236  0.0 [kworker/u8:0-writeback] ← unbound
+
+# Work queue stats (with CONFIG_WQ_WATCHDOG)
+cat /proc/sys/kernel/watchdog_thresh
+```
+
+## Further reading
+
+- [Softirqs](softirq.md) — Lower-level, non-sleeping deferred work
+- [Tasklets](tasklets.md) — Simpler but deprecated, non-sleeping
+- [Threaded IRQs](threaded-irq.md) — Process-context IRQ handlers
+- `Documentation/core-api/workqueue.rst` — Complete workqueue documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -234,3 +234,15 @@ nav:
       - Lockdep: locking/lockdep.md
       - Lock Contention Debugging: locking/lock-debugging.md
       - Futex Internals: locking/futex.md
+  - Interrupts:
+    - Getting Started: interrupts/README.md
+    - Fundamentals:
+      - Interrupt Handling Overview: interrupts/interrupts.md
+      - IRQ Descriptor and irq_chip: interrupts/irq-desc.md
+      - request_irq and free_irq: interrupts/request-irq.md
+      - Threaded IRQs: interrupts/threaded-irq.md
+    - Deferred Work:
+      - Softirqs: interrupts/softirq.md
+      - Tasklets: interrupts/tasklets.md
+      - Workqueues: interrupts/workqueues.md
+      - Timers and hrtimers: interrupts/timers.md


### PR DESCRIPTION
## Summary
- `interrupts/README.md`: Overview with context table (hardirq/softirq/thread/workqueue)
- `interrupts/interrupts.md`: x86 IDT, vector → irq_desc lookup, irq_enter/irq_exit, /proc/interrupts, IRQ affinity
- `interrupts/irq-desc.md`: struct irq_desc, struct irqaction chain, struct irq_chip operations, IRQ domains, flow handlers (edge vs level)
- `interrupts/request-irq.md`: IRQF_* flags, handler return values, shared IRQs, disable_irq/enable_irq, synchronize_irq, devm_request_irq
- `interrupts/threaded-irq.md`: request_threaded_irq, IRQF_ONESHOT for level-triggered, from_tasklet pattern, IRQ thread priority
- `interrupts/softirq.md`: 10 softirq types and priorities, handle_softirqs loop, ksoftirqd, /proc/softirqs, local_bh_disable
- `interrupts/tasklets.md`: tasklet_struct, modern callback API, from_tasklet, serialization guarantee, deprecation notice
- `interrupts/workqueues.md`: INIT_WORK, system_wq, alloc_workqueue flags, concurrency-managed pools, cancel_work_sync teardown pattern
- `interrupts/timers.md`: timer_list/timer wheel, hrtimer/rb-tree, CLOCK_MONOTONIC vs REALTIME, HRTIMER_MODE_SOFT/HARD

Closes #250, #251, #252, #253, #254, #255, #256, #257

## Test plan
- [ ] mkdocs build passes without errors
- [ ] Cross-links to net/napi, sched/pi-mutexes resolve