### PR TITLE
Add block layer documentation: bio, blk-mq, I/O schedulers

### DIFF
--- a/docs/block/README.md
+++ b/docs/block/README.md
@@ -1,0 +1,30 @@
+# Block Layer
+
+> How the kernel handles storage I/O from filesystem to hardware
+
+## The block layer's role
+
+The block layer sits between filesystems (and direct I/O users) and block device drivers. It provides:
+
+- A uniform interface (`struct bio`) for submitting I/O to any block device
+- I/O scheduling: reorders requests for efficiency (merging, elevator algorithms)
+- Request queuing: batches and plugs I/O for throughput
+- Multi-queue support (blk-mq): maps to modern NVMe and SAS hardware with multiple queues
+
+```
+Filesystem (ext4, btrfs...)
+    ↓ submit_bio()
+Block layer core
+    ↓ (optional) I/O scheduler (BFQ, mq-deadline, kyber)
+    ↓ blk-mq: software queue → hardware queue
+Device driver (NVMe, SCSI, virtio-blk...)
+    ↓ DMA
+Storage hardware
+```
+
+## Contents
+
+- [Block Layer Overview](block-overview.md) — Key structures and submission path
+- [bio and request structures](bio-request.md) — The I/O descriptor objects
+- [blk-mq: Multi-Queue Block Layer](blk-mq.md) — Modern driver interface
+- [I/O Schedulers](io-schedulers.md) — BFQ, mq-deadline, kyber

--- a/docs/block/bio-request.md
+++ b/docs/block/bio-request.md
@@ -1,0 +1,172 @@
+# bio and request structures
+
+> The objects that describe I/O operations in the block layer
+
+## struct bio: the submission unit
+
+A `bio` (Block I/O) is the fundamental I/O descriptor. It describes a scatter-gather I/O operation: one or more physical memory segments mapped to contiguous sectors on a block device.
+
+```c
+/* include/linux/blk_types.h */
+struct bio {
+    struct bio          *bi_next;     /* for chaining bios in a request */
+    struct block_device *bi_bdev;     /* target block device */
+    blk_opf_t            bi_opf;      /* operation + flags (REQ_OP_READ/WRITE, etc.) */
+    blk_status_t         bi_status;   /* completion status */
+
+    /* The scatter-gather list */
+    struct bio_vec      *bi_io_vec;   /* array of (page, offset, len) */
+    struct bvec_iter     bi_iter;     /* current position in bi_io_vec */
+
+    bio_end_io_t        *bi_end_io;   /* completion callback */
+    void                *bi_private;  /* caller's private data */
+    atomic_t             __bi_remaining; /* for splitting: how many sub-bios remain */
+};
+```
+
+### struct bio_vec: one scatter-gather segment
+
+```c
+/* include/linux/bvec.h */
+struct bio_vec {
+    struct page  *bv_page;    /* the page containing the data */
+    unsigned int  bv_len;     /* number of bytes */
+    unsigned int  bv_offset;  /* byte offset within the page */
+};
+```
+
+Each `bio_vec` describes a contiguous chunk of memory (one page or less). A bio with multiple `bio_vec`s is a scatter-gather operation:
+
+```
+bio->bi_io_vec:
+  [0]: page A, offset 0, len 4096    → sectors 1024..1031
+  [1]: page B, offset 2048, len 2048  → sectors 1032..1035
+  [2]: page C, offset 0, len 4096    → sectors 1036..1043
+
+All map to contiguous sectors on disk.
+```
+
+### bio_vec iteration
+
+```c
+/* Iterate over all segments in a bio */
+struct bvec_iter iter;
+struct bio_vec bvec;
+
+bio_for_each_segment(bvec, bio, iter) {
+    /* bvec.bv_page, bvec.bv_offset, bvec.bv_len */
+    void *addr = page_address(bvec.bv_page) + bvec.bv_offset;
+    /* process bvec.bv_len bytes at addr */
+}
+```
+
+## bio operations (bi_opf)
+
+```c
+/* Operation types */
+REQ_OP_READ        /* read data from device */
+REQ_OP_WRITE       /* write data to device */
+REQ_OP_FLUSH       /* flush device write cache */
+REQ_OP_DISCARD     /* discard sectors (TRIM for SSDs) */
+REQ_OP_ZONE_RESET  /* reset a zoned device zone */
+REQ_OP_WRITE_ZEROES /* zero out sectors */
+
+/* Flags that modify the operation */
+REQ_SYNC      /* caller is waiting for completion */
+REQ_META      /* metadata I/O (higher priority) */
+REQ_PRIO      /* priority I/O */
+REQ_NOMERGE   /* don't merge with adjacent requests */
+REQ_IDLE      /* hint: submit when queue is idle */
+REQ_FUA       /* force unit access (bypass write cache) */
+REQ_PREFLUSH  /* issue flush before this write */
+REQ_RAHEAD    /* read-ahead, can be dropped under pressure */
+```
+
+## Allocating and submitting a bio
+
+```c
+#include <linux/bio.h>
+
+/* Allocate a bio with nr_vecs bio_vec slots */
+struct bio *bio = bio_alloc(GFP_KERNEL, nr_vecs);
+
+bio->bi_bdev = bdev;
+bio_set_op_attrs(bio, REQ_OP_WRITE, 0);
+bio->bi_iter.bi_sector = sector;   /* starting sector (512-byte units) */
+bio->bi_end_io = my_bio_complete;  /* completion callback */
+bio->bi_private = my_data;
+
+/* Add pages to the bio */
+bio_add_page(bio, page, len, offset);
+
+/* Submit */
+submit_bio(bio);
+
+/* Completion callback */
+static void my_bio_complete(struct bio *bio)
+{
+    if (bio->bi_status != BLK_STS_OK)
+        handle_error(bio->bi_status);
+    /* free resources */
+    bio_put(bio);
+}
+```
+
+## struct request: the scheduled unit
+
+While `bio` is the submission unit from the filesystem, `struct request` is what the I/O scheduler works with. Multiple bios can be **merged** into a single request if they are adjacent on disk:
+
+```c
+/* include/linux/blkdev.h */
+struct request {
+    struct request_queue *q;        /* the queue */
+    struct blk_mq_ctx    *mq_ctx;   /* software queue context */
+    struct blk_mq_hw_ctx *mq_hctx; /* hardware queue context */
+    blk_opf_t             cmd_flags; /* REQ_OP_* + flags */
+    struct bio            *bio;      /* first bio in the chain */
+    struct bio            *biotail;  /* last bio in the chain */
+    unsigned int          __data_len; /* total bytes */
+    sector_t              __sector;  /* starting sector */
+    unsigned int          nr_phys_segments; /* scatter-gather segment count */
+    /* ... tag, timeout, stats ... */
+};
+```
+
+### Bio merging
+
+The I/O scheduler tries to merge adjacent bios into one request before dispatch:
+
+```
+Before merging:
+  Request A: sectors 1000-1007 (write)
+  Bio:        sectors 1008-1015 (write to same device)
+
+After merging:
+  Request A: sectors 1000-1015 (merged write)
+  → fewer interrupts, larger DMA transfers, better throughput
+```
+
+Merging is constrained by hardware limits:
+- `queue->limits.max_sectors` — maximum request size
+- `queue->limits.max_segments` — maximum scatter-gather segments
+- `queue->limits.max_segment_size` — maximum bytes per segment
+
+## bio splitting
+
+When a bio exceeds hardware limits, the block layer splits it:
+
+```c
+/* bio_split: split bio at 'sectors' sectors from start */
+struct bio *split = bio_split(bio, sectors, GFP_NOIO, &q->bio_split);
+bio_chain(split, bio);   /* link them: split completes before bio */
+submit_bio(split);
+submit_bio(bio);
+```
+
+Splitting is transparent to the filesystem — the completion callback fires only when all sub-bios complete.
+
+## Further reading
+
+- [Block Layer Overview](block-overview.md) — Where bios fit in the stack
+- [blk-mq](blk-mq.md) — How requests are dispatched to hardware
+- [DMA](../mm/dma.md) — How bio pages are DMA-mapped for the controller

--- a/docs/block/blk-mq.md
+++ b/docs/block/blk-mq.md
@@ -1,0 +1,213 @@
+# blk-mq: Multi-Queue Block Layer
+
+> The modern block layer interface for high-performance storage
+
+## Why blk-mq?
+
+Traditional block layer had a single request queue per device, protected by a global lock. This was fine for HDDs (which are sequential anyway) but became a bottleneck for NVMe SSDs that can handle millions of IOPS across multiple hardware queues.
+
+blk-mq (introduced in Linux 3.13) uses:
+- **Multiple software queues** (one per CPU or CPU group) to eliminate lock contention
+- **Multiple hardware queues** (mapped to NVMe queues, SCSI host adapters, etc.)
+- **Per-CPU tag allocation** for request objects
+
+## Two-level queue architecture
+
+```
+CPUs
+ CPU 0    CPU 1    CPU 2    CPU 3
+   │        │        │        │
+   ▼        ▼        ▼        ▼
+Software Queue (blk_mq_ctx)  ← per-CPU, no contention between CPUs
+   │        │        │        │
+   └────────┴────────┘        │
+           │                  │
+    ┌──────▼──────┐   ┌───────▼──────┐
+    │  Hardware   │   │  Hardware    │
+    │  Queue 0    │   │  Queue 1     │  ← maps to NVMe submission queues
+    └─────────────┘   └──────────────┘
+```
+
+### Software queues (blk_mq_ctx)
+
+One per CPU. Requests are initially queued here without any locking (each CPU has its own queue):
+
+```c
+/* Per-CPU software queue context */
+struct blk_mq_ctx {
+    struct {
+        spinlock_t      lock;
+        struct list_head rq_lists[HCTX_MAX_TYPES]; /* pending requests */
+    } ____cacheline_aligned_in_smp;
+
+    unsigned int        cpu;        /* CPU this belongs to */
+    unsigned short      index_hw[HCTX_MAX_TYPES]; /* hw queue index */
+    struct blk_mq_hw_ctx *hctxs[HCTX_MAX_TYPES];
+    struct request_queue *queue;
+};
+```
+
+### Hardware queues (blk_mq_hw_ctx)
+
+One per hardware queue (NVMe namespace, virtio queue, etc.):
+
+```c
+/* Hardware queue context */
+struct blk_mq_hw_ctx {
+    spinlock_t          lock;         /* protects dispatch list */
+    struct list_head    dispatch;     /* requests ready to dispatch */
+    unsigned long       state;        /* BLK_MQ_S_* */
+    struct blk_mq_tags *tags;         /* tag allocation for this hw queue */
+    cpumask_var_t       cpumask;      /* CPUs mapped to this hw queue */
+    unsigned long       flags;        /* BLK_MQ_F_* */
+};
+```
+
+## Implementing a blk-mq driver
+
+### 1. Define the operations
+
+```c
+static const struct blk_mq_ops my_mq_ops = {
+    .queue_rq     = my_queue_rq,     /* submit a request to hardware */
+    .complete     = my_complete_rq,  /* called on completion from interrupt */
+    .timeout      = my_timeout,      /* called when a request times out */
+    .poll         = my_poll,         /* for polled I/O (no interrupt) */
+};
+```
+
+### 2. Set up tag_set
+
+```c
+struct blk_mq_tag_set tag_set;
+
+memset(&tag_set, 0, sizeof(tag_set));
+tag_set.ops        = &my_mq_ops;
+tag_set.nr_hw_queues = num_online_cpus();  /* or: number of NVMe queues */
+tag_set.queue_depth  = 128;               /* max in-flight requests */
+tag_set.numa_node    = NUMA_NO_NODE;
+tag_set.cmd_size     = sizeof(struct my_request);  /* driver-private per-request data */
+tag_set.flags        = BLK_MQ_F_SHOULD_MERGE;
+
+ret = blk_mq_alloc_tag_set(&tag_set);
+```
+
+### 3. Allocate disk
+
+```c
+struct gendisk *disk = blk_mq_alloc_disk(&tag_set, NULL, my_dev);
+disk->major       = 0;  /* let kernel assign */
+disk->first_minor = 0;
+disk->minors      = 1;
+disk->fops        = &my_block_ops;
+snprintf(disk->disk_name, DISK_NAME_LEN, "myblk%d", index);
+
+/* Set capacity (in 512-byte sectors) */
+set_capacity(disk, total_bytes >> 9);
+
+/* Register */
+add_disk(disk);
+```
+
+### 4. queue_rq: submitting to hardware
+
+```c
+static blk_status_t my_queue_rq(struct blk_mq_hw_ctx *hctx,
+                                  const struct blk_mq_queue_data *bd)
+{
+    struct request *rq = bd->rq;
+    struct my_request *my_req = blk_mq_rq_to_pdu(rq);
+
+    /* Mark request as started */
+    blk_mq_start_request(rq);
+
+    /* Build hardware command */
+    my_req->sector = blk_rq_pos(rq);     /* starting sector */
+    my_req->count  = blk_rq_sectors(rq); /* sector count */
+    my_req->dir    = rq_data_dir(rq);    /* READ or WRITE */
+
+    /* Map scatter-gather list for DMA */
+    my_req->nsegs = blk_rq_map_sg(hctx->queue, rq, my_req->sglist);
+
+    /* Submit to hardware */
+    if (my_hw_submit(hctx->driver_data, my_req) != 0) {
+        blk_mq_requeue_request(rq, true);
+        return BLK_STS_RESOURCE;
+    }
+
+    return BLK_STS_OK;
+}
+```
+
+### 5. Completion from interrupt
+
+```c
+/* Called from IRQ handler when hardware signals completion */
+static void my_irq_handler(void *data)
+{
+    struct my_request *my_req = data;
+    struct request *rq = blk_mq_rq_from_pdu(my_req);
+
+    rq->result = 0;  /* success */
+    blk_mq_complete_request(rq);  /* signals completion to blk-mq */
+}
+
+/* blk_mq_complete_request calls: */
+static void my_complete_rq(struct request *rq)
+{
+    blk_mq_end_request(rq, rq->result ? BLK_STS_IOERR : BLK_STS_OK);
+    /* This notifies the bio and its filesystem/application */
+}
+```
+
+## Tag allocation
+
+Each in-flight request gets a **tag** — a small integer that uniquely identifies it while it's outstanding. The driver uses the tag to correlate completion events with requests.
+
+```c
+/* Tag range: 0 to queue_depth-1 */
+int tag = rq->tag;    /* set by blk-mq before calling queue_rq */
+
+/* Retrieve request from tag in completion */
+struct request *rq = blk_mq_tag_to_rq(hctx->tags, tag);
+```
+
+## Polled I/O
+
+For ultra-low latency NVMe, spinning for completion is faster than waiting for an interrupt:
+
+```c
+/* Submit with polling flag */
+bio->bi_opf |= REQ_POLLED;
+submit_bio(bio);
+
+/* Poll for completion */
+blk_poll(q, cookie, true);
+```
+
+This avoids interrupt overhead (~1-2µs) at the cost of burning a CPU. Useful when latency target is under 10µs.
+
+## Observing blk-mq
+
+```bash
+# Queue depth and inflight
+cat /sys/block/nvme0n1/queue/nr_requests      # max queue depth
+cat /sys/block/nvme0n1/inflight               # current in-flight requests
+
+# Per-hardware queue stats (if driver exposes)
+ls /sys/block/nvme0n1/mq/
+cat /sys/block/nvme0n1/mq/0/nr_tags
+
+# blktrace: trace individual I/O events
+blktrace -d /dev/nvme0n1 -o - | blkparse -i -
+# C = completion, D = driver, I = insert, Q = queued
+
+# iostat: throughput and latency
+iostat -x 1 /dev/nvme0n1
+```
+
+## Further reading
+
+- [bio and request structures](bio-request.md) — What blk-mq dispatches
+- [I/O Schedulers](io-schedulers.md) — What runs before blk-mq dispatch
+- [Block Layer Overview](block-overview.md) — The full picture

--- a/docs/block/block-overview.md
+++ b/docs/block/block-overview.md
@@ -1,0 +1,147 @@
+# Block Layer Overview
+
+> Key structures and the I/O submission path
+
+## Key data structures
+
+The block layer uses three key structures:
+
+```
+gendisk                    ← represents the whole disk (/dev/sda)
+  │
+  ├── block_device         ← represents a partition or whole disk (/dev/sda1)
+  │
+  └── request_queue        ← I/O queue + scheduler state
+        │
+        └── blk_mq_tag_set ← hardware queue mapping (blk-mq)
+```
+
+### struct gendisk
+
+`gendisk` represents a physical disk or virtual block device:
+
+```c
+/* include/linux/blkdev.h */
+struct gendisk {
+    int                    major;         /* device major number */
+    int                    first_minor;   /* first minor number */
+    int                    minors;        /* number of minors (partitions) */
+    char                   disk_name[DISK_NAME_LEN]; /* "sda", "nvme0n1" */
+    struct xarray          part_tbl;      /* partition table */
+    struct block_device   *part0;         /* whole-disk block_device */
+    const struct block_device_operations *fops;  /* driver operations */
+    struct request_queue  *queue;         /* I/O queue */
+    void                  *private_data;  /* driver private data */
+    int                   flags;          /* GENHD_FL_* */
+};
+```
+
+### struct block_device
+
+One `block_device` per partition (or whole disk). This is what filesystems use:
+
+```c
+struct block_device {
+    sector_t           bd_start_sect;  /* start sector of partition */
+    sector_t           bd_nr_sectors;  /* size in 512-byte sectors */
+    struct gendisk    *bd_disk;        /* the physical disk */
+    struct inode      *bd_inode;       /* inode in bdev filesystem */
+    struct super_block *bd_super;      /* superblock if mounted */
+    fmode_t            bd_openers;     /* open count */
+    struct mutex       bd_mutex;       /* open/close mutex */
+};
+```
+
+### struct request_queue
+
+The `request_queue` is the central object for I/O management:
+
+```c
+struct request_queue {
+    const struct blk_mq_ops  *mq_ops;   /* driver operations */
+    struct blk_mq_tag_set    *tag_set;   /* hardware queue mapping */
+    struct elevator_queue    *elevator;  /* I/O scheduler */
+    struct queue_limits       limits;    /* sector size, max request size, etc. */
+    unsigned long             queue_flags; /* QUEUE_FLAG_* */
+    /* ... */
+};
+```
+
+## The submit_bio() path
+
+```c
+/* Filesystem or direct I/O: */
+submit_bio(bio)
+    ↓
+submit_bio_noacct(bio)
+    ↓
+blk_mq_submit_bio(bio)    ← blk-mq path (all modern drivers)
+    │
+    ├── Try to merge with existing request in plug list
+    │
+    ├── Allocate a request from tag set
+    │
+    ├── If I/O scheduler: elevator->type->ops.insert_requests()
+    │     mq-deadline: add to deadline queue sorted by deadline
+    │     BFQ: add to BFQ per-process queue
+    │     none: add directly to hardware queue
+    │
+    └── blk_mq_run_hw_queue()
+          → driver's .queue_rq() called
+          → DMA mapping
+          → hardware command submission
+```
+
+## /proc and /sys for block devices
+
+```bash
+# List block devices
+lsblk
+# NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+# sda      8:0    0  100G  0 disk
+# ├─sda1   8:1    0   99G  0 part /
+# └─sda2   8:2    0    1G  0 part [SWAP]
+# nvme0n1 259:0   0  500G  0 disk
+# └─nvme0n1p1 259:1 0 500G 0 part /data
+
+# Block device stats
+cat /proc/diskstats
+# 8  0 sda 123456 7890 12345678 12345 234567 8901 23456789 23456 0 12345 23456
+# Fields: major minor name reads_completed reads_merged sectors_read ms_reading
+#         writes_completed writes_merged sectors_written ms_writing io_in_progress
+#         ms_io ms_weighted_io
+
+# Per-queue sysfs
+ls /sys/block/sda/queue/
+cat /sys/block/sda/queue/scheduler          # current scheduler
+cat /sys/block/sda/queue/nr_requests        # queue depth
+cat /sys/block/sda/queue/read_ahead_kb      # readahead size
+cat /sys/block/sda/queue/rotational         # 1=HDD, 0=SSD/NVMe
+cat /sys/block/sda/queue/logical_block_size # typically 512 or 4096
+```
+
+## I/O plug and unplug
+
+For throughput, the block layer "plugs" the queue briefly to accumulate requests before submitting:
+
+```c
+/* Driver/filesystem code that issues many bios */
+struct blk_plug plug;
+blk_start_plug(&plug);
+
+submit_bio(bio1);
+submit_bio(bio2);
+submit_bio(bio3);
+/* Requests accumulate in plug->mq_list */
+
+blk_finish_plug(&plug);
+/* All requests dispatched at once → better merging, fewer interrupts */
+```
+
+This is analogous to TCP's Nagle algorithm: batching small operations into larger ones.
+
+## Further reading
+
+- [bio and request structures](bio-request.md) — The I/O descriptor objects
+- [blk-mq](blk-mq.md) — The modern multi-queue dispatch mechanism
+- [I/O Schedulers](io-schedulers.md) — How requests are reordered

--- a/docs/block/io-schedulers.md
+++ b/docs/block/io-schedulers.md
@@ -1,0 +1,163 @@
+# I/O Schedulers
+
+> How the block layer reorders requests for efficiency
+
+## What I/O schedulers do
+
+An I/O scheduler (also called an elevator) sits between the block layer submission path and the hardware dispatch. It can:
+
+1. **Merge** adjacent requests into one (fewer I/O operations)
+2. **Reorder** requests to reduce HDD seek distance or improve fairness
+3. **Prioritize** certain types of requests (metadata, interactive I/O)
+4. **Throttle** requests from processes that are using too much I/O
+
+On modern blk-mq hardware (NVMe, virtio-blk), schedulers are optional — for NVMe with many queues, "none" (no scheduler) is often optimal.
+
+## Available schedulers
+
+```bash
+# Check available schedulers for a device
+cat /sys/block/sda/queue/scheduler
+# [mq-deadline] none bfq kyber
+# Current scheduler in brackets
+
+# Change scheduler
+echo mq-deadline > /sys/block/sda/queue/scheduler
+echo none > /sys/block/nvme0n1/queue/scheduler  # for NVMe
+```
+
+### none
+
+No scheduling. Requests are dispatched in submission order. Optimal for:
+- NVMe SSDs with hardware queues (no seek latency, no benefit from reordering)
+- Very low-latency workloads where scheduler overhead matters
+
+```bash
+echo none > /sys/block/nvme0n1/queue/scheduler
+```
+
+### mq-deadline
+
+**Default for most block devices.** Prevents request starvation by giving each request a deadline. Uses two separate queues: read and write.
+
+Algorithm:
+1. Requests are sorted in an elevator (rb-tree sorted by sector)
+2. Each request also gets a **deadline**: reads default 500ms, writes 5000ms
+3. Scheduler normally dispatches in sector order (fewer seeks)
+4. If any request reaches its deadline, it's dispatched immediately
+
+```c
+/* block/mq-deadline.c */
+struct deadline_data {
+    struct rb_root sort_list[DD_DIR_COUNT];  /* sorted by sector */
+    struct list_head fifo_list[DD_DIR_COUNT]; /* sorted by deadline */
+    sector_t last_sector[DD_DIR_COUNT];
+    unsigned int batching;    /* current batch count */
+    unsigned int starved;     /* write starvation count */
+};
+```
+
+Tuning:
+```bash
+# Deadline for reads (ms, default 500)
+cat /sys/block/sda/queue/iosched/read_expire
+echo 100 > /sys/block/sda/queue/iosched/read_expire
+
+# Deadline for writes (ms, default 5000)
+cat /sys/block/sda/queue/iosched/write_expire
+
+# How many read requests to dispatch before switching to writes
+cat /sys/block/sda/queue/iosched/writes_starved  # default 2
+
+# Number of requests to batch before switching direction
+cat /sys/block/sda/queue/iosched/fifo_batch  # default 16
+```
+
+### BFQ (Budget Fair Queueing)
+
+**Best for desktop/interactive workloads.** Provides proportional-share I/O scheduling with a focus on low latency for interactive applications (browser, desktop UI) even under heavy background I/O.
+
+BFQ assigns each process or group a **budget** of sectors to serve. When the budget is exhausted, the scheduler moves to the next process. Budget is dynamically sized based on workload characteristics.
+
+Key properties:
+- Interactive processes get boosted priority (short bursts are rewarded)
+- cgroups integration: `/sys/block/sda/queue/iosched/` exposes per-group weights
+- `CONFIG_BFQ_GROUP_IOSCHED` enables cgroup-based I/O isolation
+
+```bash
+echo bfq > /sys/block/sda/queue/scheduler
+
+# BFQ tunables
+cat /sys/block/sda/queue/iosched/slice_idle    # idle time between requests (µs)
+cat /sys/block/sda/queue/iosched/back_seek_max  # max backward seek allowed
+
+# Per-process I/O priority (ionice)
+ionice -c 2 -n 4 rsync source/ dest/   # best-effort, priority 4
+ionice -c 3 rsync source/ dest/         # idle class
+```
+
+### kyber
+
+**For multi-queue, low-latency devices (NVMe, SSDs).** Uses per-operation-type queues (read, write, discard) with token-based latency targeting.
+
+Rather than reordering, kyber:
+- Limits in-flight requests per category to hit target latencies
+- Doesn't do merging (relies on hardware)
+- Very low overhead
+
+```bash
+echo kyber > /sys/block/nvme0n1/queue/scheduler
+
+# Latency targets (ns)
+cat /sys/block/nvme0n1/queue/iosched/read_lat_nsec    # default 2000000 (2ms)
+cat /sys/block/nvme0n1/queue/iosched/write_lat_nsec   # default 10000000 (10ms)
+```
+
+## Choosing a scheduler
+
+| Workload | Recommended scheduler |
+|----------|----------------------|
+| NVMe SSD | `none` or `kyber` |
+| SATA SSD | `mq-deadline` or `none` |
+| HDD (spinning) | `mq-deadline` or `bfq` |
+| Desktop/interactive | `bfq` |
+| Database server | `mq-deadline` or `none` |
+| Container I/O isolation | `bfq` (with cgroups) |
+
+```bash
+# Check if rotational (0=SSD, 1=HDD)
+cat /sys/block/sda/queue/rotational
+
+# Automatic scheduler selection at boot (udev rules)
+# /usr/lib/udev/rules.d/60-io-scheduler.rules
+ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="0",
+  ATTR{queue/scheduler}="mq-deadline"
+ACTION=="add|change", KERNEL=="nvme[0-9]*",
+  ATTR{queue/scheduler}="none"
+```
+
+## Monitoring I/O performance
+
+```bash
+# iostat: throughput, IOPS, latency
+iostat -x 1 /dev/sda
+# Device    r/s   w/s  rkB/s  wkB/s  await  svctm  %util
+# sda       0.5  50.2   8.0  801.0    4.5    1.2   6.1
+
+# await: average total latency (queue wait + service time)
+# svctm: average service time at device
+# %util: device utilization
+
+# blktrace: detailed per-request tracing
+blktrace -d /dev/sda -o trace
+blkparse -i trace.blktrace.0 | head -50
+
+# biolatency (BCC): histogram of I/O latencies
+biolatency -d sda 10 1
+```
+
+## Further reading
+
+- [blk-mq](blk-mq.md) — The dispatch layer below the scheduler
+- [bio and request structures](bio-request.md) — What the scheduler reorders
+- `Documentation/block/` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -256,3 +256,9 @@ nav:
     - Lifecycle:
       - Life of a write() Syscall: vfs/life-of-write.md
       - Dentry and Inode Caches: vfs/dcache-icache.md
+  - Block Layer:
+    - Getting Started: block/README.md
+    - Block Layer Overview: block/block-overview.md
+    - bio and request structures: block/bio-request.md
+    - blk-mq (Multi-Queue): block/blk-mq.md
+    - I/O Schedulers: block/io-schedulers.md


### PR DESCRIPTION
## Summary
- `block/README.md`: Overview with stack diagram (filesystem → bio → blk-mq → driver → hardware)
- `block/block-overview.md`: gendisk/block_device/request_queue structures, submit_bio path, blk_start_plug/finish_plug batching, /proc/diskstats and /sys/block sysfs
- `block/bio-request.md`: struct bio with bi_io_vec scatter-gather, bio_vec layout, REQ_OP_* and flags, bio_add_page/submit_bio pattern, struct request for merged bios, bio merging/splitting
- `block/blk-mq.md`: Two-level queue architecture (sw queue per-CPU, hw queue per NVMe queue), blk_mq_tag_set setup, queue_rq/complete implementation pattern, tag allocation, polled I/O
- `block/io-schedulers.md`: none/mq-deadline/BFQ/kyber comparison, mq-deadline expire tuning, BFQ interactive boost, kyber latency targeting, scheduler selection guide, iostat/blktrace/biolatency monitoring

Closes #269, #270, #271, #272

## Test plan
- [ ] mkdocs build passes without errors
- [ ] Cross-links to mm/dma resolve