### PR TITLE
Add system calls documentation

### DIFF
--- a/docs/syscalls/README.md
+++ b/docs/syscalls/README.md
@@ -1,0 +1,61 @@
+# System Calls
+
+> The contract between userspace and the kernel
+
+## What system calls are
+
+A system call is a controlled entry point into the kernel. It:
+
+1. **Saves CPU state** — registers, flags
+2. **Switches privilege** — user mode (ring 3) → kernel mode (ring 0)
+3. **Validates arguments** — checks pointers, copies data from userspace
+4. **Executes kernel code** — the actual operation
+5. **Returns to userspace** — restores registers, switches back to ring 3
+
+On x86-64, the `syscall` instruction triggers this transition. The kernel uses the value in `rax` as the syscall number to dispatch to the right handler.
+
+```
+Userspace                    Kernel
+─────────────────────────────────────────────────────
+glibc: write(fd, buf, len)
+  │
+  │  mov rax, 1  (SYS_write)
+  │  mov rdi, fd
+  │  mov rsi, buf
+  │  mov rdx, len
+  │  syscall
+  │              ──────────→  entry_SYSCALL_64
+  │                           saves registers
+  │                           calls sys_write()
+  │                               → vfs_write()
+  │              ←──────────  returns result in rax
+  │
+  │  return rax (bytes written, or -errno)
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Syscall Entry Path](syscall-entry.md) | x86-64 entry, privilege switch, argument passing, vDSO |
+| [SYSCALL_DEFINE and dispatch](syscall-define.md) | How syscalls are defined, the dispatch table, ABI |
+| [Adding a new syscall](adding-syscall.md) | Step-by-step walkthrough for kernel contributors |
+
+## Quick reference
+
+```bash
+# List all syscalls with numbers
+ausyscall --dump | head -20
+
+# Trace syscalls of a process
+strace ls
+
+# Count syscalls
+strace -c ls 2>&1
+
+# See syscall overhead
+perf stat -e 'syscalls:sys_enter_*' -- ls
+
+# See syscall table in kernel
+grep -r "SYSCALL_DEFINE" kernel/sys.c | head -10
+```

--- a/docs/syscalls/adding-syscall.md
+++ b/docs/syscalls/adding-syscall.md
@@ -1,0 +1,315 @@
+# Adding a New System Call
+
+> A complete walkthrough for kernel contributors
+
+## When to add a new syscall
+
+A new syscall is the right approach when:
+- Exposing a new kernel capability to userspace
+- The operation requires privilege or atomic semantics unavailable in userspace
+- It needs access to kernel-internal state
+
+Avoid adding syscalls for things that can be done via:
+- `ioctl` on an existing device/file (for device-specific operations)
+- `sysfs`/`procfs` (for configuration and observation)
+- Netlink (for networking-related configuration)
+- An existing syscall extension (e.g., `fcntl` with a new `cmd`)
+
+## Step 1: Define the syscall
+
+Use the modern struct-based pattern for new syscalls:
+
+```c
+/* Example: a hypothetical "hello" syscall in kernel/hello.c */
+#include <linux/syscalls.h>
+#include <linux/uaccess.h>
+#include <uapi/linux/hello.h>
+
+/**
+ * sys_hello - write a greeting to a buffer
+ * @uargs: pointer to struct hello_args in userspace
+ * @size: size of the struct passed by userspace
+ *
+ * Returns 0 on success, -errno on failure.
+ */
+SYSCALL_DEFINE2(hello, struct hello_args __user *, uargs, size_t, size)
+{
+    struct hello_args args;
+    char kernel_name[64];
+    int ret;
+
+    /* Validate and copy the struct */
+    if (size < HELLO_ARGS_SIZE_VER0)
+        return -EINVAL;
+    if (copy_struct_from_user(&args, sizeof(args), uargs, size))
+        return -EFAULT;
+
+    /* Validate flags: only known flags allowed */
+    if (args.flags & ~HELLO_FLAG_LOUD)
+        return -EINVAL;
+
+    /* Copy the name string from userspace */
+    if (strncpy_from_user(kernel_name, u64_to_user_ptr(args.name),
+                          sizeof(kernel_name)) < 0)
+        return -EFAULT;
+    kernel_name[sizeof(kernel_name) - 1] = '\0';
+
+    /* Do the work */
+    pr_info("Hello, %s!\n", kernel_name);
+    if (args.flags & HELLO_FLAG_LOUD)
+        pr_info("HELLO, %s!!!\n", kernel_name);
+
+    return 0;
+}
+```
+
+## Step 2: Define the UAPI struct
+
+Put userspace-visible types in `include/uapi/linux/hello.h`:
+
+```c
+/* include/uapi/linux/hello.h */
+#ifndef _UAPI_LINUX_HELLO_H
+#define _UAPI_LINUX_HELLO_H
+
+#include <linux/types.h>
+
+/* Flags for hello() */
+#define HELLO_FLAG_LOUD  (1 << 0)
+
+/* Version 0 struct size */
+#define HELLO_ARGS_SIZE_VER0  (sizeof(struct hello_args))
+
+struct hello_args {
+    __u32   flags;      /* HELLO_FLAG_* */
+    __u32   pad;        /* explicit padding (never leave implicit gaps) */
+    __u64   name;       /* pointer to name string (use __u64 for 64/32-bit compat) */
+};
+
+#endif /* _UAPI_LINUX_HELLO_H */
+```
+
+Key rules for UAPI structs:
+- Use `__u8`, `__u16`, `__u32`, `__u64` (not `int`, `long`, etc.)
+- Add explicit padding (`__u32 pad`) for alignment — never rely on implicit struct holes
+- Use `__u64` for pointer-sized fields (enables compat with 32-bit userspace)
+- The struct is an ABI — once merged it cannot be changed incompatibly
+
+## Step 3: Add to the syscall table
+
+### For x86-64: `arch/x86/entry/syscalls/syscall_64.tbl`
+
+```
+# Append at the end (after the highest existing number)
+451     common  hello           sys_hello
+```
+
+### For generic architectures: `include/uapi/asm-generic/unistd.h`
+
+```c
+#define __NR_hello 451
+__SYSCALL(__NR_hello, sys_hello)
+#undef __NR_syscalls
+#define __NR_syscalls 452
+```
+
+### For ARM64: `arch/arm64/include/asm/unistd.h`
+
+ARM64 uses the generic table, so `include/uapi/asm-generic/unistd.h` covers it.
+
+### For 32-bit compat
+
+If the syscall takes a struct with pointers (stored as `__u64`), it already works correctly for 32-bit processes — no compat version needed. If it uses architecture-specific types, add a compat version:
+
+```c
+/* Only if needed (most modern syscalls don't need this) */
+#ifdef CONFIG_COMPAT
+COMPAT_SYSCALL_DEFINE2(hello, compat_uptr_t, uargs, compat_size_t, size)
+{
+    /* handle 32-bit callers */
+}
+#endif
+```
+
+## Step 4: Add the kernel header
+
+```c
+/* include/linux/hello.h */
+#ifndef _LINUX_HELLO_H
+#define _LINUX_HELLO_H
+
+#include <uapi/linux/hello.h>
+
+/* kernel-internal declarations (not exported to userspace) */
+long ksys_hello(struct hello_args __user *uargs, size_t size);
+
+#endif
+```
+
+## Step 5: Wire it up in the build
+
+Add to the appropriate `Makefile`:
+
+```makefile
+# kernel/Makefile
+obj-y += hello.o
+```
+
+Or add it to an existing file if it's small enough.
+
+## Step 6: Add a man page stub
+
+```
+man2/hello.2  ← syscall man pages live in section 2
+```
+
+The man-pages project (not in the kernel tree) documents syscalls. Submit a patch there too.
+
+## Step 7: Write a selftest
+
+```c
+/* tools/testing/selftests/hello/hello_test.c */
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <assert.h>
+
+#ifndef __NR_hello
+#define __NR_hello 451
+#endif
+
+#include <linux/hello.h>
+
+int main(void)
+{
+    struct hello_args args = {
+        .flags = 0,
+        .pad   = 0,
+        .name  = (unsigned long)"world",
+    };
+
+    long ret = syscall(__NR_hello, &args, sizeof(args));
+    assert(ret == 0);
+
+    /* Test: unknown flag should fail */
+    args.flags = 0xdeadbeef;
+    ret = syscall(__NR_hello, &args, sizeof(args));
+    assert(ret == -1 && errno == EINVAL);
+
+    /* Test: NULL pointer should fail */
+    args.flags = 0;
+    args.name = 0;
+    ret = syscall(__NR_hello, &args, sizeof(args));
+    assert(ret == -1 && errno == EFAULT);
+
+    printf("All tests passed\n");
+    return 0;
+}
+```
+
+```makefile
+# tools/testing/selftests/hello/Makefile
+TEST_GEN_PROGS := hello_test
+include ../lib.mk
+```
+
+## Common mistakes
+
+### Forgetting to validate struct size
+
+```c
+/* WRONG: assumes struct is exactly this size */
+if (copy_from_user(&args, uargs, sizeof(args)))
+
+/* RIGHT: use copy_struct_from_user for versioned structs */
+if (copy_struct_from_user(&args, sizeof(args), uargs, size))
+```
+
+### Leaving implicit padding in structs
+
+```c
+/* WRONG: compiler adds 4 bytes of padding after flags */
+struct bad_args {
+    __u32 flags;
+    __u64 ptr;   /* 8-byte alignment requires 4 bytes padding before this */
+};
+
+/* RIGHT: explicit padding, no surprises */
+struct good_args {
+    __u32 flags;
+    __u32 pad;   /* explicit padding */
+    __u64 ptr;
+};
+```
+
+### Using kernel types in UAPI
+
+```c
+/* WRONG: size_t is 4 or 8 bytes depending on arch */
+struct bad {
+    size_t size;
+};
+
+/* RIGHT: explicitly sized */
+struct good {
+    __u64 size;
+};
+```
+
+### Directly dereferencing userspace pointers
+
+```c
+/* WRONG: UB + security vulnerability */
+int result = *(int *)uargs->ptr;
+
+/* RIGHT: use copy_from_user or get_user */
+int value;
+if (get_user(value, (int __user *)uargs->ptr))
+    return -EFAULT;
+```
+
+### Missing capability check
+
+```c
+/* If the syscall requires privilege: */
+if (!capable(CAP_SYS_ADMIN))
+    return -EPERM;
+
+/* For namespace-scoped privilege: */
+if (!ns_capable(current_user_ns(), CAP_SYS_ADMIN))
+    return -EPERM;
+```
+
+## Testing without merging
+
+```bash
+# Build the kernel with your changes
+make -j$(nproc) LOCALVERSION="-test"
+
+# Install in a VM
+make INSTALL_MOD_PATH=/tmp/modules modules_install
+make INSTALL_PATH=/boot install
+
+# Test with the selftest
+cd tools/testing/selftests/hello
+make
+sudo ./run_kselftest.sh
+```
+
+## The review process
+
+Expect these questions from reviewers:
+1. **Why a new syscall?** Can't this be done with ioctl/sysfs/etc.?
+2. **ABI review**: Is the struct future-proof? Does it have explicit padding?
+3. **Security**: Are all pointers validated? Can a malicious value cause harm?
+4. **Error handling**: All paths return meaningful errno?
+5. **Compat**: Does it work for 32-bit processes on 64-bit kernels?
+6. **Documentation**: man page? kernel-doc comments?
+7. **Tests**: selftests included?
+
+## Further reading
+
+- [Syscall Entry Path](syscall-entry.md) — How the new syscall gets called
+- [SYSCALL_DEFINE and dispatch](syscall-define.md) — The dispatch mechanism
+- `Documentation/process/adding-syscalls.rst` — The authoritative kernel guide
+- `man 2 syscall` — Low-level syscall invocation from C

--- a/docs/syscalls/syscall-define.md
+++ b/docs/syscalls/syscall-define.md
@@ -1,0 +1,260 @@
+# SYSCALL_DEFINE and Dispatch
+
+> How syscalls are defined in C and wired into the dispatch table
+
+## SYSCALL_DEFINE macro
+
+Every syscall in the kernel is defined using a macro that:
+1. Creates a function with the right signature (`asmlinkage`)
+2. Handles argument extraction from `struct pt_regs`
+3. Provides instrumentation hooks (tracepoints, audit)
+
+```c
+/* include/linux/syscalls.h */
+
+/* SYSCALL_DEFINE<N> where N is the number of arguments */
+SYSCALL_DEFINE0(getpid)
+SYSCALL_DEFINE1(close, unsigned int, fd)
+SYSCALL_DEFINE3(write, unsigned int, fd,
+                const char __user *, buf,
+                size_t, count)
+SYSCALL_DEFINE6(mmap, unsigned long, addr,
+                unsigned long, len,
+                unsigned long, prot,
+                unsigned long, flags,
+                unsigned long, fd,
+                unsigned long, off)
+```
+
+The `__user` annotation marks pointers that point into userspace (not kernel memory). The sparse tool uses this to catch missing `copy_from_user` calls.
+
+### What SYSCALL_DEFINE expands to
+
+```c
+/* SYSCALL_DEFINE3(write, unsigned int, fd, const char __user *, buf, size_t, count)
+   expands to approximately: */
+
+static long __do_sys_write(unsigned int fd, const char __user *buf, size_t count);
+
+/* Outer wrapper: extracts args from pt_regs */
+__visible long __x64_sys_write(const struct pt_regs *regs)
+{
+    return __do_sys_write(
+        (unsigned int)regs->di,    /* rdi = first arg */
+        (const char __user *)regs->si,  /* rsi */
+        (size_t)regs->dx           /* rdx */
+    );
+}
+
+/* Also creates __ia32_sys_write for 32-bit compat */
+
+/* And the actual implementation: */
+static long __do_sys_write(unsigned int fd, const char __user *buf, size_t count)
+{
+    /* implementation here */
+}
+
+/* SYSCALL_METADATA() creates tracepoint data and audit hooks */
+```
+
+### Full example: sys_write
+
+```c
+/* fs/read_write.c */
+SYSCALL_DEFINE3(write, unsigned int, fd, const char __user *, buf,
+                size_t, count)
+{
+    return ksys_write(fd, buf, count);
+}
+
+ssize_t ksys_write(unsigned int fd, const char __user *buf, size_t count)
+{
+    struct fd f = fdget_pos(fd);  /* get file from fd table */
+    ssize_t ret = -EBADF;
+
+    if (f.file) {
+        loff_t pos, *ppos = file_ppos(f.file);
+        if (ppos) {
+            pos = *ppos;
+            ppos = &pos;
+        }
+        ret = vfs_write(f.file, buf, count, ppos);
+        if (ret >= 0 && ppos)
+            f.file->f_pos = pos;
+        fdput_pos(f);
+    }
+
+    return ret;
+}
+```
+
+Note the `ksys_write()` wrapper: it allows calling the syscall logic from within the kernel (e.g., in `init` code) without going through the syscall entry path. This pattern is used for syscalls that the kernel itself needs to call internally.
+
+## The syscall table
+
+### 64-bit: arch/x86/entry/syscalls/syscall_64.tbl
+
+```
+# <number>  <abi>   <name>         <entry point>
+0           common  read           sys_read
+1           common  write          sys_write
+2           common  open           sys_open
+3           common  close          sys_close
+...
+```
+
+ABI can be `64` (only for 64-bit), `x32` (x32 ABI), or `common` (both). The build system generates `arch/x86/include/generated/asm/syscalls_64.h`:
+
+```c
+/* Auto-generated */
+__SYSCALL(0,  sys_read)
+__SYSCALL(1,  sys_write)
+__SYSCALL(2,  sys_open)
+...
+```
+
+Which is included in the syscall table array:
+
+```c
+/* arch/x86/entry/syscall_64.c */
+asmlinkage const sys_call_ptr_t sys_call_table[] = {
+#include <asm/syscalls_64.h>
+};
+const int sys_call_table_size = sizeof(sys_call_table);
+```
+
+### Architecture-independent: include/uapi/asm-generic/unistd.h
+
+For architectures without their own syscall tables:
+
+```c
+/* include/uapi/asm-generic/unistd.h */
+#define __NR_io_setup 0
+__SC_COMP(__NR_io_setup, sys_io_setup, compat_sys_io_setup)
+#define __NR_io_destroy 1
+__SYSCALL(__NR_io_destroy, sys_io_destroy)
+...
+```
+
+## Syscall ABI stability
+
+Once a syscall is merged, its number and argument semantics are **never changed**. This is a hard kernel rule: user-space must not break.
+
+Specific guarantees:
+- Syscall numbers don't change
+- Existing arguments are never reinterpreted
+- Structs passed by pointer only grow (new fields at the end, with zero meaning "not set")
+
+For new features, the kernel adds new syscalls rather than extend old ones in incompatible ways:
+- `clone()` → `clone3()` (struct-based, extensible)
+- `open()` → `openat()` → `openat2()` (added `how` struct)
+- `read()` → `pread64()`, `readv()`, `preadv()`, `preadv2()`
+
+## struct-based syscalls (modern pattern)
+
+The modern approach passes arguments in a struct, allowing future extension without new syscalls:
+
+```c
+/* struct-based syscall: clone3 */
+SYSCALL_DEFINE2(clone3, struct clone_args __user *, uargs, size_t, size)
+{
+    struct clone_args kargs;
+    pid_t set_tid[MAX_PID_NS_LEVEL];
+
+    if (size < CLONE_ARGS_SIZE_VER0)
+        return -EINVAL;
+    if (size > PAGE_SIZE)
+        return -E2BIG;
+
+    /* Copy only what caller provided; zero-initialize the rest */
+    if (copy_struct_from_user(&kargs, sizeof(kargs), uargs, size))
+        return -EFAULT;
+
+    /* ... validate and use kargs ... */
+}
+```
+
+`copy_struct_from_user` handles the versioning:
+- If `size < sizeof(kargs)`: copies what's there, zeros the rest (old userspace)
+- If `size > sizeof(kargs)`: checks that extension bytes are zero (new userspace, old kernel)
+
+## 32-bit compat syscalls
+
+64-bit kernels support 32-bit userspace binaries. Compat syscalls handle argument size differences:
+
+```c
+/* For types that differ between 32/64-bit: */
+#ifdef CONFIG_COMPAT
+COMPAT_SYSCALL_DEFINE6(mmap2, ...)
+{
+    /* 32-bit mmap uses 4KB page units for offset, not bytes */
+    /* 32-bit uses u32 fd, offset; 64-bit uses long */
+}
+#endif
+```
+
+32-bit processes use `ia32_sys_call_table` (separate from `sys_call_table`).
+
+## Syscall tracing and audit
+
+The SYSCALL_DEFINE macro automatically generates tracepoints:
+
+```bash
+# Available syscall tracepoints
+ls /sys/kernel/tracing/events/syscalls/
+# sys_enter_read  sys_exit_read  sys_enter_write  sys_exit_write ...
+
+# Trace all write() calls
+echo 1 > /sys/kernel/tracing/events/syscalls/sys_enter_write/enable
+cat /sys/kernel/tracing/trace_pipe
+# bash-1234 [000] sys_enter_write: fd=1, buf=0x7fff..., count=6
+
+# strace uses ptrace, which intercepts at a different level
+strace -e write ls
+```
+
+The `audit` subsystem also hooks into syscall entry/exit for security logging:
+
+```bash
+# Audit all opens by uid 1000
+auditctl -a always,exit -F arch=b64 -S open,openat -F uid=1000
+ausearch -k access
+```
+
+## Slow path vs fast path
+
+Some syscalls go through a "slow path" that handles signals, scheduling, restart:
+
+```c
+/* syscall_exit_to_user_mode_work: checks on return to userspace */
+static void exit_to_user_mode_loop(struct pt_regs *regs,
+                                    u32 cached_flags)
+{
+    while (true) {
+        local_irq_enable();
+
+        if (cached_flags & _TIF_NEED_RESCHED)
+            schedule();                  /* preemption point */
+
+        if (cached_flags & _TIF_SIGPENDING)
+            arch_do_signal_or_restart(regs);  /* deliver signal */
+
+        if (cached_flags & _TIF_NOTIFY_RESUME)
+            resume_user_mode_work(regs); /* seccomp, ptrace notify */
+
+        /* Check again for new work */
+        cached_flags = read_thread_flags();
+        if (!(cached_flags & EXIT_TO_USER_MODE_WORK))
+            break;
+    }
+}
+```
+
+This is why syscalls are preemption and signal delivery points — the kernel checks `TIF_*` flags on every syscall return.
+
+## Further reading
+
+- [Syscall Entry Path](syscall-entry.md) — Hardware mechanism and entry assembly
+- [Adding a new syscall](adding-syscall.md) — Step-by-step guide
+- `include/linux/syscalls.h` — SYSCALL_DEFINE macros
+- `Documentation/process/adding-syscalls.rst` — Official guide for new syscalls

--- a/docs/syscalls/syscall-entry.md
+++ b/docs/syscalls/syscall-entry.md
@@ -1,0 +1,265 @@
+# Syscall Entry Path
+
+> From the `syscall` instruction to kernel code — and back
+
+## x86-64 hardware mechanism
+
+When userspace executes `syscall`:
+
+1. **CPU saves**: `rip` → `rcx`, `rflags` → `r11`, then clears IF
+2. **CPU loads**: `rip` from `IA32_LSTAR` MSR (set to `entry_SYSCALL_64` at boot)
+3. **CPU switches**: CS/SS from `IA32_STAR` MSR (kernel segments)
+
+The `rax` register holds the syscall number. Arguments go in: `rdi`, `rsi`, `rdx`, `r10`, `r8`, `r9` (note: `r10` not `rcx` — `rcx` is clobbered by `syscall`).
+
+Return value comes back in `rax`. On error, the kernel negates errno and userspace glibc converts it.
+
+## entry_SYSCALL_64: the assembly entry point
+
+```asm
+/* arch/x86/entry/entry_64.S */
+SYM_CODE_START(entry_SYSCALL_64)
+    UNWIND_HINT_ENTRY
+    ENDBR
+
+    swapgs                  /* load kernel GS (points to per-CPU data) */
+    /* Set up kernel stack using per-CPU cpu_current_top_of_stack */
+    movq    %rsp, PER_CPU_VAR(cpu_tss_rw + TSS_sp2)
+    SWITCH_TO_KERNEL_CR3 scratch_reg=%rsp
+    movq    PER_CPU_VAR(cpu_current_top_of_stack), %rsp
+
+    /* Push pt_regs — save all user registers */
+    pushq   $__USER_DS                  /* ss */
+    pushq   PER_CPU_VAR(cpu_tss_rw + TSS_sp2)  /* rsp */
+    pushq   %r11                        /* rflags */
+    pushq   $__USER_CS                  /* cs */
+    pushq   %rcx                        /* rip */
+    pushq   %rax                        /* syscall number (orig_rax) */
+    PUSH_AND_CLEAR_REGS rax=$-ENOSYS    /* rax=-ENOSYS as default return */
+
+    /* ... (IBRS mitigation, context tracking) ... */
+
+    movq    %rax, %rdi                  /* syscall number as first arg */
+    movq    %rsp, %rsi                  /* pt_regs pointer */
+    call    do_syscall_64
+    /* ... return path ... */
+SYM_CODE_END(entry_SYSCALL_64)
+```
+
+## struct pt_regs: saved register state
+
+```c
+/* arch/x86/include/asm/ptrace.h */
+struct pt_regs {
+    unsigned long r15;
+    unsigned long r14;
+    unsigned long r13;
+    unsigned long r12;
+    unsigned long rbp;
+    unsigned long rbx;
+    unsigned long r11;
+    unsigned long r10;
+    unsigned long r9;
+    unsigned long r8;
+    unsigned long rax;      /* syscall number / return value */
+    unsigned long rcx;      /* saved rip (from syscall instruction) */
+    unsigned long rdx;
+    unsigned long rsi;
+    unsigned long rdi;
+    unsigned long orig_rax; /* original syscall number (rax before call) */
+    unsigned long rip;      /* userspace instruction pointer */
+    unsigned long cs;
+    unsigned long eflags;
+    unsigned long rsp;      /* userspace stack pointer */
+    unsigned long ss;
+};
+```
+
+## do_syscall_64: the dispatch
+
+```c
+/* arch/x86/entry/common.c */
+__visible noinstr void do_syscall_64(struct pt_regs *regs, int nr)
+{
+    add_random_kstack_offset();
+    nr = syscall_enter_from_user_mode(regs, nr);
+
+    instrumentation_begin();
+
+    if (!do_syscall_x64(regs, nr) && !do_syscall_x32(regs, nr) && nr != -1) {
+        /* syscall number out of range */
+        regs->ax = __x64_sys_ni_syscall(regs);  /* -ENOSYS */
+    }
+
+    instrumentation_end();
+    syscall_exit_to_user_mode(regs);
+}
+
+static __always_inline bool do_syscall_x64(struct pt_regs *regs, int nr)
+{
+    unsigned int unr = nr;
+
+    if (likely(unr < NR_syscalls)) {
+        unr = array_index_nospec(unr, NR_syscalls);  /* Spectre mitigation */
+        regs->ax = sys_call_table[unr](regs);         /* dispatch! */
+        return true;
+    }
+    return false;
+}
+```
+
+## sys_call_table: the dispatch table
+
+```c
+/* arch/x86/entry/syscall_64.c */
+asmlinkage const sys_call_ptr_t sys_call_table[] = {
+#include <asm/syscalls_64.h>
+};
+```
+
+The `syscalls_64.h` is generated from `syscall_64.tbl`:
+
+```
+# syscall_64.tbl (arch/x86/entry/syscalls/syscall_64.tbl)
+# <number> <abi>  <name>           <entry point>
+0          common  read              sys_read
+1          common  write             sys_write
+2          common  open              sys_open
+3          common  close             sys_close
+...
+62         common  kill              sys_kill
+...
+435        common  clone3            sys_clone3
+```
+
+## Argument passing and copying
+
+Syscall arguments come in registers. For pointers into userspace, the kernel must **copy** them in — it can never directly dereference a userspace pointer:
+
+```c
+/* Copying from userspace */
+copy_from_user(kernel_buf, user_ptr, size)
+    → check_access_ok(user_ptr, size)  /* is address in user range? */
+    → __copy_from_user()               /* architecture-specific copy */
+    → returns bytes NOT copied (0 = success)
+
+/* Copying to userspace */
+copy_to_user(user_ptr, kernel_buf, size)
+
+/* Copying a string from userspace (stops at NUL or len) */
+strncpy_from_user(kernel_buf, user_ptr, max_len)
+
+/* Single value helpers (inlined, optimized) */
+get_user(x, user_ptr)   /* x = *user_ptr */
+put_user(x, user_ptr)   /* *user_ptr = x */
+```
+
+Why mandatory copies?
+- User pointers might be NULL or invalid
+- Kernel and user address spaces are separate (KPTI)
+- Userspace can change the pointed-to memory after the check (TOCTOU)
+
+## KPTI and CR3 switching
+
+Kernel Page Table Isolation (KPTI) prevents Meltdown by using different page tables in user mode vs kernel mode:
+
+```
+User mode:  CR3 → user page tables (kernel not mapped, only entry stubs)
+                  ↓ syscall instruction
+Kernel mode: SWITCH_TO_KERNEL_CR3 (expensive TLB flush!)
+             CR3 → kernel page tables (full mapping)
+                  ↓ sysretq / swapgs
+User mode:  SWITCH_TO_USER_CR3
+```
+
+On modern CPUs with PCID support, KPTI uses Process Context IDs to avoid full TLB flushes, keeping each address space's TLB entries tagged.
+
+## The vDSO: avoiding syscalls for fast operations
+
+Some syscalls are called millions of times per second (e.g., `gettimeofday`, `clock_gettime`). The kernel exports a virtual Dynamic Shared Object (vDSO) — a small piece of code mapped into every process — that implements these without entering kernel mode:
+
+```bash
+# See the vDSO mapped in a process
+cat /proc/self/maps | grep vdso
+# 7fff12345000-7fff12346000 r-xp 00000000 00:00 0  [vdso]
+
+# Functions in the vDSO
+nm /proc/self/maps  # doesn't work, but:
+objdump -T /lib/x86_64-linux-gnu/vdso.so.1 2>/dev/null | grep -i clock
+```
+
+The vDSO reads kernel timekeeping data from a shared memory page (`vvar`) that the kernel updates atomically. The vDSO function reads the data directly, with no privilege switch:
+
+```c
+/* vDSO: arch/x86/entry/vdso/vclock_gettime.c */
+static __always_inline int
+do_hres(const struct vdso_data *vd, clockid_t clk,
+        struct __kernel_timespec *ts)
+{
+    const struct vdso_timestamp *vdso_ts = &vd->basetime[clk];
+    u64 cycles, last, sec, ns;
+    u32 seq;
+
+    do {
+        seq = vdso_read_begin(vd);     /* seqlock read_begin */
+        cycles = vdso_cycles();        /* read TSC (no syscall) */
+        ns = vdso_ts->nsec;
+        last = vd->cycle_last;
+        if (unlikely((s64)(cycles - last) < 0))
+            return clock_gettime_fallback(clk, ts);
+        ns += vdso_calc_delta(cycles, last, vd->mask, vd->mult);
+        ns >>= vd->shift;
+        sec = vdso_ts->sec;
+    } while (unlikely(vdso_read_retry(vd, seq)));  /* seqlock retry */
+
+    ts->tv_sec  = sec + __iter_div_u64_rem(ns, NSEC_PER_SEC, &ns);
+    ts->tv_nsec = ns;
+    return 0;
+}
+```
+
+Syscalls fast-pathed through the vDSO (no ring switch):
+- `clock_gettime(CLOCK_REALTIME/MONOTONIC/...)`
+- `gettimeofday()`
+- `clock_getres()`
+- `getcpu()`
+
+## Seccomp: restricting syscalls
+
+The seccomp filter runs on every syscall before the dispatch table:
+
+```c
+/* kernel/seccomp.c: in syscall_enter_from_user_mode() */
+if (unlikely(task_work_pending(current)))
+    task_work_run();
+
+if (unlikely(test_thread_flag(TIF_SECCOMP))) {
+    u32 action = seccomp_run_filters(nr, &match);
+    /* action can be: ALLOW, KILL, ERRNO, TRACE, LOG, TRAP */
+}
+```
+
+## Signals and restarts
+
+Some syscalls can be interrupted by signals (`EINTR`). The kernel supports automatic restart for these:
+
+```c
+/* ERESTARTSYS: restart if no signal handler, return EINTR if one */
+return -ERESTARTSYS;
+
+/* ERESTARTNOINTR: always restart, transparent to userspace */
+return -ERESTARTNOINTR;
+
+/* ERESTARTNOHAND: restart if no handler installed */
+return -ERESTARTNOHAND;
+```
+
+These special codes (`< -MAX_ERRNO`) never reach userspace — the signal path converts them to either `EINTR` or re-queues the syscall.
+
+## Further reading
+
+- [SYSCALL_DEFINE and dispatch](syscall-define.md) — Defining syscalls in C
+- [Adding a new syscall](adding-syscall.md) — Practical guide for kernel contributors
+- `arch/x86/entry/entry_64.S` — Assembly entry point
+- `arch/x86/entry/common.c` — do_syscall_64()
+- `Documentation/process/adding-syscalls.rst` — kernel documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -275,3 +275,8 @@ nav:
     - Resource Controllers: cgroups/cgroup-controllers.md
     - Namespaces: cgroups/namespaces.md
     - Container Isolation: cgroups/container-isolation.md
+  - System Calls:
+    - Getting Started: syscalls/README.md
+    - Syscall Entry Path: syscalls/syscall-entry.md
+    - SYSCALL_DEFINE and Dispatch: syscalls/syscall-define.md
+    - Adding a New Syscall: syscalls/adding-syscall.md


### PR DESCRIPTION
## Summary

- **Syscall entry path** (`syscall-entry.md`): `entry_SYSCALL_64` assembly (swapgs, kernel stack switch, pt_regs save), `do_syscall_64` dispatch with Spectre `array_index_nospec`, `copy_from_user` and why userspace pointer derefs are forbidden, KPTI CR3 switching with PCID, vDSO (clock_gettime seqlock-based shared memory, no ring switch), seccomp filter in syscall path, EINTR/ERESTARTSYS restart semantics
- **SYSCALL_DEFINE and dispatch** (`syscall-define.md`): macro expansion to `__x64_sys_*`/`__do_sys_*`, `ksys_` wrapper pattern for in-kernel calls, syscall_64.tbl format and code generation, ABI stability rules, struct-based versioned syscalls with `copy_struct_from_user`, compat syscalls for 32-bit, tracepoints and audit hooks, `TIF_*` flags checked on syscall exit
- **Adding a new syscall** (`adding-syscall.md`): complete walkthrough (SYSCALL_DEFINE2, UAPI struct rules, syscall table entries, build system, selftests), common mistakes (implicit padding, using non-`__u*` types, missing capability checks, direct userspace pointer deref)

Closes #286, #287

## Test plan

- [ ] All 4 pages render in mkdocs
- [ ] Code blocks are syntactically correct C
- [ ] Cross-links work