### PR TITLE
Add VFS documentation: superblock, inode, dentry, namei, file ops, mounting

### DIFF
--- a/docs/vfs/README.md
+++ b/docs/vfs/README.md
@@ -1,0 +1,44 @@
+# Virtual Filesystem (VFS)
+
+> The kernel's filesystem abstraction layer
+
+## What is VFS?
+
+The Virtual Filesystem Switch (VFS) is an abstraction layer that allows the kernel to support many different filesystems (ext4, btrfs, tmpfs, procfs, NFS...) through a common interface. When your program calls `read()`, it goes through VFS, which dispatches to the appropriate filesystem implementation.
+
+VFS makes the following possible:
+- A single `open()`, `read()`, `write()` API works for ext4, NFS, /proc, /sys, pipes, and sockets
+- Files can be accessed across mounted filesystems transparently
+- Filesystems can be developed as kernel modules
+
+## The four VFS objects
+
+VFS defines four core objects:
+
+| Object | Represents | Kernel struct |
+|--------|-----------|---------------|
+| Superblock | A mounted filesystem instance | `struct super_block` |
+| Inode | A file or directory | `struct inode` |
+| Dentry | A path component (name → inode mapping) | `struct dentry` |
+| File | An open file (open() creates one) | `struct file` |
+
+Each has an associated operations table (vtable) that the filesystem must implement:
+
+| Object | Operations struct |
+|--------|------------------|
+| Superblock | `struct super_operations` |
+| Inode | `struct inode_operations` |
+| Dentry | `struct dentry_operations` |
+| File | `struct file_operations` |
+
+## Contents
+
+### Fundamentals
+- [VFS Objects: superblock, inode, dentry, file](vfs-objects.md) — The four core objects in detail
+- [Path Resolution](namei.md) — How `/usr/bin/bash` becomes an inode
+- [File Operations](file-ops.md) — The file_operations vtable and open/read/write
+- [Filesystem Registration and Mounting](mounting.md) — How filesystems plug into VFS
+
+### Lifecycle
+- [Life of a write() syscall](life-of-write.md) — From write() to disk
+- [Dentry and Inode Caches](dcache-icache.md) — Caching for performance

--- a/docs/vfs/dcache-icache.md
+++ b/docs/vfs/dcache-icache.md
@@ -1,0 +1,206 @@
+# Dentry and Inode Caches
+
+> How VFS caches filesystem lookups for performance
+
+## Why caches are essential
+
+Without caching, every path component lookup would require a disk read to find the directory entry. On a system doing thousands of `open()` calls per second, that would be catastrophically slow. VFS caches path lookups in the **dentry cache (dcache)** and stores open inodes in the **inode cache (icache)**.
+
+## The dentry cache (dcache)
+
+The dcache is a hash table mapping `(parent_dentry, name) → dentry`. Once a path component is looked up, its dentry is cached so subsequent lookups skip the filesystem:
+
+```
+First lookup of "/usr/bin/bash":
+  "/" → dentry for /   (in cache)
+  "usr" → miss → ext4_lookup("/", "usr") → read disk → cache
+  "bin" → miss → ext4_lookup("/usr", "bin") → read disk → cache
+  "bash" → miss → ext4_lookup("/usr/bin", "bash") → read disk → cache
+
+Second lookup of "/usr/bin/bash":
+  "/" → hit
+  "usr" → hit
+  "bin" → hit
+  "bash" → hit (entire path resolved from cache, no disk I/O)
+```
+
+### Dentry states
+
+```
+In-use (d_lockref.count > 0):
+  Referenced by a struct file, nameidata, or other kernel object.
+  Not eligible for eviction.
+
+Unused (d_lockref.count == 0):
+  Not currently referenced. On the LRU list.
+  May be evicted under memory pressure.
+
+Negative (d_inode == NULL):
+  Cached "file not found" result.
+  Avoids repeated filesystem lookups for non-existent files.
+```
+
+### dcache operations
+
+```c
+/* Look up in dcache (RCU, lock-free fast path) */
+struct dentry *__d_lookup_rcu(const struct dentry *parent,
+                               const struct qstr *name, unsigned *seqp);
+
+/* Full lookup with reference */
+struct dentry *d_lookup(const struct dentry *parent, const struct qstr *name);
+
+/* Add a new dentry to the cache */
+struct dentry *d_add(struct dentry *entry, struct inode *inode);
+
+/* Mark a dentry as unused (release reference) */
+dput(dentry);
+
+/* Invalidate and remove from cache */
+d_invalidate(dentry);
+
+/* Check if a dentry is a mountpoint */
+d_mountpoint(dentry);
+```
+
+### dcache size and statistics
+
+```bash
+# Current dcache size
+cat /proc/sys/fs/dentry-state
+# 234567 198765 45 0 0 0
+# nr_dentry nr_unused age_limit want_pages nr_negative nr_unused
+
+# Memory used by dcache
+cat /proc/slabinfo | grep dentry
+# dentry  198765  198765   192  21  1 : tunables  0  0  0 : slabdata  9465  9465  0
+
+# Tune dcache: keep more entries (default: auto-sized)
+echo 1000000 > /proc/sys/fs/dentry-state  # not directly writable; tuned via vfs_cache_pressure
+```
+
+### vfs_cache_pressure
+
+Controls how aggressively the kernel reclaims dcache and icache under memory pressure:
+
+```bash
+# Default: 100 (balanced)
+cat /proc/sys/vm/vfs_cache_pressure
+
+# Higher: more aggressive reclaim (lower memory usage, more cache misses)
+echo 200 > /proc/sys/vm/vfs_cache_pressure
+
+# Lower: keep more entries (faster lookups, more memory used)
+echo 50 > /proc/sys/vm/vfs_cache_pressure
+```
+
+## The inode cache (icache)
+
+When a dentry's inode is loaded from disk (or created), it's stored in the inode cache. The inode stays in cache as long as it's referenced (either by a dentry or an open file).
+
+### Inode states
+
+```
+In-use: referenced by at least one dentry or open file
+  I_NEW: being initialized, not yet visible
+  I_DIRTY_*: has dirty metadata (needs writeback)
+  I_WRITEBACK: currently being written to disk
+  I_FREEING: being evicted from cache
+
+Unreferenced: no dentries, no open files
+  On the inode LRU list, eligible for eviction
+```
+
+### Inode lifecycle
+
+```c
+/* Allocate a new inode (called by filesystem) */
+struct inode *new_inode(struct super_block *sb)
+{
+    struct inode *inode = alloc_inode(sb);
+    /* sb->s_op->alloc_inode() called if defined */
+    inode->i_sb = sb;
+    inode_init_always(sb, inode);
+    return inode;
+}
+
+/* Get an existing inode (or create if not in cache) */
+struct inode *iget_locked(struct super_block *sb, unsigned long ino)
+{
+    /* Hash lookup by (sb, ino) */
+    inode = find_inode(sb, ino);
+    if (inode)
+        return inode;  /* cache hit */
+
+    /* Cache miss: allocate and mark I_NEW */
+    inode = alloc_inode(sb);
+    insert_inode_hash(inode);
+    /* Caller must fill in inode fields and call unlock_new_inode() */
+    return inode;
+}
+
+/* Release inode reference */
+iput(inode)
+    → if (--i_count == 0) {
+        /* No more references: call evict_inode */
+        if (inode->i_nlink == 0)
+            sb->s_op->evict_inode(inode);  /* delete from filesystem */
+        /* If nlink > 0: move to LRU for potential reclaim */
+    }
+```
+
+### Eviction
+
+When memory is low, the kernel calls `prune_icache()` to free unused inodes:
+
+```c
+/* Called by the shrinker */
+static long super_cache_scan(struct shrinker *shrink,
+                              struct shrink_control *sc)
+{
+    struct super_block *sb = shrink->private_data;
+    /* Evict unused dentries and inodes */
+    prune_dcache_sb(sb, sc);
+    prune_icache_sb(sb, sc);
+}
+```
+
+Before an inode is freed, `evict_inode()` is called. For ext4, this writes back dirty data and releases journal resources.
+
+## Cache statistics
+
+```bash
+# Slab allocator stats (incl. dentry and inode caches)
+cat /proc/slabinfo | grep -E "^dentry|^inode_cache|ext4_inode"
+
+# Total slab memory breakdown
+cat /proc/meminfo | grep -E "Slab|SReclaimable|SUnreclaim"
+# Slab:           2345678 kB
+# SReclaimable:   1234567 kB  ← can be reclaimed under pressure (dcache, icache)
+# SUnreclaim:     1111111 kB  ← cannot be reclaimed
+
+# How much dcache/icache is actually using:
+vmstat -m | grep -E "dentry|inode"
+```
+
+## Forcing cache drop (for testing)
+
+```bash
+# Drop all caches (pagecache + dcache + icache) — don't use in production
+echo 3 > /proc/sys/vm/drop_caches
+
+# Only drop dentries and inodes
+echo 2 > /proc/sys/vm/drop_caches
+
+# Only drop pagecache
+echo 1 > /proc/sys/vm/drop_caches
+```
+
+This is useful for benchmarking to ensure you're measuring cold-cache performance. It doesn't free any dirty pages (they would be flushed first anyway).
+
+## Further reading
+
+- [VFS Objects](vfs-objects.md) — What dentries and inodes are
+- [Path Resolution](namei.md) — How the dcache is used during lookup
+- [Page Cache](../mm/page-cache.md) — The analogous cache for file data
+- [Shrinker API](../mm/shrinker.md) — How caches register with the memory reclaim system

--- a/docs/vfs/file-ops.md
+++ b/docs/vfs/file-ops.md
@@ -1,0 +1,187 @@
+# File Operations and the file struct
+
+> How open(), read(), write(), and close() work in VFS
+
+## The file_operations vtable
+
+Every open file has a `struct file` with an `f_op` pointer to the filesystem's `file_operations`. VFS calls through this vtable for all I/O operations:
+
+```c
+/* include/linux/fs.h */
+struct file_operations {
+    loff_t  (*llseek)(struct file *, loff_t, int);
+    ssize_t (*read)(struct file *, char __user *, size_t, loff_t *);
+    ssize_t (*write)(struct file *, const char __user *, size_t, loff_t *);
+    ssize_t (*read_iter)(struct kiocb *, struct iov_iter *);   /* preferred */
+    ssize_t (*write_iter)(struct kiocb *, struct iov_iter *);  /* preferred */
+    int     (*mmap)(struct file *, struct vm_area_struct *);
+    int     (*open)(struct inode *, struct file *);
+    int     (*release)(struct inode *, struct file *);  /* on last close */
+    int     (*fsync)(struct file *, loff_t, loff_t, int datasync);
+    long    (*unlocked_ioctl)(struct file *, unsigned int, unsigned long);
+    int     (*iterate_shared)(struct file *, struct dir_context *);
+    __poll_t (*poll)(struct file *, struct poll_table_struct *);
+};
+```
+
+Filesystems typically only implement a subset. For fields left NULL, VFS uses generic fallbacks (e.g., `generic_file_read_iter`, `noop_llseek`).
+
+## open(): from syscall to struct file
+
+```c
+/* Simplified: open("/path/to/file", O_RDWR) */
+SYSCALL_DEFINE3(open, ...) → do_sys_open()
+    1. Get a new file descriptor number
+    2. do_filp_open()
+         a. path_openat(): resolve pathname → path + flags
+         b. do_last(): handle the final component
+              - Permission check: inode_permission()
+              - If O_CREAT and file doesn't exist: call i_op->create()
+              - alloc_file(): allocate struct file
+                   f_path = resolved path
+                   f_op = inode->i_fop
+                   f_mode = FMODE_READ | FMODE_WRITE
+              - Call f_op->open(inode, file)
+                   (ext4_file_open, for example)
+    3. Install fd → struct file in process's file table
+    4. Return fd
+```
+
+The `f_op->open()` call is the filesystem's chance to set up `file->private_data` (e.g., for /proc files that generate content dynamically).
+
+## read(): the syscall path
+
+```c
+/* read(fd, buf, count) */
+SYSCALL_DEFINE3(read, unsigned int, fd, char __user *, buf, size_t, count)
+{
+    struct fd f = fdget_pos(fd);  /* get struct file, increment f_pos lock */
+    loff_t pos = file_pos_read(f.file);
+
+    ret = vfs_read(f.file, buf, count, &pos);  /* calls f_op->read or read_iter */
+
+    file_pos_write(f.file, pos);  /* update f_pos */
+    fdput_pos(f);
+    return ret;
+}
+
+/* vfs_read → calls filesystem's read_iter */
+ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
+{
+    if (file->f_op->read)
+        ret = file->f_op->read(file, buf, count, pos);
+    else if (file->f_op->read_iter)
+        ret = new_sync_read(file, buf, count, pos);
+    /* new_sync_read wraps read_iter with an iov_iter */
+}
+```
+
+For regular files, `read_iter` calls `generic_file_read_iter()`, which:
+1. Checks the page cache for the needed pages
+2. If cached: copy pages to userspace (`copy_to_user`)
+3. If not cached: trigger `readahead` → `mapping->a_ops->readpage()` → disk I/O → wait → copy
+
+## write(): dirty pages and writeback
+
+```c
+/* write(fd, buf, count) */
+vfs_write() → file->f_op->write_iter()
+    → generic_file_write_iter()
+        → generic_perform_write()
+            for each page that needs writing:
+                1. Find or allocate page in page cache
+                2. copy_from_user() → page
+                3. Mark page dirty (set_page_dirty())
+                4. Update inode size if needed
+
+/* Pages are NOT written to disk immediately!
+   They're marked dirty in the page cache.
+   Writeback (pdflush/kworker) writes them later. */
+```
+
+Data is only guaranteed on disk after:
+- `fsync(fd)` or `fdatasync(fd)` — explicit flush
+- The writeback daemon flushes (typically after 30 seconds or when memory pressure is high)
+- The filesystem's `sync_fs()` is called
+
+## llseek(): updating the file position
+
+```c
+loff_t vfs_llseek(struct file *file, loff_t offset, int whence)
+{
+    if (file->f_op->llseek)
+        return file->f_op->llseek(file, offset, whence);
+    return generic_file_llseek(file, offset, whence);
+}
+
+/* Generic implementation */
+loff_t generic_file_llseek(struct file *file, loff_t offset, int whence)
+{
+    switch (whence) {
+    case SEEK_SET: offset = offset; break;
+    case SEEK_CUR: offset = file->f_pos + offset; break;
+    case SEEK_END: offset = inode->i_size + offset; break;
+    }
+    /* Validate and update f_pos */
+    file->f_pos = offset;
+    return offset;
+}
+```
+
+## mmap(): mapping the file into address space
+
+```c
+/* mmap(NULL, len, PROT_READ, MAP_SHARED, fd, offset) */
+vm_mmap() → do_mmap()
+    → mmap_region()
+        → vma = vm_area_alloc(mm)
+        → call_mmap(file, vma)    /* file->f_op->mmap() */
+
+/* For regular files: */
+int generic_file_mmap(struct file *file, struct vm_area_struct *vma)
+{
+    vma->vm_ops = &generic_file_vm_ops;
+    /* vm_ops->fault() will handle page faults on demand */
+    return 0;
+}
+```
+
+The actual pages aren't faulted in until accessed. Each fault calls `filemap_fault()` which reads from the page cache (or disk).
+
+## release(): last close
+
+`f_op->release()` is called when the last file descriptor pointing to a `struct file` is closed. Note: `close()` doesn't immediately call `release()` — it decrements the reference count, and `release()` is called only when it reaches zero.
+
+```c
+/* close(fd) */
+__close_fd() → filp_close()
+    → f_op->flush()      /* called on every close */
+    → fput(file)         /* decrements refcount */
+        → if (--f_ref == 0): __fput(file)
+            → f_op->release(inode, file)
+            → dput(dentry)   /* release dentry reference */
+```
+
+`flush()` vs `release()`:
+- `flush()`: called on every `close()` — some filesystems use this for error checking (NFS flushing dirty data)
+- `release()`: called only when the last reference to the `struct file` is dropped (e.g., after all `dup()`'d fds are closed)
+
+## fsync(): forcing data to disk
+
+```c
+int vfs_fsync(struct file *file, int datasync)
+{
+    return file->f_op->fsync(file, 0, LLONG_MAX, datasync);
+}
+
+/* Filesystems implement this to flush:
+   datasync=0: flush data + metadata (full fsync)
+   datasync=1: flush data + size metadata only (fdatasync) */
+```
+
+## Further reading
+
+- [VFS Objects](vfs-objects.md) — The four VFS structures
+- [Life of a write() syscall](life-of-write.md) — End-to-end write path
+- [Page Cache](../mm/page-cache.md) — Where file data is buffered
+- [Life of a file read](../mm/life-of-read.md) — The full read path

--- a/docs/vfs/life-of-write.md
+++ b/docs/vfs/life-of-write.md
@@ -1,0 +1,223 @@
+# Life of a write() Syscall
+
+> From application call to dirty page in the page cache (and eventually to disk)
+
+## Overview
+
+```
+Application: write(fd, buf, 4096)
+    ↓
+Syscall entry → vfs_write()
+    ↓
+Permission check
+    ↓
+generic_file_write_iter()
+    ↓
+Page cache: find or create pages
+    ↓
+copy_from_user() → dirty page
+    ↓
+Mark inode dirty, update i_size
+    ↓
+Return to application
+    ↓ (later)
+Writeback daemon (kworker/flusher)
+    ↓
+Filesystem's ->writepages() (ext4, etc.)
+    ↓
+Block layer → disk
+```
+
+## Phase 1: Syscall entry
+
+```c
+/* arch/x86/entry/syscalls/syscall_64.tbl → sys_write */
+SYSCALL_DEFINE3(write, unsigned int, fd, const char __user *, buf, size_t, count)
+{
+    /* 1. Get struct file from fd */
+    struct fd f = fdget_pos(fd);
+
+    /* 2. Get current position */
+    loff_t pos = file_pos_read(f.file);
+
+    /* 3. Dispatch to VFS */
+    ret = vfs_write(f.file, buf, count, &pos);
+
+    /* 4. Update file position */
+    file_pos_write(f.file, pos);
+    fdput_pos(f);
+    return ret;
+}
+```
+
+## Phase 2: VFS checks
+
+```c
+/* fs/read_write.c */
+ssize_t vfs_write(struct file *file, const char __user *buf,
+                  size_t count, loff_t *pos)
+{
+    /* Check that file is open for writing */
+    if (!(file->f_mode & FMODE_WRITE))
+        return -EBADF;
+
+    /* Security check (SELinux, AppArmor, etc.) */
+    ret = security_file_permission(file, MAY_WRITE);
+
+    /* Dispatch to filesystem's write_iter */
+    if (file->f_op->write_iter)
+        ret = new_sync_write(file, buf, count, pos);
+    else if (file->f_op->write)
+        ret = file->f_op->write(file, buf, count, pos);
+}
+```
+
+## Phase 3: generic_file_write_iter
+
+For regular files, the filesystem's `write_iter` (e.g., `ext4_file_write_iter`) eventually calls `generic_file_write_iter()`:
+
+```c
+/* mm/filemap.c */
+ssize_t generic_file_write_iter(struct kiocb *iocb, struct iov_iter *from)
+{
+    struct file *file = iocb->ki_filp;
+    struct inode *inode = file->f_mapping->host;
+
+    /* Lock inode for writing (prevents concurrent writes) */
+    inode_lock(inode);
+
+    /* Check file size limits */
+    ret = generic_write_checks(iocb, from);
+
+    /* Write to page cache */
+    ret = generic_perform_write(iocb, from);
+
+    inode_unlock(inode);
+    return ret;
+}
+```
+
+## Phase 4: writing to the page cache
+
+`generic_perform_write()` loops over each page needed:
+
+```c
+ssize_t generic_perform_write(struct kiocb *iocb, struct iov_iter *i)
+{
+    struct address_space *mapping = iocb->ki_filp->f_mapping;
+    loff_t pos = iocb->ki_pos;
+
+    do {
+        unsigned long offset = pos & (PAGE_SIZE - 1); /* offset within page */
+        size_t bytes = min(PAGE_SIZE - offset, iov_iter_count(i));
+
+        /* 1. Find or allocate page in page cache */
+        page = a_ops->write_begin(file, mapping, pos, bytes, &page, &fsdata);
+        /* write_begin may read the page from disk if partially written */
+
+        /* 2. Copy data from userspace into the page */
+        copied = copy_page_from_iter_atomic(page, offset, bytes, i);
+
+        /* 3. Mark page dirty and update state */
+        a_ops->write_end(file, mapping, pos, bytes, copied, page, fsdata);
+        /* write_end calls set_page_dirty() → marks page for writeback */
+
+        pos += copied;
+    } while (iov_iter_count(i));
+
+    return pos - iocb->ki_pos;
+}
+```
+
+## Phase 5: dirty tracking
+
+After `set_page_dirty()`, multiple structures are marked dirty:
+
+```c
+/* Page is added to address_space->i_pages as a dirty folio */
+set_page_dirty(page)
+    → folio_mark_dirty(folio)
+        → mapping->a_ops->dirty_folio()
+        → __set_page_dirty()
+            → radix_tree_tag_set(mapping, page_index, PAGECACHE_TAG_DIRTY)
+
+/* Inode is added to the superblock's dirty inode list */
+__mark_inode_dirty(inode, I_DIRTY_PAGES)
+    → list_move(&inode->i_io_list, &wb->b_dirty)
+    /* wb = writeback control (one per bdi = block device) */
+
+/* Writeback timer is armed if not already */
+wb_wakeup_delayed(wb)
+```
+
+## Phase 6: writeback
+
+The writeback daemon (`kworker`) periodically flushes dirty pages to disk:
+
+```c
+/* Called by kworker thread in fs/fs-writeback.c */
+void wb_workfn(struct bdi_writeback *wb)
+{
+    /* Find all dirty inodes */
+    while (!list_empty(&wb->b_io)) {
+        inode = list_first_entry(&wb->b_io, ...);
+
+        /* Write all dirty pages for this inode */
+        writeback_single_inode(inode, wbc);
+            → mapping->a_ops->writepages(mapping, wbc)
+                → ext4_writepages()
+                    → mpage_writepages()
+                        → for each dirty page:
+                            submit_bio(READ/WRITE, bio)
+                            → block layer → disk
+    }
+}
+```
+
+Writeback is triggered by:
+- **Time**: after `dirty_expire_centisecs` (default 3000 = 30 seconds)
+- **Memory pressure**: when dirty pages exceed `dirty_ratio` (default 20% of RAM)
+- **fsync()**: explicit flush by the application
+
+## Viewing dirty page state
+
+```bash
+# Current dirty memory
+cat /proc/meminfo | grep -i dirty
+# Dirty:          102400 kB   ← data written but not yet on disk
+# Writeback:        4096 kB   ← data being written to disk right now
+
+# Writeback tunables
+cat /proc/sys/vm/dirty_ratio          # max dirty as % of RAM before throttle
+cat /proc/sys/vm/dirty_background_ratio  # % to start background writeback
+cat /proc/sys/vm/dirty_expire_centisecs  # age before dirty data is written
+cat /proc/sys/vm/dirty_writeback_centisecs  # how often to wake writeback
+
+# Per-device writeback stats
+ls /sys/class/bdi/*/
+cat /sys/class/bdi/8:0/read_ahead_kb
+```
+
+## fsync() vs fdatasync() vs sync()
+
+```c
+/* fsync: flush data + metadata for this file */
+fsync(fd)
+    → vfs_fsync() → file->f_op->fsync()
+    → ext4_sync_file()
+        → filemap_write_and_wait_range()  ← flush dirty pages
+        → ext4_flush_completed_IO()       ← journal commit
+
+/* fdatasync: flush data + size metadata only (no atime/mtime) */
+fdatasync(fd)  /* faster than fsync when only data matters */
+
+/* sync: flush ALL dirty data and metadata system-wide */
+sync()         /* use sparingly — blocks until complete */
+```
+
+## Further reading
+
+- [Page Cache](../mm/page-cache.md) — How dirty pages are stored in memory
+- [File Operations](file-ops.md) — The file_operations vtable
+- [VFS Objects](vfs-objects.md) — struct file, inode, dentry, superblock
+- [Life of a file read](../mm/life-of-read.md) — The read direction

--- a/docs/vfs/mounting.md
+++ b/docs/vfs/mounting.md
@@ -1,0 +1,217 @@
+# Filesystem Registration and Mounting
+
+> How filesystems plug into VFS and how mount() works
+
+## Registering a filesystem type
+
+Every filesystem must define a `file_system_type` and register it with VFS:
+
+```c
+/* include/linux/fs.h */
+struct file_system_type {
+    const char *name;       /* "ext4", "tmpfs", "proc", etc. */
+    int fs_flags;           /* FS_REQUIRES_DEV, FS_USERNS_MOUNT, etc. */
+    int (*init_fs_context)(struct fs_context *); /* fill in mount context */
+    void (*kill_sb)(struct super_block *);       /* unmount cleanup */
+    struct module *owner;
+    struct file_system_type *next;     /* linked list of all filesystems */
+    struct hlist_head fs_supers;       /* all superblocks of this type */
+};
+
+/* Register at module load time */
+static struct file_system_type my_fs_type = {
+    .name           = "myfs",
+    .init_fs_context = my_init_fs_context,
+    .kill_sb        = kill_litter_super,  /* for simple in-memory fs */
+    .owner          = THIS_MODULE,
+};
+
+static int __init myfs_init(void)
+{
+    return register_filesystem(&my_fs_type);
+}
+module_init(myfs_init);
+
+static void __exit myfs_exit(void)
+{
+    unregister_filesystem(&my_fs_type);
+}
+module_exit(myfs_exit);
+```
+
+After registration, the filesystem appears in `/proc/filesystems`:
+
+```bash
+cat /proc/filesystems
+# nodev  sysfs
+# nodev  tmpfs
+# nodev  bdev
+# nodev  proc
+#        ext4
+# nodev  btrfs
+#        vfat
+```
+
+`nodev` means the filesystem doesn't require a block device.
+
+## The mount syscall
+
+```c
+/* User calls: mount("/dev/sda1", "/mnt/data", "ext4", 0, "") */
+SYSCALL_DEFINE5(mount, ...)
+    → path_mount()
+        → do_new_mount()
+            1. get_fs_type("ext4")    ← find registered ext4 fs_type
+            2. fs_context_for_mount() ← allocate fs_context
+            3. vfs_get_tree()
+                 → fs_type->init_fs_context(fc)  ← filesystem fills context
+                 → fc->ops->get_tree(fc)          ← create/find superblock
+                    → ext4_get_tree() → mount_bdev()
+                        a. blkdev_get_by_path("/dev/sda1") ← open block device
+                        b. sget_dev(): find or create super_block for this device
+                        c. ext4_fill_super(): read superblock from disk,
+                           set s_op, s_root, etc.
+            4. do_new_mount_fc(): attach mount to the tree
+                 → graft_tree(): insert new vfsmount at mountpoint
+
+/* The result: a new struct mount attached to the namespace's mount tree */
+```
+
+## Mount namespace and vfsmount
+
+Each process has a **mount namespace** (`struct mnt_namespace`) containing a tree of `vfsmount` objects. Each `vfsmount` represents one mount point:
+
+```c
+struct vfsmount {
+    struct dentry *mnt_root;     /* root dentry of this mounted fs */
+    struct super_block *mnt_sb;  /* superblock */
+    int mnt_flags;               /* MNT_READONLY, MNT_NOSUID, etc. */
+};
+
+struct mount {
+    struct vfsmount mnt;
+    struct mount *mnt_parent;   /* mount that this is mounted on */
+    struct dentry *mnt_mountpoint; /* dentry in parent where we're mounted */
+    struct list_head mnt_child;    /* children of mnt_parent */
+};
+```
+
+When path resolution reaches a mountpoint dentry, `follow_mount()` switches to the mounted filesystem's root dentry, crossing into the new `vfsmount`.
+
+## /proc/mounts and /proc/self/mountinfo
+
+```bash
+# All current mounts
+cat /proc/mounts
+# sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+# proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+# /dev/sda1 / ext4 rw,relatime,errors=remount-ro 0 0
+# tmpfs /tmp tmpfs rw,nosuid,nodev 0 0
+
+# Detailed format with mount IDs (used by systemd)
+cat /proc/self/mountinfo
+# 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext4 /dev/sdb rw,errors=remount-ro
+# ^  ^  ^    ^     ^                ^           ^    ^
+# mount_id parent_id maj:min root  mount_point opts peer_group fstype source
+```
+
+## Implementing a simple in-memory filesystem
+
+Here's the minimal skeleton for a new filesystem:
+
+```c
+/* Inode operations for a directory */
+static struct inode_operations myfs_dir_iops = {
+    .lookup = simple_lookup,
+    .create = myfs_create,
+    .mkdir  = myfs_mkdir,
+    .unlink = simple_unlink,
+    .rmdir  = simple_rmdir,
+};
+
+/* File operations for a regular file */
+static struct file_operations myfs_file_fops = {
+    .read_iter  = generic_file_read_iter,
+    .write_iter = generic_file_write_iter,
+    .llseek     = generic_file_llseek,
+    .mmap       = generic_file_mmap,
+    .fsync      = noop_fsync,
+};
+
+/* Address space operations (page cache) */
+static struct address_space_operations myfs_aops = {
+    .dirty_folio    = __set_page_dirty_nobuffers,
+    .writepage      = simple_writepage,
+};
+
+/* Superblock operations */
+static struct super_operations myfs_super_ops = {
+    .statfs         = simple_statfs,
+    .drop_inode     = generic_delete_inode,
+};
+
+/* Fill in the superblock (called during mount) */
+static int myfs_fill_super(struct super_block *sb, struct fs_context *fc)
+{
+    struct inode *root_inode;
+
+    sb->s_maxbytes = MAX_LFS_FILESIZE;
+    sb->s_blocksize = PAGE_SIZE;
+    sb->s_blocksize_bits = PAGE_SHIFT;
+    sb->s_magic = 0x4D594653;  /* 'MYFS' */
+    sb->s_op = &myfs_super_ops;
+
+    /* Create root inode */
+    root_inode = new_inode(sb);
+    root_inode->i_ino = 1;
+    root_inode->i_mode = S_IFDIR | 0755;
+    root_inode->i_op = &myfs_dir_iops;
+    root_inode->i_fop = &simple_dir_operations;
+
+    /* Create root dentry */
+    sb->s_root = d_make_root(root_inode);
+
+    return 0;
+}
+
+static int myfs_get_tree(struct fs_context *fc)
+{
+    return get_tree_nodev(fc, myfs_fill_super);
+}
+
+static const struct fs_context_operations myfs_context_ops = {
+    .get_tree = myfs_get_tree,
+};
+
+static int myfs_init_fs_context(struct fs_context *fc)
+{
+    fc->ops = &myfs_context_ops;
+    return 0;
+}
+
+static struct file_system_type myfs_type = {
+    .name            = "myfs",
+    .init_fs_context = myfs_init_fs_context,
+    .kill_sb         = kill_litter_super,
+    .owner           = THIS_MODULE,
+};
+```
+
+## bind mount and move mount
+
+```bash
+# Bind mount: mount a directory at another location
+mount --bind /original/path /new/path
+# Creates a new vfsmount pointing to the same dentry/inode tree
+
+# Move mount: atomically change mount location
+mount --move /old/mountpoint /new/mountpoint
+```
+
+Bind mounts are widely used in containers to share host directories into a container's namespace.
+
+## Further reading
+
+- [VFS Objects](vfs-objects.md) — What superblock, inode, dentry, file are
+- [Path Resolution](namei.md) — How mount points are crossed during lookup
+- [Life of a write() syscall](life-of-write.md) — What happens after mounting

--- a/docs/vfs/namei.md
+++ b/docs/vfs/namei.md
@@ -1,0 +1,209 @@
+# Path Resolution (namei)
+
+> How the kernel converts a string like "/usr/bin/bash" into an inode
+
+## The challenge
+
+Path resolution sounds simple: split the path on `/`, look up each component in the parent directory. But it must handle:
+
+- Symlinks (which themselves contain paths to resolve)
+- Mount points (crossing into a different filesystem)
+- Concurrent modifications (another process renames a directory while you traverse it)
+- `.` (current directory) and `..` (parent directory)
+- Permission checks at each level
+
+The kernel's path resolution lives in `fs/namei.c` and is called the **namei** subsystem (from the historical Unix function name).
+
+## Entry point: filename_lookup
+
+Most VFS operations start with a path. The kernel resolves it through:
+
+```c
+/* Simplified call chain for open("/usr/bin/bash", O_RDONLY) */
+do_sys_open()
+  → do_filp_open()
+    → path_openat()
+      → link_path_walk()   ← main resolution loop
+        → walk_component()  ← resolve one path component
+          → lookup_fast()   ← dcache lookup (RCU, lock-free)
+          → lookup_slow()   ← filesystem lookup (takes i_rwsem)
+      → do_last()          ← handle final component (open file)
+```
+
+## The nameidata structure
+
+`struct nameidata` carries state through the resolution:
+
+```c
+/* fs/namei.c */
+struct nameidata {
+    struct path path;         /* current position: (dentry, vfsmount) */
+    struct qstr last;         /* name of last component */
+    struct path root;         /* root for this lookup */
+    struct inode *inode;      /* inode of current directory */
+    unsigned int flags;       /* LOOKUP_* flags */
+    unsigned int state;       /* ND_* state bits */
+    unsigned int depth;       /* symlink recursion depth */
+    int last_type;            /* LAST_NORM, LAST_ROOT, LAST_DOT, LAST_DOTDOT */
+    /* ... */
+};
+```
+
+## link_path_walk: the main loop
+
+`link_path_walk()` iterates over path components separated by `/`:
+
+```c
+/* fs/namei.c (simplified) */
+static int link_path_walk(const char *name, struct nameidata *nd)
+{
+    /* Skip leading slashes */
+    while (*name == '/')
+        name++;
+
+    for (;;) {
+        struct qstr this;
+        int type;
+
+        /* Get next component (up to next '/') */
+        type = hash_name(nd->path.dentry, name, &this);
+
+        /* Special cases: "." and ".." */
+        if (type != LAST_NORM) {
+            /* handle . and .. */
+        }
+
+        /* Look up the component */
+        err = walk_component(nd, WALK_MORE);
+
+        /* Advance past the "/" */
+        name += this.len;
+        while (*name == '/')
+            name++;
+        if (!*name)
+            break;  /* end of path */
+    }
+    return 0;
+}
+```
+
+## walk_component: RCU-walk and ref-walk
+
+Each component is looked up in two stages:
+
+### Stage 1: RCU walk (lock-free, optimistic)
+
+```c
+static struct dentry *lookup_fast(struct nameidata *nd)
+{
+    struct dentry *parent = nd->path.dentry;
+
+    /* Try to find in dcache under RCU (no locks, very fast) */
+    dentry = __d_lookup_rcu(parent, &nd->last, &nd->next_seq);
+    if (!dentry)
+        return NULL;  /* miss: fall through to ref-walk */
+
+    /* Validate: did the dentry get deleted while we looked? */
+    if (!__d_rcu_to_refcount(dentry, nd->next_seq))
+        return NULL;  /* invalidated: retry */
+
+    return dentry;
+}
+```
+
+The RCU walk uses `d_seq` (a seqlock on each dentry) to detect concurrent modifications without taking any lock. This is the fast path — most lookups hit the dcache and return without taking a lock.
+
+### Stage 2: Ref walk (takes i_rwsem)
+
+If RCU walk fails (cache miss or retry):
+
+```c
+static struct dentry *lookup_slow(const struct qstr *name,
+                                   struct dentry *dir, unsigned int flags)
+{
+    struct inode *inode = dir->d_inode;
+    struct dentry *dentry;
+
+    /* Lock directory for reading */
+    inode_lock_shared(inode);  /* down_read(&inode->i_rwsem) */
+
+    /* Check dcache again (race: could have been added) */
+    dentry = __d_lookup(dir, name);
+    if (!dentry) {
+        /* Not in cache: call filesystem */
+        dentry = d_alloc(dir, name);
+        inode->i_op->lookup(inode, dentry, flags);
+        /* dentry is now positive (with inode) or negative */
+    }
+
+    inode_unlock_shared(inode);
+    return dentry;
+}
+```
+
+`i_op->lookup()` calls into the filesystem (e.g., ext4) which reads the directory from disk, finds the entry, and associates its inode with the dentry.
+
+## Mount point crossing
+
+When resolution hits a mount point, it silently crosses into the mounted filesystem:
+
+```c
+/* At a mountpoint: switch to the new filesystem's root */
+if (d_mountpoint(dentry)) {
+    /* Follow the mount: nd->path = mnt->mnt_root */
+    follow_mount(&nd->path);
+    /* Continue resolution in the new filesystem */
+}
+```
+
+This is why `cd /proc/net` works transparently even though `/proc` is a different filesystem from `/`.
+
+## Symlink resolution
+
+When a component is a symlink, `link_path_walk` is called recursively with the symlink's target:
+
+```c
+/* Symlink: get the link target and resolve it */
+const char *link = nd->inode->i_op->get_link(nd->path.dentry,
+                                               nd->inode, &delayed);
+/* Recurse into link_path_walk with link as the new path */
+nd->depth++;
+if (nd->depth > MAXSYMLINKS)  /* default 40 */
+    return -ELOOP;
+err = link_path_walk(link, nd);
+nd->depth--;
+```
+
+## LOOKUP flags
+
+```c
+LOOKUP_FOLLOW    /* follow final symlink */
+LOOKUP_DIRECTORY /* final component must be a directory */
+LOOKUP_OPEN      /* called from open(): prepare for file creation */
+LOOKUP_CREATE    /* create if not exists */
+LOOKUP_EXCL      /* fail if exists (for O_EXCL) */
+LOOKUP_REVAL     /* force dentry revalidation (NFS) */
+LOOKUP_RCU       /* stay in RCU walk mode if possible */
+```
+
+## /proc/self/fd and /proc/self/fdinfo
+
+```bash
+# Each open file has a symlink in /proc/self/fd/
+ls -la /proc/self/fd
+# lrwxrwxrwx 1 root 0 -> /dev/null
+# lrwxrwxrwx 1 root 1 -> /dev/pts/0
+# lrwxrwxrwx 1 root 2 -> /dev/pts/0
+
+# Reading the link resolves to the file's path
+readlink /proc/self/fd/0
+# /dev/null
+```
+
+The `/proc/self/fd/N` symlinks use a special resolution path that goes through the process's file descriptor table rather than through the filesystem.
+
+## Further reading
+
+- [VFS Objects](vfs-objects.md) — What superblock, inode, dentry, file are
+- [Dentry and Inode Caches](dcache-icache.md) — How path lookups are cached
+- [File Operations](file-ops.md) — What happens after the path is resolved

--- a/docs/vfs/vfs-objects.md
+++ b/docs/vfs/vfs-objects.md
@@ -1,0 +1,204 @@
+# VFS Objects: superblock, inode, dentry, file
+
+> The four data structures that represent every file system object in Linux
+
+## Overview
+
+VFS defines four objects that together represent any filesystem resource:
+
+```
+Mounted filesystem
+    │
+    └── struct super_block
+           (one per mounted filesystem)
+               │
+               └── struct inode  ←────────────────────────────────┐
+                      (one per file/dir/symlink)                   │
+                          │                                        │
+                          └── struct dentry ──────── struct dentry │
+                                 /                                 bin
+                                 usr                               bash
+                          (path components, cached)
+                          │
+                          └── struct file
+                                 (one per open() call)
+```
+
+## struct super_block: the mounted filesystem
+
+A `super_block` exists for each mounted filesystem instance. It holds the global state of the mounted filesystem:
+
+```c
+/* include/linux/fs/super_types.h */
+struct super_block {
+    dev_t                    s_dev;       /* device identifier */
+    unsigned long            s_blocksize; /* block size in bytes */
+    loff_t                   s_maxbytes;  /* maximum file size */
+    struct file_system_type *s_type;      /* filesystem type */
+    const struct super_operations *s_op; /* superblock operations vtable */
+    unsigned long            s_flags;    /* MS_RDONLY etc */
+    unsigned long            s_magic;    /* filesystem magic number */
+    struct dentry           *s_root;     /* root directory dentry */
+    struct rw_semaphore      s_umount;   /* unmount semaphore */
+    void                    *s_fs_info;  /* filesystem-private data */
+};
+
+struct super_operations {
+    struct inode *(*alloc_inode)(struct super_block *sb);
+    void         (*destroy_inode)(struct inode *inode);
+    void         (*dirty_inode)(struct inode *inode, int flags);
+    int          (*write_inode)(struct inode *inode,
+                                struct writeback_control *wbc);
+    void         (*evict_inode)(struct inode *inode);
+    void         (*put_super)(struct super_block *sb);
+    int          (*sync_fs)(struct super_block *sb, int wait);
+    int          (*statfs)(struct dentry *dentry, struct kstatfs *kstatfs);
+};
+```
+
+`s_fs_info` is the "escape hatch" — the filesystem stores its own private data here. For ext4, it's a `struct ext4_sb_info` with journal handle, block group descriptors, etc.
+
+## struct inode: a file system object
+
+An `inode` represents a file, directory, symlink, device node, or socket — any named object in the filesystem. One inode can have multiple names (hard links) but a single set of metadata.
+
+```c
+/* include/linux/fs.h */
+struct inode {
+    umode_t              i_mode;     /* file type + permissions */
+    unsigned int         i_flags;    /* S_IMMUTABLE, S_APPEND, etc. */
+    kuid_t               i_uid;      /* owner UID */
+    kgid_t               i_gid;      /* owner GID */
+    const struct inode_operations *i_op;  /* inode operations vtable */
+    struct super_block  *i_sb;       /* the filesystem this belongs to */
+    struct address_space *i_mapping; /* page cache for this file */
+    unsigned long        i_ino;      /* inode number */
+    unsigned int         i_nlink;    /* number of hard links */
+    loff_t               i_size;     /* file size in bytes */
+    blkcnt_t             i_blocks;   /* number of 512-byte blocks */
+    spinlock_t           i_lock;     /* protects i_blocks, i_bytes, i_size */
+    struct timespec64    __i_atime;  /* access time */
+    struct timespec64    __i_mtime;  /* modification time */
+    struct timespec64    __i_ctime;  /* change time */
+};
+
+struct inode_operations {
+    struct dentry *(*lookup)(struct inode *, struct dentry *, unsigned int);
+    int (*create)(struct mnt_idmap *, struct inode *, struct dentry *,
+                  umode_t, bool);
+    int (*link)(struct dentry *, struct inode *, struct dentry *);
+    int (*unlink)(struct inode *, struct dentry *);
+    int (*mkdir)(struct mnt_idmap *, struct inode *, struct dentry *, umode_t);
+    int (*rmdir)(struct inode *, struct dentry *);
+    int (*rename)(struct mnt_idmap *, struct inode *, struct dentry *,
+                  struct inode *, struct dentry *, unsigned int);
+    int (*setattr)(struct mnt_idmap *, struct dentry *, struct iattr *);
+    int (*getattr)(struct mnt_idmap *, const struct path *,
+                   struct kstat *, u32, unsigned int);
+    int (*permission)(struct mnt_idmap *, struct inode *, int);
+    const char *(*get_link)(struct dentry *, struct inode *,
+                             struct delayed_call *);  /* for symlinks */
+};
+```
+
+The `i_mapping` field points to the `address_space` structure that links this inode to its pages in the page cache. When you `read()` a file, data goes into pages indexed by this `address_space`.
+
+## struct dentry: a path component
+
+A `dentry` (directory entry) caches the mapping from a name to an inode. The **dentry cache** (dcache) is VFS's primary lookup cache — before going to disk, the kernel checks if the path component is already in the dcache.
+
+```c
+/* include/linux/dcache.h */
+struct dentry {
+    unsigned int              d_flags;    /* state flags */
+    seqcount_spinlock_t       d_seq;      /* seqlock for RCU walks */
+    struct hlist_bl_node      d_hash;     /* hash table for lookup */
+    struct dentry            *d_parent;   /* parent directory dentry */
+    struct qstr               d_name;     /* name (quick string with hash) */
+    struct inode             *d_inode;    /* inode this name refers to
+                                            (NULL = negative dentry) */
+    const struct dentry_operations *d_op;
+    struct super_block       *d_sb;       /* filesystem superblock */
+    struct lockref            d_lockref;  /* refcount + spinlock */
+    struct list_head          d_lru;      /* LRU eviction list */
+    struct hlist_head         d_children; /* child dentries */
+};
+```
+
+Key distinction:
+- **Positive dentry**: `d_inode != NULL` — the name exists in the filesystem
+- **Negative dentry**: `d_inode == NULL` — the name was looked up but doesn't exist (cached to avoid repeated failed lookups)
+
+Multiple dentries can point to the same inode (hard links). When you `link("a", "b")`, you create a new dentry `b` pointing to the same inode as `a`.
+
+## struct file: an open file description
+
+A `file` is created each time `open()` is called. Multiple `file` structs can refer to the same inode (from different processes or multiple opens in the same process):
+
+```c
+/* include/linux/fs.h */
+struct file {
+    spinlock_t                    f_lock;
+    fmode_t                       f_mode;     /* FMODE_READ, FMODE_WRITE */
+    const struct file_operations *f_op;       /* file operations vtable */
+    struct address_space         *f_mapping;  /* page cache */
+    struct inode                 *f_inode;    /* the inode */
+    unsigned int                  f_flags;    /* O_RDONLY, O_NONBLOCK, etc. */
+    const struct cred            *f_cred;     /* credentials at open time */
+    struct path                   f_path;     /* dentry + vfsmount */
+    loff_t                        f_pos;      /* current file position */
+    file_ref_t                    f_ref;      /* reference count */
+    void                         *private_data; /* filesystem-private per-open state */
+};
+
+struct file_operations {
+    loff_t  (*llseek)(struct file *, loff_t, int);
+    ssize_t (*read)(struct file *, char __user *, size_t, loff_t *);
+    ssize_t (*write)(struct file *, const char __user *, size_t, loff_t *);
+    ssize_t (*read_iter)(struct kiocb *, struct iov_iter *);
+    ssize_t (*write_iter)(struct kiocb *, struct iov_iter *);
+    int     (*mmap)(struct file *, struct vm_area_struct *);
+    int     (*open)(struct inode *, struct file *);
+    int     (*release)(struct inode *, struct file *);  /* called on last close */
+    int     (*fsync)(struct file *, loff_t, loff_t, int datasync);
+    long    (*unlocked_ioctl)(struct file *, unsigned int, unsigned long);
+    int     (*iterate_shared)(struct file *, struct dir_context *);  /* readdir */
+};
+```
+
+`f_pos` is per-open-file, which is why two processes with the same `open()` of the same file can read at different positions. But after `fork()`, parent and child share the same `struct file` (and thus the same `f_pos`) until one of them calls `open()` again.
+
+## How the four objects relate to user operations
+
+```
+open("/usr/bin/bash", O_RDONLY)
+  ↓
+namei resolution:
+  dentry "/" → inode of /
+  dentry "usr" → inode of /usr
+  dentry "bin" → inode of /usr/bin
+  dentry "bash" → inode of /usr/bin/bash  ← target inode found
+  ↓
+alloc_file():
+  new struct file created
+  f_inode = bash's inode
+  f_op = inode->i_fop  (ext4_file_operations)
+  f_op->open() called
+  ↓
+returns fd (index into process's file descriptor table)
+
+read(fd, buf, 4096)
+  ↓
+file = task->files->fdt->fd[fd]
+file->f_op->read_iter()
+  → ext4_file_read_iter()
+  → generic_file_read_iter()
+  → page cache lookup → disk read if miss
+```
+
+## Further reading
+
+- [Path Resolution](namei.md) — How VFS walks from "/" to the target dentry
+- [File Operations](file-ops.md) — The file_operations vtable in detail
+- [Dentry and Inode Caches](dcache-icache.md) — How VFS caches lookups
+- [Page Cache](../mm/page-cache.md) — Where file data lives in memory

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -246,3 +246,13 @@ nav:
       - Tasklets: interrupts/tasklets.md
       - Workqueues: interrupts/workqueues.md
       - Timers and hrtimers: interrupts/timers.md
+  - VFS:
+    - Getting Started: vfs/README.md
+    - Fundamentals:
+      - "VFS Objects: superblock, inode, dentry, file": vfs/vfs-objects.md
+      - Path Resolution: vfs/namei.md
+      - File Operations: vfs/file-ops.md
+      - Filesystem Registration and Mounting: vfs/mounting.md
+    - Lifecycle:
+      - Life of a write() Syscall: vfs/life-of-write.md
+      - Dentry and Inode Caches: vfs/dcache-icache.md


### PR DESCRIPTION
## Summary
- `vfs/README.md`: Overview with four-object table and execution context note
- `vfs/vfs-objects.md`: struct super_block/inode/dentry/file with field-by-field explanation, super_operations/inode_operations/file_operations vtables, how the four objects relate to open()/read()
- `vfs/namei.md`: struct nameidata, link_path_walk loop, lookup_fast (RCU seqlock), lookup_slow (i_rwsem), mount crossing, symlink recursion, LOOKUP_* flags
- `vfs/file-ops.md`: open() → alloc_file path, read() → generic_file_read_iter, write() → page cache dirty marking, llseek, mmap → filemap_fault, release vs flush distinction
- `vfs/mounting.md`: file_system_type registration, mount syscall → sget → fill_super path, vfsmount/mount namespace, /proc/mounts vs /proc/mountinfo, minimal filesystem skeleton
- `vfs/life-of-write.md`: end-to-end write() trace, generic_perform_write page-by-page loop, dirty tracking in radix tree + inode list, writeback daemon, fsync/fdatasync
- `vfs/dcache-icache.md`: dentry states (in-use/unused/negative), RCU lookup, vfs_cache_pressure, inode lifecycle (iget_locked, iput, evict_inode), drop_caches

Closes #261, #262, #263, #264, #265, #266

## Test plan
- [ ] mkdocs build passes without errors
- [ ] Cross-links to mm/page-cache, mm/life-of-read, locking/rwlock-rwsem resolve