### PR TITLE
Add device drivers documentation

### DIFF
--- a/docs/drivers/README.md
+++ b/docs/drivers/README.md
@@ -1,0 +1,60 @@
+# Device Drivers
+
+> How hardware becomes accessible to userspace
+
+## Overview
+
+Device drivers bridge hardware and the rest of the kernel. The Linux driver model organizes this with:
+
+- **Devices** (`struct device`) — represent hardware or logical devices
+- **Buses** (`struct bus_type`) — communication channel (PCI, USB, I2C, platform)
+- **Drivers** (`struct device_driver`) — code that handles a specific device
+- **Classes** (`struct class`) — groups of devices with similar behavior (e.g., "input", "net")
+
+```
+sysfs (/sys/bus/pci/devices/0000:00:1f.2)
+         │
+         ▼
+struct device ←────── struct pci_dev (bus-specific extension)
+         │
+    bus_type.match()
+         │
+         ▼
+struct device_driver ←── struct pci_driver (driver-specific extension)
+         │
+    driver.probe()
+         │
+         ▼
+    Hardware
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Linux Device Model](device-model.md) | struct device, bus, driver, kobject, sysfs |
+| [Platform Drivers](platform-driver.md) | Platform bus, probe/remove, devm_, device tree |
+| [Character and Misc Devices](chardev.md) | cdev, file_operations, ioctl, mmap from driver side |
+
+## Quick reference
+
+```bash
+# List all devices and their drivers
+ls /sys/bus/pci/devices/
+ls /sys/bus/platform/devices/
+
+# See driver for a device
+cat /sys/bus/pci/devices/0000:00:1f.2/driver/module/name
+
+# Load a kernel module
+modprobe e1000e
+lsmod | grep e1000
+
+# Bind/unbind a driver manually
+echo "0000:00:1f.2" > /sys/bus/pci/drivers/ahci/unbind
+echo "0000:00:1f.2" > /sys/bus/pci/drivers/ahci/bind
+
+# Character device major/minor
+ls -la /dev/null /dev/random
+# crw-rw-rw- 1 root root 1, 3 ... /dev/null  ← major=1, minor=3
+```

--- a/docs/drivers/chardev.md
+++ b/docs/drivers/chardev.md
@@ -1,0 +1,409 @@
+# Character and Misc Devices
+
+> Exposing driver functionality to userspace via /dev
+
+## Character devices
+
+A character device (cdev) is a special file in `/dev` that provides a byte-stream interface to a driver. Unlike block devices, character devices do not buffer data in the page cache — I/O goes directly to the driver.
+
+```
+/dev/mydevice (major=240, minor=0)
+        │
+        ▼
+ struct cdev ────────► struct file_operations
+        │                   .open
+        │                   .read
+        │                   .write
+        │                   .unlocked_ioctl
+        │                   .mmap
+        │                   .release
+        ▼
+   driver code
+```
+
+## Allocating major/minor numbers
+
+```c
+/* Static allocation (reserved in Documentation/admin-guide/devices.txt) */
+int ret = register_chrdev_region(MKDEV(240, 0), 1, "mydev");
+
+/* Dynamic allocation (preferred): kernel assigns major */
+dev_t devt;
+int ret = alloc_chrdev_region(&devt, 0, /* first minor */
+                               1,        /* count */
+                               "mydev");
+int major = MAJOR(devt);
+int minor = MINOR(devt);
+
+/* Release on exit */
+unregister_chrdev_region(devt, 1);
+```
+
+## struct cdev
+
+```c
+#include <linux/cdev.h>
+
+struct cdev {
+    struct kobject          kobj;
+    struct module          *owner;
+    const struct file_operations *ops;
+    struct list_head        list;
+    dev_t                   dev;         /* major:minor */
+    unsigned int            count;       /* number of minors */
+};
+```
+
+## struct file_operations
+
+```c
+/* include/linux/fs.h */
+struct file_operations {
+    struct module *owner;
+    loff_t (*llseek)(struct file *, loff_t, int);
+    ssize_t (*read)(struct file *, char __user *, size_t, loff_t *);
+    ssize_t (*write)(struct file *, const char __user *, size_t, loff_t *);
+    ssize_t (*read_iter)(struct kiocb *, struct iov_iter *);  /* preferred */
+    ssize_t (*write_iter)(struct kiocb *, struct iov_iter *);
+    int (*iopoll)(struct kiocb *, struct io_comp_batch *, unsigned int flags);
+    int (*iterate_shared)(struct file *, struct dir_context *);
+    __poll_t (*poll)(struct file *, struct poll_table_struct *);
+    long (*unlocked_ioctl)(struct file *, unsigned int, unsigned long);
+    long (*compat_ioctl)(struct file *, unsigned int, unsigned long);
+    int (*mmap)(struct file *, struct vm_area_struct *);
+    int (*open)(struct inode *, struct file *);
+    int (*flush)(struct file *, fl_owner_t id);
+    int (*release)(struct inode *, struct file *);
+    int (*fsync)(struct file *, loff_t, loff_t, int datasync);
+    int (*fasync)(int, struct file *, int);
+    /* ... */
+};
+```
+
+## A complete minimal character driver
+
+```c
+/* drivers/mychardev/mychardev.c */
+#include <linux/module.h>
+#include <linux/cdev.h>
+#include <linux/fs.h>
+#include <linux/uaccess.h>
+#include <linux/slab.h>
+
+#define DEVICE_NAME "mychardev"
+#define BUF_SIZE    4096
+
+struct mychardev {
+    struct cdev cdev;
+    char    *buf;
+    size_t   buf_len;
+    struct mutex lock;
+};
+
+static struct mychardev mydev;
+static dev_t devt;
+
+static int mydev_open(struct inode *inode, struct file *filp)
+{
+    /* Store per-file state in filp->private_data if needed */
+    struct mychardev *dev = container_of(inode->i_cdev,
+                                          struct mychardev, cdev);
+    filp->private_data = dev;
+    return 0;
+}
+
+static ssize_t mydev_read(struct file *filp, char __user *buf,
+                           size_t count, loff_t *ppos)
+{
+    struct mychardev *dev = filp->private_data;
+    ssize_t ret;
+
+    mutex_lock(&dev->lock);
+
+    if (*ppos >= dev->buf_len) {
+        ret = 0;  /* EOF */
+        goto out;
+    }
+
+    count = min(count, dev->buf_len - (size_t)*ppos);
+    if (copy_to_user(buf, dev->buf + *ppos, count)) {
+        ret = -EFAULT;
+        goto out;
+    }
+
+    *ppos += count;
+    ret = count;
+
+out:
+    mutex_unlock(&dev->lock);
+    return ret;
+}
+
+static ssize_t mydev_write(struct file *filp, const char __user *buf,
+                            size_t count, loff_t *ppos)
+{
+    struct mychardev *dev = filp->private_data;
+    ssize_t ret;
+
+    if (count > BUF_SIZE)
+        return -EINVAL;
+
+    mutex_lock(&dev->lock);
+
+    if (copy_from_user(dev->buf, buf, count)) {
+        ret = -EFAULT;
+        goto out;
+    }
+
+    dev->buf_len = count;
+    *ppos = 0;
+    ret = count;
+
+out:
+    mutex_unlock(&dev->lock);
+    return ret;
+}
+
+static int mydev_release(struct inode *inode, struct file *filp)
+{
+    return 0;
+}
+
+static const struct file_operations mydev_fops = {
+    .owner   = THIS_MODULE,
+    .open    = mydev_open,
+    .read    = mydev_read,
+    .write   = mydev_write,
+    .release = mydev_release,
+    .llseek  = default_llseek,  /* uses f_pos */
+};
+
+static int __init mydev_init(void)
+{
+    int ret;
+
+    /* Allocate device number */
+    ret = alloc_chrdev_region(&devt, 0, 1, DEVICE_NAME);
+    if (ret)
+        return ret;
+
+    /* Allocate and initialize cdev */
+    cdev_init(&mydev.cdev, &mydev_fops);
+    mydev.cdev.owner = THIS_MODULE;
+
+    /* Allocate buffer */
+    mydev.buf = kzalloc(BUF_SIZE, GFP_KERNEL);
+    if (!mydev.buf) {
+        unregister_chrdev_region(devt, 1);
+        return -ENOMEM;
+    }
+
+    mutex_init(&mydev.lock);
+
+    /* Register cdev — after this, open() can be called */
+    ret = cdev_add(&mydev.cdev, devt, 1);
+    if (ret) {
+        kfree(mydev.buf);
+        unregister_chrdev_region(devt, 1);
+        return ret;
+    }
+
+    pr_info("mychardev: major=%d minor=%d\n", MAJOR(devt), MINOR(devt));
+    return 0;
+}
+
+static void __exit mydev_exit(void)
+{
+    cdev_del(&mydev.cdev);
+    kfree(mydev.buf);
+    unregister_chrdev_region(devt, 1);
+}
+
+module_init(mydev_init);
+module_exit(mydev_exit);
+MODULE_LICENSE("GPL");
+```
+
+```bash
+# After loading the module:
+mknod /dev/mychardev c $(cat /sys/class/mychardev/mychardev/dev | cut -d: -f1) \
+                      $(cat /sys/class/mychardev/mychardev/dev | cut -d: -f2)
+# Or use class/device to auto-create with udev
+echo "hello" > /dev/mychardev
+cat /dev/mychardev  # → hello
+```
+
+## misc_register: the easy path
+
+For simple devices that don't need multiple minors, `misc_register` handles major/minor allocation and class creation automatically:
+
+```c
+#include <linux/miscdevice.h>
+
+static struct miscdevice mymisc = {
+    .minor = MISC_DYNAMIC_MINOR,   /* kernel assigns minor */
+    .name  = "mymisc",             /* /dev/mymisc */
+    .fops  = &mydev_fops,
+};
+
+static int __init mymisc_init(void)
+{
+    return misc_register(&mymisc);
+    /* /dev/mymisc created automatically via udev */
+}
+
+static void __exit mymisc_exit(void)
+{
+    misc_deregister(&mymisc);
+}
+```
+
+All misc devices share major number 10. They appear under `/sys/class/misc/`.
+
+## ioctl: control operations
+
+ioctl lets userspace send control commands to the driver:
+
+```c
+/* In driver: */
+static long mydev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+{
+    struct mydev_query query;
+
+    switch (cmd) {
+    case MYDEV_IOCTL_RESET:
+        reset_hardware();
+        return 0;
+
+    case MYDEV_IOCTL_QUERY:
+        /* Copy struct to/from userspace */
+        if (copy_from_user(&query, (void __user *)arg, sizeof(query)))
+            return -EFAULT;
+        query.result = do_query(query.param);
+        if (copy_to_user((void __user *)arg, &query, sizeof(query)))
+            return -EFAULT;
+        return 0;
+
+    default:
+        return -ENOTTY;  /* unknown ioctl */
+    }
+}
+```
+
+ioctl numbers use a structured format to avoid conflicts:
+
+```c
+/* include/uapi/linux/mydev.h */
+#include <linux/ioctl.h>
+
+/* _IO(type, nr)          — no argument */
+/* _IOR(type, nr, dtype)  — read from kernel */
+/* _IOW(type, nr, dtype)  — write to kernel */
+/* _IOWR(type, nr, dtype) — read+write */
+
+#define MYDEV_MAGIC 'M'
+#define MYDEV_IOCTL_RESET  _IO(MYDEV_MAGIC, 0)
+#define MYDEV_IOCTL_QUERY  _IOWR(MYDEV_MAGIC, 1, struct mydev_query)
+```
+
+```c
+/* Userspace: */
+int fd = open("/dev/mydev", O_RDWR);
+ioctl(fd, MYDEV_IOCTL_RESET);
+ioctl(fd, MYDEV_IOCTL_QUERY, &query);
+```
+
+## mmap: mapping device memory to userspace
+
+Drivers can let userspace map device memory or kernel buffers directly:
+
+```c
+static int mydev_mmap(struct file *filp, struct vm_area_struct *vma)
+{
+    struct mychardev *dev = filp->private_data;
+    unsigned long size = vma->vm_end - vma->vm_start;
+
+    if (size > BUF_SIZE)
+        return -EINVAL;
+
+    /* Map kernel buffer to userspace */
+    return remap_pfn_range(vma,
+        vma->vm_start,
+        virt_to_phys(dev->buf) >> PAGE_SHIFT,
+        size,
+        vma->vm_page_prot);
+}
+
+/* For device I/O memory (e.g., PCI BAR): */
+static int mydev_mmap_io(struct file *filp, struct vm_area_struct *vma)
+{
+    unsigned long phys = dev->bar_phys + (vma->vm_pgoff << PAGE_SHIFT);
+    unsigned long size = vma->vm_end - vma->vm_start;
+
+    /* Mark as non-cacheable for device registers */
+    vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+
+    return remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
+                           size, vma->vm_page_prot);
+}
+```
+
+```c
+/* Userspace: */
+void *mapped = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+/* Access device memory directly: */
+volatile uint32_t *reg = (volatile uint32_t *)mapped;
+uint32_t val = *reg;
+```
+
+## poll/select support
+
+```c
+static __poll_t mydev_poll(struct file *filp, poll_table *wait)
+{
+    struct mychardev *dev = filp->private_data;
+    __poll_t mask = 0;
+
+    poll_wait(filp, &dev->read_queue, wait);
+
+    if (dev->data_available)
+        mask |= EPOLLIN | EPOLLRDNORM;
+    if (dev->write_space)
+        mask |= EPOLLOUT | EPOLLWRNORM;
+
+    return mask;
+}
+```
+
+## struct device integration
+
+To get a proper `/sys/class/` entry and auto-create `/dev/`:
+
+```c
+static struct class *mydev_class;
+
+static int __init mydev_init(void)
+{
+    /* ... alloc_chrdev_region, cdev_init, cdev_add ... */
+
+    /* Create /sys/class/mydev/ */
+    mydev_class = class_create(THIS_MODULE, "mydev");
+    if (IS_ERR(mydev_class))
+        goto err_class;
+
+    /* Create /sys/class/mydev/mydev0/ and trigger udev → /dev/mydev0 */
+    device_create(mydev_class, NULL, devt, NULL, "mydev%d", 0);
+
+    return 0;
+
+err_class:
+    /* cleanup */
+}
+```
+
+## Further reading
+
+- [Linux Device Model](device-model.md) — struct device, class, kobject
+- [Platform Drivers](platform-driver.md) — devm_ resource management
+- [VFS: File Operations](../vfs/file-ops.md) — How open/read/write reach the driver
+- `Documentation/driver-api/miscellaneous_devices.rst`

--- a/docs/drivers/device-model.md
+++ b/docs/drivers/device-model.md
@@ -1,0 +1,324 @@
+# Linux Device Model
+
+> The object-oriented framework that organizes all kernel devices
+
+## Why the device model exists
+
+Before 2.6, each bus subsystem (PCI, USB, SCSI) independently managed power, hotplug, and sysfs. The device model (introduced in 2.5) unified this into a single framework:
+
+- **Power management**: suspend/resume traverse the device tree in order
+- **Hotplug**: consistent uevent notifications for adding/removing devices
+- **sysfs**: every device and driver automatically appears in `/sys/`
+- **Reference counting**: devices live exactly as long as they're needed
+
+## kobject: the base object
+
+Every kernel object that appears in sysfs has a `kobject`:
+
+```c
+/* include/linux/kobject.h */
+struct kobject {
+    const char          *name;        /* directory name in sysfs */
+    struct list_head     entry;       /* list of siblings */
+    struct kobject      *parent;      /* parent in sysfs hierarchy */
+    struct kset         *kset;        /* containing set */
+    const struct kobj_type *ktype;    /* type with sysfs ops */
+    struct kernfs_node  *sd;          /* sysfs directory node */
+    struct kref          kref;        /* reference count */
+    unsigned int state_initialized:1;
+    unsigned int state_in_sysfs:1;
+    unsigned int state_add_uevent_sent:1;
+    unsigned int state_remove_uevent_sent:1;
+    unsigned int uevent_suppress:1;
+};
+```
+
+Reference counting:
+```c
+kobject_get(kobj);    /* increment refcount */
+kobject_put(kobj);    /* decrement; calls ktype->release() when zero */
+```
+
+## struct device: the universal device
+
+```c
+/* include/linux/device.h */
+struct device {
+    struct kobject          kobj;          /* base kobject — first field */
+    struct device           *parent;       /* parent device */
+    struct device_private   *p;            /* private driver core data */
+
+    const char              *init_name;    /* initial device name */
+    const struct device_type *type;        /* device type */
+
+    struct bus_type         *bus;          /* bus this device is on */
+    struct device_driver    *driver;       /* driver assigned to device */
+    void                    *driver_data;  /* driver-private data */
+
+    struct dev_links_info   links;         /* supplier/consumer links */
+    struct dev_pm_info      power;         /* power management state */
+    struct dev_pm_domain    *pm_domain;
+
+    struct device_node      *of_node;      /* device tree node */
+    struct fwnode_handle    *fwnode;       /* firmware node (DT or ACPI) */
+
+    dev_t                   devt;          /* major:minor (if applicable) */
+    struct class            *class;        /* class (input, block, net...) */
+
+    const struct attribute_group **groups; /* sysfs attribute groups */
+    void (*release)(struct device *dev);   /* called when refcount hits 0 */
+
+    struct iommu_group      *iommu_group;
+    /* ... */
+};
+```
+
+Key operations:
+```c
+device_initialize(dev);          /* initialize kobject */
+device_add(dev);                 /* register in sysfs, send uevent */
+device_register(dev);            /* = initialize + add */
+device_unregister(dev);          /* remove from sysfs */
+
+device_get(dev);                 /* get reference */
+put_device(dev);                 /* release reference */
+
+dev_set_drvdata(dev, data);      /* store driver-private pointer */
+dev_get_drvdata(dev);            /* retrieve it */
+```
+
+## struct bus_type: the bus abstraction
+
+```c
+struct bus_type {
+    const char          *name;          /* "pci", "usb", "platform", "i2c" */
+    const char          *dev_name;      /* format for auto-named devices */
+    struct device       *dev_root;      /* bus root device */
+
+    const struct attribute_group **bus_groups;
+    const struct attribute_group **dev_groups;
+    const struct attribute_group **drv_groups;
+
+    /* Called to see if a driver handles this device */
+    int (*match)(struct device *dev, struct device_driver *drv);
+    /* Called by userspace write to /sys/.../uevent */
+    int (*uevent)(struct device *dev, struct kobj_uevent_env *env);
+    /* Called when a device is about to be bound to a driver */
+    int (*probe)(struct device *dev);
+    /* Ordered device listing for PM */
+    int (*remove)(struct device *dev);
+    void (*shutdown)(struct device *dev);
+
+    int (*online)(struct device *dev);
+    int (*offline)(struct device *dev);
+
+    int (*suspend)(struct device *dev, pm_message_t state);
+    int (*resume)(struct device *dev);
+
+    int (*num_vf)(struct device *dev);
+    int (*dma_configure)(struct device *dev);
+    void (*dma_cleanup)(struct device *dev);
+
+    const struct dev_pm_ops *pm;
+    const struct iommu_ops  *iommu_ops;
+    struct subsys_private   *p;         /* private bus core data */
+    struct lock_class_key   lock_key;
+    bool need_parent_lock;
+};
+```
+
+```c
+/* Register a bus type */
+int bus_register(struct bus_type *bus);
+void bus_unregister(struct bus_type *bus);
+
+/* Iterate over devices on a bus */
+bus_for_each_dev(bus, start, data, fn);
+bus_for_each_drv(bus, start, data, fn);
+```
+
+## struct device_driver
+
+```c
+struct device_driver {
+    const char              *name;         /* driver name */
+    struct bus_type         *bus;
+    struct module           *owner;        /* THIS_MODULE */
+    const char              *mod_name;
+
+    bool                     suppress_bind_attrs;
+    enum probe_type          probe_type;   /* synchronous, async, force_sync */
+
+    const struct of_device_id   *of_match_table; /* device tree matches */
+    const struct acpi_device_id *acpi_match_table;
+
+    int (*probe)(struct device *dev);      /* bind driver to device */
+    void (*sync_state)(struct device *dev);
+    int (*remove)(struct device *dev);     /* unbind */
+    void (*shutdown)(struct device *dev);
+    int (*suspend)(struct device *dev, pm_message_t state);
+    int (*resume)(struct device *dev);
+    const struct attribute_group **groups;
+    const struct attribute_group **dev_groups;
+
+    const struct dev_pm_ops *pm;
+    void (*coredump)(struct device *dev);
+
+    struct driver_private *p;
+};
+```
+
+## The match and probe flow
+
+When a device is registered (or a driver is registered), the bus iterates all drivers (or devices) calling `bus->match()`. On a match, `driver_probe_device()` is called:
+
+```c
+/* drivers/base/dd.c: simplified */
+static int driver_probe_device(struct device_driver *drv, struct device *dev)
+{
+    int ret;
+
+    /* Check if already bound */
+    if (dev->driver)
+        return 0;
+
+    /* bus-level permission check */
+    if (drv->bus->match && !drv->bus->match(dev, drv))
+        return 0;
+
+    /* pin device and driver */
+    dev->driver = drv;
+
+    /* call bus probe (which usually calls driver->probe) */
+    if (dev->bus->probe)
+        ret = dev->bus->probe(dev);
+    else if (drv->probe)
+        ret = drv->probe(dev);
+
+    if (ret) {
+        dev->driver = NULL;
+        return ret;
+    }
+
+    /* success: device is now bound */
+    driver_bound(dev);
+    return 0;
+}
+```
+
+## sysfs attributes
+
+Drivers and devices expose attributes (files) in sysfs:
+
+```c
+/* Simple device attribute */
+static ssize_t temperature_show(struct device *dev,
+                                 struct device_attribute *attr,
+                                 char *buf)
+{
+    struct my_device *mydev = dev_get_drvdata(dev);
+    return sysfs_emit(buf, "%d\n", read_temperature(mydev));
+}
+
+static ssize_t setpoint_store(struct device *dev,
+                               struct device_attribute *attr,
+                               const char *buf, size_t count)
+{
+    struct my_device *mydev = dev_get_drvdata(dev);
+    int val;
+
+    if (kstrtoint(buf, 10, &val) < 0)
+        return -EINVAL;
+    set_setpoint(mydev, val);
+    return count;
+}
+
+/* DEVICE_ATTR_RO: read-only, name = "temperature" */
+static DEVICE_ATTR_RO(temperature);
+
+/* DEVICE_ATTR_WO: write-only */
+/* DEVICE_ATTR_RW: read-write */
+static DEVICE_ATTR_RW(setpoint);
+
+/* Group them */
+static struct attribute *mydev_attrs[] = {
+    &dev_attr_temperature.attr,
+    &dev_attr_setpoint.attr,
+    NULL,
+};
+ATTRIBUTE_GROUPS(mydev);  /* creates mydev_groups[] */
+
+/* In driver probe: */
+device_add_groups(dev, mydev_groups);
+```
+
+```bash
+# Result in sysfs
+cat /sys/bus/platform/devices/mydev.0/temperature
+# 45
+echo 50 > /sys/bus/platform/devices/mydev.0/setpoint
+```
+
+## uevent: hotplug notification
+
+When devices are added/removed, the kernel sends uevents to userspace (received by `udevd`/`systemd-udevd`):
+
+```bash
+# Watch uevents live
+udevadm monitor --kernel --udev
+
+# KERNEL: add@/devices/pci0000:00/0000:00:14.0/usb1/1-1
+# ACTION=add
+# DEVPATH=/devices/pci0000:00/...
+# SUBSYSTEM=usb
+# ...
+
+# Rule to rename a network interface
+# /etc/udev/rules.d/70-persistent-net.rules:
+# SUBSYSTEM=="net", ACTION=="add", ATTR{address}=="aa:bb:cc:dd:ee:ff", NAME="eth0"
+```
+
+The kernel's `kobject_uevent()` sends netlink messages; udevd receives them and runs rules.
+
+## Power management: dev_pm_ops
+
+```c
+static const struct dev_pm_ops my_pm_ops = {
+    .suspend  = my_suspend,   /* save state, reduce power */
+    .resume   = my_resume,    /* restore state */
+    .freeze   = my_freeze,    /* for hibernation snapshot */
+    .thaw     = my_thaw,
+    .restore  = my_restore,
+    /* Runtime PM: */
+    .runtime_suspend = my_runtime_suspend,  /* auto-suspend when idle */
+    .runtime_resume  = my_runtime_resume,
+};
+
+/* In driver: */
+static int my_suspend(struct device *dev)
+{
+    struct my_device *mydev = dev_get_drvdata(dev);
+    /* save registers, turn off clocks, etc. */
+    return 0;
+}
+```
+
+```c
+/* Enable runtime PM for a device */
+pm_runtime_enable(dev);
+pm_runtime_set_active(dev);
+pm_runtime_use_autosuspend(dev);
+pm_runtime_set_autosuspend_delay(dev, 1000);  /* 1 second idle → suspend */
+
+/* In device operations: */
+pm_runtime_get_sync(dev);   /* increment usage count, resume if suspended */
+/* ... use device ... */
+pm_runtime_put_autosuspend(dev);  /* decrement, autosuspend timer starts */
+```
+
+## Further reading
+
+- [Platform Drivers](platform-driver.md) — The most common embedded driver pattern
+- [Character and Misc Devices](chardev.md) — Exposing devices to userspace via /dev
+- `Documentation/driver-api/driver-model/` — kernel driver model documentation
+- `drivers/base/` — core device model implementation

--- a/docs/drivers/platform-driver.md
+++ b/docs/drivers/platform-driver.md
@@ -1,0 +1,329 @@
+# Platform Drivers
+
+> The most common driver pattern for embedded and SoC devices
+
+## What platform devices are
+
+Platform devices are devices that are not discoverable by hardware (unlike PCI or USB). They are instantiated via:
+- **Device tree** (ARM, RISC-V, embedded)
+- **ACPI** (x86, modern ARM servers)
+- **Board files** (old ARM, legacy)
+
+Examples: UARTs, I2C controllers, GPIO controllers, clocks — hardware that's wired onto the SoC and can't be dynamically probed.
+
+## struct platform_driver
+
+```c
+/* include/linux/platform_device.h */
+struct platform_driver {
+    int (*probe)(struct platform_device *);   /* device found, bind driver */
+    int (*remove)(struct platform_device *);  /* device removed, unbind */
+    void (*shutdown)(struct platform_device *);
+    int (*suspend)(struct platform_device *, pm_message_t state);
+    int (*resume)(struct platform_device *);
+    struct device_driver driver;              /* embedded generic driver */
+    const struct platform_device_id *id_table; /* legacy ID matching */
+    bool prevent_deferred_probe;
+    bool driver_managed_dma;
+};
+
+struct platform_device {
+    const char      *name;           /* for legacy matching */
+    int              id;             /* appended to name: "serial.0" */
+    struct device    dev;            /* embedded generic device */
+    u32              num_resources;
+    struct resource *resource;       /* I/O memory, IRQ, etc. */
+    const struct platform_device_id *id_entry;
+    const char      *driver_override; /* force specific driver */
+    struct mfd_cell *mfd_cell;
+    struct pdev_archdata archdata;
+};
+```
+
+## A minimal platform driver
+
+```c
+/* drivers/mydriver/mydriver.c */
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/io.h>
+#include <linux/interrupt.h>
+#include <linux/clk.h>
+
+struct mydev {
+    void __iomem    *base;    /* mapped register base */
+    struct clk      *clk;
+    int              irq;
+};
+
+/* IRQ handler */
+static irqreturn_t mydev_irq(int irq, void *data)
+{
+    struct mydev *dev = data;
+    u32 status = readl(dev->base + STATUS_REG);
+
+    if (!(status & MY_IRQ_BIT))
+        return IRQ_NONE;
+
+    /* handle interrupt */
+    writel(MY_IRQ_BIT, dev->base + STATUS_CLR_REG);
+    return IRQ_HANDLED;
+}
+
+static int mydev_probe(struct platform_device *pdev)
+{
+    struct mydev *dev;
+    struct resource *res;
+    int ret;
+
+    /* Allocate driver private data (devm: freed automatically on remove) */
+    dev = devm_kzalloc(&pdev->dev, sizeof(*dev), GFP_KERNEL);
+    if (!dev)
+        return -ENOMEM;
+
+    /* Map I/O memory from resource #0 */
+    dev->base = devm_platform_ioremap_resource(pdev, 0);
+    if (IS_ERR(dev->base))
+        return PTR_ERR(dev->base);
+
+    /* Get and enable clock */
+    dev->clk = devm_clk_get(&pdev->dev, "mydev_clk");
+    if (IS_ERR(dev->clk))
+        return PTR_ERR(dev->clk);
+
+    ret = clk_prepare_enable(dev->clk);
+    if (ret)
+        return ret;
+
+    /* Request IRQ */
+    dev->irq = platform_get_irq(pdev, 0);
+    if (dev->irq < 0)
+        return dev->irq;
+
+    ret = devm_request_irq(&pdev->dev, dev->irq, mydev_irq,
+                           IRQF_SHARED, "mydev", dev);
+    if (ret)
+        return ret;
+
+    /* Store driver data */
+    platform_set_drvdata(pdev, dev);
+
+    dev_info(&pdev->dev, "mydev initialized at %p, irq %d\n",
+             dev->base, dev->irq);
+    return 0;
+}
+
+static int mydev_remove(struct platform_device *pdev)
+{
+    struct mydev *dev = platform_get_drvdata(pdev);
+
+    /* devm resources freed automatically; only need to disable clock */
+    clk_disable_unprepare(dev->clk);
+    return 0;
+}
+
+/* Device tree match table */
+static const struct of_device_id mydev_of_match[] = {
+    { .compatible = "vendor,mydev-v1" },
+    { .compatible = "vendor,mydev-v2", .data = &mydev_v2_config },
+    { }  /* sentinel */
+};
+MODULE_DEVICE_TABLE(of, mydev_of_match);
+
+/* Legacy platform ID match (non-DT) */
+static const struct platform_device_id mydev_id_table[] = {
+    { "mydev", 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(platform, mydev_id_table);
+
+static struct platform_driver mydev_driver = {
+    .probe  = mydev_probe,
+    .remove = mydev_remove,
+    .id_table = mydev_id_table,
+    .driver = {
+        .name           = "mydev",
+        .of_match_table = mydev_of_match,
+        .pm             = &mydev_pm_ops,  /* optional */
+    },
+};
+
+module_platform_driver(mydev_driver);
+/* Expands to module_init/module_exit that call
+   platform_driver_register/unregister */
+
+MODULE_DESCRIPTION("Example platform driver");
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Example Author <author@example.com>");
+```
+
+## devm_: automatic resource management
+
+`devm_` (device-managed) functions bind resource lifetime to a `struct device`. When the device is unbound (removed), all `devm_` resources are freed in reverse registration order.
+
+```c
+/* Memory */
+devm_kzalloc(&dev, size, GFP_KERNEL)    /* freed on device removal */
+devm_kmalloc(&dev, size, GFP_KERNEL)
+
+/* I/O memory */
+devm_ioremap(&dev, phys_addr, size)
+devm_ioremap_resource(&dev, resource)
+devm_platform_ioremap_resource(pdev, index)  /* map resource by index */
+
+/* IRQ */
+devm_request_irq(&dev, irq, handler, flags, name, data)
+devm_request_threaded_irq(...)
+
+/* Clock */
+devm_clk_get(&dev, "clock-name")
+devm_clk_get_enabled(&dev, "clock-name")  /* get + enable in one call */
+
+/* GPIO */
+devm_gpiod_get(&dev, "reset", GPIOD_OUT_LOW)
+
+/* Regulator */
+devm_regulator_get(&dev, "vdd")
+
+/* DMA */
+devm_dma_request_chan(&dev, "tx")
+
+/* Register your own cleanup */
+devm_add_action(&dev, my_cleanup_fn, my_data);
+devm_add_action_or_reset(&dev, my_cleanup_fn, my_data);
+```
+
+### Why devm_ matters
+
+```c
+/* Without devm: error paths are a nightmare */
+static int probe(struct platform_device *pdev)
+{
+    dev->base = ioremap(res->start, resource_size(res));
+    if (!dev->base) { return -ENOMEM; }
+
+    ret = request_irq(irq, handler, 0, "dev", dev);
+    if (ret) {
+        iounmap(dev->base);  /* must undo ioremap */
+        return ret;
+    }
+
+    dev->clk = clk_get(&pdev->dev, "myclk");
+    if (IS_ERR(dev->clk)) {
+        free_irq(irq, dev);   /* must undo request_irq */
+        iounmap(dev->base);   /* must undo ioremap */
+        return PTR_ERR(dev->clk);
+    }
+    /* ... */
+}
+
+/* With devm: errors just return, devm handles cleanup */
+static int probe(struct platform_device *pdev)
+{
+    dev->base = devm_platform_ioremap_resource(pdev, 0);
+    if (IS_ERR(dev->base)) return PTR_ERR(dev->base);
+
+    ret = devm_request_irq(&pdev->dev, irq, handler, 0, "dev", dev);
+    if (ret) return ret;
+
+    dev->clk = devm_clk_get(&pdev->dev, "myclk");
+    if (IS_ERR(dev->clk)) return PTR_ERR(dev->clk);
+    /* ... */
+}
+```
+
+## Device tree binding
+
+The device tree describes hardware topology. Each node with a `compatible` property can be matched by a driver:
+
+```dts
+/* Example device tree node */
+/ {
+    soc {
+        mydev: mydev@10000000 {
+            compatible = "vendor,mydev-v1";
+            reg = <0x10000000 0x1000>;  /* I/O memory: base, size */
+            interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL_HIGH>;
+            clocks = <&ccu CLK_MYDEV>;
+            clock-names = "mydev_clk";
+            reset-gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+            status = "okay";
+        };
+    };
+};
+```
+
+The platform bus automatically creates a `platform_device` from this node when the kernel boots. The driver's `of_match_table` is compared against `compatible`.
+
+### Reading device tree properties
+
+```c
+static int mydev_probe(struct platform_device *pdev)
+{
+    struct device_node *np = pdev->dev.of_node;
+    u32 frequency;
+    bool active_high;
+
+    /* Read simple integer properties */
+    if (of_property_read_u32(np, "clock-frequency", &frequency))
+        frequency = 100000;  /* default */
+
+    /* Read boolean property */
+    active_high = of_property_read_bool(np, "active-high");
+
+    /* Get a named GPIO */
+    struct gpio_desc *reset_gpio = devm_gpiod_get(&pdev->dev, "reset",
+                                                   GPIOD_OUT_LOW);
+
+    /* Get compatible string data */
+    const struct mydev_config *cfg =
+        of_device_get_match_data(&pdev->dev);
+}
+```
+
+## Deferring probe
+
+If a resource isn't ready yet (e.g., a clock driver hasn't probed yet):
+
+```c
+static int mydev_probe(struct platform_device *pdev)
+{
+    dev->clk = devm_clk_get(&pdev->dev, "myclk");
+    if (IS_ERR(dev->clk)) {
+        if (PTR_ERR(dev->clk) == -EPROBE_DEFER)
+            return -EPROBE_DEFER;  /* retry later when clk is available */
+        return PTR_ERR(dev->clk);
+    }
+}
+```
+
+`-EPROBE_DEFER` tells the probe infrastructure to retry this driver once any other driver finishes probing.
+
+## Observing platform devices
+
+```bash
+# List platform devices
+ls /sys/bus/platform/devices/
+
+# See driver bound to a platform device
+cat /sys/bus/platform/devices/mydev.0/driver/module/name
+
+# See resources (I/O memory, IRQ)
+cat /sys/bus/platform/devices/mydev.0/resource
+# 0x10000000 0x10000fff 0x200  ← start end flags
+
+# Force rebind
+echo mydev.0 > /sys/bus/platform/drivers/mydev/unbind
+echo mydev.0 > /sys/bus/platform/drivers/mydev/bind
+
+# Check kernel log for probe messages
+dmesg | grep mydev
+```
+
+## Further reading
+
+- [Linux Device Model](device-model.md) — struct device, bus, driver internals
+- [Character and Misc Devices](chardev.md) — Exposing devices via /dev
+- `Documentation/driver-api/driver-model/platform.rst`
+- `Documentation/devicetree/bindings/` — DT binding documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -280,3 +280,8 @@ nav:
     - Syscall Entry Path: syscalls/syscall-entry.md
     - SYSCALL_DEFINE and Dispatch: syscalls/syscall-define.md
     - Adding a New Syscall: syscalls/adding-syscall.md
+  - Device Drivers:
+    - Getting Started: drivers/README.md
+    - Linux Device Model: drivers/device-model.md
+    - Platform Drivers: drivers/platform-driver.md
+    - Character and Misc Devices: drivers/chardev.md


### PR DESCRIPTION
## Summary

- **Linux device model** (`device-model.md`): struct kobject (reference counting base), struct device (of_node, driver_data, devt, class, release), struct bus_type (match/probe/uevent callbacks), struct device_driver (probe/remove/of_match_table), driver_probe_device flow, sysfs attributes (DEVICE_ATTR_RO/WO/RW, ATTRIBUTE_GROUPS), uevent/udevd integration, dev_pm_ops runtime power management
- **Platform drivers** (`platform-driver.md`): struct platform_driver + platform_device, complete minimal driver with devm_, devm_ resource management (kzalloc, ioremap_resource, request_irq, clk_get, gpiod_get — all auto-freed on remove), device tree binding (of_device_id, DTS node example, of_property_read_u32, gpiod_get), -EPROBE_DEFER for dependency ordering, observability commands
- **Character and misc devices** (`chardev.md`): cdev lifecycle (alloc_chrdev_region, cdev_init, cdev_add), file_operations vtable, complete read/write/open/release driver, misc_register for simple single-device drivers, ioctl with _IO/_IOR/_IOW number convention, mmap (remap_pfn_range for kernel buffers, noncached for device I/O memory), poll/select support, class/device_create for udev auto-creation

Closes #290, #291, #292

## Test plan

- [ ] All 4 pages render correctly
- [ ] Code blocks are valid C
- [ ] Cross-links to VFS, mm/dma work