### PR TITLE
Add kernel tracing documentation

### DIFF
--- a/docs/tracing/README.md
+++ b/docs/tracing/README.md
@@ -1,0 +1,57 @@
+# Kernel Tracing and Observability
+
+> Instrumentation tools for understanding kernel behavior
+
+## The tracing ecosystem
+
+Linux provides multiple complementary tracing mechanisms:
+
+```
+                    What you want to observe
+                           │
+          ┌────────────────┼────────────────────┐
+          │                │                    │
+    Function calls   Kernel events         Hardware
+      kprobe/BPF      tracepoints         perf PMU
+      ftrace           TRACE_EVENT         cycles/cache
+          │                │                    │
+          └────────────────┼────────────────────┘
+                           │
+                    Collection frontends
+                   ┌───────┴──────────┐
+                   │                  │
+                ftrace              perf
+                trace-cmd         bpftrace
+                perf-tools           BCC
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [ftrace](ftrace.md) | Function tracing, tracefs, ring buffer, trace-cmd |
+| [Kprobes and Tracepoints](kprobes-tracepoints.md) | kprobe/kretprobe, static tracepoints, TRACE_EVENT |
+| [perf Events](perf-events.md) | perf_event_open, PMU counters, sampling, flamegraphs |
+
+## Quick reference
+
+```bash
+# ftrace: trace all calls to schedule()
+echo function > /sys/kernel/tracing/current_tracer
+echo schedule > /sys/kernel/tracing/set_ftrace_filter
+echo 1 > /sys/kernel/tracing/tracing_on
+sleep 1
+echo 0 > /sys/kernel/tracing/tracing_on
+cat /sys/kernel/tracing/trace | head -20
+
+# perf: CPU cycles profile
+perf record -g -F 99 -- sleep 10
+perf report
+
+# bpftrace: trace write() calls
+bpftrace -e 'tracepoint:syscalls:sys_enter_write { printf("%s %d\n", comm, args->count); }'
+
+# trace-cmd: ftrace frontend
+trace-cmd record -e syscalls:sys_enter_read sleep 1
+trace-cmd report
+```

--- a/docs/tracing/ftrace.md
+++ b/docs/tracing/ftrace.md
@@ -1,0 +1,250 @@
+# ftrace: Function Tracer
+
+> The kernel's built-in function tracing infrastructure
+
+## What ftrace is
+
+ftrace is the kernel's main tracing framework, accessible via tracefs at `/sys/kernel/tracing/`. It:
+
+- Records every kernel function call (function tracer)
+- Traces execution paths and call graphs (function_graph tracer)
+- Provides a ring buffer for low-overhead event collection
+- Is the backend for BPF `fentry`/`fexit`, kprobes, and tracepoints
+
+## tracefs interface
+
+```bash
+# Mount tracefs (if not already mounted)
+mount -t tracefs tracefs /sys/kernel/tracing
+
+# Key files:
+/sys/kernel/tracing/
+├── current_tracer           # active tracer (nop/function/function_graph/etc.)
+├── tracing_on               # 1=enable, 0=disable
+├── trace                    # read the trace buffer (blocking)
+├── trace_pipe               # stream trace output (consuming read)
+├── trace_options            # comma-separated options
+├── available_tracers        # list of compiled-in tracers
+├── available_filter_funcs   # functions that can be filtered
+├── set_ftrace_filter        # limit function tracing to these functions
+├── set_ftrace_notrace       # exclude these functions
+├── set_graph_function       # function_graph: enter graph at these
+├── set_graph_notrace
+├── tracing_cpumask          # which CPUs to trace
+├── per_cpu/                 # per-CPU ring buffers
+│   └── cpu0/
+│       ├── trace
+│       └── stats
+├── events/                  # tracepoint events
+│   ├── enable               # enable all events
+│   └── syscalls/
+│       ├── sys_enter_read/
+│       │   ├── enable
+│       │   ├── filter
+│       │   └── format
+│       └── ...
+├── instances/               # separate trace instances (non-interfering)
+└── snapshot                 # freeze a snapshot of the ring buffer
+```
+
+## Function tracer
+
+```bash
+# Trace all function calls
+echo function > /sys/kernel/tracing/current_tracer
+echo 1 > /sys/kernel/tracing/tracing_on
+sleep 0.001
+echo 0 > /sys/kernel/tracing/tracing_on
+cat /sys/kernel/tracing/trace | head -30
+# bash-1234  [000] ..... 12345.678901: do_sys_open <-do_open_execat
+# bash-1234  [000] ..... 12345.678902: _raw_spin_lock <-jiffies_to_timespec64
+
+# Limit to specific functions
+echo "tcp_*" > /sys/kernel/tracing/set_ftrace_filter
+echo function > /sys/kernel/tracing/current_tracer
+echo 1 > /sys/kernel/tracing/tracing_on
+
+# Filter by module
+echo ":mod:ext4" > /sys/kernel/tracing/set_ftrace_filter
+
+# Multiple patterns (append with >>)
+echo "schedule" >> /sys/kernel/tracing/set_ftrace_filter
+
+# Clear filter (trace all)
+echo "" > /sys/kernel/tracing/set_ftrace_filter
+```
+
+## Function graph tracer
+
+Shows call hierarchy and execution time:
+
+```bash
+echo function_graph > /sys/kernel/tracing/current_tracer
+echo vfs_read > /sys/kernel/tracing/set_graph_function  # entry point
+echo 1 > /sys/kernel/tracing/tracing_on
+cat /some/file  # trigger the trace
+echo 0 > /sys/kernel/tracing/tracing_on
+cat /sys/kernel/tracing/trace
+# CPU DURATION              FUNCTION CALLS
+#  0  |  8.234 us  |        } /* vfs_read */
+#  0  |            |        vfs_read() {
+#  0  |            |          rw_verify_area() {
+#  0  |  0.512 us  |            security_file_permission();
+#  0  |  1.234 us  |          }
+#  0  |            |          generic_file_read_iter() {
+#  0  |            |            filemap_read() {
+```
+
+## How ftrace instruments functions
+
+When `CONFIG_DYNAMIC_FTRACE=y` and `CONFIG_HAVE_FENTRY=y`, the compiler inserts a call to `__fentry__` (or `mcount`) at the start of every traceable function:
+
+```asm
+/* Every kernel function begins with: */
+func:
+    callq   __fentry__      ; 5 bytes (E8 + 4-byte offset)
+    ; ... actual function code ...
+```
+
+When tracing is disabled, these calls are patched to `nop` instructions at boot time — **zero overhead when not tracing**.
+
+When enabled:
+```asm
+func:
+    callq   ftrace_caller   ; patched back in
+```
+
+`ftrace_caller` looks up which tracers are registered for this function and calls them. The patching is done with `stop_machine()` to safely modify text.
+
+Since Linux 5.x with `CONFIG_HAVE_FENTRY`, the compiler uses `__fentry__` (called before the function prologue saves registers) rather than `mcount`, which makes the hook faster and allows reliable stack unwinding.
+
+## Ring buffer
+
+ftrace uses a lockless per-CPU ring buffer (`kernel/trace/ring_buffer.c`):
+
+```c
+/* Architecture: */
+struct ring_buffer {
+    struct ring_buffer_per_cpu *buffers[NR_CPUS];
+};
+
+struct ring_buffer_per_cpu {
+    /* Writer: */
+    unsigned long   tail_page;   /* current write page */
+    unsigned long   commit_page; /* last committed page */
+    /* Reader: */
+    unsigned long   reader_page;
+    unsigned long   head_page;
+    /* ... */
+};
+```
+
+- Each CPU writes to its own buffer (no lock contention)
+- Ring behavior: old events are overwritten when full (unless `trace_options` has `overwrite` disabled)
+- Events are timestamped with per-CPU clock
+
+```bash
+# Check buffer size
+cat /sys/kernel/tracing/buffer_size_kb
+# 1408 (per CPU)
+
+# Increase for long captures
+echo 65536 > /sys/kernel/tracing/buffer_size_kb
+```
+
+## Dynamic events: kprobe_events and uprobe_events
+
+```bash
+# Add a kprobe on tcp_sendmsg: print first argument (sk)
+echo 'p:my_probe tcp_sendmsg sk=%di' > /sys/kernel/tracing/kprobe_events
+echo 1 > /sys/kernel/tracing/events/kprobes/my_probe/enable
+
+cat /sys/kernel/tracing/trace_pipe
+# bash-1234 [000] ..... 12345.0: my_probe: (tcp_sendmsg+0x0) sk=0xffff888...
+
+# Remove the probe
+echo '-:my_probe' >> /sys/kernel/tracing/kprobe_events
+
+# Add a kretprobe: print return value
+echo 'r:my_ret tcp_sendmsg retval=$retval' > /sys/kernel/tracing/kprobe_events
+
+# Add uprobe
+echo 'p:myapp /usr/bin/myapp:0x1234 arg1=%di' > /sys/kernel/tracing/uprobe_events
+```
+
+## Event tracing: tracepoints
+
+```bash
+# List available tracepoint events
+ls /sys/kernel/tracing/events/
+
+# Enable all events in a subsystem
+echo 1 > /sys/kernel/tracing/events/block/enable
+
+# Enable a specific event
+echo 1 > /sys/kernel/tracing/events/syscalls/sys_enter_read/enable
+
+# Filter: only events from PID 1234
+echo "common_pid == 1234" > /sys/kernel/tracing/events/syscalls/sys_enter_read/filter
+
+# View event format
+cat /sys/kernel/tracing/events/syscalls/sys_enter_read/format
+# name: sys_enter_read
+# ID: 682
+# format:
+#     field:unsigned short common_type;    offset:0; size:2; signed:0;
+#     field:unsigned char common_flags;    offset:2; size:1; signed:0;
+#     field:unsigned char common_preempt_count;  offset:3; size:1; signed:0;
+#     field:int common_pid;                offset:4; size:4; signed:1;
+#     field:int __syscall_nr;              offset:8; size:4; signed:1;
+#     field:unsigned int fd;               offset:16; size:8; signed:0;
+#     field:char * buf;                    offset:24; size:8; signed:0;
+#     field:size_t count;                  offset:32; size:8; signed:0;
+```
+
+## trace-cmd: the ftrace frontend
+
+```bash
+# Record syscalls for 5 seconds
+trace-cmd record -e 'syscalls:sys_enter_*' sleep 5
+
+# Record function graph for ext4
+trace-cmd record -p function_graph -l "ext4_*" sleep 1
+
+# Report
+trace-cmd report | head -50
+
+# Filter by CPU
+trace-cmd report --cpu 0 | head -20
+
+# Live tracing
+trace-cmd stream -e sched:sched_switch
+
+# kernel-shark: GUI frontend for trace-cmd output
+kernelshark trace.dat
+```
+
+## trace instances: non-interfering sessions
+
+```bash
+# Create a private instance (doesn't affect the global trace)
+mkdir /sys/kernel/tracing/instances/myinstance
+
+# Each instance has its own ring buffer and tracer
+echo function > /sys/kernel/tracing/instances/myinstance/current_tracer
+echo "net_*" > /sys/kernel/tracing/instances/myinstance/set_ftrace_filter
+echo 1 > /sys/kernel/tracing/instances/myinstance/tracing_on
+
+# Multiple tools can trace simultaneously without interfering
+cat /sys/kernel/tracing/instances/myinstance/trace_pipe &
+# ... while main trace continues normally ...
+
+rmdir /sys/kernel/tracing/instances/myinstance  # cleanup
+```
+
+## Further reading
+
+- [Kprobes and Tracepoints](kprobes-tracepoints.md) — Dynamic and static event hooks
+- [perf Events](perf-events.md) — Hardware PMU and sampling
+- [BPF: Architecture](../bpf/bpf-overview.md) — BPF programs attached to fentry/fexit
+- `Documentation/trace/ftrace.rst` — kernel documentation

--- a/docs/tracing/kprobes-tracepoints.md
+++ b/docs/tracing/kprobes-tracepoints.md
@@ -1,0 +1,304 @@
+# Kprobes and Tracepoints
+
+> Dynamic and static instrumentation points in the kernel
+
+## Kprobes: dynamic probes on any instruction
+
+A kprobe can be attached to any instruction in the kernel (not just function entries). When hit, it calls a handler in your code.
+
+### How kprobes work
+
+```c
+/* kernel/kprobes.c: simplified */
+
+/* At probe registration: */
+register_kprobe(kp)
+  → find instruction at kp->addr
+  → copy original instruction (for single-stepping)
+  → replace first byte(s) with INT3 (0xCC) breakpoint
+  → /* on x86 */
+
+/* At runtime, when INT3 fires: */
+do_int3()
+  → kprobe_int3_handler()
+      → call kp->pre_handler(kp, regs)
+      → set up single-step: restore original instruction, set TF flag
+      → /* return to single-step the original instruction */
+  → after single-step:
+      → kprobe_single_step_handler()
+          → call kp->post_handler(kp, regs, 0)
+          → restore INT3 breakpoint
+```
+
+On x86-64 with `CONFIG_KPROBES_ON_FTRACE`, kprobes at function entry use the existing ftrace hook instead of INT3, eliminating the breakpoint overhead.
+
+### Registering kprobes from a kernel module
+
+```c
+/* drivers/mymodule/mymodule.c */
+#include <linux/kprobes.h>
+
+static int pre_handler(struct kprobe *p, struct pt_regs *regs)
+{
+    /* Called BEFORE the probed instruction executes */
+    /* regs contains register state at probe point */
+    printk(KERN_INFO "kprobe: hit tcp_sendmsg, rdi=0x%lx\n", regs->di);
+    return 0;
+}
+
+static void post_handler(struct kprobe *p, struct pt_regs *regs,
+                          unsigned long flags)
+{
+    /* Called AFTER the probed instruction executes (single-stepped) */
+}
+
+static struct kprobe kp = {
+    .symbol_name = "tcp_sendmsg",  /* or .addr = (kprobe_opcode_t *)addr */
+    .pre_handler = pre_handler,
+    .post_handler = post_handler,
+};
+
+static int __init mymodule_init(void)
+{
+    int ret = register_kprobe(&kp);
+    if (ret < 0) {
+        pr_err("register_kprobe failed: %d\n", ret);
+        return ret;
+    }
+    pr_info("kprobe registered at %p\n", kp.addr);
+    return 0;
+}
+
+static void __exit mymodule_exit(void)
+{
+    unregister_kprobe(&kp);
+}
+```
+
+### kretprobe: hook on function return
+
+```c
+static int entry_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+    /* Called on function entry; can store data in ri->data */
+    *(ktime_t *)ri->data = ktime_get();
+    return 0;
+}
+
+static int return_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+    /* Called on function return */
+    ktime_t start = *(ktime_t *)ri->data;
+    long retval = regs_return_value(regs);
+    ktime_t elapsed = ktime_sub(ktime_get(), start);
+
+    pr_info("tcp_sendmsg returned %ld, took %lld ns\n",
+            retval, ktime_to_ns(elapsed));
+    return 0;
+}
+
+static struct kretprobe my_kretprobe = {
+    .handler     = return_handler,
+    .entry_handler = entry_handler,
+    .data_size   = sizeof(ktime_t),  /* per-instance data */
+    .maxactive   = 20,               /* max concurrent instances */
+    .kp.symbol_name = "tcp_sendmsg",
+};
+```
+
+## Static tracepoints: TRACE_EVENT
+
+Static tracepoints are annotation points compiled into the kernel at specific places. They have:
+- Zero overhead when disabled (a single no-op test)
+- Rich structured data (not just register dumps)
+- Stable ABI (unlike kprobes which depend on function names)
+
+### TRACE_EVENT macro
+
+```c
+/* include/trace/events/sched.h */
+TRACE_EVENT(sched_switch,
+
+    /* Arguments to the tracepoint call: */
+    TP_PROTO(bool preempt,
+             struct task_struct *prev,
+             struct task_struct *next,
+             unsigned int prev_state),
+
+    /* Actual call arguments: */
+    TP_ARGS(preempt, prev, next, prev_state),
+
+    /* Fields stored in the ring buffer: */
+    TP_STRUCT__entry(
+        __array(        char,   prev_comm,  TASK_COMM_LEN   )
+        __field(        pid_t,  prev_pid                    )
+        __field(        int,    prev_prio                   )
+        __field(        long,   prev_state                  )
+        __array(        char,   next_comm,  TASK_COMM_LEN   )
+        __field(        pid_t,  next_pid                    )
+        __field(        int,    next_prio                   )
+    ),
+
+    /* Code to copy data into the ring buffer entry: */
+    TP_fast_assign(
+        memcpy(__entry->next_comm, next->comm, TASK_COMM_LEN);
+        __entry->prev_pid   = prev->pid;
+        __entry->prev_prio  = prev->prio;
+        __entry->prev_state = __trace_sched_switch_state(preempt, prev_state, prev);
+        memcpy(__entry->prev_comm, prev->comm, TASK_COMM_LEN);
+        __entry->next_pid   = next->pid;
+        __entry->next_prio  = next->prio;
+    ),
+
+    /* Format string for human-readable output: */
+    TP_printk("prev_comm=%s prev_pid=%d prev_prio=%d prev_state=%s%s ==> "
+              "next_comm=%s next_pid=%d next_prio=%d",
+              __entry->prev_comm, __entry->prev_pid, __entry->prev_prio,
+              ...)
+);
+```
+
+### Adding a tracepoint to your code
+
+```c
+/* 1. Define the tracepoint (once, in a header): */
+/* include/trace/events/mysubsystem.h */
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM mysubsystem
+
+#if !defined(_TRACE_MYSUBSYSTEM_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _TRACE_MYSUBSYSTEM_H
+
+#include <linux/tracepoint.h>
+
+TRACE_EVENT(my_event,
+    TP_PROTO(int value, const char *name),
+    TP_ARGS(value, name),
+    TP_STRUCT__entry(
+        __field(int, value)
+        __string(name, name)  /* variable-length string */
+    ),
+    TP_fast_assign(
+        __entry->value = value;
+        __assign_str(name, name);
+    ),
+    TP_printk("value=%d name=%s", __entry->value, __get_str(name))
+);
+
+#endif /* _TRACE_MYSUBSYSTEM_H */
+#include <trace/define_trace.h>
+
+/* 2. Use in source files: */
+/* kernel/mysubsystem.c */
+#define CREATE_TRACE_POINTS
+#include <trace/events/mysubsystem.h>
+
+void my_function(int val, const char *name)
+{
+    /* Tracepoint: zero-overhead when disabled */
+    trace_my_event(val, name);
+    /* ... */
+}
+```
+
+### How tracepoints achieve zero overhead
+
+```c
+/* Generated by TRACE_EVENT: */
+static inline void trace_my_event(int value, const char *name)
+{
+    /* Single branch: check if any caller is registered */
+    if (static_key_false(&__tracepoint_my_event.key)) {
+        /* overhead only when enabled */
+        __tracepoint_my_event.funcs(value, name);
+    }
+}
+```
+
+`static_key_false` uses a patched nop/jmp instruction (via jump labels) — the entire `if` block is patched out at runtime when no one is listening.
+
+## uprobes: userspace dynamic probes
+
+uprobes work like kprobes but for userspace binaries. The kernel inserts a breakpoint into the mapped pages:
+
+```bash
+# Trace all calls to malloc in any process
+echo 'p:malloc /lib/x86_64-linux-gnu/libc.so.6:0x9d430' \
+    > /sys/kernel/tracing/uprobe_events
+echo 1 > /sys/kernel/tracing/events/uprobes/malloc/enable
+
+# Trace by symbol name (requires debug symbols)
+echo 'p:my_func /usr/bin/myapp:my_function' \
+    > /sys/kernel/tracing/uprobe_events
+```
+
+```c
+/* Kernel struct uprobe */
+struct uprobe {
+    struct rb_node  rb_node;   /* inode's uprobe tree */
+    refcount_t      ref;
+    struct rw_semaphore register_rwsem;
+    struct rw_semaphore consumer_rwsem;
+    struct list_head   pending_list;
+    struct uprobe_consumer *consumers;
+    struct inode       *inode;   /* target binary's inode */
+    loff_t              offset;  /* offset within file */
+    loff_t              ref_ctr_offset;
+    unsigned long       flags;
+    struct arch_uprobe  arch;    /* arch-specific saved instruction */
+};
+```
+
+## USDT: userspace statically defined tracepoints
+
+Similar to kernel TRACE_EVENT, USDT probes are static markers in userspace code:
+
+```c
+/* In C code (requires systemtap-sdt-dev or dtrace probes): */
+#include <sys/sdt.h>
+DTRACE_PROBE2(myapp, request_start, req_id, req_type);
+/* ... */
+DTRACE_PROBE1(myapp, request_end, req_id);
+```
+
+```bash
+# List USDT probes in a binary
+readelf --notes /usr/bin/python3 | grep stapsdt
+
+# Trace with bpftrace
+bpftrace -e 'usdt:/usr/bin/python3:function__entry { printf("%s\n", str(arg1)); }'
+
+# Trace with perf
+perf probe -x /usr/bin/python3 sdt_pythonX_Y:function__entry
+```
+
+## Observing probe activity
+
+```bash
+# Count kprobe hits
+cat /sys/kernel/tracing/kprobe_profile
+# tcp_sendmsg        42         0  ← hits, misses
+
+# Event hit counts
+cat /sys/kernel/tracing/events/syscalls/sys_enter_read/hist
+
+# Aggregate with bpftrace
+bpftrace -e 'kprobe:tcp_sendmsg { @[comm] = count(); }'
+# Attaching 1 probe...
+# ^C
+# @[nginx]: 1234
+# @[postgres]: 567
+
+# Dynamic function graph with kprobe
+echo function_graph > /sys/kernel/tracing/current_tracer
+echo 'tcp_sendmsg' > /sys/kernel/tracing/set_graph_function
+echo 1 > /sys/kernel/tracing/tracing_on
+```
+
+## Further reading
+
+- [ftrace](ftrace.md) — Ring buffer and tracefs interface
+- [perf Events](perf-events.md) — Hardware counters and sampling
+- [BPF: Architecture](../bpf/bpf-overview.md) — kprobe/tracepoint BPF programs
+- `Documentation/trace/kprobes.rst` — kernel kprobe documentation
+- `Documentation/trace/tracepoints.rst` — static tracepoint documentation

--- a/docs/tracing/perf-events.md
+++ b/docs/tracing/perf-events.md
@@ -1,0 +1,306 @@
+# perf Events
+
+> Hardware performance counters, sampling, and profiling
+
+## What perf events are
+
+`perf_event_open` is the Linux syscall for accessing performance monitoring hardware:
+
+- **Hardware counters** (PMU): CPU cycles, instructions, cache misses, branch mispredictions
+- **Software counters**: page faults, context switches, CPU migrations
+- **Tracepoints**: static kernel events
+- **Dynamic events**: kprobes, uprobes, BPF
+- **Sampling**: record PC/stack every N events for statistical profiling
+
+## perf_event_open syscall
+
+```c
+#include <linux/perf_event.h>
+
+struct perf_event_attr attr = {
+    .type           = PERF_TYPE_HARDWARE,
+    .config         = PERF_COUNT_HW_CPU_CYCLES,  /* count CPU cycles */
+    .size           = sizeof(attr),
+    .disabled       = 1,    /* start disabled */
+    .exclude_kernel = 0,    /* count kernel events too */
+    .exclude_hv     = 1,    /* exclude hypervisor */
+};
+
+/* Monitor the current process on any CPU */
+int fd = syscall(SYS_perf_event_open, &attr,
+                 0,    /* pid: 0=current process */
+                 -1,   /* cpu: -1=any */
+                 -1,   /* group_fd: -1=no group */
+                 0);   /* flags */
+
+/* Start counting */
+ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+
+/* ... code to measure ... */
+
+/* Read counter */
+long long count;
+read(fd, &count, sizeof(count));
+printf("CPU cycles: %lld\n", count);
+
+/* Stop */
+ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+close(fd);
+```
+
+## Event types
+
+```c
+/* Hardware events (CPU PMU) */
+.type = PERF_TYPE_HARDWARE
+.config:
+    PERF_COUNT_HW_CPU_CYCLES         /* CPU cycles */
+    PERF_COUNT_HW_INSTRUCTIONS       /* retired instructions */
+    PERF_COUNT_HW_CACHE_REFERENCES   /* cache accesses */
+    PERF_COUNT_HW_CACHE_MISSES       /* cache misses */
+    PERF_COUNT_HW_BRANCH_INSTRUCTIONS /* branch instructions */
+    PERF_COUNT_HW_BRANCH_MISSES      /* branch mispredictions */
+    PERF_COUNT_HW_BUS_CYCLES
+    PERF_COUNT_HW_STALLED_CYCLES_FRONTEND
+    PERF_COUNT_HW_STALLED_CYCLES_BACKEND
+
+/* Software events (kernel counters) */
+.type = PERF_TYPE_SOFTWARE
+.config:
+    PERF_COUNT_SW_CPU_CLOCK          /* CPU clock (ns) */
+    PERF_COUNT_SW_TASK_CLOCK         /* task-local clock */
+    PERF_COUNT_SW_PAGE_FAULTS        /* page faults */
+    PERF_COUNT_SW_CONTEXT_SWITCHES   /* voluntary + involuntary */
+    PERF_COUNT_SW_CPU_MIGRATIONS     /* task moved between CPUs */
+    PERF_COUNT_SW_PAGE_FAULTS_MIN    /* minor faults (no disk I/O) */
+    PERF_COUNT_SW_PAGE_FAULTS_MAJ    /* major faults (disk I/O) */
+    PERF_COUNT_SW_ALIGNMENT_FAULTS
+    PERF_COUNT_SW_EMULATION_FAULTS
+    PERF_COUNT_SW_DUMMY
+
+/* Hardware cache events */
+.type = PERF_TYPE_HW_CACHE
+/* .config encodes: cache_id | (cache_op_id << 8) | (result_id << 16) */
+/* e.g., L1D read misses: */
+.config = PERF_COUNT_HW_CACHE_L1D | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+          (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)
+
+/* Tracepoint events */
+.type = PERF_TYPE_TRACEPOINT
+.config = <tracepoint_id>  /* from /sys/kernel/tracing/events/.../id */
+
+/* Raw CPU PMU events */
+.type = PERF_TYPE_RAW
+.config = <cpu-specific PMU event code>  /* e.g., Intel perfmon event */
+```
+
+## Sampling mode
+
+Sampling records the instruction pointer (and optionally call stack) every N events:
+
+```c
+struct perf_event_attr attr = {
+    .type           = PERF_TYPE_HARDWARE,
+    .config         = PERF_COUNT_HW_CPU_CYCLES,
+    .sample_type    = PERF_SAMPLE_IP | PERF_SAMPLE_TID |
+                      PERF_SAMPLE_TIME | PERF_SAMPLE_CALLCHAIN,
+    .sample_period  = 1000000,  /* every 1M cycles */
+    /* OR: */
+    .sample_freq    = 99,       /* ~99 Hz (kernel adjusts period) */
+    .freq           = 1,        /* enable freq mode */
+    .wakeup_events  = 1,        /* wake userspace every N samples */
+    /* Callchain depth: */
+    .exclude_callchain_kernel = 0,
+    .exclude_callchain_user   = 0,
+};
+```
+
+Samples are written to an `mmap`'d ring buffer (the perf mmap buffer):
+
+```c
+/* Map the ring buffer */
+void *mmap_buf = mmap(NULL, (1 + pages) * PAGE_SIZE,
+                      PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+
+struct perf_event_mmap_page *header = mmap_buf;
+/* header->data_head: write position (updated by kernel) */
+/* header->data_tail: read position (updated by userspace) */
+
+void *data = mmap_buf + PAGE_SIZE;  /* ring starts after metadata page */
+
+/* Read loop: */
+while (header->data_tail != header->data_head) {
+    struct perf_event_header *event = data + (header->data_tail % data_size);
+    /* process event */
+    header->data_tail += event->size;
+}
+```
+
+## perf tool: the userspace frontend
+
+### Counting
+
+```bash
+# Count events for a command
+perf stat ls
+# Performance counter stats for 'ls':
+#      0.98 msec task-clock                #    0.783 CPUs utilized
+#         1      context-switches          #    1.022 K/sec
+#         0      cpu-migrations            #    0.000 /sec
+#       163      page-faults               #  166.389 K/sec
+#   2,345,678    cycles                    #    2.394 GHz
+#   1,234,567    instructions              #    0.53  insn per cycle
+#     456,789    branches                  #  466.520 M/sec
+#      12,345    branch-misses             #    2.70% of all branches
+
+# Specific events
+perf stat -e cycles,instructions,cache-misses,cache-references -- ./myapp
+
+# System-wide
+perf stat -a sleep 5
+
+# CPI (cycles per instruction) analysis
+perf stat -e cycles,instructions -r 3 ./myapp  # repeat 3 times
+```
+
+### CPU profiling with perf record
+
+```bash
+# Record with call graphs (frame pointer)
+perf record -g -F 99 -- ./myapp
+# Or: sample all CPUs
+perf record -g -F 99 -a sleep 30
+
+# Report
+perf report
+# Overhead  Command   Symbol
+#  25.43%   myapp     [k] __schedule
+#  18.21%   myapp     [.] malloc
+#  12.33%   myapp     [.] my_function
+
+# Show call graph
+perf report --call-graph=graph
+
+# Annotate with source
+perf report --stdio --tui
+```
+
+### Flame graphs
+
+```bash
+# Record
+perf record -g -F 99 -p <pid> sleep 30
+
+# Convert to flame graph (via Brendan Gregg's scripts)
+perf script | stackcollapse-perf.pl | flamegraph.pl > flamegraph.svg
+
+# Or use hotspot (GUI)
+hotspot perf.data
+```
+
+### Kernel internals: struct perf_event
+
+```c
+/* include/linux/perf_event.h */
+struct perf_event {
+    struct list_head        event_entry;
+    struct list_head        sibling_list; /* group siblings */
+    struct list_head        active_list;
+
+    struct perf_event_attr  attr;         /* user-space config */
+    struct hw_perf_event    hw;           /* PMU hardware state */
+
+    struct perf_event_context *ctx;       /* context (task or CPU) */
+    atomic_long_t           refcount;
+
+    /* Callback when an overflow/sample occurs: */
+    perf_overflow_handler_t overflow_handler;
+    void                   *overflow_handler_context;
+
+    /* Ring buffer for samples: */
+    struct perf_buffer __rcu *rb;
+
+    /* Tracepoint: */
+    struct trace_event_call *tp_event;
+
+    /* BPF: */
+    struct bpf_prog         *prog;
+
+    u64                     id;           /* unique event ID */
+    /* ... */
+};
+
+struct hw_perf_event {
+    /* PMU hardware registers: */
+    union {
+        struct { /* hardware */
+            u64 config;          /* programmed into PMU */
+            u64 last_tag;
+            unsigned long config_base;
+            unsigned long event_base;
+            int event_base_rdpmc;
+            int idx;             /* counter index */
+            int last_cpu;
+            int flags;
+        };
+        /* ... */
+    };
+    u64                     prev_count;  /* last read value */
+    u64                     sample_period;
+    u64                     last_period;
+    local64_t               period_left;
+    /* ... */
+};
+```
+
+### PMU: Hardware Performance Monitoring Unit
+
+Each CPU architecture has a PMU with a limited number of programmable counters. On Intel:
+
+```
+Intel PMU (Skylake):
+  - 4 general-purpose counters (PERFCTR0..3)  ← programmable with any event
+  - 3 fixed-function counters:
+      FIXED_CTR0 = instructions retired
+      FIXED_CTR1 = CPU clock cycles
+      FIXED_CTR2 = reference cycles
+  - Each counter generates an NMI when it overflows
+
+Relevant MSRs:
+  IA32_PERFEVTSELx: event selector (event, umask, usr, os, edge, etc.)
+  IA32_PMCx:        counter value
+  IA32_FIXED_CTR_CTRL: enable fixed counters
+  IA32_PERF_GLOBAL_CTRL: enable/disable all counters
+```
+
+The perf subsystem multiplexes software events onto the limited hardware counters using `context_switch` and `rotation`.
+
+## Observing perf internals
+
+```bash
+# List available events
+perf list
+
+# Check if PMU is working
+perf stat -e cycles echo hello
+
+# Hardware event codes for raw events
+# Intel: https://perfmon-events.intel.com/
+perf stat -e r4c14  # raw Intel event code (hex)
+
+# Check NMI handler
+cat /proc/interrupts | grep NMI
+
+# perf_event_paranoid: controls access
+cat /proc/sys/kernel/perf_event_paranoid
+# -1: no restrictions, 0: allow kernel profiling (default), 1: user only, 2: no kernel addr
+echo 0 > /proc/sys/kernel/perf_event_paranoid
+```
+
+## Further reading
+
+- [ftrace](ftrace.md) — Low-level function tracing
+- [Kprobes and Tracepoints](kprobes-tracepoints.md) — Dynamic and static events used with perf
+- [BPF: Architecture](../bpf/bpf-overview.md) — BPF_PROG_TYPE_PERF_EVENT programs
+- `tools/perf/` in the kernel tree — perf tool source
+- `Documentation/admin-guide/perf-security.rst`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -294,3 +294,8 @@ nav:
     - Getting Started: io-uring/README.md
     - Architecture and Rings: io-uring/io-uring-arch.md
     - Operations and Advanced Features: io-uring/io-uring-ops.md
+  - Tracing:
+    - Getting Started: tracing/README.md
+    - ftrace: tracing/ftrace.md
+    - Kprobes and Tracepoints: tracing/kprobes-tracepoints.md
+    - perf Events: tracing/perf-events.md


### PR DESCRIPTION
## Summary

- **ftrace** (`ftrace.md`): tracefs layout (/sys/kernel/tracing), function/function_graph tracers, __fentry__ instrumentation with nop patching at boot (zero overhead when disabled), per-CPU lockless ring buffer internals, set_ftrace_filter patterns, kprobe_events/uprobe_events dynamic probes from tracefs, event filtering with format strings, trace instances for non-interfering sessions, trace-cmd commands
- **Kprobes and tracepoints** (`kprobes-tracepoints.md`): kprobe INT3 insertion + single-step execution flow, kretprobe with per-instance data storage, struct kprobe/kretprobe kernel layout, TRACE_EVENT macro (TP_PROTO/TP_ARGS/TP_STRUCT__entry/TP_fast_assign/TP_printk), static_key_false jump label for zero-overhead when disabled, adding custom tracepoints to your subsystem, uprobes and USDT probes, bpftrace examples
- **perf events** (`perf-events.md`): perf_event_open syscall, all PERF_TYPE_* and PERF_COUNT_HW_* event types, sampling mode with mmap ring buffer (perf_event_mmap_page head/tail), struct perf_event + hw_perf_event internals, Intel PMU architecture (4 GP counters + 3 fixed, NMI overflow, relevant MSRs), perf stat/record/report, flame graph generation, perf_event_paranoid

Closes #304, #305, #306

## Test plan

- [ ] All 4 pages render correctly
- [ ] Cross-links to bpf/, mm/ work
- [ ] Shell commands are syntactically correct