### PR TITLE
Add filesystem documentation: ext4, tmpfs, btrfs

### DIFF
--- a/docs/filesystems/README.md
+++ b/docs/filesystems/README.md
@@ -1,0 +1,44 @@
+# Filesystems
+
+> How data is organized and persisted on storage
+
+## The filesystem stack
+
+```
+Application: open("/data/file", O_RDONLY)
+          │
+          ▼
+     VFS layer            ← generic operations (see vfs/)
+          │
+          ▼
+  Filesystem driver       ← ext4, btrfs, xfs, tmpfs, ...
+          │
+          ▼
+     Page cache           ← in-memory cache of disk blocks
+          │
+          ▼
+   Block layer (bio)      ← submits I/O to disk
+          │
+          ▼
+    Block device          ← NVMe, SATA, virtio-blk
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [ext4](ext4.md) | On-disk layout, extents, journaling with jbd2 |
+| [tmpfs and ramfs](tmpfs.md) | Memory-backed filesystems, size limits |
+| [btrfs](btrfs.md) | Copy-on-Write B-tree, subvolumes, snapshots |
+
+## Choosing a filesystem
+
+| Filesystem | Use case | Key feature |
+|-----------|---------|-------------|
+| ext4 | General purpose, servers | Stable, journaled |
+| btrfs | Desktop, NAS | CoW, snapshots, RAID |
+| xfs | High-performance servers | High scalability |
+| tmpfs | /tmp, /run, shared memory | RAM-backed, fast |
+| overlayfs | Container images | Union of layers |
+| squashfs | Read-only (LiveCD, containers) | Compressed, read-only |
+| erofs | Android, embedded | Compressed, fast read |

--- a/docs/filesystems/btrfs.md
+++ b/docs/filesystems/btrfs.md
@@ -1,0 +1,242 @@
+# btrfs
+
+> Copy-on-Write B-tree filesystem with snapshots, checksums, and RAID
+
+## Core concepts
+
+btrfs is built on a single fundamental mechanism: **Copy-on-Write (CoW) B-trees**. Instead of modifying data in-place, btrfs writes new versions and updates parent pointers atomically. This enables:
+
+- **Snapshots**: zero-copy point-in-time copies (shared CoW pages)
+- **Checksums**: every data and metadata block is checksummed
+- **Self-healing**: with redundant data, corrupted blocks are repaired automatically
+- **Online resize**: grow/shrink while mounted
+- **Built-in RAID**: stripe, mirror, or RAID5/6 without MD/LVM
+
+## The B-tree structure
+
+All btrfs data is organized in a forest of CoW B-trees. Each tree has a root stored in the superblock or its parent tree:
+
+```
+Superblock
+    │
+    ├── Root Tree ─────────────────────────────────────┐
+    │   (tree of trees — maps tree IDs to roots)       │
+    │   ├── FS Tree root (subvol 5 = default)  ←───────┤
+    │   ├── Snapshot Tree root (subvol 256)    ←───────┤
+    │   └── ...                                        │
+    │                                                  │
+    ├── Chunk Tree ──────────────────────────────────── physical location mapping
+    │   (maps logical addresses to physical extents)
+    │
+    └── Device Tree ─────────────────────────────────── device info
+```
+
+### B-tree nodes
+
+```c
+/* fs/btrfs/ctree.h */
+struct btrfs_header {
+    /* checksummed area starts here: */
+    u8      csum[BTRFS_CSUM_SIZE];  /* checksum of node */
+    u8      fsid[BTRFS_FSID_SIZE];  /* filesystem UUID */
+    __le64  bytenr;                  /* logical address of this node */
+    __le64  flags;
+    u8      chunk_tree_uuid[BTRFS_UUID_SIZE];
+    __le64  generation;              /* transaction ID that wrote this */
+    __le64  owner;                   /* which tree owns this node */
+    __le32  nritems;                 /* number of items */
+    u8      level;                   /* 0 = leaf, >0 = internal */
+};
+
+/* Leaf node item (internal nodes use btrfs_key_ptr instead): */
+struct btrfs_item {
+    struct btrfs_disk_key key;
+    __le32 offset;  /* offset within leaf data area */
+    __le32 size;    /* size of item data */
+};
+
+/* Key: identifies all btrfs items */
+struct btrfs_disk_key {
+    __le64  objectid;   /* inode number, subvol ID, etc. */
+    u8      type;       /* BTRFS_INODE_ITEM_KEY, BTRFS_EXTENT_DATA_KEY, ... */
+    __le64  offset;     /* file offset, extent start, etc. */
+};
+```
+
+## Copy-on-Write mechanics
+
+When btrfs modifies a block:
+
+```
+1. Allocate a new block at a free location
+2. Write new data to the new block
+3. Update parent node: change pointer to new block
+4. Parent node is also CoW'd (recursively up to the root)
+5. Update superblock to point to new root
+6. Old blocks are freed when no snapshot references them
+```
+
+This means:
+- Old data remains valid until all snapshots drop their references
+- No partial writes: either the new root is committed or the old is used
+- Crash safety: the superblock update is atomic (single write)
+
+## Subvolumes and snapshots
+
+A **subvolume** is an independent filesystem tree (its own FS tree root). The default mount point is subvolume 5 (or the one set with `btrfs subvolume set-default`).
+
+```bash
+# Create a subvolume
+btrfs subvolume create /data/mysubvol
+# mounts as: /data/mysubvol/
+
+# List subvolumes
+btrfs subvolume list /data
+# ID 256 gen 42 top level 5 path mysubvol
+
+# Snapshot: instant copy-on-write copy
+btrfs subvolume snapshot /data/mysubvol /data/snap-20240115
+# Takes nanoseconds: just creates a new root pointing to same leaves
+
+# Read-only snapshot (for backups)
+btrfs subvolume snapshot -r /data/mysubvol /data/snap-readonly
+
+# Delete a subvolume/snapshot
+btrfs subvolume delete /data/snap-20240115
+```
+
+### Snapshot internals
+
+A snapshot is just a new FS tree root that shares all B-tree nodes with its parent. Shared nodes have their reference counts incremented. When a shared node needs modification, it's CoW'd and the reference count decremented:
+
+```
+Before snapshot:         After snapshot:
+FS Tree                  FS Tree    Snapshot
+  Root                     Root       Root
+  [gen=42]                [gen=42]   [gen=42]←─shared, refcount=2
+     │                       │         │
+   dir a                   dir a     dir a (same node, refcount=2)
+```
+
+When a file in the snapshot changes, only the modified path gets CoW'd; unchanged subtrees remain shared.
+
+## Checksums
+
+Every data and metadata block has a checksum stored in its B-tree parent:
+
+```bash
+# Default checksum: crc32c
+btrfs inspect-internal dump-super /dev/sda | grep csum_type
+# csum_type 0 (crc32c)
+
+# SHA256 checksum (slower but cryptographic)
+mkfs.btrfs --checksum sha256 /dev/sda
+
+# BLAKE2b (fast and cryptographic)
+mkfs.btrfs --checksum blake2 /dev/sda
+
+# Verify checksums
+btrfs scrub start /data    # check all data/metadata on device
+btrfs scrub status /data   # check status
+```
+
+When a read encounters a checksum mismatch:
+- Single device: returns EIO
+- RAID1/RAID10: reads from redundant copy and repairs the bad block
+
+## Built-in RAID
+
+```bash
+# Create with RAID1 metadata + RAID1 data (2 devices)
+mkfs.btrfs -m raid1 -d raid1 /dev/sda /dev/sdb
+
+# RAID5 (3+ devices, 1 parity)
+mkfs.btrfs -m raid1 -d raid5 /dev/sda /dev/sdb /dev/sdc
+
+# Check RAID status
+btrfs filesystem df /data
+# Data, RAID1: total=10.00GiB, used=8.50GiB
+# Metadata, RAID1: total=1.00GiB, used=0.50GiB
+
+# Balance: restripe data across devices
+btrfs balance start -dconvert=raid1 /data
+```
+
+## Deduplication
+
+btrfs supports extents sharing (CoW-based dedup):
+
+```bash
+# Online dedup with duperemove
+duperemove -dr /data/
+
+# Or FIDEDUPERANGE ioctl (kernel 4.5+): share identical extents
+# btrfs-dedupe tool
+```
+
+Dedup works by finding files with identical content ranges and pointing their extent references to the same physical block (with refcounting).
+
+## Transparent compression
+
+```bash
+# Mount with transparent compression
+mount -o compress=zstd /dev/sda /data    # zstd (recommended)
+mount -o compress=lzo /dev/sda /data     # lzo (faster)
+mount -o compress=zlib /dev/sda /data    # zlib (best ratio)
+
+# Set per-file compression attribute
+btrfs property set /data/myfile compression zstd
+
+# Check compression ratio
+compsize /data/
+# Uncompressed size:  100G
+# Compressed size:    60G
+# Compression ratio:  1.67
+```
+
+## Send/receive: efficient incremental backup
+
+```bash
+# Initial backup: send full snapshot
+btrfs subvolume snapshot -r /data/subvol /data/snap-1
+btrfs send /data/snap-1 | btrfs receive /backup/
+
+# Incremental: only send the diff
+btrfs subvolume snapshot -r /data/subvol /data/snap-2
+btrfs send -p /data/snap-1 /data/snap-2 | btrfs receive /backup/
+# Much smaller than a full send — only CoW'd blocks
+
+# Send to remote
+btrfs send /data/snap-2 | ssh backup-server btrfs receive /backup/
+```
+
+## Monitoring btrfs
+
+```bash
+# Filesystem stats
+btrfs filesystem show /data
+btrfs filesystem df /data
+
+# Device stats (I/O errors, checksum errors)
+btrfs device stats /data
+# [/dev/sda].write_io_errs   0
+# [/dev/sda].read_io_errs    0
+# [/dev/sda].flush_io_errs   0
+# [/dev/sda].corruption_errs 0
+# [/dev/sda].generation_errs 0
+
+# Extent and tree statistics
+btrfs inspect-internal dump-tree /dev/sda   # dump all B-tree data
+btrfs inspect-internal inode-resolve <ino> /data
+
+# Balance status
+btrfs balance status /data
+```
+
+## Further reading
+
+- [ext4](ext4.md) — Traditional journaled alternative
+- [tmpfs](tmpfs.md) — Memory-backed filesystem
+- [VFS: Dentry and Inode Caches](../vfs/dcache-icache.md) — How btrfs integrates with VFS
+- [Copy-on-Write](../mm/cow.md) — CoW mechanism from mm perspective
+- `Documentation/filesystems/btrfs.rst`

--- a/docs/filesystems/ext4.md
+++ b/docs/filesystems/ext4.md
@@ -1,0 +1,274 @@
+# ext4
+
+> The default Linux filesystem: journaled, extent-based, battle-tested
+
+## On-disk layout
+
+An ext4 filesystem is divided into **block groups**. Each block group contains:
+
+```
+Block Group 0:
+┌─────────────────────────────────────────────────────────────────┐
+│ Super-   │ Group     │ Block    │ Inode    │ Inode │ Data       │
+│ block    │ Descriptor│ Bitmap   │ Bitmap   │ Table │ Blocks     │
+│ (1 block)│ Table     │ (1 block)│ (1 block)│       │            │
+└─────────────────────────────────────────────────────────────────┘
+
+Superblock: copies in groups 0, 1, 3^n, 5^n, 7^n (backup)
+```
+
+```bash
+# Inspect filesystem layout
+dumpe2fs /dev/sda1 | head -80
+# Inode count:              2621440
+# Block count:              10485760
+# Block size:               4096
+# Blocks per group:         32768
+# Inodes per group:         8192
+# Inode size:               256
+# Journal inode:            8
+```
+
+## The ext4 superblock
+
+```c
+/* fs/ext4/ext4.h */
+struct ext4_super_block {
+    __le32  s_inodes_count;         /* total inodes */
+    __le32  s_blocks_count_lo;      /* total blocks (low 32 bits) */
+    __le32  s_r_blocks_count_lo;    /* reserved blocks */
+    __le32  s_free_blocks_count_lo;
+    __le32  s_free_inodes_count;
+    __le32  s_first_data_block;     /* first data block (0 for 4K blocks) */
+    __le32  s_log_block_size;       /* block size = 1024 << s_log_block_size */
+    __le32  s_blocks_per_group;
+    __le32  s_inodes_per_group;
+    __le32  s_mtime;                /* last mount time */
+    __le32  s_wtime;                /* last write time */
+    __le16  s_magic;                /* 0xEF53 */
+    __le16  s_state;                /* filesystem state: clean/errors */
+    __le16  s_errors;               /* error behavior: continue/remount-ro/panic */
+    /* ... */
+    __le32  s_feature_compat;       /* compatible feature flags */
+    __le32  s_feature_incompat;     /* incompatible feature flags */
+    __le32  s_feature_ro_compat;    /* read-only compatible features */
+    __u8    s_uuid[16];             /* filesystem UUID */
+    char    s_volume_name[16];
+    /* ... journal info, encryption, etc. */
+};
+```
+
+## The ext4 inode
+
+```c
+struct ext4_inode {
+    __le16  i_mode;             /* file mode (S_IFREG, S_IFDIR, etc.) */
+    __le16  i_uid;              /* lower 16 bits of UID */
+    __le32  i_size_lo;          /* file size (lower 32 bits) */
+    __le32  i_atime;            /* access time */
+    __le32  i_ctime;            /* inode change time */
+    __le32  i_mtime;            /* modification time */
+    __le32  i_dtime;            /* deletion time */
+    __le16  i_gid;
+    __le16  i_links_count;      /* hard link count */
+    __le32  i_blocks_lo;        /* 512-byte blocks used */
+    __le32  i_flags;            /* EXT4_EXTENTS_FL, EXT4_INLINE_DATA_FL, ... */
+    __le32  i_block[EXT4_N_BLOCKS]; /* 15 words: extent tree root OR block map */
+    __le32  i_generation;
+    __le32  i_file_acl_lo;      /* extended attribute block */
+    __le32  i_size_high;        /* upper 32 bits of file size */
+    /* ... extra fields at offset 128 for inodes > 128 bytes ... */
+    __le16  i_extra_isize;      /* extra inode size (allows new fields) */
+    /* nanosecond timestamps: */
+    __le32  i_ctime_extra;
+    __le32  i_mtime_extra;
+    __le32  i_atime_extra;
+    __le32  i_crtime;           /* creation time */
+    __le32  i_crtime_extra;
+    /* ... version, checksum ... */
+};
+```
+
+## Extent tree: efficient large file representation
+
+ext4 uses extents (contiguous block runs) instead of the old indirect block maps:
+
+```
+i_block[0..3] holds the extent tree root:
+┌──────────────────────────────────────────────────────┐
+│ ext4_extent_header                                    │
+│   eh_magic=0xF30A, eh_entries=N, eh_depth=0 (leaf)   │
+├──────────────────────────────────────────────────────┤
+│ ext4_extent[0]: ee_block=0,  ee_len=128, ee_start=1024│
+│ ext4_extent[1]: ee_block=128,ee_len=64,  ee_start=2048│
+└──────────────────────────────────────────────────────┘
+
+For deep files, eh_depth>0: i_block contains internal nodes
+with ext4_extent_idx entries pointing to child blocks
+```
+
+```c
+struct ext4_extent {
+    __le32  ee_block;       /* first logical block covered */
+    __le16  ee_len;         /* number of blocks (or 0x8000 | len for unwritten) */
+    __le16  ee_start_hi;    /* physical block (high 16 bits) */
+    __le32  ee_start_lo;    /* physical block (low 32 bits) */
+};
+
+struct ext4_extent_header {
+    __le16  eh_magic;       /* 0xF30A */
+    __le16  eh_entries;     /* number of entries */
+    __le16  eh_max;         /* capacity of this node */
+    __le16  eh_depth;       /* depth (0=leaf, >0=internal) */
+    __le32  eh_generation;
+};
+```
+
+Benefits over old indirect maps:
+- A single extent covers contiguous blocks (e.g., 128MB in one entry)
+- Sequential reads are contiguous on disk → fast
+- Reduces inode tree depth for large files
+
+## Journaling with jbd2
+
+ext4 uses the Journal Block Device (jbd2) for crash consistency:
+
+### Write modes
+
+| Mode | journaled | Data safety | Performance |
+|------|-----------|-------------|-------------|
+| `data=writeback` | metadata only | Data may be pre-allocated garbage after crash | Fastest |
+| `data=ordered` (default) | metadata only, but data written before metadata | Data is committed when metadata is | Good balance |
+| `data=journal` | both metadata and data | Strongest | Slowest |
+
+```bash
+# Check current mode
+tune2fs -l /dev/sda1 | grep "Default mount options"
+# Default mount options: user_xattr acl
+
+# Mount with specific journal mode
+mount -o data=journal /dev/sda1 /mnt
+```
+
+### Journal structure (jbd2)
+
+```c
+/* fs/jbd2/journal.c */
+struct journal_s {              /* journal_t */
+    unsigned long   j_flags;   /* JBD2_UNMOUNT, JBD2_ABORT, ... */
+    int             j_errno;
+
+    struct buffer_head *j_sb_buffer; /* journal superblock */
+    journal_superblock_t *j_superblock;
+
+    unsigned long   j_head;     /* latest transaction sequence number */
+    unsigned long   j_tail;     /* oldest committed transaction still on disk */
+    unsigned long   j_free;     /* free space remaining */
+
+    struct transaction_s *j_running_transaction;  /* current transaction */
+    struct transaction_s *j_committing_transaction;
+    struct list_head j_checkpoint_transactions;
+
+    wait_queue_head_t j_wait_transaction_locked;
+    wait_queue_head_t j_wait_done_commit;
+    wait_queue_head_t j_wait_commit;
+    wait_queue_head_t j_wait_updates;
+
+    struct task_struct *j_task;  /* kjournald thread */
+    int j_max_transaction_buffers;
+    unsigned long j_commit_interval;  /* default 5 seconds */
+};
+```
+
+### Transaction flow
+
+```
+1. jbd2_journal_start(): begin transaction
+      → get handle_t for this transaction
+      → reserve journal space (journal credits)
+
+2. jbd2_journal_get_write_access(bh): mark buffer as modified
+      → copy original buffer to journal (for undo)
+
+3. Modify the buffer (update data)
+
+4. jbd2_journal_dirty_metadata(bh): mark buffer dirty in journal
+
+5. jbd2_journal_stop(): end transaction
+      → if journal full or commit_interval elapsed:
+          kjournald2 commits:
+            → write commit record to journal
+            → write data blocks to disk
+            → write journal blocks to disk
+            → checkpoint: mark journal space free
+
+6. On crash: journal replay restores consistency
+```
+
+## Delayed allocation (delalloc)
+
+ext4 delays block allocation until actual writeback:
+
+```c
+/* When a page is written: */
+/* 1. Mark page dirty, NO block allocated yet */
+/* 2. On writeback (dirty expire or sync): */
+ext4_writepages()
+  → ext4_da_convert_inline_data()
+  → mpage_map_and_submit_extent()
+      → ext4_map_blocks(CREATE)  ← allocate blocks NOW
+          → ext4_ext_map_blocks() → find/create extent
+          → jbd2_journal_get_write_access()
+```
+
+Benefits:
+- Small writes that are quickly deleted never need block allocation
+- Large sequential writes get contiguous blocks (better for extent efficiency)
+- Reduces journal pressure (allocations batched)
+
+## Online features
+
+```bash
+# Online resize (grow filesystem)
+resize2fs /dev/sda1  # grow to fill partition
+
+# Online defrag (for fragmented files)
+e4defrag /data/myfile
+e4defrag /data/  # defrag directory
+
+# Check filesystem health
+e2fsck -n /dev/sda1   # dry run, don't fix
+
+# Tune journaling commit interval (default 5s)
+tune2fs -o journal_data_ordered /dev/sda1
+mount -o commit=60 /dev/sda1 /mnt  # commit every 60s (less safe, faster)
+
+# Enable inline data (small files stored in inode directly)
+tune2fs -O inline_data /dev/sda1
+```
+
+## Key ext4 statistics
+
+```bash
+# ext4 stats via debugfs
+debugfs /dev/sda1
+> stats
+> icheck <block_number>  # find inode owning block
+> ncheck <inode_number>  # find name of inode
+> blocks <inode_number>  # show blocks used by inode
+
+# ext4 tracepoints
+ls /sys/kernel/tracing/events/ext4/
+echo 1 > /sys/kernel/tracing/events/ext4/ext4_da_write_begin/enable
+cat /sys/kernel/tracing/trace_pipe
+
+# Block allocation stats
+cat /proc/fs/ext4/sda1/mb_groups  # buddy allocator per-group state
+```
+
+## Further reading
+
+- [tmpfs and ramfs](tmpfs.md) — Memory-backed alternative
+- [btrfs](btrfs.md) — Copy-on-Write alternative
+- [VFS: Life of a write()](../vfs/life-of-write.md) — How writes reach ext4
+- `Documentation/filesystems/ext4/` — detailed on-disk format

--- a/docs/filesystems/tmpfs.md
+++ b/docs/filesystems/tmpfs.md
@@ -1,0 +1,174 @@
+# tmpfs and ramfs
+
+> Memory-backed filesystems with no persistent storage
+
+## What tmpfs is
+
+tmpfs is a filesystem that lives entirely in RAM (and optionally swap). It's backed by the page cache — each file's data is anonymous memory, evictable to swap under memory pressure.
+
+```bash
+# Mount a tmpfs
+mount -t tmpfs -o size=512m tmpfs /mnt/mytmpfs
+
+# Common uses:
+# /tmp — temporary files
+# /run — runtime data (PID files, sockets)
+# /dev/shm — POSIX shared memory (shm_open)
+# container overlays — Docker container upper layers
+# /var/cache — build caches
+```
+
+## tmpfs vs ramfs
+
+| | tmpfs | ramfs |
+|---|-------|-------|
+| Size limit | Yes (configurable) | No (can OOM) |
+| Swap | Yes (pages evicted to swap) | No (always in RAM) |
+| VFS operations | Full (truncate, etc.) | Full |
+| Persistence | No (lost on umount) | No (lost on umount) |
+| shmem backed | Yes | No |
+| Use case | /tmp, /run, shm | embedded with no swap |
+
+## tmpfs implementation
+
+tmpfs is built on top of `shmem` (shared memory) subsystem:
+
+```c
+/* mm/shmem.c */
+static const struct file_system_type shmem_fs_type = {
+    .name           = "tmpfs",
+    .init_fs_context = shmem_init_fs_context,
+    .kill_sb        = kill_litter_super,
+    .fs_flags       = FS_USERNS_MOUNT,
+};
+```
+
+### shmem inode
+
+```c
+struct shmem_inode_info {
+    spinlock_t          lock;
+    unsigned int        seals;          /* F_SEAL_* for memfd */
+    unsigned long       flags;
+    unsigned long       alloced;        /* pages allocated */
+    unsigned long       swapped;        /* pages swapped out */
+    pgoff_t             fallocend;      /* end of fallocate range */
+    struct list_head    shrinklist;     /* list of inodes with swap */
+    struct list_head    swaplist;       /* link to global swap list */
+    struct shared_policy policy;        /* NUMA policy */
+    struct simple_xattrs xattrs;
+    atomic_long_t       i_direct_seals;
+    struct inode        vfs_inode;      /* MUST be last */
+};
+```
+
+### Page fault path for tmpfs
+
+When a process reads from a tmpfs file and the page isn't in memory:
+
+```c
+/* mm/shmem.c: shmem_fault() → shmem_get_folio() */
+shmem_get_folio(inode, index, ...)
+  → filemap_get_folio()   /* check page cache */
+  → if not found:
+      shmem_alloc_and_add_folio()
+          → alloc_folio(GFP_HIGHUSER)
+          → /* if page was swapped: swap_read_folio() */
+          → /* otherwise: zero the page */
+          → add_to_page_cache()
+```
+
+For pages that were swapped out, `shmem_fault` reads them back from swap before returning. This is transparent to the application.
+
+### Size limits
+
+```bash
+# Default: half of RAM or swap (whichever is larger)
+mount -t tmpfs tmpfs /tmp
+
+# Explicit size
+mount -t tmpfs -o size=1g tmpfs /tmp       # 1GB hard limit
+mount -t tmpfs -o size=50% tmpfs /tmp      # 50% of RAM
+
+# nr_inodes limit
+mount -t tmpfs -o size=512m,nr_inodes=100k tmpfs /tmp
+
+# Check current usage
+df -h /tmp
+cat /proc/mounts | grep tmpfs
+
+# tmpfs stats
+cat /proc/meminfo | grep -E "Shmem|Swap"
+# Shmem:           524288 kB  ← total tmpfs usage
+```
+
+### NUMA policy
+
+```bash
+# Mount with preferred NUMA node
+mount -t tmpfs -o mpol=prefer:0 tmpfs /tmp  # prefer node 0
+
+# Interleave across nodes
+mount -t tmpfs -o mpol=interleave tmpfs /tmp
+
+# Bind to specific node
+mount -t tmpfs -o mpol=bind:0-1 tmpfs /tmp
+```
+
+## devtmpfs: /dev filesystem
+
+devtmpfs is a special tmpfs populated by the kernel with device nodes before udev runs:
+
+```bash
+mount | grep devtmpfs
+# devtmpfs on /dev type devtmpfs (rw,nosuid,size=...)
+
+# Kernel creates nodes as devices are discovered:
+ls -la /dev/sda /dev/null /dev/tty
+# brw-rw---- root disk  8, 0  /dev/sda   ← block device (major=8, minor=0)
+# crw-rw-rw- root root  1, 3  /dev/null  ← char device
+# crw-rw-rw- root tty   5, 0  /dev/tty
+```
+
+## tmpfs and Linux's /proc, /sys
+
+Both `/proc` and `/sys` are special pseudo-filesystems built on the same infrastructure:
+
+```c
+/* proc_fs_type */
+static struct file_system_type proc_fs_type = {
+    .name           = "proc",
+    .init_fs_context = proc_init_fs_context,
+    .kill_sb        = proc_kill_sb,
+    .fs_flags       = FS_USERNS_MOUNT,
+};
+
+/* sysfs built on kernfs */
+static struct file_system_type sysfs_fs_type = {
+    .name           = "sysfs",
+    .init_fs_context = sysfs_init_fs_context,
+    .kill_sb        = sysfs_kill_sb,
+    .fs_flags       = FS_USERNS_MOUNT,
+};
+```
+
+These filesystems don't use backing storage — reads synthesize data from kernel data structures; writes trigger kernel operations.
+
+## Volatile mounts: tmpfs in container use
+
+Containers use tmpfs for writable layers and ephemeral storage:
+
+```bash
+# Docker: mount tmpfs for /tmp in container
+docker run --tmpfs /tmp:size=512m,mode=1777 ubuntu bash
+
+# Kubernetes: emptyDir with medium: Memory
+# Creates a tmpfs mount for the pod's ephemeral volume
+```
+
+## Further reading
+
+- [ext4](ext4.md) — Persistent alternative
+- [btrfs](btrfs.md) — CoW persistent alternative
+- [Memory Management: mmap](../mm/mmap.md) — How tmpfs pages are faulted in
+- [IPC: Shared Memory](../ipc/shared-memory.md) — POSIX shm backed by tmpfs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -303,3 +303,8 @@ nav:
     - Getting Started: modules/README.md
     - Writing and Loading Modules: modules/module-basics.md
     - Parameters, Symbols, and Kconfig: modules/module-params.md
+  - Filesystems:
+    - Getting Started: filesystems/README.md
+    - ext4: filesystems/ext4.md
+    - tmpfs and ramfs: filesystems/tmpfs.md
+    - btrfs: filesystems/btrfs.md


### PR DESCRIPTION
## Summary

- **ext4** (`ext4.md`): block group layout, ext4_super_block fields, ext4_inode with i_block extent tree root, extent tree (ext4_extent/ext4_extent_header, contiguous block runs), jbd2 journaling (data=writeback/ordered/journal modes, journal_s/transaction_s internals, transaction flow), delayed allocation (delalloc defers block allocation to writeback), online resize/defrag, debugfs inspection
- **tmpfs** (`tmpfs.md`): shmem-backed implementation, shmem_inode_info struct, anonymous page fault path with swap eviction, size limits and % syntax, NUMA mpol policy, devtmpfs, comparison table (tmpfs vs ramfs), container use cases
- **btrfs** (`btrfs.md`): CoW B-tree forest (Root/Chunk/Device trees), btrfs_header/btrfs_item/btrfs_disk_key on-disk structures, CoW mechanics (recursive parent update, atomic superblock, crash safety), subvolumes (btrfs_subvolume_create, independent FS tree roots), snapshots (shared B-tree nodes with refcount, instant zero-copy), checksums (crc32c/sha256/blake2b, RAID self-repair), built-in RAID modes, transparent compression (zstd/lzo/zlib), send/receive for incremental backup

Closes #313, #314, #315

## Test plan

- [ ] All 4 pages render correctly
- [ ] Cross-links to vfs/, mm/ work
- [ ] Shell commands are syntactically correct