### PR TITLE
Add io_uring documentation

### DIFF
--- a/docs/io-uring/README.md
+++ b/docs/io-uring/README.md
@@ -1,0 +1,58 @@
+# io_uring
+
+> True async I/O for everything
+
+## What io_uring is
+
+io_uring (introduced in Linux 5.1) is a high-performance async I/O interface that:
+
+- **Eliminates syscall overhead**: submit and reap operations via shared memory rings, not per-operation syscalls
+- **Works for all I/O**: files, sockets, pipes, splice, cancel, timeout — not just O_DIRECT block I/O like the older aio
+- **Zero-copy**: fixed buffers eliminate per-I/O allocation and copying
+- **Kernel-side polling**: SQPOLL thread eliminates `io_uring_enter()` syscalls entirely
+
+```
+Userspace                    Kernel
+─────────────────────────────────────────────────────────────
+                        ┌──────────────────────┐
+  SQ ring (mmap'd)  ──► │  io_uring instance   │
+  CQ ring (mmap'd)  ◄── │  (per-fd state)      │
+                        └──────────────────────┘
+                                  │
+                        io_uring_enter() → process SQEs
+                                  │
+                            async I/O workers / direct dispatch
+                                  │
+                          complete → post CQE
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Architecture and Rings](io-uring-arch.md) | Setup, SQ/CQ ring layout, SQE/CQE structures |
+| [Operations and Advanced Features](io-uring-ops.md) | Supported ops, fixed files/buffers, SQPOLL, linked requests |
+
+## Quick reference
+
+```c
+/* Typical io_uring workflow with liburing */
+#include <liburing.h>
+
+struct io_uring ring;
+io_uring_queue_init(32, &ring, 0);     /* 32 SQE slots */
+
+/* Submit a read */
+struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+io_uring_prep_read(sqe, fd, buf, len, offset);
+sqe->user_data = 1;   /* tag for matching completions */
+io_uring_submit(&ring);
+
+/* Wait for completion */
+struct io_uring_cqe *cqe;
+io_uring_wait_cqe(&ring, &cqe);
+int result = cqe->res;   /* bytes read, or -errno */
+io_uring_cqe_seen(&ring, cqe);  /* advance CQ tail */
+
+io_uring_queue_exit(&ring);
+```

--- a/docs/io-uring/io-uring-arch.md
+++ b/docs/io-uring/io-uring-arch.md
@@ -1,0 +1,261 @@
+# io_uring Architecture and Rings
+
+> Shared memory rings, SQEs, and CQEs
+
+## The problem io_uring solves
+
+Traditional I/O interfaces:
+- `read()`/`write()`: one syscall per operation, blocking
+- `aio_read()` (POSIX AIO): only works for O_DIRECT files; complex API
+- `epoll` + non-blocking: two syscalls per operation (one to check, one to act), no batching
+- Linux `libaio`: low-level, incomplete operation coverage
+
+io_uring's solution: **two lock-free rings in shared memory**. Userspace writes to the Submission Queue; the kernel posts results to the Completion Queue. No per-operation syscall needed (especially with SQPOLL).
+
+## io_uring_setup
+
+```c
+#include <linux/io_uring.h>
+
+struct io_uring_params params = {
+    .flags = IORING_SETUP_SQPOLL,  /* optional: kernel polling thread */
+    /* .sq_thread_cpu, .sq_thread_idle, etc. */
+};
+
+int ring_fd = io_uring_setup(32,  /* sq_entries: power of 2 */
+                              &params);
+
+/* params is filled in by the kernel: */
+/* params.sq_off: offsets within sq ring mmap */
+/* params.cq_off: offsets within cq ring mmap */
+/* params.features: IORING_FEAT_SINGLE_MMAP, IORING_FEAT_NODROP, etc. */
+```
+
+After `io_uring_setup`, userspace maps two (or one, if `IORING_FEAT_SINGLE_MMAP`) memory regions:
+
+```c
+/* Map the SQ and CQ rings */
+void *sq_ring = mmap(NULL, params.sq_off.array + params.sq_entries * sizeof(u32),
+                     PROT_READ|PROT_WRITE, MAP_SHARED|MAP_POPULATE,
+                     ring_fd, IORING_OFF_SQ_RING);
+
+void *cq_ring = mmap(NULL, params.cq_off.cqes +
+                           params.cq_entries * sizeof(struct io_uring_cqe),
+                     PROT_READ|PROT_WRITE, MAP_SHARED|MAP_POPULATE,
+                     ring_fd, IORING_OFF_CQ_RING);
+
+/* Map the SQE array separately */
+struct io_uring_sqe *sqes = mmap(NULL,
+    params.sq_entries * sizeof(struct io_uring_sqe),
+    PROT_READ|PROT_WRITE, MAP_SHARED|MAP_POPULATE,
+    ring_fd, IORING_OFF_SQES);
+```
+
+## Ring layout
+
+```
+SQ ring (at IORING_OFF_SQ_RING):
+  ┌─────────────────────────────────────────┐
+  │ head     (u32) ← kernel reads from here │
+  │ tail     (u32) ← userspace writes here  │
+  │ mask     (u32) = sq_entries - 1         │
+  │ entries  (u32) = sq_entries             │
+  │ flags    (u32) = IORING_SQ_NEED_WAKEUP  │
+  │ dropped  (u32) = dropped SQEs           │
+  │ array[]  (u32) = indices into SQE array │
+  └─────────────────────────────────────────┘
+
+SQE array (at IORING_OFF_SQES):
+  ┌──────────────────────────────────────────┐
+  │ sqe[0] │ sqe[1] │ ... │ sqe[sq_entries-1] │
+  └──────────────────────────────────────────┘
+
+CQ ring (at IORING_OFF_CQ_RING):
+  ┌─────────────────────────────────────────┐
+  │ head     (u32) ← userspace reads here   │
+  │ tail     (u32) ← kernel writes here     │
+  │ mask     (u32) = cq_entries - 1         │
+  │ entries  (u32) = cq_entries             │
+  │ overflow (u32) = CQEs dropped (if full) │
+  │ cqes[]   = CQE ring array               │
+  └─────────────────────────────────────────┘
+```
+
+## struct io_uring_sqe
+
+The Submission Queue Entry describes one I/O operation:
+
+```c
+/* include/uapi/linux/io_uring.h */
+struct io_uring_sqe {
+    __u8    opcode;         /* IORING_OP_READ, IORING_OP_WRITE, ... */
+    __u8    flags;          /* IOSQE_FIXED_FILE, IOSQE_IO_LINK, ... */
+    __u16   ioprio;         /* I/O priority (ionice class/level) */
+    __s32   fd;             /* file descriptor (or fixed file index) */
+    union {
+        __u64   off;        /* offset for read/write */
+        __u64   addr2;      /* used by some ops */
+        struct {
+            __u32 cmd_op;
+            __u32 __pad1;
+        };
+    };
+    union {
+        __u64   addr;       /* pointer to buffer (or fixed buffer index) */
+        __u64   splice_off_in;
+    };
+    __u32   len;            /* buffer length, or sqe count for LINK */
+    union {
+        __kernel_rwf_t  rw_flags;   /* read/write flags */
+        __u32           fsync_flags;
+        __u16           poll_events;
+        __u32           poll32_events;
+        __u32           sync_range_flags;
+        __u32           msg_flags;
+        __u32           timeout_flags;
+        __u32           accept_flags;
+        __u32           cancel_flags;
+        __u32           open_flags;
+        __u32           statx_flags;
+        __u32           fadvise_advice;
+        __u32           splice_flags;
+        __u32           rename_flags;
+        __u32           unlink_flags;
+        __u32           hardlink_flags;
+        __u32           xattr_flags;
+        __u32           msg_ring_flags;
+        __u32           uring_cmd_flags;
+    };
+    __u64   user_data;      /* tag copied to CQE — for matching completions */
+    union {
+        __u16   buf_index;  /* fixed buffer index (for IORING_OP_*) */
+        __u16   buf_group;  /* buffer group for buffer selection */
+    };
+    __u16   personality;    /* credential to use for this op */
+    union {
+        __s32   splice_fd_in;
+        __u32   file_index;   /* for fixed files */
+        __u32   optlen;
+        struct {
+            __u16 addr_len;
+            __u16 __pad3[1];
+        };
+    };
+    union {
+        struct {
+            __u64 addr3;
+            __u64 __pad2[1];
+        };
+        __u8 cmd[0];  /* IORING_OP_URING_CMD payload */
+    };
+};
+```
+
+## struct io_uring_cqe
+
+The Completion Queue Entry carries the result:
+
+```c
+struct io_uring_cqe {
+    __u64   user_data;  /* copied from SQE (for matching) */
+    __s32   res;        /* result code: bytes transferred, or -errno */
+    __u32   flags;      /* IORING_CQE_F_MORE, IORING_CQE_F_SOCK_NONEMPTY */
+    __u64   big_cqe[];  /* if IORING_SETUP_CQE32: extra 16 bytes */
+};
+```
+
+`res` semantics mirror the corresponding blocking syscall:
+- `IORING_OP_READ`: bytes read, or -errno
+- `IORING_OP_WRITE`: bytes written, or -errno
+- `IORING_OP_ACCEPT`: new fd, or -errno
+- `IORING_OP_CONNECT`: 0 on success, or -errno
+
+## Submission flow
+
+```
+1. Get an SQE slot:
+   tail = sq_ring->tail & sq_ring->mask
+   sqe = &sqes[tail]
+
+2. Fill the SQE:
+   sqe->opcode = IORING_OP_READ
+   sqe->fd = fd
+   sqe->addr = (uintptr_t)buf
+   sqe->len = len
+   sqe->off = offset
+   sqe->user_data = my_tag
+
+3. Advance tail (publish to kernel):
+   sq_ring->array[tail] = tail  /* indirect index */
+   smp_store_release(&sq_ring->tail, tail + 1)
+
+4. Optionally: io_uring_enter(ring_fd, to_submit, min_complete, flags)
+   /* with SQPOLL: skip this — kernel polls automatically */
+```
+
+## Completion harvesting
+
+```
+1. Check if new CQEs available:
+   if (cq_ring->head == READ_ONCE(cq_ring->tail)) { /* no completions */ }
+
+2. Process CQE:
+   head = cq_ring->head & cq_ring->mask
+   cqe = &cq_ring->cqes[head]
+   result = cqe->res
+   tag = cqe->user_data
+
+3. Advance head (consume):
+   smp_store_release(&cq_ring->head, cq_ring->head + 1)
+```
+
+## io_uring_enter: the syscall
+
+```c
+int io_uring_enter(unsigned int fd,    /* ring fd */
+                   unsigned int to_submit,  /* SQEs to submit */
+                   unsigned int min_complete, /* wait for N CQEs */
+                   unsigned int flags,   /* IORING_ENTER_GETEVENTS, ... */
+                   sigset_t *sig,        /* optional signal mask during wait */
+                   size_t sigsz);
+```
+
+With batching, a single `io_uring_enter` can submit many operations and wait for many completions. This amortizes the syscall overhead across all concurrent I/O.
+
+## Kernel side: struct io_ring_ctx
+
+```c
+/* io_uring/io_uring.h */
+struct io_ring_ctx {
+    struct {
+        unsigned        flags;
+        unsigned        compat;
+        unsigned        drain_next;
+        unsigned        eventfd_async;
+        /* ... */
+    } ____cacheline_aligned_in_smp;
+
+    struct io_rings     *rings;          /* the shared SQ/CQ rings */
+    struct io_uring_sqe *sq_sqes;        /* SQE array */
+
+    /* completion state */
+    spinlock_t          completion_lock;
+    struct list_head    locked_free_list;
+    unsigned int        locked_free_nr;
+
+    /* submission state */
+    struct io_sq_data   *sq_data;        /* SQPOLL thread */
+
+    /* workers for blocking ops */
+    struct io_wq        *io_wq;
+
+    /* ... many more fields ... */
+};
+```
+
+## Further reading
+
+- [Operations and Advanced Features](io-uring-ops.md) — Supported ops, SQPOLL, fixed buffers
+- [BPF](../bpf/README.md) — io_uring + BPF programs
+- `io_uring/` in the kernel tree — full implementation (~25,000 lines)
+- `liburing` — userspace library with convenience API

--- a/docs/io-uring/io-uring-ops.md
+++ b/docs/io-uring/io-uring-ops.md
@@ -1,0 +1,341 @@
+# io_uring Operations and Advanced Features
+
+> From basic read/write to SQPOLL and linked requests
+
+## Supported operations
+
+io_uring supports a wide range of operations, all async:
+
+### File and socket I/O
+
+```c
+/* Read/write (like pread64/pwrite64) */
+IORING_OP_READ        /* read from fd at offset */
+IORING_OP_WRITE       /* write to fd at offset */
+IORING_OP_READV       /* scatter read (struct iovec) */
+IORING_OP_WRITEV      /* gather write */
+IORING_OP_READ_FIXED  /* read into pre-registered buffer */
+IORING_OP_WRITE_FIXED /* write from pre-registered buffer */
+
+/* Socket operations */
+IORING_OP_ACCEPT      /* accept connection */
+IORING_OP_CONNECT     /* connect to address */
+IORING_OP_SEND        /* send on socket */
+IORING_OP_RECV        /* receive from socket */
+IORING_OP_SENDMSG     /* sendmsg (scatter/gather, ancillary data) */
+IORING_OP_RECVMSG     /* recvmsg */
+IORING_OP_SEND_ZC     /* zero-copy send (kernel 6.0+) */
+IORING_OP_SENDMSG_ZC
+
+/* File operations */
+IORING_OP_OPENAT      /* open file */
+IORING_OP_OPENAT2     /* openat2 with how struct */
+IORING_OP_CLOSE       /* close fd */
+IORING_OP_STATX       /* statx */
+IORING_OP_FADVISE     /* posix_fadvise */
+IORING_OP_FALLOCATE   /* fallocate */
+IORING_OP_FSYNC       /* fsync/fdatasync */
+IORING_OP_SYNC_FILE_RANGE
+
+/* Directory operations */
+IORING_OP_RENAMEAT    /* rename */
+IORING_OP_UNLINKAT    /* unlink/rmdir */
+IORING_OP_MKDIRAT     /* mkdir */
+IORING_OP_LINKAT      /* link */
+IORING_OP_SYMLINKAT   /* symlink */
+
+/* Splice */
+IORING_OP_SPLICE      /* splice between fds */
+IORING_OP_TEE         /* tee */
+
+/* Timing */
+IORING_OP_TIMEOUT     /* wait for a duration, then post CQE */
+IORING_OP_TIMEOUT_REMOVE  /* cancel a timeout */
+IORING_OP_LINK_TIMEOUT    /* timeout linked to another SQE */
+
+/* Polling */
+IORING_OP_POLL_ADD    /* add fd to poll */
+IORING_OP_POLL_REMOVE /* remove poll */
+
+/* Miscellaneous */
+IORING_OP_CANCEL      /* cancel pending operation */
+IORING_OP_ASYNC_CANCEL
+IORING_OP_MSG_RING    /* send CQE to another ring */
+IORING_OP_URING_CMD   /* driver-specific commands */
+IORING_OP_WAITID      /* async waitid() */
+IORING_OP_SOCKET      /* create a socket */
+IORING_OP_EPOLL_CTL   /* async epoll_ctl */
+IORING_OP_PROVIDE_BUFFERS /* register buffer pool */
+IORING_OP_REMOVE_BUFFERS
+```
+
+## liburing: the convenience wrapper
+
+Most applications use `liburing` instead of raw syscalls:
+
+```c
+#include <liburing.h>
+
+/* Initialize a ring with 256 entries */
+struct io_uring ring;
+io_uring_queue_init(256, &ring, 0);
+
+/* Or with flags */
+io_uring_queue_init_params(256, &ring, &(struct io_uring_params){
+    .flags = IORING_SETUP_SQPOLL | IORING_SETUP_SQ_AFF,
+    .sq_thread_cpu = 2,
+    .sq_thread_idle = 2000,  /* idle 2s before sleeping */
+});
+```
+
+### Batch example: submit multiple reads
+
+```c
+struct io_uring_sqe *sqe;
+struct io_uring_cqe *cqe;
+
+/* Submit 8 reads at once */
+for (int i = 0; i < 8; i++) {
+    sqe = io_uring_get_sqe(&ring);
+    io_uring_prep_read(sqe, fds[i], bufs[i], BUF_SIZE, 0);
+    io_uring_sqe_set_data64(sqe, (uint64_t)i);  /* tag */
+}
+
+/* One syscall to submit all 8 */
+io_uring_submit(&ring);
+
+/* Collect completions */
+for (int i = 0; i < 8; i++) {
+    io_uring_wait_cqe(&ring, &cqe);
+    int idx = (int)io_uring_cqe_get_data64(cqe);
+    if (cqe->res < 0)
+        fprintf(stderr, "read[%d] error: %s\n", idx, strerror(-cqe->res));
+    io_uring_cqe_seen(&ring, cqe);
+}
+```
+
+## SQPOLL: eliminating syscalls entirely
+
+With `IORING_SETUP_SQPOLL`, a dedicated kernel thread polls the SQ ring continuously. Userspace never needs to call `io_uring_enter` — it just writes SQEs and they're picked up automatically:
+
+```c
+io_uring_queue_init_params(256, &ring, &(struct io_uring_params){
+    .flags = IORING_SETUP_SQPOLL,
+    .sq_thread_idle = 2000,  /* kernel thread sleeps after 2s of idle */
+});
+
+/* Submit without syscall: */
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_read(sqe, fd, buf, len, 0);
+io_uring_sqe_set_flags(sqe, 0);
+
+/* Just update the SQ tail — no io_uring_enter() needed */
+io_uring_submit(&ring);  /* liburing: detects SQPOLL, writes directly */
+
+/* Check if kernel thread needs wakeup */
+if (io_sq_ring_needs_enter(ring_ptr))
+    io_uring_enter(ring_fd, 0, 0, IORING_ENTER_SQ_WAKEUP, NULL, 0);
+```
+
+The kernel SQPOLL thread is pinned to a CPU (`sq_thread_cpu`) and runs at `SCHED_FIFO` priority. For ultra-low latency I/O, it avoids the ~1µs overhead of a syscall.
+
+```bash
+# See the SQPOLL thread
+ps aux | grep io_uring-sq
+# root 1234  99.9  0.0  0  0 [io_uring-sq]
+```
+
+## Fixed files (registered file descriptors)
+
+Registering file descriptors eliminates per-operation fd lookups:
+
+```c
+/* Register up to 4096 fds with the ring */
+int fds[4096] = { fd0, fd1, fd2, -1, -1, ... };
+io_uring_register_files(&ring, fds, 4096);
+
+/* Use fixed file index instead of fd */
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_read(sqe, 0, buf, len, 0);  /* 0 = fixed file index 0 */
+io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+
+/* Update a slot without re-registering all */
+io_uring_register_files_update(&ring, slot_index, &new_fd, 1);
+
+/* Unregister */
+io_uring_unregister_files(&ring);
+```
+
+Fixed files avoid taking a reference to the `struct file` on every operation — significant for high-IOPS workloads.
+
+## Fixed buffers (registered buffers)
+
+Pre-registered buffers avoid per-I/O pinning of pages:
+
+```c
+/* Register 8 buffers */
+struct iovec iovecs[8];
+for (int i = 0; i < 8; i++) {
+    iovecs[i].iov_base = bufs[i];
+    iovecs[i].iov_len  = BUF_SIZE;
+}
+io_uring_register_buffers(&ring, iovecs, 8);
+
+/* Use IORING_OP_READ_FIXED with buffer index */
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_read_fixed(sqe, fd, bufs[0], BUF_SIZE, offset, 0);
+/*                                                              ^ buf_index */
+
+io_uring_unregister_buffers(&ring);
+```
+
+Fixed buffers are pinned in memory once at registration. Per-I/O page pinning/unpinning (which requires page table walks) is eliminated.
+
+## Linked requests
+
+Chain SQEs so that the next one only starts when the previous completes successfully:
+
+```c
+/* Sequence: connect → send → recv */
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_connect(sqe, fd, addr, addrlen);
+io_uring_sqe_set_flags(sqe, IOSQE_IO_LINK);  /* link to next */
+
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_send(sqe, fd, request, req_len, 0);
+io_uring_sqe_set_flags(sqe, IOSQE_IO_LINK);  /* link to next */
+
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_recv(sqe, fd, response, resp_len, 0);
+/* no IOSQE_IO_LINK: end of chain */
+
+io_uring_submit(&ring);
+/* If connect fails → send/recv get CQE with -ECANCELED */
+```
+
+For hard chains that ignore errors, use `IOSQE_IO_HARDLINK` instead.
+
+## Buffer selection: provided buffers
+
+Instead of pre-assigning buffers to SQEs, let the kernel pick from a pool (useful when you don't know how many bytes will arrive):
+
+```c
+/* Register a buffer group */
+struct io_uring_buf_reg reg = {
+    .ring_addr    = (uint64_t)buf_ring,  /* shared ring of buffers */
+    .ring_entries = NUM_BUFS,
+    .bgid         = 0,                   /* buffer group ID */
+};
+io_uring_register_buf_ring(&ring, &reg, 0);
+
+/* Add buffers to the group */
+for (int i = 0; i < NUM_BUFS; i++) {
+    io_uring_buf_ring_add(buf_ring, bufs[i], BUF_SIZE, i, ring_mask, i);
+}
+io_uring_buf_ring_advance(buf_ring, NUM_BUFS);
+
+/* Use buffer selection on recv */
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_recv(sqe, fd, NULL, 0, 0);  /* NULL = kernel picks buffer */
+sqe->buf_group = 0;
+io_uring_sqe_set_flags(sqe, IOSQE_BUFFER_SELECT);
+
+/* CQE tells you which buffer was used */
+io_uring_wait_cqe(&ring, &cqe);
+int buf_id = cqe->flags >> IORING_CQE_BUFFER_SHIFT;
+int bytes = cqe->res;
+void *data = bufs[buf_id];
+/* process data[0..bytes-1] */
+/* Return buffer to pool: */
+io_uring_buf_ring_add(buf_ring, bufs[buf_id], BUF_SIZE, buf_id, ring_mask, 0);
+io_uring_buf_ring_advance(buf_ring, 1);
+```
+
+## Multishot operations
+
+Some operations can post multiple CQEs from a single SQE:
+
+```c
+/* IORING_OP_ACCEPT_MULTISHOT: accept new connections continuously */
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_multishot_accept(sqe, listen_fd, NULL, NULL, 0);
+
+/* Each new connection posts a CQE with the new fd in cqe->res */
+/* IORING_CQE_F_MORE set while multishot is still active */
+while (1) {
+    io_uring_wait_cqe(&ring, &cqe);
+    if (cqe->res >= 0) {
+        int client_fd = cqe->res;
+        handle_client(client_fd);
+    }
+    bool more = cqe->flags & IORING_CQE_F_MORE;
+    io_uring_cqe_seen(&ring, cqe);
+    if (!more) break;  /* multishot ended (e.g., listen_fd closed) */
+}
+
+/* Also available: */
+IORING_OP_RECV_MULTISHOT     /* recv on socket continuously */
+IORING_OP_POLL_ADD_MULTISHOT /* poll fd for events repeatedly */
+```
+
+## io_uring and BPF
+
+BPF programs can be attached to io_uring operations:
+
+```c
+/* BPF program type: BPF_PROG_TYPE_SYSCALL can intercept io_uring_enter */
+/* More commonly: io_uring + BPF via socket_filter for network paths */
+
+/* io_uring credentials: run this SQE with a different uid/caps */
+sqe->personality = io_uring_register_personality(&ring);
+/* The SQE executes with the registered identity */
+```
+
+## Observing io_uring
+
+```bash
+# List io_uring instances
+ls /proc/*/fdinfo/ | xargs grep -l "sq entries" 2>/dev/null
+
+# io_uring stats for a process
+cat /proc/<pid>/fdinfo/<ring_fd>
+# pos:     0
+# flags:   0100002
+# sq entries:     256
+# cq entries:     512
+# sq head:         42
+# sq tail:         43
+# sq mask:        255
+# sq array off:    128
+# cq head:         40
+# cq tail:         42
+# ...
+
+# System-wide io_uring stats
+cat /proc/sys/fs/io_uring_groups
+cat /sys/kernel/debug/io_uring_stats 2>/dev/null
+
+# Trace io_uring events
+trace-cmd record -e io_uring:* sleep 1
+trace-cmd report
+
+# BPF tracing
+bpftrace -e 'tracepoint:io_uring:io_uring_submit_sqe { printf("%s\n", comm); }'
+```
+
+## Performance comparison
+
+| Interface | Setup | Per-op syscall | Max IOPS (NVMe) |
+|-----------|-------|----------------|-----------------|
+| `read()`/`write()` | None | Yes (1 per op) | ~300K |
+| `libaio` + O_DIRECT | AIO context | `io_submit` (batched) | ~700K |
+| io_uring (no SQPOLL) | Ring init | `io_uring_enter` (batched) | ~1.5M |
+| io_uring + SQPOLL | Ring + thread | None | ~2M+ |
+
+## Further reading
+
+- [Architecture and Rings](io-uring-arch.md) — Ring layout and SQE/CQE structures
+- [BPF/eBPF](../bpf/README.md) — io_uring + BPF integration
+- [Block Layer: blk-mq](../block/blk-mq.md) — Where io_uring ops eventually land
+- `io_uring/` directory in the kernel tree
+- `liburing` GitHub repository — high-level C API

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -290,3 +290,7 @@ nav:
     - Signals: ipc/signals.md
     - Pipes and FIFOs: ipc/pipes.md
     - Shared Memory and Semaphores: ipc/shared-memory.md
+  - io_uring:
+    - Getting Started: io-uring/README.md
+    - Architecture and Rings: io-uring/io-uring-arch.md
+    - Operations and Advanced Features: io-uring/io-uring-ops.md


### PR DESCRIPTION
## Summary

- **Architecture and Rings** (`io-uring-arch.md`): `io_uring_setup` params, mmap offsets (IORING_OFF_SQ_RING/IORING_OFF_SQES/IORING_OFF_CQ_RING), complete SQ/CQ ring layout diagram, struct io_uring_sqe all fields, struct io_uring_cqe, lock-free submission path (head/tail + smp_store_release), completion harvesting, io_ring_ctx kernel structure
- **Operations and Advanced Features** (`io-uring-ops.md`): complete IORING_OP_* list (read/write/accept/connect/send/recv/splice/timeout/cancel/msg_ring/uring_cmd), liburing batch submission example, SQPOLL thread (eliminates syscalls, sq_thread_cpu/idle, SCHED_FIFO), fixed files (io_uring_register_files, IOSQE_FIXED_FILE), fixed buffers (registered iovec array, READ_FIXED), linked requests (IOSQE_IO_LINK chain for connect→send→recv), provided buffers (buf_ring, IOSQE_BUFFER_SELECT, IORING_CQE_BUFFER_SHIFT), multishot operations (ACCEPT_MULTISHOT), observability (/proc/fdinfo, tracepoints, bpftrace), performance comparison table

Closes #300, #301

## Test plan

- [ ] All 3 pages render correctly
- [ ] Cross-links to block/blk-mq, bpf/ work
- [ ] Code examples are valid C