### PR TITLE
Add kernel modules documentation

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -1,0 +1,41 @@
+# Kernel Modules
+
+> Dynamically loadable code that extends the kernel
+
+## What kernel modules are
+
+A kernel module is an ELF shared object loaded into the kernel at runtime. Modules:
+- Share the kernel's address space and run at ring 0 (full privilege)
+- Can export and use symbols from other modules or the core kernel
+- Are loaded by `insmod`/`modprobe` and removed by `rmmod`
+- Have an init function called on load and an exit function called on unload
+
+Most device drivers, filesystems, and network protocols ship as modules.
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Writing and Loading Modules](module-basics.md) | module_init/exit, lifecycle, /proc/modules, debugging |
+| [Parameters, Symbols, and Kconfig](module-params.md) | module_param, EXPORT_SYMBOL, Kconfig integration |
+
+## Quick reference
+
+```bash
+# Load a module
+insmod ./mymodule.ko
+modprobe e1000e      # load with dependencies
+
+# Unload
+rmmod mymodule
+modprobe -r e1000e   # remove with unused dependencies
+
+# List loaded modules
+lsmod
+
+# Module info
+modinfo e1000e
+
+# Check kernel log for module messages
+dmesg | tail -20
+```

--- a/docs/modules/module-basics.md
+++ b/docs/modules/module-basics.md
@@ -1,0 +1,248 @@
+# Writing and Loading Kernel Modules
+
+> The lifecycle of a kernel module from source to running code
+
+## A minimal kernel module
+
+```c
+/* hello.c */
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+
+static int __init hello_init(void)
+{
+    pr_info("Hello, kernel!\n");  /* prints to kernel log */
+    return 0;                      /* non-zero = load failed */
+}
+
+static void __exit hello_exit(void)
+{
+    pr_info("Goodbye, kernel!\n");
+}
+
+module_init(hello_init);
+module_exit(hello_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Example Author");
+MODULE_DESCRIPTION("A minimal hello world module");
+MODULE_VERSION("1.0");
+```
+
+```makefile
+# Makefile
+obj-m := hello.o
+
+# If source is out-of-tree:
+KDIR ?= /lib/modules/$(shell uname -r)/build
+
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+```
+
+```bash
+# Build
+make
+
+# Load
+sudo insmod hello.ko
+
+# Check output
+dmesg | tail -3
+# [12345.678] Hello, kernel!
+
+# Unload
+sudo rmmod hello
+
+dmesg | tail -3
+# [12346.789] Goodbye, kernel!
+```
+
+## Module lifecycle
+
+```
+insmod/modprobe                                  rmmod
+    │                                              │
+    ▼                                              ▼
+kernel_init_module()                         free_module()
+    │                                              │
+    ├── verify_elf()          module refcount = 0 ─┤
+    ├── layout_sections()          (checked first)  │
+    ├── load_module()               module_exit() ──┘
+    │     ├── parse .modinfo                        │
+    │     ├── relocate symbols                      ▼
+    │     ├── check MODULE_LICENSE           free_module_core()
+    │     └── call module_init()                 vfree(module ELF)
+    │              │
+    │              └── return 0: success
+    │              └── return -errno: unload immediately
+    │
+    └── add to modules list (/proc/modules)
+        export symbols to other modules
+```
+
+## Module sections
+
+A module `.ko` file is an ELF with special sections:
+
+```bash
+objdump -h hello.ko | grep -E "(\.init|\.exit|\.text|\.data|__param|__mod)"
+# .init.text   contains hello_init() (freed after module loads)
+# .exit.text   contains hello_exit() (kept until module unloads)
+# .text        normal code
+# .data        read-write data
+# .rodata      read-only data
+# __param      module_param definitions
+# .modinfo     MODULE_LICENSE, MODULE_AUTHOR, etc.
+```
+
+The `__init` attribute marks functions that should be freed after the module init runs (saving memory). Similarly `__exit` code can be discarded on permanent modules.
+
+## /proc/modules
+
+```bash
+lsmod
+# Module                  Size  Used by
+# e1000e               262144  0
+# ptp                   28672  1 e1000e
+
+cat /proc/modules
+# e1000e 262144 0 - Live 0xffffffffc0400000 (OE)
+# Field: name size refcount deps state address (flags)
+# Flags: O=out-of-tree, E=unsigned, F=forced
+
+# See module dependencies
+cat /lib/modules/$(uname -r)/modules.dep | grep e1000e
+```
+
+## The module struct in the kernel
+
+```c
+/* include/linux/module.h */
+struct module {
+    enum module_state state;       /* MODULE_STATE_LIVE/COMING/GOING/UNFORMED */
+    struct list_head  list;        /* linked into modules list */
+    char              name[MODULE_NAME_LEN];
+    const char       *srcversion;  /* source hash for module signing */
+
+    struct module_kobject mkobj;   /* /sys/module/name/ */
+    struct module_attribute *modinfo_attrs;
+
+    const char       *version;
+    const char       *srcversion;
+    struct kobject   *holders_dir; /* /sys/module/name/holders/ */
+
+    /* Exported symbols: */
+    const struct kernel_symbol *syms;
+    const s32                  *crcs;
+    unsigned int                num_syms;
+
+    /* GPL-only exported symbols: */
+    const struct kernel_symbol *gpl_syms;
+    const s32                  *gpl_crcs;
+    unsigned int                num_gpl_syms;
+
+    /* Module sections: */
+    void *module_init;        /* .init.text (freed after init) */
+    void *module_core;        /* .text, .data, .rodata */
+    unsigned long init_size;
+    unsigned long core_size;
+
+    /* Reference counting: */
+    atomic_t refcnt;
+
+    /* init/exit: */
+    int (*init)(void);
+    void (*exit)(void);
+
+    /* Parameters: */
+    struct kernel_param *kp;
+    unsigned int num_kp;
+
+    /* Tracepoints: */
+    struct tracepoint * const *tracepoints_ptrs;
+    unsigned int num_tracepoints;
+    /* ... */
+};
+```
+
+## pr_* logging
+
+```c
+/* Logging macros (prefer these over printk directly): */
+pr_emerg("...");   /* KERN_EMERG — system is unusable */
+pr_alert("...");   /* KERN_ALERT — action must be taken immediately */
+pr_crit("...");    /* KERN_CRIT */
+pr_err("...");     /* KERN_ERR — error conditions */
+pr_warn("...");    /* KERN_WARNING */
+pr_notice("...");  /* KERN_NOTICE */
+pr_info("...");    /* KERN_INFO */
+pr_debug("...");   /* KERN_DEBUG — only printed if CONFIG_DYNAMIC_DEBUG */
+
+/* Device-specific logging (prefixes with device name): */
+dev_err(&pdev->dev, "failed to allocate: %d\n", ret);
+dev_info(&pdev->dev, "initialized at %p\n", base);
+
+/* Rate-limited logging: */
+pr_info_ratelimited("too many events\n");
+
+/* Dynamic debug: selectively enable at runtime */
+/* echo "module hello +p" > /sys/kernel/debug/dynamic_debug/control */
+pr_debug("This only shows when enabled dynamically\n");
+```
+
+## Module signing
+
+Modern kernels can enforce that modules are signed by a trusted key:
+
+```bash
+# Check if kernel requires signed modules
+cat /proc/sys/kernel/modules_disabled  # 0=allow, 1=only signed
+
+# Sign a module
+/usr/src/linux-headers-$(uname -r)/scripts/sign-file \
+    sha256 signing_key.pem signing_key.x509 hello.ko
+
+# Check module signature
+modinfo hello.ko | grep sig
+
+# Kernel boot params:
+# module.sig_enforce=1   — require signature
+# module.sig_unenforce=1 — allow unsigned (for testing)
+```
+
+## Module debugging
+
+```bash
+# Dynamic debug: enable pr_debug() for a module
+echo "module hello +p" > /sys/kernel/debug/dynamic_debug/control
+echo "file hello.c +p" > /sys/kernel/debug/dynamic_debug/control
+echo "func hello_init +p" > /sys/kernel/debug/dynamic_debug/control
+
+# Show all dynamic debug settings
+cat /sys/kernel/debug/dynamic_debug/control
+
+# KASAN for memory errors (CONFIG_KASAN=y)
+# Load module and trigger bug → KASAN reports use-after-free, etc.
+
+# Check module's kallsyms
+grep hello /proc/kallsyms
+# ffffffffc0401000 t hello_init [hello]
+# ffffffffc0401020 t hello_exit [hello]
+
+# Crash debugging with gdb
+gdb vmlinux
+(gdb) add-symbol-file /path/to/hello.ko 0xffffffffc0401000
+(gdb) list hello_init
+```
+
+## Further reading
+
+- [Parameters, Symbols, and Kconfig](module-params.md) — module_param, EXPORT_SYMBOL
+- [Platform Drivers](../drivers/platform-driver.md) — Most drivers are modules
+- [BPF Verifier](../bpf/bpf-verifier.md) — Alternative to modules for safe kernel extension
+- `Documentation/kbuild/modules.rst` — kernel build system for modules

--- a/docs/modules/module-params.md
+++ b/docs/modules/module-params.md
@@ -1,0 +1,285 @@
+# Module Parameters, Symbols, and Kconfig
+
+> Configuring modules at load time and sharing symbols across the kernel
+
+## module_param: runtime configuration
+
+```c
+/* Declare module parameters */
+static int debug = 0;
+static unsigned int timeout_ms = 100;
+static char *device_name = "mydevice";
+static bool enable_feature = false;
+
+module_param(debug, int, 0644);
+MODULE_PARM_DESC(debug, "Debug level (0=off, 1=basic, 2=verbose)");
+
+module_param(timeout_ms, uint, 0644);
+MODULE_PARM_DESC(timeout_ms, "Timeout in milliseconds (default: 100)");
+
+module_param(device_name, charp, 0444);  /* read-only after load */
+MODULE_PARM_DESC(device_name, "Device name string");
+
+module_param(enable_feature, bool, 0644);
+MODULE_PARM_DESC(enable_feature, "Enable experimental feature");
+```
+
+The third argument is the `sysfs` permission:
+- `0644` — owner read-write, group/other read-only → visible and changeable
+- `0444` — read-only for everyone
+- `0` — not exposed in sysfs (load-time only)
+
+```bash
+# Set at load time
+sudo modprobe mymodule debug=2 timeout_ms=500
+
+# Or with insmod
+sudo insmod mymodule.ko debug=2
+
+# Read/write via sysfs (if permission allows)
+cat /sys/module/mymodule/parameters/debug
+echo 3 > /sys/module/mymodule/parameters/debug
+```
+
+### Arrays
+
+```c
+static int irq_nums[4];
+static int irq_count = 0;
+
+module_param_array(irq_nums, int, &irq_count, 0444);
+MODULE_PARM_DESC(irq_nums, "IRQ numbers (comma-separated)");
+```
+
+```bash
+sudo insmod mymodule.ko irq_nums=5,6,7  # irq_count set to 3 by kernel
+```
+
+### Callbacks on parameter change
+
+```c
+static int my_debug = 0;
+
+static int debug_set(const char *val, const struct kernel_param *kp)
+{
+    int n;
+    int ret = kstrtoint(val, 10, &n);
+    if (ret)
+        return ret;
+    if (n < 0 || n > 3)
+        return -EINVAL;
+    my_debug = n;
+    pr_info("debug level changed to %d\n", n);
+    return 0;
+}
+
+static const struct kernel_param_ops debug_ops = {
+    .set = debug_set,
+    .get = param_get_int,
+};
+module_param_cb(debug, &debug_ops, &my_debug, 0644);
+```
+
+## EXPORT_SYMBOL: sharing symbols between modules
+
+```c
+/* In module A (or core kernel): */
+int shared_function(int arg)
+{
+    return arg * 2;
+}
+EXPORT_SYMBOL(shared_function);             /* available to any module */
+EXPORT_SYMBOL_GPL(shared_function_gpl);     /* GPL modules only */
+EXPORT_SYMBOL_NS(shared_function, MYNS);    /* namespaced export (5.4+) */
+```
+
+```c
+/* In module B: */
+extern int shared_function(int arg);  /* or just include the header */
+
+static int __init moduleB_init(void)
+{
+    int result = shared_function(21);  /* works: symbol is exported */
+    pr_info("result = %d\n", result);
+    return 0;
+}
+```
+
+### EXPORT_SYMBOL vs EXPORT_SYMBOL_GPL
+
+`EXPORT_SYMBOL_GPL` makes the symbol usable only by modules with `MODULE_LICENSE("GPL")` or compatible licenses. This enforces that proprietary modules can't use kernel-internal interfaces.
+
+When a module imports a GPL-only symbol:
+```bash
+modinfo mymodule.ko | grep license
+# license: GPL
+
+# If you use a GPL-only symbol with non-GPL license, load fails:
+# ERROR: "shared_function_gpl" [mymodule.ko] undefined!
+```
+
+### Symbol versioning (CRC)
+
+Each exported symbol has a CRC of its type signature. If the symbol's definition changes, the CRC changes, and modules compiled against the old interface refuse to load:
+
+```bash
+# Check symbol CRCs
+modpost output:
+# WARNING: modpost: "tcp_sendmsg" [...] has no CRC!
+# (happens if kernel isn't built with CONFIG_MODVERSIONS=y)
+```
+
+## /proc/kallsyms: all kernel symbols
+
+```bash
+# Find where a function lives
+grep "tcp_sendmsg" /proc/kallsyms
+# ffffffff81a12345 T tcp_sendmsg          ← T=text (exported)
+# ffffffffc0401000 t hello_init [hello]   ← t=text (local), [module]
+
+# Address → function name
+awk '/ffffffff81a12345/{print $3}' /proc/kallsyms
+
+# All module symbols
+grep "\[mymodule\]" /proc/kallsyms
+```
+
+Symbol types:
+- `T`/`t` — code (.text) — uppercase=global, lowercase=local
+- `D`/`d` — data (.data)
+- `R`/`r` — read-only data (.rodata)
+- `B`/`b` — BSS (zero-initialized)
+- `U` — undefined (imported)
+
+## Kconfig: compile-time configuration
+
+```kconfig
+# drivers/mydriver/Kconfig
+
+config MY_DRIVER
+    tristate "My example driver"
+    depends on PCI
+    select DMA_ENGINE
+    help
+      Enable support for the MyDriver hardware.
+
+      If unsure, say N.
+      To compile as a module, say M.
+
+config MY_DRIVER_DEBUG
+    bool "Enable MyDriver debug output"
+    depends on MY_DRIVER
+    default n
+    help
+      Enable verbose debug logging for MyDriver.
+```
+
+`tristate` means: `y` (built-in), `m` (module), or `n` (disabled).
+
+```makefile
+# drivers/mydriver/Makefile
+obj-$(CONFIG_MY_DRIVER) += mydriver.o
+mydriver-objs := mydriver_main.o mydriver_pci.o
+
+# Conditional compilation
+obj-$(CONFIG_MY_DRIVER_DEBUG) += mydriver_debug.o
+```
+
+```c
+/* In source: */
+#ifdef CONFIG_MY_DRIVER_DEBUG
+void debug_dump(void) { /* ... */ }
+#else
+static inline void debug_dump(void) {}
+#endif
+```
+
+```bash
+# Configure
+make menuconfig
+# Navigate to your driver section
+
+# Check what's enabled
+grep MY_DRIVER .config
+# CONFIG_MY_DRIVER=m
+# CONFIG_MY_DRIVER_DEBUG=n
+
+# Build only this module
+make M=drivers/mydriver
+```
+
+## Module dependencies
+
+`modprobe` reads dependency information to automatically load required modules:
+
+```bash
+# Regenerate dependency database (after installing new modules)
+depmod -a
+
+# Check what mymodule requires
+modinfo mymodule.ko | grep depends
+# depends: ptp,i2c-algo-bit
+
+# See full dependency tree
+modprobe --show-depends e1000e
+# insmod /lib/modules/.../ptp.ko
+# insmod /lib/modules/.../e1000e.ko
+
+# Blacklist a module
+echo "blacklist nouveau" >> /etc/modprobe.d/blacklist.conf
+modprobe -r nouveau
+```
+
+```bash
+# /lib/modules/$(uname -r)/ directory
+ls /lib/modules/$(uname -r)/
+# build           kernel          modules.alias      modules.builtin
+# modules.dep     modules.order   modules.softdep    modules.symbols
+
+# modules.dep: generated by depmod
+cat /lib/modules/$(uname -r)/modules.dep | grep e1000e
+# kernel/drivers/net/ethernet/intel/e1000e/e1000e.ko: kernel/drivers/ptp/ptp.ko
+```
+
+## Module loading hooks
+
+udev/systemd-udevd automatically loads modules based on device discovery:
+
+```bash
+# Add a MODULE_ALIAS to match hardware IDs
+# In source:
+MODULE_ALIAS("pci:v00008086d00001234*");  /* Intel device 0x1234 */
+
+# generates entry in modules.alias:
+# alias pci:v00008086d00001234* e1000e
+
+# When kernel discovers this device, it calls:
+# modprobe pci:v00008086d00001234...
+# which matches e1000e via modules.alias
+```
+
+## Symbol namespaces (5.4+)
+
+For large subsystems, symbol namespaces prevent accidental use of internal symbols:
+
+```c
+/* Export with a namespace */
+EXPORT_SYMBOL_NS(my_internal_func, MY_SUBSYSTEM);
+
+/* Module that uses it must import the namespace */
+MODULE_IMPORT_NS(MY_SUBSYSTEM);
+
+extern int my_internal_func(void);
+```
+
+Without `MODULE_IMPORT_NS`, loading fails:
+```
+ERROR: module uses symbol from namespace MY_SUBSYSTEM but does not import it.
+```
+
+## Further reading
+
+- [Module Basics](module-basics.md) — module_init/exit, lifecycle
+- [Platform Drivers](../drivers/platform-driver.md) — Modules as drivers
+- [Linux Device Model](../drivers/device-model.md) — How modules integrate with sysfs
+- `Documentation/kbuild/kconfig-language.rst` — Kconfig syntax reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -299,3 +299,7 @@ nav:
     - ftrace: tracing/ftrace.md
     - Kprobes and Tracepoints: tracing/kprobes-tracepoints.md
     - perf Events: tracing/perf-events.md
+  - Kernel Modules:
+    - Getting Started: modules/README.md
+    - Writing and Loading Modules: modules/module-basics.md
+    - Parameters, Symbols, and Kconfig: modules/module-params.md


### PR DESCRIPTION
## Summary

- **Module basics** (`module-basics.md`): minimal module with Makefile, module lifecycle (kernel_init_module → layout_sections → relocate → init), struct module internals (state enum, syms/crcs arrays, module_init/core pointers, refcnt), ELF sections (.init.text freed post-init, .modinfo), /proc/modules format, pr_* logging macros (pr_emerg through pr_debug, dev_err, rate-limited, dynamic debug), module signing with sign-file, gdb debugging with add-symbol-file
- **Parameters, symbols, Kconfig** (`module-params.md`): module_param for all types (int/uint/bool/charp/array), sysfs permissions (0644/0444/0), param change callbacks via kernel_param_ops, EXPORT_SYMBOL vs EXPORT_SYMBOL_GPL (GPL enforcement at load time), symbol CRC versioning, /proc/kallsyms symbol type letters (T/D/R/B/U), Kconfig tristate with depends/select/help/default, Makefile obj-$(CONFIG_*) and conditional objs, modprobe dependency graph (depmod, modules.dep), MODULE_ALIAS for udev auto-loading, symbol namespaces (EXPORT_SYMBOL_NS/MODULE_IMPORT_NS, 5.4+)

Closes #309, #310

## Test plan

- [ ] All 3 pages render correctly
- [ ] Code examples are valid C and shell
- [ ] Cross-links to drivers/, bpf/ work