### PR TITLE
Add cgroups v2 and namespaces documentation

### DIFF
--- a/docs/cgroups/README.md
+++ b/docs/cgroups/README.md
@@ -1,0 +1,69 @@
+# Cgroups & Namespaces
+
+> Resource control and isolation primitives that underpin containers
+
+## What cgroups and namespaces do
+
+**Cgroups (control groups)** limit *how much* resource a group of processes can use:
+- CPU time (cpu.weight, cpu.max)
+- Memory (memory.max, memory.swap.max)
+- I/O bandwidth (io.weight, io.max)
+- Process count (pids.max)
+
+**Namespaces** control *what* processes can see:
+- Which processes are visible (PID namespace)
+- Which filesystem view they have (mount namespace)
+- Which network interfaces and addresses they have (network namespace)
+- Their hostname and domain (UTS namespace)
+- Their user/group IDs (user namespace)
+
+Together they implement container isolation: Docker, Kubernetes pods, and systemd services are built on these primitives.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Container / Pod                                              │
+│  ┌─────────────────────────┐  ┌────────────────────────────┐ │
+│  │ Namespaces (isolation)  │  │ Cgroup (resource limits)   │ │
+│  │  - PID: pid 1 inside    │  │  - cpu.max 200000/1000000  │ │
+│  │  - mnt: own filesystem  │  │  - memory.max 512M         │ │
+│  │  - net: own veth pair   │  │  - pids.max 100            │ │
+│  │  - user: uid 0 → 1000   │  │                            │ │
+│  └─────────────────────────┘  └────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Cgroup v2 Architecture](cgroup-v2.md) | Hierarchy, controllers, struct cgroup |
+| [Resource Controllers](cgroup-controllers.md) | cpu, memory, io, pids controllers in detail |
+| [Namespaces](namespaces.md) | All 8 namespace types, clone/unshare/setns |
+| [Container Isolation](container-isolation.md) | How namespaces + cgroups combine for containers |
+
+## Quick reference
+
+```bash
+# Cgroup v2 filesystem
+mount | grep cgroup2
+# cgroup2 on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime)
+
+# Current process's cgroup
+cat /proc/self/cgroup
+# 0::/user.slice/user-1000.slice/session-1.scope
+
+# Systemd creates cgroups automatically
+systemctl status nginx
+# CGroup: /system.slice/nginx.service
+
+# Namespaces of current process
+ls -la /proc/self/ns/
+# lrwxrwxrwx ... cgroup -> 'cgroup:[4026531835]'
+# lrwxrwxrwx ... mnt -> 'mnt:[4026531840]'
+# lrwxrwxrwx ... net -> 'net:[4026531992]'
+# lrwxrwxrwx ... pid -> 'pid:[4026531836]'
+# lrwxrwxrwx ... user -> 'user:[4026531837]'
+# lrwxrwxrwx ... uts -> 'uts:[4026531838]'
+# lrwxrwxrwx ... ipc -> 'ipc:[4026531839]'
+# lrwxrwxrwx ... time -> 'time:[4026531834]'
+```

--- a/docs/cgroups/cgroup-controllers.md
+++ b/docs/cgroups/cgroup-controllers.md
@@ -1,0 +1,308 @@
+# Cgroup v2 Resource Controllers
+
+> Controlling CPU, memory, I/O, and process count
+
+## cpu controller
+
+Controls CPU bandwidth allocation.
+
+### Interface files
+
+```bash
+# CPU time weight (relative, default 100, range 1–10000)
+cat /sys/fs/cgroup/myapp/cpu.weight
+echo 200 > /sys/fs/cgroup/myapp/cpu.weight  # 2x normal priority
+
+# CPU bandwidth quota: <quota_us> <period_us>
+# "200000 1000000" = 20% of one CPU
+# "max 1000000"    = unlimited
+cat /sys/fs/cgroup/myapp/cpu.max
+echo "200000 1000000" > /sys/fs/cgroup/myapp/cpu.max
+
+# Per-CPU burst: allow exceeding quota temporarily
+echo "100000 1000000" > /sys/fs/cgroup/myapp/cpu.max.burst
+
+# CPU stats
+cat /sys/fs/cgroup/myapp/cpu.stat
+# usage_usec 1234567        ← total CPU time used (µs)
+# user_usec 987654
+# system_usec 246913
+# nr_periods 1234           ← number of periods elapsed
+# nr_throttled 56           ← times throttled
+# throttled_usec 12345      ← total throttled time
+```
+
+### How cpu.max works internally
+
+```c
+/* kernel/sched/core.c: scheduler checks bandwidth */
+struct cfs_bandwidth {
+    ktime_t         period;       /* quota refill period */
+    u64             quota;        /* quota per period (ns) */
+    u64             burst;        /* allowed burst above quota */
+    u64             runtime;      /* remaining runtime this period */
+    u64             runtime_expires;
+
+    short           idle;         /* no tasks waiting */
+    short           period_active;
+    struct hrtimer  period_timer;  /* refills runtime each period */
+    struct hrtimer  slack_timer;   /* returns unused runtime */
+
+    struct list_head throttled_cfs_rq; /* rqs that hit zero runtime */
+    int             throttled;
+    int             nr_periods;
+    int             nr_throttled;
+    int             nr_burst;
+    u64             burst_time;
+    u64             throttled_time;
+};
+```
+
+When a cfs_rq runs out of quota, it's added to `throttled_cfs_rq` and pulled off the runqueue until the period timer fires to refill `runtime`.
+
+### cpu.weight and EEVDF
+
+`cpu.weight` maps to the EEVDF scheduler's `se.weight`. A process with weight 200 gets twice the CPU share of a weight-100 process when both are runnable.
+
+```c
+/* Conversion: cpu.weight → scheduler weight */
+static u32 sched_weight_from_cgroup(unsigned long cgroup_weight)
+{
+    /* cgroup uses 1–10000, scheduler uses 1–1048576 */
+    return scale_load_down(cgroup_weight *
+                           (SCHED_WEIGHT_SCALE / CGROUP_WEIGHT_DFL));
+}
+```
+
+## memory controller
+
+Controls memory usage. The most complex controller due to accounting overhead.
+
+### Interface files
+
+```bash
+# Hard memory limit (OOM kill when exceeded)
+echo "512M" > /sys/fs/cgroup/myapp/memory.max
+
+# Soft limit (hint for memory reclaim pressure)
+echo "400M" > /sys/fs/cgroup/myapp/memory.high
+
+# OOM notification: send SIGKILL vs return ENOMEM
+# By default, cgroup OOM kills the process that triggered it
+
+# Swap limit (memory + swap combined)
+echo "1G" > /sys/fs/cgroup/myapp/memory.swap.max
+
+# Current usage
+cat /sys/fs/cgroup/myapp/memory.current    # bytes used
+cat /sys/fs/cgroup/myapp/memory.peak       # historical peak
+
+# Detailed stats (see mm/memory-stat.md for field descriptions)
+cat /sys/fs/cgroup/myapp/memory.stat
+
+# OOM events
+cat /sys/fs/cgroup/myapp/memory.events
+# low 0
+# high 12          ← times memory.high was exceeded
+# max 0            ← times memory.max was exceeded (with retry)
+# oom 2            ← OOM kills triggered
+# oom_kill 3       ← processes killed by OOM
+# oom_group_kill 0
+```
+
+### memory.high: the reclaim throttle
+
+`memory.high` is a soft limit that triggers reclaim instead of killing:
+
+```c
+/* mm/memcontrol.c: mem_cgroup_handle_over_high() */
+/* Called after each page allocation if usage > memory.high */
+void mem_cgroup_handle_over_high(gfp_t gfp_mask)
+{
+    unsigned long penalty_jiffies;
+    unsigned long overage;
+
+    overage = mem_find_max_overage(current->nsproxy->cgroup_ns);
+    if (!overage)
+        return;
+
+    /* Throttle: sleep proportional to how much we're over high */
+    penalty_jiffies = calculate_high_delay(memcg, nr_pages, overage);
+    schedule_timeout_killable(penalty_jiffies);
+
+    /* Also try to reclaim */
+    mem_cgroup_reclaim(memcg, gfp_mask, 0);
+}
+```
+
+### Page accounting
+
+Each page is charged to one `mem_cgroup` via `page_counter`:
+
+```c
+/* include/linux/page_counter.h */
+struct page_counter {
+    atomic_long_t   usage;       /* current usage in pages */
+    unsigned long   min;         /* memory.min (protection) */
+    unsigned long   low;         /* memory.low (protection) */
+    unsigned long   high;        /* memory.high (soft limit) */
+    unsigned long   max;         /* memory.max (hard limit) */
+    struct page_counter *parent; /* parent in cgroup hierarchy */
+    unsigned long   watermark;   /* peak usage */
+    unsigned long   failcnt;     /* count of max hits */
+};
+```
+
+When a page is allocated:
+```c
+mem_cgroup_charge(page, mm, gfp)
+  → get_mem_cgroup_from_mm(mm)      /* find which memcg this mm belongs to */
+  → charge_memcg(memcg, nr_pages)
+      → page_counter_try_charge(&memcg->memory, nr_pages, &counter)
+      → if over max: try to reclaim → if still over: OOM
+```
+
+### memory.min and memory.low: protection
+
+```bash
+# Reserve at least 256MB for this cgroup (never reclaim below this)
+echo "256M" > /sys/fs/cgroup/myapp/memory.min
+
+# Try to keep at least 256MB (reclaim this last, under global pressure)
+echo "256M" > /sys/fs/cgroup/myapp/memory.low
+```
+
+## io controller
+
+Controls block I/O bandwidth and IOPS using BFQ or mq-deadline scheduler integration.
+
+### Interface files
+
+```bash
+# Relative weight for I/O scheduler (default 100, range 1–10000)
+echo "8:0 200" > /sys/fs/cgroup/myapp/io.weight  # major:minor weight
+
+# Absolute limits: <major>:<minor> rbps=N wbps=N riops=N wiops=N
+echo "8:0 rbps=10485760 wbps=5242880" > /sys/fs/cgroup/myapp/io.max
+# 10MB/s read, 5MB/s write on device 8:0
+
+# I/O stats per device
+cat /sys/fs/cgroup/myapp/io.stat
+# 8:0 rbytes=1048576 wbytes=524288 rios=128 wios=64 dbytes=0 dios=0
+
+# I/O pressure (PSI)
+cat /sys/fs/cgroup/myapp/io.pressure
+# some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+# full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+```
+
+### How io.max works
+
+The io controller uses the block layer's throttle path:
+
+```c
+/* block/blk-cgroup.c: blkcg_policy_ops for throttle */
+struct blkcg_policy blkcg_policy_throttl = {
+    .pd_alloc_fn  = tg_pd_alloc,
+    .pd_init_fn   = tg_pd_init,
+    .pd_free_fn   = tg_pd_free,
+    /* ... */
+};
+
+/* When a bio is submitted: */
+blk_throtl_bio(bio)
+  → find tg (throtl_grp) for current task's blkcg
+  → check against rbps/wbps/riops/wiops limits
+  → if over limit: queue bio in tg, schedule timer to dispatch later
+```
+
+## pids controller
+
+Limits the total number of processes and threads.
+
+### Interface files
+
+```bash
+# Limit to 100 processes/threads total
+echo 100 > /sys/fs/cgroup/myapp/pids.max
+
+# Current count
+cat /sys/fs/cgroup/myapp/pids.current   # current PIDs
+
+# Events
+cat /sys/fs/cgroup/myapp/pids.events
+# max 3  ← times fork() was rejected due to pids.max
+```
+
+### How pids.max is enforced
+
+```c
+/* kernel/fork.c: copy_process() */
+static struct task_struct *copy_process(...)
+{
+    /* ... */
+    retval = cgroup_can_fork(p, args);
+    /* pids_can_fork() checks: */
+    if (atomic64_read(&pids_cgrp->counter) >= pids_max)
+        return -EAGAIN;  /* fork() returns EAGAIN */
+    /* ... */
+}
+```
+
+## cpuset controller
+
+Pins processes to specific CPUs and NUMA nodes:
+
+```bash
+# Allow only CPUs 0-3
+echo "0-3" > /sys/fs/cgroup/myapp/cpuset.cpus
+
+# Require memory from NUMA node 0 only
+echo "0" > /sys/fs/cgroup/myapp/cpuset.mems
+
+# Exclusive: no other cgroup uses these CPUs
+echo 1 > /sys/fs/cgroup/myapp/cpuset.cpus.exclusive
+```
+
+## Monitoring cgroup resource usage
+
+```bash
+# CPU pressure (PSI — Pressure Stall Information)
+cat /sys/fs/cgroup/myapp/cpu.pressure
+# some avg10=1.23 avg60=0.45 avg300=0.12 total=12345678
+# "some" = at least one task stalled
+# "full" = all tasks stalled (not shown for CPU)
+
+# Memory pressure
+cat /sys/fs/cgroup/myapp/memory.pressure
+
+# Watch cgroup stats with systemd-cgtop
+systemd-cgtop
+
+# Watch with cgroupv2 tools
+cat /sys/fs/cgroup/myapp/cpu.stat
+cat /sys/fs/cgroup/myapp/memory.current
+```
+
+## Delegation for rootless containers
+
+```bash
+# Grant unprivileged user ownership of a subtree
+chown -R user:user /sys/fs/cgroup/myapp/
+
+# User can now create sub-cgroups and move their own processes
+# but cannot enable controllers not already enabled by parent
+```
+
+The `nsdelegate` mount option prevents container breakouts:
+```bash
+mount -o remount,nsdelegate /sys/fs/cgroup
+# Now: tasks in a namespace can only control their subtree
+```
+
+## Further reading
+
+- [Cgroup v2 Architecture](cgroup-v2.md) — Hierarchy and core data structures
+- [Memory Cgroups](../mm/memcg.md) — Deep dive into memcg accounting
+- [PSI](../mm/psi.md) — Pressure stall information
+- `Documentation/admin-guide/cgroup-v2.rst` — Complete controller reference

--- a/docs/cgroups/cgroup-v2.md
+++ b/docs/cgroups/cgroup-v2.md
@@ -1,0 +1,265 @@
+# Cgroup v2 Architecture
+
+> The unified resource control hierarchy
+
+## Cgroup v1 vs v2
+
+| Feature | v1 | v2 |
+|---------|----|----|
+| Hierarchy | One per controller | Single unified hierarchy |
+| Controller attachment | Any cgroup | Must be enabled at parent |
+| Thread vs process | Per-thread control | Per-process (thread mode opt-in) |
+| Delegation | Complex ACLs | Clean subtree delegation |
+| BPF integration | Limited | cgroup BPF programs |
+
+Cgroup v2 (unified hierarchy) was merged in 4.5 and is now the default on modern distros. Most subsystems support only v2.
+
+## The single hierarchy
+
+All cgroup v2 resources hang off a single filesystem at `/sys/fs/cgroup`:
+
+```
+/sys/fs/cgroup/                    ← root cgroup
+├── cgroup.controllers             ← available controllers
+├── cgroup.subtree_control         ← controllers delegated to children
+├── cpu.stat
+├── memory.current
+├── system.slice/                  ← systemd service cgroup
+│   ├── nginx.service/
+│   │   ├── cgroup.procs           ← PIDs in this cgroup
+│   │   ├── cpu.max                ← CPU quota
+│   │   ├── memory.max             ← memory limit
+│   │   └── io.max                 ← I/O bandwidth limit
+│   └── sshd.service/
+└── user.slice/
+    └── user-1000.slice/
+        └── session-1.scope/
+```
+
+## Key data structures
+
+### struct cgroup
+
+```c
+/* kernel/cgroup/cgroup-internal.h */
+struct cgroup {
+    struct cgroup_subsys_state self;  /* CSS for cgroup_subsys itself */
+    unsigned long   flags;
+    int             level;            /* depth from root (root=0) */
+    int             max_depth;        /* subtree depth limit */
+    int             nr_descendants;   /* non-empty descendant count */
+
+    struct cgroup  *dom_cgrp;         /* domain cgroup (for v2) */
+    struct cgroup  *old_dom_cgrp;
+
+    struct kernfs_node *kn;           /* cgroup's kernfs directory node */
+    struct cgroup_file  procs_file;   /* handle for cgroup.procs */
+    struct cgroup_file  events_file;  /* handle for cgroup.events */
+
+    u16 subtree_control;              /* controllers enabled for children */
+    u16 subtree_ss_mask;
+
+    struct list_head    self_css_set_list;
+    struct rb_root      ancestor_ids_root;
+
+    struct cgroup_bpf   bpf;          /* BPF programs attached here */
+
+    atomic_t            nr_dying_descendants;
+    struct cgroup_stats __percpu *bstat;
+
+    /* Active per-subsystem state: */
+    struct cgroup_subsys_state *subsys[CGROUP_SUBSYS_COUNT];
+};
+```
+
+### struct cgroup_subsys_state (CSS)
+
+Each controller attaches per-cgroup state via a CSS:
+
+```c
+struct cgroup_subsys_state {
+    struct cgroup        *cgroup;     /* the cgroup this CSS belongs to */
+    struct cgroup_subsys *ss;         /* the controller subsystem */
+    struct percpu_ref     refcnt;     /* reference count */
+    struct list_head      sibling;    /* list of sibling CSS under parent */
+    struct list_head      children;   /* list of child CSS */
+    struct list_head      rstat_css_node;
+
+    u64     id;                       /* unique ID */
+    unsigned int flags;               /* CSS_NO_REF, CSS_ONLINE, CSS_DYING */
+    struct work_struct destroy_work;
+    struct rcu_work destroy_rwork;
+    struct cgroup_subsys_state *parent;
+};
+```
+
+Controllers (cpu, memory, io, etc.) embed a `cgroup_subsys_state` as their first field:
+
+```c
+/* mm/memcontrol.c */
+struct mem_cgroup {
+    struct cgroup_subsys_state css;  /* MUST be first */
+    /* ... memory controller state ... */
+    struct page_counter memory;
+    struct page_counter swap;
+    struct page_counter memsw;
+    unsigned long       soft_limit;
+    /* ... */
+};
+
+/* Access pattern: CSS → mem_cgroup */
+struct mem_cgroup *memcg = container_of(css, struct mem_cgroup, css);
+```
+
+### struct cgroup_subsys
+
+Each controller registers itself:
+
+```c
+struct cgroup_subsys {
+    struct cgroup_subsys_state *(*css_alloc)(struct cgroup_subsys_state *parent);
+    int (*css_online)(struct cgroup_subsys_state *css);
+    void (*css_offline)(struct cgroup_subsys_state *css);
+    void (*css_free)(struct cgroup_subsys_state *css);
+    void (*css_reset)(struct cgroup_subsys_state *css);
+
+    int (*can_attach)(struct cgroup_taskset *tset);
+    void (*attach)(struct cgroup_taskset *tset);  /* task moved here */
+    void (*post_attach)(void);
+    int (*can_fork)(struct task_struct *task, struct css_set *cset);
+    void (*cancel_fork)(struct task_struct *task, struct css_set *cset);
+    void (*fork)(struct task_struct *task);        /* new process */
+    void (*exit)(struct task_struct *task);
+    void (*release)(struct task_struct *task);
+    void (*bind)(struct cgroup_subsys_state *root_css);
+
+    bool        early_init:1;
+    bool        implicit_on_dfl:1;
+    bool        threaded:1;
+    int         id;
+    const char  *name;
+    const char  *legacy_name;
+    struct cgroupfs_root *root;
+    struct idr  css_idr;
+    struct list_head cfts;           /* cftypes (interface files) */
+    struct cftype *dfl_cftypes;      /* default v2 files */
+    struct cftype *legacy_cftypes;   /* v1 files */
+    unsigned int depends_on;
+};
+```
+
+## Enabling controllers
+
+Controllers must be explicitly enabled in the subtree:
+
+```bash
+# See what's available at root
+cat /sys/fs/cgroup/cgroup.controllers
+# cpuset cpu io memory hugetlb pids rdma misc
+
+# Enable controllers for children of root
+echo "+cpu +memory +io +pids" > /sys/fs/cgroup/cgroup.subtree_control
+
+# Create a cgroup
+mkdir /sys/fs/cgroup/myapp
+
+# Enable controllers for myapp's children
+echo "+cpu +memory" > /sys/fs/cgroup/myapp/cgroup.subtree_control
+
+# Add a process (moves it and all threads atomically)
+echo $$ > /sys/fs/cgroup/myapp/cgroup.procs
+```
+
+**No Internal Process Constraint**: in v2, a cgroup with enabled controllers cannot have processes directly. Only leaf cgroups (or the root) can hold processes.
+
+## css_set: the task-to-cgroup link
+
+Each task has a pointer to a `css_set`, which holds references to one CSS per active controller:
+
+```c
+struct css_set {
+    struct cgroup_subsys_state *subsys[CGROUP_SUBSYS_COUNT];
+    refcount_t   refcount;          /* shared when tasks have same CSS combination */
+    struct hlist_node hlist;        /* hash table of all css_sets */
+    struct list_head tasks;         /* tasks in this set */
+    struct list_head mg_tasks;      /* tasks being migrated */
+    struct list_head dying_tasks;
+    struct list_head task_iters;
+    struct list_head e_cset_node[CGROUP_SUBSYS_COUNT]; /* for each subsystem */
+    struct list_head threaded_csets;
+    struct list_head threaded_csets_node;
+    struct rcu_head  rcu_head;
+    struct list_head mg_preload_node;
+    struct list_head mg_node;
+    struct cgroup   *mg_src_cgrp;
+    struct cgroup   *mg_dst_cgrp;
+    struct css_set  *mg_dst_cset;
+    bool             dead;
+    struct work_struct release_work;
+};
+```
+
+CSS sets are shared: if two tasks are in exactly the same set of cgroups (one per controller), they share a `css_set`. This keeps the number of css_set objects small.
+
+## Moving processes between cgroups
+
+```bash
+# Move process PID to a cgroup
+echo <pid> > /sys/fs/cgroup/myapp/cgroup.procs
+```
+
+Internally:
+```c
+/* kernel/cgroup/cgroup.c: cgroup_procs_write() */
+cgroup_attach_task()
+  → cgroup_taskset_migrate()
+      → for each controller:
+          css->ss->can_attach(tset)    /* permission check */
+      → move task to new css_set
+      → for each controller:
+          css->ss->attach(tset)        /* notify controller */
+```
+
+## cgroup.events and notifications
+
+```bash
+# Monitor cgroup for empty/non-empty transitions
+cat /sys/fs/cgroup/myapp/cgroup.events
+# populated 1
+# frozen 0
+
+# Watch for changes (inotify or poll on the file)
+inotifywait -e modify /sys/fs/cgroup/myapp/cgroup.events
+```
+
+## BPF programs on cgroups
+
+```bash
+# Attach a BPF program to a cgroup (e.g., network filter)
+bpftool cgroup attach /sys/fs/cgroup/myapp/ ingress id <prog_id>
+bpftool cgroup show /sys/fs/cgroup/myapp/
+```
+
+```c
+/* BPF program attached to cgroup for socket filtering */
+SEC("cgroup/skb")
+int cgroup_filter(struct __sk_buff *skb)
+{
+    /* Allow or deny based on socket/connection properties */
+    return 1;  /* 1=allow, 0=deny */
+}
+```
+
+Supported BPF attach types on cgroups:
+- `BPF_CGROUP_INET_INGRESS` / `BPF_CGROUP_INET_EGRESS`
+- `BPF_CGROUP_INET_SOCK_CREATE` / `BPF_CGROUP_SOCK_OPS`
+- `BPF_CGROUP_DEVICE` — device access control
+- `BPF_CGROUP_SYSCTL` — sysctl read/write control
+- `BPF_CGROUP_INET4_CONNECT` / `BPF_CGROUP_INET6_CONNECT`
+- `BPF_CGROUP_INET4_BIND` / `BPF_CGROUP_INET6_BIND`
+
+## Further reading
+
+- [Resource Controllers](cgroup-controllers.md) — cpu, memory, io, pids in detail
+- [Container Isolation](container-isolation.md) — How cgroups combine with namespaces
+- `Documentation/admin-guide/cgroup-v2.rst` — comprehensive kernel documentation

--- a/docs/cgroups/container-isolation.md
+++ b/docs/cgroups/container-isolation.md
@@ -1,0 +1,279 @@
+# Container Isolation Internals
+
+> How Docker, Kubernetes, and container runtimes use namespaces and cgroups
+
+## What a container is, kernel-side
+
+A container is a process (or process tree) that:
+
+1. Lives in a set of **namespaces** (isolated view of system resources)
+2. Is governed by a **cgroup** (resource limits)
+3. Has a **filesystem root** (via mount namespace + chroot/pivot_root)
+4. Is optionally restricted by **seccomp** (syscall filtering) and **LSM** (AppArmor/SELinux)
+
+There is no "container" kernel object — it's a combination of existing primitives.
+
+```
+                    Container
+    ┌─────────────────────────────────────────┐
+    │  PID namespace: PIDs 1,2,3,...          │
+    │  Mount namespace: / → container rootfs  │
+    │  Net namespace: eth0=veth pair          │
+    │  User namespace: uid 0=container root   │
+    │  UTS namespace: hostname=container-1    │
+    │  IPC namespace: isolated SysV/POSIX     │
+    │  Cgroup namespace: /sys/fs/cgroup view  │
+    ├─────────────────────────────────────────┤
+    │  Cgroup: /sys/fs/cgroup/containers/c1/  │
+    │    cpu.max = 500000/1000000 (50%)        │
+    │    memory.max = 512M                    │
+    │    pids.max = 100                       │
+    ├─────────────────────────────────────────┤
+    │  seccomp: syscall whitelist/blacklist   │
+    │  AppArmor/SELinux: MAC policy           │
+    └─────────────────────────────────────────┘
+```
+
+## Container creation sequence
+
+This is what `docker run` or `runc` does at the kernel level:
+
+```c
+/* Simplified runc container creation */
+
+/* 1. Create new namespaces via clone() */
+pid_t child = clone(container_init,
+    stack + STACK_SIZE,
+    CLONE_NEWPID    /* new PID namespace */
+    | CLONE_NEWNS   /* new mount namespace */
+    | CLONE_NEWNET  /* new network namespace */
+    | CLONE_NEWIPC  /* new IPC namespace */
+    | CLONE_NEWUTS  /* new UTS namespace */
+    | CLONE_NEWCGROUP  /* new cgroup namespace */
+    | SIGCHLD,
+    &config);
+
+/* 2. Set up cgroup (from parent namespace) */
+/* Write pid to cgroup.procs */
+write_to_file("/sys/fs/cgroup/containers/c1/cgroup.procs", pid_str);
+
+/* 3. Set up network (veth pair, from parent namespace) */
+/* runc calls netlink to create veth0/veth1, move veth1 to child netns */
+
+/* 4. In child: pivot_root to container filesystem */
+/* mounts container rootfs, calls pivot_root or chroot */
+
+/* 5. In child: setuid/setgid, drop capabilities */
+
+/* 6. In child: install seccomp filter */
+prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog);
+
+/* 7. exec the container entrypoint */
+execve("/entrypoint", argv, envp);
+```
+
+## pivot_root: switching filesystem root
+
+Containers use `pivot_root` (not just `chroot`) to fully isolate the filesystem:
+
+```c
+/* Container init: */
+
+/* 1. Mount container rootfs at a temp location */
+mount(rootfs_path, "/new_root", "none", MS_BIND, NULL);
+
+/* 2. Make mount namespace private (prevent propagation to host) */
+mount("", "/", "none", MS_PRIVATE | MS_REC, NULL);
+
+/* 3. Put old root somewhere under new root */
+mkdir("/new_root/.old_root", 0755);
+
+/* 4. pivot_root: new_root becomes /, old root goes to /.old_root */
+syscall(SYS_pivot_root, "/new_root", "/new_root/.old_root");
+
+/* 5. Unmount the old root to complete isolation */
+umount2("/.old_root", MNT_DETACH);
+rmdir("/.old_root");
+
+/* Now /proc, /sys, /dev need to be mounted fresh */
+mount("proc", "/proc", "proc", 0, NULL);
+mount("sysfs", "/sys", "sysfs", 0, NULL);
+mount("tmpfs", "/dev", "tmpfs", 0, NULL);
+```
+
+## Network setup: veth pairs
+
+Container networking uses virtual ethernet pairs:
+
+```
+Host namespace                    Container namespace
+─────────────────                 ──────────────────
+veth0 (10.0.0.1)  ←──────────→  eth0 (172.17.0.2)
+    │                  kernel
+    │                  bridge
+docker0 bridge
+(172.17.0.1)
+    │
+    └── routes, NAT (iptables MASQUERADE)
+```
+
+```bash
+# What runc does for container networking (simplified):
+ip link add veth0 type veth peer name eth0
+ip link set eth0 netns <container_pid>
+
+# In host namespace:
+ip link set veth0 master docker0
+ip link set veth0 up
+
+# In container namespace:
+ip netns exec <container_pid> ip addr add 172.17.0.2/16 dev eth0
+ip netns exec <container_pid> ip route add default via 172.17.0.1
+```
+
+## Cgroup namespace: container's view of cgroups
+
+Without a cgroup namespace, a container would see the full host cgroup hierarchy. With `CLONE_NEWCGROUP`:
+
+```bash
+# Host sees:
+cat /proc/1/cgroup
+# 0::/
+
+# Container (in its cgroup namespace) sees:
+cat /proc/1/cgroup  # from inside container
+# 0::/              ← the container's own cgroup looks like root
+
+# /sys/fs/cgroup/ inside the container shows only its subtree
+```
+
+The cgroup namespace makes the container's cgroup appear as root, so `systemd` in a container doesn't see the host hierarchy.
+
+## User namespace: rootless containers
+
+Rootless containers (Docker rootless, Podman) run entirely as unprivileged users:
+
+```
+Host:     uid=1000 (user)
+          uid=100000-165535 (subuid range)
+
+Container: uid=0 (root inside)
+           = uid=100000 outside  (via uid_map: 0 → 100000, range 65536)
+```
+
+```bash
+# /etc/subuid maps users to subordinate UID ranges
+cat /etc/subuid
+# user:100000:65536
+
+# Start rootless container
+podman run --rm -it ubuntu bash
+# Inside: id → uid=0(root)
+# Outside: ps shows process running as uid=100000
+
+# The kernel enforces: this "root" has no host privilege
+# It cannot access /etc/shadow, load modules, etc.
+```
+
+The user namespace also enables unprivileged namespace creation for all other types.
+
+## seccomp: syscall filtering
+
+Seccomp restricts which syscalls a container can make:
+
+```c
+/* Install a seccomp filter (BPF program over syscall args) */
+struct sock_filter filter[] = {
+    /* Load syscall number */
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+             offsetof(struct seccomp_data, nr)),
+
+    /* Allow read, write, exit, sigreturn */
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_read, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_write, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    /* Default: kill */
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL),
+};
+
+struct sock_fprog prog = {
+    .len = ARRAY_SIZE(filter),
+    .filter = filter,
+};
+prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog);
+```
+
+Docker's default seccomp profile blocks ~40 syscalls (including `keyctl`, `kexec_load`, `perf_event_open`, `ptrace`, etc.).
+
+## OCI runtime spec
+
+The Open Container Initiative (OCI) runtime spec defines what a container runtime (runc, crun, kata) must do. The spec is a JSON file (`config.json`):
+
+```json
+{
+  "ociVersion": "1.0.0",
+  "process": {
+    "user": {"uid": 0, "gid": 0},
+    "args": ["/bin/sh"],
+    "capabilities": {
+      "bounding": ["CAP_NET_BIND_SERVICE", "CAP_KILL", ...]
+    },
+    "rlimits": [{"type": "RLIMIT_NOFILE", "hard": 1024, "soft": 1024}],
+    "seccompProfile": "default.json"
+  },
+  "root": {"path": "rootfs", "readonly": true},
+  "mounts": [
+    {"destination": "/proc", "type": "proc", "source": "proc"},
+    {"destination": "/dev", "type": "tmpfs", "source": "tmpfs"}
+  ],
+  "linux": {
+    "namespaces": [
+      {"type": "pid"}, {"type": "network"}, {"type": "ipc"},
+      {"type": "uts"}, {"type": "mount"}, {"type": "cgroup"}
+    ],
+    "cgroupsPath": "/containers/mycontainer",
+    "resources": {
+      "memory": {"limit": 536870912},
+      "cpu": {"quota": 200000, "period": 1000000}
+    }
+  }
+}
+```
+
+## Debugging container isolation
+
+```bash
+# Check what namespaces a container process is in
+PID=$(docker inspect --format '{{.State.Pid}}' mycontainer)
+ls -la /proc/$PID/ns/
+
+# Enter a container's namespace
+nsenter --target $PID --mount --pid --net -- bash
+
+# Check cgroup of a container process
+cat /proc/$PID/cgroup
+
+# See container's cgroup limits
+cat /sys/fs/cgroup/$(cat /proc/$PID/cgroup | cut -d: -f3)/memory.max
+
+# strace a container process from the host
+strace -p $PID
+
+# Check seccomp filter installed
+cat /proc/$PID/status | grep Seccomp
+# Seccomp: 2    ← 0=none, 1=strict, 2=filter
+
+# Check capabilities
+cat /proc/$PID/status | grep Cap
+# CapPrm: 00000000a80425fb
+capsh --decode=00000000a80425fb
+```
+
+## Further reading
+
+- [Cgroup v2 Architecture](cgroup-v2.md) — Resource control internals
+- [Resource Controllers](cgroup-controllers.md) — cpu, memory, io limits
+- [Namespaces](namespaces.md) — All 8 namespace types in detail
+- [BPF/eBPF](../bpf/README.md) — seccomp-bpf and cgroup BPF programs
+- `runc` source code — reference OCI container runtime

--- a/docs/cgroups/namespaces.md
+++ b/docs/cgroups/namespaces.md
@@ -1,0 +1,363 @@
+# Linux Namespaces
+
+> Isolating what processes can see
+
+## The eight namespace types
+
+| Namespace | Flag | Isolates |
+|-----------|------|----------|
+| Mount | `CLONE_NEWNS` | Mount points, filesystem view |
+| UTS | `CLONE_NEWUTS` | Hostname, NIS domain name |
+| IPC | `CLONE_NEWIPC` | SysV IPC, POSIX message queues |
+| PID | `CLONE_NEWPID` | Process IDs |
+| Network | `CLONE_NEWNET` | Network interfaces, routing, sockets |
+| User | `CLONE_NEWUSER` | User/group IDs |
+| Cgroup | `CLONE_NEWCGROUP` | Cgroup root view |
+| Time | `CLONE_NEWTIME` | CLOCK_MONOTONIC, CLOCK_BOOTTIME offsets |
+
+## Creating namespaces
+
+### clone() — create child in new namespace
+
+```c
+#define _GNU_SOURCE
+#include <sched.h>
+#include <unistd.h>
+
+/* Stack for child */
+static char child_stack[65536];
+
+static int child_fn(void *arg)
+{
+    /* Running in new namespace(s) */
+    printf("child PID: %d\n", getpid());  /* prints 1 in new PID ns */
+    return 0;
+}
+
+int main(void)
+{
+    pid_t child = clone(child_fn,
+                        child_stack + sizeof(child_stack),
+                        CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWNET | SIGCHLD,
+                        NULL);
+    waitpid(child, NULL, 0);
+    return 0;
+}
+```
+
+### unshare() — current process enters new namespace
+
+```c
+/* Detach from shared namespaces */
+unshare(CLONE_NEWNS | CLONE_NEWUTS | CLONE_NEWIPC);
+
+/* Equivalent shell command */
+/* unshare --mount --uts --ipc bash */
+```
+
+```bash
+# Shell: run bash in new namespaces
+unshare --pid --mount --fork --mount-proc bash
+# Now in isolated PID+mount namespace, ps shows only this bash subtree
+```
+
+### setns() — join an existing namespace
+
+```c
+#include <fcntl.h>
+#include <sched.h>
+
+/* Enter another process's network namespace */
+int nsfd = open("/proc/1234/ns/net", O_RDONLY);
+setns(nsfd, CLONE_NEWNET);
+close(nsfd);
+/* Now in pid 1234's network namespace */
+```
+
+```bash
+# nsenter: enter namespaces of a running container
+nsenter --target <pid> --mount --pid --net -- bash
+```
+
+## struct nsproxy: the task's namespace set
+
+Each task holds a reference to its namespace set:
+
+```c
+/* include/linux/nsproxy.h */
+struct nsproxy {
+    atomic_t          count;          /* reference count */
+    struct uts_namespace   *uts_ns;
+    struct ipc_namespace   *ipc_ns;
+    struct mnt_namespace   *mnt_ns;
+    struct pid_namespace   *pid_ns_for_children;
+    struct net             *net_ns;
+    struct time_namespace  *time_ns;
+    struct time_namespace  *time_ns_for_children;
+    struct cgroup_namespace *cgroup_ns;
+};
+
+/* In struct task_struct: */
+struct nsproxy *nsproxy;
+```
+
+Processes that share all namespaces point to the same `nsproxy` (refcount). When any namespace diverges, a new nsproxy is allocated.
+
+## PID namespace
+
+Each PID namespace has its own numbering starting from 1. A process has different PIDs in different namespaces:
+
+```
+Host PID namespace:        pid=1234 (systemd), pid=5678 (container init)
+Container PID namespace:   pid=1 (container init), pid=100 (nginx)
+```
+
+```c
+/* include/linux/pid_namespace.h */
+struct pid_namespace {
+    struct idr      idr;            /* pid → task mapping */
+    struct rcu_head rcu;
+    unsigned int    level;          /* nesting depth (0=init_pid_ns) */
+    struct pid_namespace *parent;
+    struct user_namespace *user_ns;
+    struct ucounts *ucounts;
+    struct ns_common ns;
+
+    struct task_struct *child_reaper; /* PID 1 in this namespace */
+    struct kmem_cache *pid_cachep;
+    unsigned int    last_pid;
+    unsigned int    nr_hashed;
+    struct task_struct *rcu_task_caches[2];
+};
+```
+
+PID 1 in a PID namespace is the init — if it exits, all processes in the namespace are killed.
+
+```bash
+# See PID translations
+cat /proc/1234/status | grep NSpid
+# NSpid:  5678   1    ← host PID 5678 = PID 1 in container's namespace
+```
+
+## Mount namespace
+
+Each mount namespace has its own copy of the mount tree. Changes in one don't affect others.
+
+```c
+/* fs/namespace.c */
+struct mnt_namespace {
+    struct ns_common    ns;
+    struct mount       *root;           /* root mount */
+    struct rb_root      mounts;         /* all mounts */
+    struct user_namespace *user_ns;
+    u64                 seq;            /* event sequence number */
+    wait_queue_head_t   poll;
+    u64                 event;
+};
+```
+
+```bash
+# Create isolated mount namespace and mount procfs for new PID ns
+unshare --mount --pid --fork --mount-proc bash
+
+# The bind mount makes the new /proc show PID namespace contents
+# Host sees the old /proc
+```
+
+### Mount propagation types
+
+```bash
+# Shared: mounts propagate to peers
+mount --make-shared /mnt
+
+# Private: no propagation
+mount --make-private /mnt
+
+# Slave: receive propagation from master, don't send back
+mount --make-slave /mnt
+
+# Unbindable: cannot be bind-mounted
+mount --make-unbindable /mnt
+```
+
+## Network namespace
+
+Each network namespace has its own:
+- Network interfaces (except loopback is separate per-ns)
+- IP routing table
+- Netfilter rules (iptables)
+- Socket table
+- `/proc/net/` view
+
+```c
+/* include/net/net_namespace.h */
+struct net {
+    /* First cache line: frequently accessed fields */
+    refcount_t          passive;      /* passive reference count */
+    spinlock_t          rules_mod_lock;
+
+    unsigned int        dev_unreg_count;
+    unsigned int        dev_base_seq;
+
+    struct list_head    list;         /* list of all net namespaces */
+    struct list_head    exit_list;
+    struct llist_node   cleanup_list;
+
+    struct user_namespace *user_ns;   /* owning user namespace */
+    struct ucounts      *ucounts;
+    struct idr          netns_ids;
+
+    struct ns_common    ns;
+    struct ref_tracker_dir  refcnt_tracker;
+
+    struct list_head    dev_base_head; /* list of net devices */
+    struct proc_dir_entry *proc_net;
+    struct proc_dir_entry *proc_net_stat;
+
+    /* Protocol-specific namespaced state: */
+    struct netns_ipv4   ipv4;
+    struct netns_ipv6   ipv6;
+    struct netns_unix   unx;
+    struct netns_packet packet;
+    struct netns_nftables nft;
+    /* ... */
+};
+```
+
+```bash
+# Create a network namespace
+ip netns add myns
+
+# Run a command in the namespace
+ip netns exec myns ip link show
+
+# Move a veth pair into a namespace (typical container networking)
+ip link add veth0 type veth peer name veth1
+ip link set veth1 netns myns
+ip addr add 10.0.0.1/24 dev veth0
+ip netns exec myns ip addr add 10.0.0.2/24 dev veth1
+ip link set veth0 up
+ip netns exec myns ip link set veth1 up
+
+# List network namespaces
+ip netns list
+ls /var/run/netns/
+```
+
+## User namespace
+
+User namespaces map UIDs/GIDs between inside and outside:
+
+```c
+/* kernel/user_namespace.c */
+struct user_namespace {
+    struct uid_gid_map  uid_map;        /* uid mapping rules */
+    struct uid_gid_map  gid_map;
+    struct uid_gid_map  projid_map;
+    struct ucounts     *ucounts;
+    struct user_namespace *parent;
+    int                 level;
+    kuid_t              owner;
+    kgid_t              group;
+    struct ns_common    ns;
+    unsigned long       flags;
+    struct list_head    keyring_name_list;
+    struct key         *user_keyring_register;
+    struct rw_semaphore keyring_sem;
+};
+
+struct uid_gid_map {
+    u32                 nr_extents;     /* number of mapping ranges */
+    union {
+        struct uid_gid_extent extent[UID_GID_MAP_MAX_BASE_EXTENTS];
+        struct {
+            struct uid_gid_extent *forward;
+            struct uid_gid_extent *reverse;
+        };
+    };
+};
+```
+
+```bash
+# Create user namespace as unprivileged user
+unshare --user --map-root-user bash
+# Now: "root" inside = uid 1000 outside
+
+# Inspect the UID mapping
+cat /proc/self/uid_map
+# 0       1000          1   ← inside_start outside_start count
+# UID 0 inside = UID 1000 outside, 1 entry
+
+# Multi-range mapping (requires privilege)
+echo "0 1000 10" > /proc/<pid>/uid_map
+# UIDs 0-9 inside map to UIDs 1000-1009 outside
+```
+
+The key property: a process can be UID 0 (root) inside a user namespace but have no privilege outside it. This enables rootless containers.
+
+### Capability scope
+
+Capabilities in a user namespace only grant privilege over resources owned by that namespace and its descendants. Root in a user namespace cannot:
+- Load kernel modules
+- Modify kernel parameters outside the namespace
+- Read files owned by other users on the host
+
+## UTS namespace
+
+```bash
+# Isolate hostname
+unshare --uts bash
+hostname container1
+# Host's hostname is unchanged
+```
+
+```c
+struct uts_namespace {
+    struct new_utsname name;    /* contains nodename (hostname) */
+    struct user_namespace *user_ns;
+    struct ucounts *ucounts;
+    struct ns_common ns;
+};
+```
+
+## Namespace file descriptors
+
+Namespaces are persistent as long as:
+1. A process is in them, OR
+2. They have a file descriptor open, OR
+3. They have a bind mount at `/proc/<pid>/ns/<type>` or `/var/run/netns/`
+
+```bash
+# Persist a network namespace across process death
+touch /var/run/netns/myns
+mount --bind /proc/<pid>/ns/net /var/run/netns/myns
+# Now myns persists even after the creating process exits
+```
+
+## Observing namespaces
+
+```bash
+# See namespace IDs for all processes (matching = shared)
+lsns
+# NS TYPE   NPROCS   PID USER       COMMAND
+# 4026531835 cgroup    102     1 root       /sbin/init
+# 4026531836 pid       102     1 root       /sbin/init
+# 4026531992 net        98     1 root       /sbin/init
+# 4026532156 mnt         1  1234 user       bash
+
+# See which namespaces a container uses
+lsns --task <container_pid>
+
+# Inspect /proc/self/ns/ symlinks
+ls -la /proc/self/ns/
+
+# Find all processes in the same network namespace
+lsns -t net
+```
+
+## Further reading
+
+- [Container Isolation](container-isolation.md) — How namespaces and cgroups combine
+- [Cgroup v2 Architecture](cgroup-v2.md) — Resource control complement to isolation
+- `man 7 namespaces` — kernel documentation for all namespace types
+- `man 2 clone`, `man 2 unshare`, `man 2 setns`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -269,3 +269,9 @@ nav:
     - BPF Verifier: bpf/bpf-verifier.md
     - BTF and CO-RE: bpf/btf-core.md
     - libbpf and Skeletons: bpf/libbpf.md
+  - Cgroups & Namespaces:
+    - Getting Started: cgroups/README.md
+    - Cgroup v2 Architecture: cgroups/cgroup-v2.md
+    - Resource Controllers: cgroups/cgroup-controllers.md
+    - Namespaces: cgroups/namespaces.md
+    - Container Isolation: cgroups/container-isolation.md


### PR DESCRIPTION
## Summary

- **Cgroup v2 architecture** (`cgroup-v2.md`): unified hierarchy, struct cgroup + cgroup_subsys_state + css_set internals, enabling controllers, cgroup.events, BPF program attachment on cgroups
- **Resource controllers** (`cgroup-controllers.md`): cpu (cpu.weight→EEVDF weight, cpu.max bandwidth throttle with cfs_bandwidth), memory (memory.high reclaim throttle, page_counter charge path, memory.min/low protection), io (blkcg throttle internals), pids (fork rejection via cgroup_can_fork), cpuset, delegation
- **Namespaces** (`namespaces.md`): all 8 types, struct nsproxy, clone/unshare/setns APIs, PID namespace (struct pid_namespace, child_reaper), mount namespace (propagation types), network namespace (struct net), user namespace (uid_gid_map, rootless containers), UTS, namespace FD persistence
- **Container isolation** (`container-isolation.md`): pivot_root sequence, veth pair networking, cgroup namespace (container's view), rootless containers with subuid ranges, seccomp BPF filtering, OCI runtime spec format, debugging commands

Closes #282, #283

## Test plan

- [ ] All 5 pages render in mkdocs
- [ ] Cross-links to mm/memcg.md, bpf/ work correctly
- [ ] Code blocks compile/run correctly