### PR TITLE
Add IPC documentation: signals, pipes, shared memory

### DIFF
--- a/docs/ipc/README.md
+++ b/docs/ipc/README.md
@@ -1,0 +1,24 @@
+# IPC: Inter-Process Communication
+
+> Mechanisms for processes to exchange data and coordinate
+
+## IPC mechanisms overview
+
+| Mechanism | Communication | Direction | Data size | Persistence |
+|-----------|--------------|-----------|-----------|-------------|
+| Signals | Event notification | One-way | Signal number only | Until delivered |
+| Pipe (anonymous) | Byte stream | Unidirectional | Buffered (~64KB) | Until both ends close |
+| FIFO (named pipe) | Byte stream | Unidirectional | Buffered | While file exists |
+| Unix socket | Stream or datagram | Bidirectional | Flexible | While fd open |
+| POSIX shared memory | Raw memory | Both | Arbitrary | Until shm_unlink |
+| POSIX message queue | Typed messages | Both | max_msg_size | Until mq_unlink |
+| eventfd | Counter + notification | Both | 8-byte counter | Until all fds closed |
+| signalfd | Signal as fd | One-way | siginfo_t | While fd open |
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Signals](signals.md) | Signal delivery, sigaction, masks, real-time signals |
+| [Pipes and FIFOs](pipes.md) | Pipe internals, splice, vmsplice |
+| [Shared Memory and Semaphores](shared-memory.md) | POSIX shm, SysV shm, semaphores, eventfd |

--- a/docs/ipc/pipes.md
+++ b/docs/ipc/pipes.md
@@ -1,0 +1,256 @@
+# Pipes and FIFOs
+
+> Unidirectional byte stream IPC
+
+## What pipes are
+
+A pipe is a kernel-managed circular buffer connecting a write end to a read end. Data written by one process is read by another — no filesystem involved.
+
+```
+Process A               Kernel              Process B
+─────────              ────────             ─────────
+write(pipefd[1], data)  →  pipe buffer  →  read(pipefd[0], buf)
+                             (64KB)
+```
+
+Properties:
+- **Unidirectional**: data flows write→read only
+- **Byte stream**: no message boundaries
+- **Blocking**: write blocks if full, read blocks if empty
+- **Atomic writes**: writes ≤ PIPE_BUF (4096) bytes are atomic (won't interleave)
+- **SIGPIPE**: write to a pipe with no readers → `SIGPIPE` + `EPIPE`
+
+## Creating pipes
+
+```c
+/* Anonymous pipe: returned as two fds */
+int pipefd[2];
+pipe2(pipefd, O_CLOEXEC | O_NONBLOCK);
+/* pipefd[0] = read end, pipefd[1] = write end */
+
+/* Classic pipe */
+pipe(pipefd);
+
+/* Typical fork + pipe pattern */
+if (fork() == 0) {
+    /* child: read from pipe */
+    close(pipefd[1]);              /* close write end */
+    read(pipefd[0], buf, sizeof(buf));
+    exit(0);
+} else {
+    /* parent: write to pipe */
+    close(pipefd[0]);              /* close read end */
+    write(pipefd[1], "hello", 5);
+    close(pipefd[1]);              /* EOF to child */
+    wait(NULL);
+}
+```
+
+## Kernel pipe data structures
+
+```c
+/* fs/pipe.c */
+struct pipe_inode_info {
+    struct mutex        mutex;          /* protects the pipe */
+    wait_queue_head_t   rd_wait;        /* readers waiting for data */
+    wait_queue_head_t   wr_wait;        /* writers waiting for space */
+
+    unsigned int        head;           /* producer head index */
+    unsigned int        tail;           /* consumer tail index */
+    unsigned int        max_usage;      /* buffer slots (default 16 = 64KB) */
+    unsigned int        ring_size;      /* power-of-2 buffer size */
+    unsigned int        nr_accounted;   /* for accounting */
+    unsigned int        readers;        /* count of read end openers */
+    unsigned int        writers;        /* count of write end openers */
+    unsigned int        files;          /* sum of readers + writers */
+    unsigned int        r_counter;      /* read counter for POLLHUP check */
+    unsigned int        w_counter;
+    unsigned int        poll_usage;
+    bool                poll_usage_aware;
+    struct page        *tmp_page;       /* reusable page */
+    struct fasync_struct *fasync_readers;
+    struct fasync_struct *fasync_writers;
+    struct pipe_buffer  *bufs;          /* ring of pipe_buffer[ring_size] */
+    struct user_struct  *user;
+};
+
+struct pipe_buffer {
+    struct page *page;          /* the page holding this chunk of data */
+    unsigned int offset;        /* byte offset within page */
+    unsigned int len;           /* number of bytes */
+    const struct pipe_buf_operations *ops;
+    unsigned int flags;         /* PIPE_BUF_FLAG_* */
+    unsigned long private;
+};
+```
+
+The pipe buffer is a ring of `pipe_buffer` slots, each pointing to a page. The default capacity is 16 pages × 4096 = 65,536 bytes.
+
+## Pipe read and write paths
+
+```c
+/* Simplified pipe write path */
+static ssize_t pipe_write(struct kiocb *iocb, struct iov_iter *from)
+{
+    struct pipe_inode_info *pipe = /* ... */;
+    size_t total_len = iov_iter_count(from);
+
+    mutex_lock(&pipe->mutex);
+
+    while (total_len > 0) {
+        unsigned int head = pipe->head;
+
+        /* Wait if pipe is full */
+        if (pipe_full(head, pipe->tail, pipe->max_usage)) {
+            mutex_unlock(&pipe->mutex);
+            wait_event_interruptible(pipe->wr_wait,
+                !pipe_full(pipe->head, pipe->tail, pipe->max_usage));
+            mutex_lock(&pipe->mutex);
+            continue;
+        }
+
+        /* Copy data into head buffer */
+        struct pipe_buffer *buf = &pipe->bufs[head & (pipe->ring_size-1)];
+        /* ... copy from user into buf->page ... */
+
+        pipe->head = head + 1;
+        wake_up_interruptible(&pipe->rd_wait);
+    }
+
+    mutex_unlock(&pipe->mutex);
+    return written;
+}
+```
+
+## Changing pipe capacity
+
+```c
+/* Increase pipe buffer (useful for high-throughput logging) */
+int new_size = 1 << 20;  /* 1MB */
+fcntl(pipefd[1], F_SETPIPE_SZ, new_size);
+
+/* Query current size */
+int size = fcntl(pipefd[1], F_GETPIPE_SZ);
+```
+
+```bash
+# System-wide maximum pipe size
+cat /proc/sys/fs/pipe-max-size  # default 1MB
+echo 4194304 > /proc/sys/fs/pipe-max-size  # increase to 4MB
+```
+
+## splice: zero-copy pipe I/O
+
+`splice` moves data between a file descriptor and a pipe without copying to userspace:
+
+```c
+/* Copy file → pipe (zero-copy read) */
+ssize_t n = splice(file_fd, &offset,
+                   pipe_fd,  NULL,
+                   count, SPLICE_F_MOVE | SPLICE_F_MORE);
+
+/* Copy pipe → socket (zero-copy send) */
+n = splice(pipe_fd, NULL,
+           socket_fd, NULL,
+           count, SPLICE_F_MOVE);
+
+/* Typical pattern: splice file to network socket without copy */
+splice(file_fd, NULL, pipe_fd, NULL, file_size, SPLICE_F_MORE);
+splice(pipe_fd, NULL, socket_fd, NULL, file_size, 0);
+```
+
+`splice` works by moving `pipe_buffer` page references — no data is copied. This is how `sendfile` is implemented internally.
+
+## vmsplice: mapping userspace memory into a pipe
+
+```c
+/* Map userspace buffer into the pipe (gift: pipe takes ownership) */
+struct iovec iov = { .iov_base = buf, .iov_len = len };
+vmsplice(pipefd[1], &iov, 1, SPLICE_F_GIFT);
+
+/* Without SPLICE_F_GIFT: pipe gets a reference, buf must not change */
+vmsplice(pipefd[1], &iov, 1, 0);
+```
+
+## tee: duplicating pipe data
+
+```c
+/* Copy data from pipe1 to pipe2 without consuming from pipe1 */
+tee(pipe1_read_fd, pipe2_write_fd, count, SPLICE_F_NONBLOCK);
+/* Data is now readable from both pipe1 and pipe2 */
+```
+
+Useful for implementing `tee(1)` (stdout → file + stdout) efficiently.
+
+## FIFOs (named pipes)
+
+A FIFO is a pipe accessible via the filesystem. Any process knowing the path can open it:
+
+```bash
+# Create FIFO
+mkfifo /tmp/myfifo
+
+# Process A: write
+echo "hello" > /tmp/myfifo  # blocks until a reader opens it
+
+# Process B: read
+cat /tmp/myfifo  # blocks until a writer opens it
+```
+
+```c
+/* Create FIFO programmatically */
+mkfifo("/tmp/myfifo", 0666);
+
+/* Open without blocking (O_NONBLOCK) */
+int fd = open("/tmp/myfifo", O_RDONLY | O_NONBLOCK);
+/* Returns -1 with ENXIO if no writers have opened yet */
+
+/* Standard blocking open */
+int fd = open("/tmp/myfifo", O_RDONLY);
+/* Blocks until a writer opens the write end */
+```
+
+Opening rules:
+- Read-only open blocks until a writer opens (unless `O_NONBLOCK`)
+- Write-only open blocks until a reader opens (unless `O_NONBLOCK`, returns `ENXIO`)
+- Read-write open never blocks
+
+## Pipe vs socket
+
+| | Pipe/FIFO | Unix socket (SOCK_STREAM) |
+|---|-----------|--------------------------|
+| Direction | Unidirectional | Bidirectional |
+| Address | Anonymous or path | Path or autobind |
+| Scatter/gather | No (writev works) | Yes (sendmsg) |
+| Out-of-band data | No | Yes (MSG_OOB) |
+| Credentials | No | Yes (SCM_CREDENTIALS) |
+| FD passing | No | Yes (SCM_RIGHTS) |
+| Overhead | Lower | Slightly higher |
+
+## Observing pipes
+
+```bash
+# Check pipe buffer usage
+ls -la /proc/self/fd/
+# lrwx 0 -> pipe:[12345678]
+
+# See all pipes open in the system
+lsof | grep "^.\{8\}pipe"
+
+# Pipe buffer size
+cat /proc/$(pgrep myproc)/fdinfo/4
+# flags:   0100001
+# mnt_id:  12
+# pos:     0
+# pipe-size: 65536  ← current pipe size
+
+# Check splice/vmsplice usage
+perf trace -e splice,vmsplice -- myprocess
+```
+
+## Further reading
+
+- [Shared Memory and Semaphores](shared-memory.md) — Alternatives without byte ordering
+- [VFS: File Operations](../vfs/file-ops.md) — How pipes fit in the VFS
+- `fs/pipe.c` — complete pipe implementation
+- `man 7 pipe` — pipe semantics and limits

--- a/docs/ipc/shared-memory.md
+++ b/docs/ipc/shared-memory.md
@@ -1,0 +1,258 @@
+# Shared Memory, Semaphores, and eventfd
+
+> Zero-copy IPC and lightweight synchronization primitives
+
+## POSIX shared memory
+
+POSIX shared memory creates a named object backed by tmpfs that multiple processes can `mmap` into their address spaces:
+
+```c
+#include <sys/mman.h>
+#include <fcntl.h>
+
+/* Process A: create and write */
+int fd = shm_open("/myshm",
+                  O_CREAT | O_RDWR,
+                  0600);
+ftruncate(fd, 4096);  /* set size */
+
+void *ptr = mmap(NULL, 4096,
+                 PROT_READ | PROT_WRITE,
+                 MAP_SHARED, fd, 0);
+close(fd);  /* fd no longer needed after mmap */
+
+*(int *)ptr = 42;
+munmap(ptr, 4096);
+
+/* Remove the name (pages freed when last mmap is gone) */
+shm_unlink("/myshm");
+
+/* Process B: open and read */
+int fd = shm_open("/myshm", O_RDONLY, 0);
+void *ptr = mmap(NULL, 4096, PROT_READ, MAP_SHARED, fd, 0);
+close(fd);
+int val = *(int *)ptr;   /* val == 42 */
+munmap(ptr, 4096);
+```
+
+`shm_open` is implemented as `open` on `/dev/shm/` (a tmpfs mount). The shared pages are in the page cache, mapped into both processes' page tables.
+
+```bash
+ls /dev/shm/   # see current shared memory objects
+ipcs -m        # see System V shared memory segments
+```
+
+## System V shared memory
+
+The older but more widely available SHM API:
+
+```c
+#include <sys/shm.h>
+#include <sys/ipc.h>
+
+/* Create/get a segment */
+key_t key = ftok("/tmp/myfile", 'A');  /* generate key from path+id */
+int shmid = shmget(key,
+                   4096,               /* size */
+                   IPC_CREAT | 0600);  /* flags */
+
+/* Attach (map into address space) */
+void *ptr = shmat(shmid, NULL, 0);     /* NULL = kernel chooses addr */
+
+/* Use it */
+*(int *)ptr = 99;
+
+/* Detach */
+shmdt(ptr);
+
+/* Remove (kernel frees when all processes detach) */
+shmctl(shmid, IPC_RMID, NULL);
+```
+
+```bash
+# Show System V shared memory
+ipcs -m
+# ------ Shared Memory Segments --------
+# key        shmid    owner   perms  bytes  nattch  status
+# 0x00000000 0        root    600    4096   0
+
+# Remove a segment
+ipcrm -m <shmid>
+```
+
+## Synchronization: POSIX semaphores
+
+Shared memory requires external synchronization. POSIX semaphores provide a counter that can be atomically incremented/decremented:
+
+### Named semaphores (between unrelated processes)
+
+```c
+#include <semaphore.h>
+
+/* Process A */
+sem_t *sem = sem_open("/mysem",
+                      O_CREAT, 0600, 1);  /* initial value = 1 */
+
+sem_wait(sem);       /* P(): decrement, block if 0 */
+/* critical section */
+sem_post(sem);       /* V(): increment, wake one waiter */
+
+sem_close(sem);      /* close fd */
+sem_unlink("/mysem"); /* remove name */
+
+/* Process B */
+sem_t *sem = sem_open("/mysem", 0);  /* open existing */
+sem_wait(sem);
+/* ... */
+sem_post(sem);
+sem_close(sem);
+```
+
+### Unnamed semaphores (shared memory or threads)
+
+```c
+/* In shared memory, accessible to multiple processes */
+struct shared {
+    sem_t sem;
+    int   data;
+};
+
+struct shared *sh = mmap(NULL, sizeof(*sh),
+                         PROT_READ|PROT_WRITE,
+                         MAP_SHARED|MAP_ANONYMOUS, -1, 0);
+
+sem_init(&sh->sem, 1, 1);  /* pshared=1: shared between processes */
+
+/* Process A/B: */
+sem_wait(&sh->sem);
+sh->data++;
+sem_post(&sh->sem);
+
+/* Cleanup */
+sem_destroy(&sh->sem);
+munmap(sh, sizeof(*sh));
+```
+
+### Kernel implementation
+
+POSIX semaphores use futexes internally:
+
+```c
+/* glibc sem_wait: */
+sem_wait(sem) {
+    if (__atomic_sub_fetch(&sem->value, 1, __ATOMIC_ACQ_REL) >= 0)
+        return;  /* fast path: counter was > 0 */
+    /* slow path: wait */
+    futex_wait(&sem->value, ...);
+}
+
+sem_post(sem) {
+    if (__atomic_add_fetch(&sem->value, 1, __ATOMIC_RELEASE) <= 0)
+        futex_wake(&sem->value, 1);  /* wake one waiter */
+}
+```
+
+## eventfd: lightweight event notification
+
+`eventfd` creates a file descriptor backed by a 64-bit counter. It's the lightest-weight notification mechanism:
+
+```c
+#include <sys/eventfd.h>
+
+/* Create eventfd with initial value 0 */
+int efd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+
+/* Signal: add 1 to counter */
+uint64_t val = 1;
+write(efd, &val, sizeof(val));
+
+/* Wait and consume: reads the counter value, resets to 0 */
+uint64_t count;
+read(efd, &count, sizeof(count));  /* blocks if counter == 0 */
+/* count = number of signals since last read */
+
+/* With EFD_SEMAPHORE: read decrements by 1 instead of resetting to 0 */
+int efd = eventfd(0, EFD_SEMAPHORE);
+write(efd, &(uint64_t){5}, 8);  /* counter = 5 */
+read(efd, &count, 8);  /* count = 1, counter = 4 */
+read(efd, &count, 8);  /* count = 1, counter = 3 */
+```
+
+### eventfd with epoll (the idiomatic pattern)
+
+```c
+/* Thread 1: event producer */
+void producer(int efd) {
+    while (1) {
+        /* ... do work ... */
+        uint64_t val = 1;
+        write(efd, &val, sizeof(val));  /* signal consumer */
+    }
+}
+
+/* Thread 2: event consumer with epoll */
+void consumer(int efd) {
+    int epfd = epoll_create1(EPOLL_CLOEXEC);
+    struct epoll_event ev = { .events = EPOLLIN, .data.fd = efd };
+    epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev);
+
+    struct epoll_event events[8];
+    while (1) {
+        int n = epoll_wait(epfd, events, 8, -1);
+        for (int i = 0; i < n; i++) {
+            uint64_t count;
+            read(events[i].data.fd, &count, sizeof(count));
+            /* process 'count' pending events */
+        }
+    }
+}
+```
+
+eventfd is used extensively in:
+- QEMU/KVM virtio notifications
+- io_uring completion notification
+- libuv/libevent event loop backends
+- Container runtimes (cgroup event notification)
+
+## memfd: anonymous file-backed shared memory
+
+`memfd_create` creates an anonymous file in memory (no filesystem path), useful for sharing without name collisions:
+
+```c
+#include <sys/mman.h>
+
+/* Create anonymous file */
+int fd = memfd_create("mydata", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+ftruncate(fd, size);
+
+void *ptr = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+
+/* Seal: prevent future modifications (useful for read-only sharing) */
+fcntl(fd, F_ADD_SEALS, F_SEAL_WRITE | F_SEAL_GROW | F_SEAL_SHRINK);
+
+/* Pass fd to another process via Unix socket (SCM_RIGHTS) */
+send_fd_over_socket(socket_fd, fd);
+/* Other process can mmap the fd — no name needed */
+```
+
+`memfd_create` is used by:
+- Graphics/Wayland: sharing framebuffers between client and compositor
+- dbus-broker: passing large messages without DBUS limits
+- D-Bus: replacing shared memory segments
+
+## Comparing shared memory approaches
+
+| Approach | Setup | Name in fs | fd | Sealing | Best for |
+|----------|-------|-----------|-----|---------|---------|
+| POSIX shm (`shm_open`) | Path in `/dev/shm/` | Yes | After open | No | Named, persistent |
+| System V (`shmget`) | IPC key | Via `ipcs` | No | No | Legacy compatibility |
+| `mmap(MAP_SHARED | MAP_ANONYMOUS)` | Anonymous | No | No | Parent-child only |
+| `memfd_create` | Anonymous file | No | Yes | Yes | Dynamic, fd-passing |
+
+## Further reading
+
+- [Signals](signals.md) — SIGSEGV from shared memory access violations
+- [Futex Internals](../locking/futex.md) — How semaphores are implemented
+- [Memory Management: mmap](../mm/mmap.md) — How MAP_SHARED mappings work
+- `man 7 shm_overview` — POSIX shared memory overview
+- `man 2 eventfd` — eventfd semantics

--- a/docs/ipc/signals.md
+++ b/docs/ipc/signals.md
@@ -1,0 +1,277 @@
+# Signals
+
+> Asynchronous notifications delivered to processes
+
+## Signal basics
+
+A signal is an integer (1–64 on x86-64) sent to a process or thread. The kernel delivers it by interrupting the target process at the next opportunity (syscall return, interrupt return).
+
+```
+Sender                Kernel                Receiver
+──────                ──────                ────────
+kill(pid, SIGTERM) →  pending bit set   →   process checks TIF_SIGPENDING
+                      on return to user     do_signal()
+                      mode:                 → runs signal handler
+                                           → or default action (terminate)
+```
+
+Standard signals (1–31) are not queued — multiple sends before delivery collapse to one. Real-time signals (32–64, `SIGRTMIN`..`SIGRTMAX`) are queued.
+
+## Signal numbers and default actions
+
+```
+SIGHUP  (1)  — hangup (terminal closed) → terminate
+SIGINT  (2)  — interrupt (Ctrl+C) → terminate
+SIGQUIT (3)  — quit (Ctrl+\) → core dump
+SIGILL  (4)  — illegal instruction → core dump
+SIGTRAP (5)  — debug trap → core dump
+SIGABRT (6)  — abort() → core dump
+SIGFPE  (8)  — arithmetic exception → core dump
+SIGKILL (9)  — kill (cannot be caught/ignored) → terminate
+SIGSEGV (11) — invalid memory access → core dump
+SIGPIPE (13) — write to closed pipe → terminate
+SIGALRM (14) — timer (alarm()) → terminate
+SIGTERM (15) — termination request → terminate
+SIGCHLD (17) — child status change → ignore
+SIGCONT (18) — continue if stopped → continue
+SIGSTOP (19) — stop (cannot be caught/ignored) → stop
+SIGTSTP (20) — terminal stop (Ctrl+Z) → stop
+SIGUSR1 (10) — user defined → terminate
+SIGUSR2 (12) — user defined → terminate
+SIGRTMIN..SIGRTMAX (32..64) — real-time → terminate
+```
+
+## Sending signals
+
+```c
+/* kill: send to process or process group */
+kill(pid, SIGTERM);   /* pid>0: specific process */
+kill(-pgrp, SIGTERM); /* pid<0: process group */
+kill(0, SIGTERM);     /* current process group */
+kill(-1, SIGTERM);    /* all processes (except init) — requires privilege */
+
+/* tkill: send to specific thread (deprecated, use tgkill) */
+tkill(tid, SIGTERM);
+
+/* tgkill: send to specific thread in specific process (POSIX) */
+tgkill(tgid, tid, SIGTERM);
+
+/* sigqueue: send with data (for real-time signals) */
+union sigval value;
+value.sival_int = 42;
+sigqueue(pid, SIGRTMIN, value);
+/* Receiver gets si_value.sival_int == 42 in siginfo_t */
+
+/* raise: send to current thread */
+raise(SIGINT);
+
+/* From kernel: */
+send_sig(SIGTERM, task, 0);         /* send to process */
+send_sig_info(SIGTERM, &info, task); /* with siginfo_t */
+kill_pgrp(pgrp, SIGTERM, 0);
+```
+
+## Kernel signal delivery path
+
+```c
+/* kernel/signal.c */
+
+/* 1. do_send_sig_info(): queues signal to target task */
+do_send_sig_info(sig, info, task, type)
+  → sigaddset(&task->pending.signal, sig)   /* add to pending set */
+  → signal_wake_up(task, sig == SIGKILL)    /* wake if sleeping, set TIF_SIGPENDING */
+
+/* 2. On return to userspace (syscall return, interrupt return): */
+exit_to_user_mode_loop()
+  → if TIF_SIGPENDING: arch_do_signal_or_restart(regs)
+      → get_signal(&ksig)               /* dequeue next signal */
+      → if handled: handle_signal(&ksig) /* set up userspace stack frame */
+      → if ignored: continue
+      → if default: do_group_exit() or coredump etc.
+
+/* 3. handle_signal: set up signal frame on userspace stack */
+handle_signal(ksig, regs)
+  → setup_rt_frame(ksig, regs)
+      /* pushes: siginfo_t, ucontext_t, trampoline code onto user stack */
+      /* sets rip = signal handler, rsp = new user stack */
+      /* sets up SIGRETURN trampoline (calls rt_sigreturn syscall) */
+```
+
+After the signal handler returns, the trampoline calls `rt_sigreturn` which restores the saved `ucontext_t` (CPU registers before signal delivery) and resumes normal execution.
+
+## struct sigaction: installing handlers
+
+```c
+#include <signal.h>
+
+/* sa_handler or sa_sigaction (not both) */
+struct sigaction {
+    union {
+        void (*sa_handler)(int signum);
+        void (*sa_sigaction)(int signum, siginfo_t *info, void *ucontext);
+    };
+    sigset_t sa_mask;     /* signals to block during handler */
+    int      sa_flags;    /* SA_SIGINFO, SA_RESTART, SA_NODEFER, ... */
+    void    (*sa_restorer)(void);  /* internal use */
+};
+```
+
+```c
+/* Install a signal handler */
+struct sigaction sa = {
+    .sa_sigaction = my_handler,
+    .sa_flags = SA_SIGINFO | SA_RESTART,
+};
+sigemptyset(&sa.sa_mask);
+sigaddset(&sa.sa_mask, SIGTERM);  /* block SIGTERM during handler */
+sigaction(SIGUSR1, &sa, NULL);
+
+/* Handler: */
+static void my_handler(int sig, siginfo_t *info, void *ctx)
+{
+    /* info->si_pid: sender's PID */
+    /* info->si_code: SI_USER, SI_QUEUE, SI_TIMER, ... */
+    /* info->si_value: data from sigqueue() */
+    printf("signal %d from pid %d\n", sig, info->si_pid);
+}
+```
+
+Important flags:
+- `SA_SIGINFO` — use `sa_sigaction` (3-arg handler) instead of `sa_handler`
+- `SA_RESTART` — auto-restart interrupted syscalls (`EINTR` hidden from app)
+- `SA_NODEFER` — don't block the signal during its own handler (reentrant)
+- `SA_RESETHAND` — reset to default after one delivery
+
+## Signal masks
+
+Each thread has a signal mask — blocked signals are not delivered until unblocked:
+
+```c
+/* Block SIGINT and SIGTERM temporarily */
+sigset_t block_set, old_set;
+sigemptyset(&block_set);
+sigaddset(&block_set, SIGINT);
+sigaddset(&block_set, SIGTERM);
+sigprocmask(SIG_BLOCK, &block_set, &old_set);
+
+/* ... critical section ... */
+
+/* Restore original mask */
+sigprocmask(SIG_SETMASK, &old_set, NULL);
+
+/* Atomically: wait for specific signal while unblocking */
+sigsuspend(&old_set);  /* replaces mask, sleeps until any signal */
+```
+
+### Kernel data structures
+
+```c
+/* Per-process signal state */
+struct signal_struct {
+    /* pending signals shared by all threads: */
+    struct sigpending   shared_pending;
+    /* ... */
+};
+
+/* Per-thread signal state */
+struct task_struct {
+    /* thread-private pending signals: */
+    struct sigpending   pending;
+    sigset_t            blocked;        /* current signal mask */
+    sigset_t            real_blocked;   /* saved mask (for sigwaitinfo) */
+    sigset_t            saved_sigmask;  /* restored on sigreturn */
+    /* ... */
+};
+
+struct sigpending {
+    struct list_head    list;           /* queued siginfo_t for RT signals */
+    sigset_t            signal;         /* bitmask of pending standard signals */
+};
+```
+
+## Real-time signals
+
+Real-time signals (SIGRTMIN..SIGRTMAX) differ from standard signals:
+- **Queued**: multiple sends before delivery are all delivered (FIFO order)
+- **Value**: can carry an integer or pointer (via sigqueue + `si_value`)
+- **Priority**: lower signal number = higher priority within real-time range
+
+```c
+/* Send with data */
+union sigval val = { .sival_int = 100 };
+sigqueue(pid, SIGRTMIN+1, val);
+
+/* Receive multiple */
+struct sigaction sa = {
+    .sa_sigaction = rt_handler,
+    .sa_flags = SA_SIGINFO,
+};
+sigaction(SIGRTMIN+1, &sa, NULL);
+
+/* Synchronously wait for signal */
+sigset_t wait_set;
+sigemptyset(&wait_set);
+sigaddset(&wait_set, SIGRTMIN+1);
+sigprocmask(SIG_BLOCK, &wait_set, NULL);  /* must block before sigwaitinfo */
+
+siginfo_t info;
+sigwaitinfo(&wait_set, &info);
+/* info.si_value.sival_int == 100 */
+```
+
+## signalfd: signals as file descriptors
+
+`signalfd` converts signal delivery into `read()` calls, enabling use with `epoll`:
+
+```c
+#include <sys/signalfd.h>
+#include <sys/epoll.h>
+
+/* Block signals we want to receive via signalfd */
+sigset_t mask;
+sigemptyset(&mask);
+sigaddset(&mask, SIGINT);
+sigaddset(&mask, SIGTERM);
+sigprocmask(SIG_BLOCK, &mask, NULL);
+
+/* Create signalfd */
+int sfd = signalfd(-1, &mask, SFD_NONBLOCK | SFD_CLOEXEC);
+
+/* Add to epoll */
+struct epoll_event ev = { .events = EPOLLIN, .data.fd = sfd };
+epoll_ctl(epfd, EPOLL_CTL_ADD, sfd, &ev);
+
+/* Read signal info */
+struct signalfd_siginfo si;
+read(sfd, &si, sizeof(si));
+if (si.ssi_signo == SIGTERM) {
+    /* clean shutdown */
+}
+```
+
+## SIGCHLD and waitpid
+
+`SIGCHLD` is sent to a parent when a child changes state (exits, stops, continues). The parent must call `waitpid` to reap the zombie:
+
+```c
+static void sigchld_handler(int sig, siginfo_t *info, void *ctx)
+{
+    int status;
+    pid_t pid;
+
+    /* Reap all exited children (loop for multiple children) */
+    while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
+        if (WIFEXITED(status))
+            printf("child %d exited with %d\n", pid, WEXITSTATUS(status));
+        else if (WIFSIGNALED(status))
+            printf("child %d killed by signal %d\n", pid, WTERMSIG(status));
+    }
+}
+```
+
+## Further reading
+
+- [Pipes and FIFOs](pipes.md) — `SIGPIPE` when writing to a broken pipe
+- [Futex Internals](../locking/futex.md) — How signals interact with futex waits
+- `kernel/signal.c` — complete signal implementation
+- `man 7 signal` — signal list and default dispositions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -285,3 +285,8 @@ nav:
     - Linux Device Model: drivers/device-model.md
     - Platform Drivers: drivers/platform-driver.md
     - Character and Misc Devices: drivers/chardev.md
+  - IPC:
+    - Getting Started: ipc/README.md
+    - Signals: ipc/signals.md
+    - Pipes and FIFOs: ipc/pipes.md
+    - Shared Memory and Semaphores: ipc/shared-memory.md


### PR DESCRIPTION
## Summary

- **Signals** (`signals.md`): standard vs real-time signals, do_send_sig_info kernel path (pending bitmask + TIF_SIGPENDING), handle_signal setup_rt_frame userspace stack manipulation, sigaction (SA_SIGINFO/SA_RESTART/SA_NODEFER/SA_RESETHAND), signal masks (sigprocmask/sigsuspend), struct sigpending/signal_struct internals, real-time signal queuing + sigqueue with si_value, signalfd for epoll integration, SIGCHLD/waitpid zombie reaping
- **Pipes** (`pipes.md`): struct pipe_inode_info (ring of pipe_buffer pages, head/tail indices, rd_wait/wr_wait queues), pipe write blocking semantics, F_SETPIPE_SZ, splice (zero-copy file→pipe→socket), vmsplice (userspace buffer → pipe gift), tee (duplicate without consuming), FIFO opening blocking rules, pipe vs Unix socket comparison
- **Shared memory and semaphores** (`shared-memory.md`): POSIX shm_open (tmpfs-backed /dev/shm), System V shmget/shmat, POSIX named and unnamed semaphores (futex-based implementation), eventfd (counter + epoll pattern, EFD_SEMAPHORE for per-event reads), memfd_create with F_SEAL_* sealing, comparison table of shared memory approaches

Closes #295, #296, #297

## Test plan

- [ ] All 4 pages render in mkdocs
- [ ] Code examples are valid C
- [ ] Cross-links to locking/futex, mm/mmap work