### PR TITLE
Add Linux security documentation: LSM, capabilities, seccomp

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,32 @@
+# Linux Security
+
+> Privilege model, mandatory access control, and syscall filtering
+
+## Security layers
+
+Linux uses a layered security model:
+
+```
+Application
+    │
+    ▼
+Syscall entry
+    │
+    ├── DAC (Discretionary Access Control): uid/gid/permissions ─── always
+    │
+    ├── Capabilities: fine-grained privilege splitting ──────────── always
+    │
+    ├── LSM hooks (SELinux / AppArmor / TOMOYO) ──────────────────── if enabled
+    │
+    └── seccomp BPF: syscall whitelist/blacklist ─────────────────── if installed
+```
+
+**DAC** (file permissions, uid/gid) is always enforced. **LSM** adds Mandatory Access Control policies on top. **Capabilities** split "root privilege" into 40 discrete permissions. **seccomp** restricts which syscalls a process can make.
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [LSM Framework](lsm.md) | LSM hooks, SELinux, AppArmor architecture |
+| [Capabilities](capabilities.md) | Linux capability model, privilege dropping |
+| [seccomp BPF](seccomp.md) | Syscall filtering, libseccomp, container profiles |

--- a/docs/security/capabilities.md
+++ b/docs/security/capabilities.md
@@ -1,0 +1,233 @@
+# Linux Capabilities
+
+> Fine-grained privilege decomposition
+
+## The problem with root
+
+Traditionally, privilege in Unix is binary: a process either has UID 0 (root, omnipotent) or it doesn't. This is too coarse — a web server needs to bind to port 80, but shouldn't have access to raw network sockets, loading kernel modules, or rebooting the system.
+
+Linux capabilities split root's power into ~40 discrete privileges that can be granted independently.
+
+## The 40 capabilities
+
+```c
+/* include/uapi/linux/capability.h */
+
+/* Networking */
+CAP_NET_BIND_SERVICE  /* bind to ports < 1024 */
+CAP_NET_RAW           /* use raw sockets, ICMP */
+CAP_NET_ADMIN         /* configure network interfaces, routing */
+CAP_NET_BROADCAST     /* make socket broadcasts */
+
+/* Process control */
+CAP_KILL             /* send signals to any process */
+CAP_SETUID           /* set any UID */
+CAP_SETGID           /* set any GID */
+CAP_SETPCAP          /* set/drop capabilities */
+
+/* System administration */
+CAP_SYS_ADMIN        /* many privileged operations (too broad) */
+CAP_SYS_BOOT         /* reboot() syscall */
+CAP_SYS_MODULE       /* load/unload kernel modules */
+CAP_SYS_TIME         /* set system clock */
+CAP_SYS_PTRACE       /* ptrace any process */
+CAP_SYS_RAWIO        /* iopl, direct port I/O */
+CAP_SYS_CHROOT       /* chroot() */
+CAP_SYS_NICE         /* set negative nice values, scheduling class */
+CAP_SYS_RESOURCE     /* set resource limits, override hard limits */
+
+/* File operations */
+CAP_CHOWN            /* change file ownership */
+CAP_DAC_OVERRIDE     /* bypass file permission checks */
+CAP_DAC_READ_SEARCH  /* bypass read/search checks */
+CAP_FOWNER           /* bypass file owner checks */
+CAP_FSETID           /* set setuid/setgid on files */
+CAP_LINUX_IMMUTABLE  /* set immutable/append-only file flags */
+CAP_MKNOD            /* create special files */
+
+/* IPC */
+CAP_IPC_LOCK         /* lock memory (mlock) */
+CAP_IPC_OWNER        /* override IPC ownership checks */
+
+/* Security */
+CAP_MAC_ADMIN        /* manage MAC policies (SELinux/AppArmor) */
+CAP_MAC_OVERRIDE     /* override MAC (SELinux) */
+CAP_AUDIT_CONTROL    /* configure audit */
+CAP_AUDIT_READ       /* read audit log */
+CAP_AUDIT_WRITE      /* write audit log */
+
+/* BPF */
+CAP_BPF              /* load and run BPF programs (5.8+) */
+CAP_PERFMON          /* perf_event_open for tracing (5.8+) */
+
+/* Checkpoint/restore */
+CAP_CHECKPOINT_RESTORE  /* CRIU restore operations */
+```
+
+## Capability sets
+
+Each process has **5 capability sets**:
+
+```c
+/* Per-thread capability state */
+struct thread_info {
+    /* ... */
+};
+
+/* In struct cred: */
+struct cred {
+    /* ... */
+    kernel_cap_t    cap_inheritable; /* can be inherited across exec */
+    kernel_cap_t    cap_permitted;   /* superset of effective */
+    kernel_cap_t    cap_effective;   /* actually used for checks */
+    kernel_cap_t    cap_bset;        /* bounding set: max cap_permitted */
+    kernel_cap_t    cap_ambient;     /* ambient: auto-added to permitted on exec */
+};
+```
+
+Rules:
+- **Effective**: used in access checks (`capable()`)
+- **Permitted**: superset of effective; can re-add dropped effective caps
+- **Inheritable**: can be passed across exec if the file also has it
+- **Bounding**: ceiling — caps in bset can be in permitted; once dropped, cannot be regained
+- **Ambient**: automatically inherited by children and across exec (5.8+)
+
+## Checking capabilities in the kernel
+
+```c
+/* Anywhere in the kernel: */
+if (!capable(CAP_SYS_ADMIN))
+    return -EPERM;
+
+/* Namespace-aware check: */
+if (!ns_capable(net->user_ns, CAP_NET_ADMIN))
+    return -EPERM;
+
+/* From task explicitly: */
+if (!task_capable(task, CAP_KILL))
+    return -EPERM;
+```
+
+`capable()` checks `current->cred->cap_effective`.
+
+## Viewing and modifying capabilities
+
+```bash
+# View capabilities of current process
+cat /proc/self/status | grep -i cap
+# CapInh: 0000000000000000
+# CapPrm: 0000003fffffffff
+# CapEff: 0000003fffffffff
+# CapBnd: 0000003fffffffff
+# CapAmb: 0000000000000000
+
+# Decode capability bitmask
+capsh --decode=0000003fffffffff
+# 0x0000003fffffffff=cap_chown,cap_dac_override,cap_dac_read_search,...
+
+# View capabilities of a running process
+cat /proc/1234/status | grep Cap
+
+# Run a command with specific capabilities
+capsh --caps="cap_net_bind_service+eip" -- -c "/usr/sbin/nginx"
+
+# Drop all capabilities (security hardening)
+capsh --drop=all -- -c "myprogram"
+```
+
+## File capabilities (setcap)
+
+Executables can have capabilities in their extended attributes, allowing them to run with elevated privileges without setuid:
+
+```bash
+# Grant capability to an executable
+setcap cap_net_bind_service=+eip /usr/bin/node
+
+# View capabilities on a file
+getcap /usr/bin/node
+# /usr/bin/node cap_net_bind_service=eip
+
+# Remove all capabilities
+setcap -r /usr/bin/node
+
+# Common use cases:
+setcap cap_net_bind_service=+eip /usr/bin/node  # Node.js on port 80
+setcap cap_net_raw=+eip /usr/bin/ping           # raw ICMP without root
+setcap cap_dac_read_search=+eip /usr/sbin/rsync  # backup without root
+```
+
+The `e`, `i`, `p` flags:
+- `e` = effective
+- `i` = inheritable
+- `p` = permitted
+
+## Capability-based privilege dropping
+
+A properly written daemon starts with root, acquires needed capabilities, then drops the rest:
+
+```c
+/* daemon startup: */
+static void drop_privileges(void)
+{
+    /* Keep only what we need: CAP_NET_BIND_SERVICE */
+    cap_t caps = cap_get_proc();
+
+    cap_value_t keep[] = { CAP_NET_BIND_SERVICE };
+
+    /* Clear all caps, then set only what we need */
+    cap_clear(caps);
+    cap_set_flag(caps, CAP_EFFECTIVE,   1, keep, CAP_SET);
+    cap_set_flag(caps, CAP_PERMITTED,   1, keep, CAP_SET);
+    cap_set_flag(caps, CAP_INHERITABLE, 0, NULL, CAP_CLEAR);
+
+    if (cap_set_proc(caps) < 0)
+        err(1, "cap_set_proc");
+    cap_free(caps);
+
+    /* Also drop from bounding set to prevent re-gaining */
+    if (prctl(PR_CAPBSET_DROP, CAP_SYS_ADMIN, 0, 0, 0) < 0)
+        err(1, "PR_CAPBSET_DROP");
+
+    /* Change to non-root uid/gid */
+    if (setgid(www_gid) < 0 || setuid(www_uid) < 0)
+        err(1, "setuid/setgid");
+}
+```
+
+## No-New-Privileges
+
+`PR_SET_NO_NEW_PRIVS` prevents a process from gaining any new privileges through exec (even via setuid binaries or file capabilities):
+
+```c
+prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+/* Now: execve() cannot gain capabilities or change uid via setuid */
+/* This is also set by seccomp filter installation */
+```
+
+```bash
+# Run with no new privileges
+unshare --user --no-new-privs bash
+```
+
+## CAP_SYS_ADMIN: the problem capability
+
+`CAP_SYS_ADMIN` is sometimes called "the new root" because it covers too many unrelated operations:
+
+- Mount/unmount filesystems
+- `chroot()`
+- Configure network namespaces
+- `ptrace` (with restrictions)
+- Access kernel keyring
+- Modify disk quotas
+- Override resource limits
+- Set hostname (UTS namespace)
+- ... and 40+ more
+
+Prefer more specific capabilities where possible. If a library says "requires CAP_SYS_ADMIN", investigate whether a narrower capability works.
+
+## Further reading
+
+- [LSM Framework](lsm.md) — MAC on top of capability checks
+- [seccomp BPF](seccomp.md) — Syscall-level filtering
+- [Cgroups & Namespaces: User Namespace](../cgroups/namespaces.md) — Capabilities in user namespaces
+- `man 7 capabilities` — complete capability reference

--- a/docs/security/lsm.md
+++ b/docs/security/lsm.md
@@ -1,0 +1,247 @@
+# Linux Security Module (LSM) Framework
+
+> The kernel's hook-based Mandatory Access Control infrastructure
+
+## What LSM is
+
+The Linux Security Module framework (introduced in 2.6) provides a set of hooks throughout the kernel where security modules can enforce additional access controls beyond standard DAC.
+
+LSM hooks are called at security-critical points:
+- File open/read/write/execute
+- Network socket creation and connections
+- Process creation and credential changes
+- IPC operations
+- Capability checks
+
+Multiple LSMs can be active simultaneously (stacking, since 4.2). The kernel evaluates all of them: access is granted only if ALL LSMs allow it.
+
+## LSM hook architecture
+
+```c
+/* security/security.c: the hook dispatch */
+
+/* All LSM hook lists */
+static struct security_hook_list *security_hook_heads;
+
+/* Example: file_open hook */
+int security_file_open(struct file *file)
+{
+    return call_int_hook(file_open, 0, file);
+    /* calls each registered LSM's file_open handler */
+    /* returns the first non-zero result (denial) */
+}
+```
+
+```c
+/* A security module registers its hooks: */
+static struct security_hook_list mymod_hooks[] __lsm_ro_after_init = {
+    LSM_HOOK_INIT(file_open, mymod_file_open),
+    LSM_HOOK_INIT(socket_connect, mymod_socket_connect),
+    LSM_HOOK_INIT(inode_permission, mymod_inode_permission),
+};
+
+static int __init mymod_init(void)
+{
+    security_add_hooks(mymod_hooks, ARRAY_SIZE(mymod_hooks), "mymod");
+    return 0;
+}
+DEFINE_LSM(mymod) = {
+    .name    = "mymod",
+    .init    = mymod_init,
+    .enabled = &mymod_enabled,
+};
+```
+
+## Complete list of LSM hook categories
+
+```c
+/* include/linux/lsm_hooks.h — over 200 hooks: */
+
+/* File and inode operations */
+file_open, file_permission, file_ioctl, file_mmap
+inode_permission, inode_create, inode_link, inode_unlink
+inode_mkdir, inode_rmdir, inode_rename, inode_readlink
+inode_setattr, inode_getattr, inode_setxattr, inode_getxattr
+
+/* Process credentials */
+bprm_check_security, bprm_creds_for_exec
+task_alloc, task_free, task_setuid, task_setgid
+cred_alloc_blank, cred_prepare, cred_transfer
+
+/* Network */
+socket_create, socket_bind, socket_connect
+socket_listen, socket_accept, socket_recvmsg, socket_sendmsg
+socket_sock_rcv_skb, socket_getpeersec_stream
+
+/* IPC */
+msg_queue_associate, msg_queue_msgctl
+sem_associate, sem_semctl
+shm_associate, shm_shmctl, shm_shmat
+
+/* Capabilities */
+capable, settime
+
+/* System */
+syslog, quotactl, sysctl, getprocattr, setprocattr
+
+/* BPF */
+bpf, bpf_map, bpf_prog
+```
+
+## SELinux
+
+SELinux (Security-Enhanced Linux) implements Mandatory Access Control based on **labels** and **policies**.
+
+### Labels
+
+Every object (file, process, socket) has a security context:
+```
+user:role:type:level
+system_u:system_r:httpd_t:s0
+```
+
+```bash
+# See file context
+ls -Z /etc/passwd
+# system_u:object_r:passwd_file_t:s0 /etc/passwd
+
+# See process context
+ps -eZ | grep httpd
+# system_u:system_r:httpd_t:s0 ... httpd
+
+# See your context
+id -Z
+# unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+```
+
+### Policy
+
+The policy defines which types can perform which operations on which other types:
+
+```
+# Allow httpd to read cert files
+allow httpd_t cert_t:file { read getattr open };
+
+# Allow httpd to bind to http ports
+allow httpd_t http_port_t:tcp_socket name_bind;
+```
+
+```bash
+# Check SELinux status
+getenforce
+# Enforcing | Permissive | Disabled
+
+sestatus
+# SELinux status:                 enabled
+# SELinuxfs mount:                /sys/fs/selinux
+# SELinux mount point:            /sys/fs/selinux
+# SELinuxfs mount:                /sys/fs/selinux
+
+# Set permissive (log but don't deny)
+setenforce 0
+
+# Check audit log for denials
+ausearch -m AVC | tail -20
+# type=AVC msg=audit(1234.567:890): avc:  denied  { read } for ...
+# pid=1234 comm="nginx" name="secret.key" scontext=httpd_t tcontext=sysadm_home_t
+
+# Fix: set correct label
+chcon -t httpd_sys_content_t /var/www/html/myfile
+restorecon /var/www/html/  # restore to policy default
+```
+
+### SELinux internals
+
+```c
+/* security/selinux/hooks.c: inode_permission hook */
+static int selinux_inode_permission(struct inode *inode, int mask)
+{
+    const struct cred *cred = current_cred();
+    struct inode_security_struct *isec;
+    struct task_security_struct *tsec;
+    u32 sid, newsid, perms;
+
+    /* Get security labels */
+    tsec = selinux_cred(cred);
+    isec = selinux_inode(inode);
+
+    /* Convert access mask to SELinux permission bits */
+    perms = file_mask_to_av(inode->i_mode, mask);
+
+    /* Call SELinux policy engine */
+    rc = avc_has_perm(&selinux_state,
+                      tsec->sid, isec->sid,
+                      isec->sclass, perms, &ad);
+    return rc;
+}
+```
+
+## AppArmor
+
+AppArmor uses **path-based** MAC — simpler than SELinux's label model. Profiles are plain text and specify what a program can do:
+
+```
+# /etc/apparmor.d/usr.bin.firefox
+/usr/bin/firefox {
+    # Allow reading these paths
+    /etc/firefox/** r,
+    /usr/share/firefox/** r,
+    @{HOME}/.mozilla/** rw,
+
+    # Deny everything else by default
+    deny /etc/passwd r,
+
+    # Network
+    network inet stream,
+    network inet6 stream,
+}
+```
+
+```bash
+# Load a profile
+apparmor_parser -r /etc/apparmor.d/usr.bin.firefox
+
+# Check status
+aa-status
+# profiles are loaded:
+#   /usr/bin/firefox (enforce)
+#   /usr/bin/evince (complain)
+
+# Set profile to complain mode (log but don't deny)
+aa-complain /usr/bin/firefox
+
+# Check logs
+journalctl -g "apparmor" | tail -20
+# apparmor="DENIED" operation="open" profile="/usr/bin/firefox"
+# name="/etc/shadow" pid=1234 comm="firefox"
+```
+
+### AppArmor internals
+
+AppArmor stores profiles as finite automata (DFA/HFA) for efficient path matching:
+
+```c
+/* security/apparmor/lsm.c: file_open hook */
+static int apparmor_file_open(struct file *file)
+{
+    struct aa_label *label = aa_current_raw_label();
+    struct aa_profile *profile;
+
+    /* match path against profile DFA */
+    aa_str_perms(profile->file.dfa,
+                 profile->file.start,
+                 path_name,
+                 &perms);
+
+    if (!(perms.allow & requested_perm))
+        return -EACCES;
+    return 0;
+}
+```
+
+## Further reading
+
+- [Capabilities](capabilities.md) — Privilege splitting without full root
+- [seccomp BPF](seccomp.md) — Syscall-level filtering
+- [Cgroups & Namespaces: Container Isolation](../cgroups/container-isolation.md) — LSM in containers
+- `Documentation/security/lsm.rst` — LSM developer guide

--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -1,0 +1,273 @@
+# seccomp BPF
+
+> Syscall filtering for privilege reduction and attack surface minimization
+
+## What seccomp does
+
+seccomp (secure computing mode) installs a BPF program that runs on every syscall entry. The filter can:
+- Allow the syscall to proceed
+- Return an error to the caller (without kernel processing)
+- Kill the process
+- Log the event
+- Notify a userspace process (SECCOMP_RET_USER_NOTIF)
+
+```
+Process → syscall instruction
+             │
+             ▼
+       seccomp filter runs   (Classic BPF on struct seccomp_data)
+             │
+     ┌───────┴───────────┐
+     │                   │
+  ALLOW              KILL_PROCESS / ERRNO / TRAP / USER_NOTIF
+     │
+     ▼
+ kernel handles syscall
+```
+
+## Classic (strict) mode
+
+Before BPF filters, seccomp offered only one mode:
+
+```c
+/* Allow only read, write, exit, sigreturn */
+prctl(PR_SET_SECCOMP, SECCOMP_MODE_STRICT);
+/* Any other syscall → SIGKILL */
+```
+
+## BPF filter mode
+
+The full seccomp uses Classic BPF programs operating on `struct seccomp_data`:
+
+```c
+/* include/uapi/linux/seccomp.h */
+struct seccomp_data {
+    int     nr;                     /* syscall number */
+    __u32   arch;                   /* AUDIT_ARCH_* */
+    __u64   instruction_pointer;    /* rip at syscall */
+    __u64   args[6];                /* syscall arguments */
+};
+```
+
+### Filter return values
+
+```c
+SECCOMP_RET_KILL_PROCESS  /* kill entire process with SIGSYS (most severe) */
+SECCOMP_RET_KILL_THREAD   /* kill calling thread only */
+SECCOMP_RET_TRAP          /* deliver SIGSYS (can be caught by signal handler) */
+SECCOMP_RET_ERRNO         /* return error: SECCOMP_RET_DATA contains errno */
+SECCOMP_RET_USER_NOTIF    /* notify supervisor process (5.0+) */
+SECCOMP_RET_TRACE         /* notify ptrace debugger */
+SECCOMP_RET_LOG           /* allow but log the syscall */
+SECCOMP_RET_ALLOW         /* allow (most permissive) */
+```
+
+Return value precedence (lowest wins): KILL > TRAP > ERRNO > USER_NOTIF > TRACE > LOG > ALLOW.
+
+### Raw BPF filter example
+
+```c
+#include <sys/prctl.h>
+#include <linux/seccomp.h>
+#include <linux/filter.h>
+#include <linux/audit.h>
+#include <sys/syscall.h>
+
+static int install_filter(void)
+{
+    struct sock_filter filter[] = {
+        /* Load architecture */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+                 (offsetof(struct seccomp_data, arch))),
+        /* Verify x86-64 */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+                 AUDIT_ARCH_X86_64, 1, 0),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+
+        /* Load syscall number */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+                 (offsetof(struct seccomp_data, nr))),
+
+        /* Allow read */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_read, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+
+        /* Allow write */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_write, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+
+        /* Allow exit_group */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_exit_group, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+
+        /* Default: kill */
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+    };
+
+    struct sock_fprog prog = {
+        .len    = ARRAY_SIZE(filter),
+        .filter = filter,
+    };
+
+    /* Must set PR_SET_NO_NEW_PRIVS before installing filter
+       (unless running as root) */
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
+        return -1;
+
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog) < 0)
+        return -1;
+
+    return 0;
+}
+```
+
+### libseccomp: high-level API
+
+Raw BPF is error-prone. Use `libseccomp` instead:
+
+```c
+#include <seccomp.h>
+
+/* Allow-list approach: start with everything blocked */
+scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_KILL_PROCESS);
+
+/* Add allowances */
+seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(read), 0);
+seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(write), 0);
+seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(exit_group), 0);
+seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mmap), 0);
+seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(munmap), 0);
+
+/* Conditional rule: only allow openat with read-only flag */
+seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(openat), 1,
+    SCMP_A2(SCMP_CMP_MASKED_EQ, O_WRONLY | O_RDWR, 0));
+/*          ^ argument 2 (flags) masked against O_WRONLY|O_RDWR must equal 0 */
+
+/* Load the filter */
+seccomp_load(ctx);
+seccomp_release(ctx);
+```
+
+```bash
+# Link against libseccomp
+gcc -o myapp myapp.c -lseccomp
+```
+
+## Container use: Docker's default profile
+
+Docker installs a seccomp profile blocking ~40 dangerous syscalls:
+
+```bash
+# Show Docker's default seccomp profile
+docker inspect --format '{{.HostConfig.SecurityOpt}}' container_name
+
+# Run with no seccomp (for debugging)
+docker run --security-opt seccomp=unconfined ubuntu bash
+
+# Run with custom profile
+docker run --security-opt seccomp=/path/to/profile.json ubuntu bash
+```
+
+The default Docker profile blocks (among others):
+- `acct` — process accounting
+- `add_key` — kernel keyring
+- `bpf` — BPF programs
+- `kexec_load` — kernel replacement
+- `mount` — filesystem mounting
+- `perf_event_open` — performance monitoring
+- `ptrace` — process tracing
+- `swapon/swapoff` — swap management
+- `syslog` — read kernel ring buffer
+- `uselib` — old library loading
+
+## SECCOMP_RET_USER_NOTIF: supervisor pattern
+
+Since Linux 5.0, a filter can defer decisions to a supervisor process. This enables:
+- Userspace policy enforcement
+- Container escape prevention (container manager approves mounts)
+- Debugging (supervisor logs allowed syscalls)
+
+```c
+/* Supervisor process: receives notifications */
+int notif_fd = seccomp_notify_fd(ctx);  /* after seccomp_load */
+
+struct seccomp_notif *notif = /* allocate */;
+struct seccomp_notif_resp *resp = /* allocate */;
+
+while (1) {
+    ioctl(notif_fd, SECCOMP_IOCTL_NOTIF_RECV, notif);
+
+    /* Inspect: notif->pid, notif->data.nr (syscall), notif->data.args */
+    if (should_allow(notif))
+        resp->error  = 0;        /* allow */
+        resp->flags  = SECCOMP_USER_NOTIF_FLAG_CONTINUE;
+    else
+        resp->error  = -EPERM;   /* deny */
+
+    resp->id = notif->id;
+    ioctl(notif_fd, SECCOMP_IOCTL_NOTIF_SEND, resp);
+}
+```
+
+This is how rootless container runtimes (Podman, nerdctl) allow containers to perform privileged operations like `mount` — the supervisor intercepts and handles them safely.
+
+## Kernel seccomp implementation
+
+```c
+/* kernel/seccomp.c: in syscall entry path */
+static int __seccomp_filter(u32 this_syscall, const struct seccomp_data *sd,
+                             const bool recheck_after_trace)
+{
+    u32 filter_ret, data;
+    struct seccomp_filter *match = NULL;
+    int action;
+
+    /* Run all installed filters (they're chained) */
+    filter_ret = run_filters(sd, &match);
+
+    data    = filter_ret & SECCOMP_RET_DATA;
+    action  = filter_ret & SECCOMP_RET_ACTION_FULL;
+
+    switch (action) {
+    case SECCOMP_RET_ALLOW:
+        return 0;
+    case SECCOMP_RET_KILL_PROCESS:
+        seccomp_do_user_notification(this_syscall, match, sd);
+        /* fall through */
+    case SECCOMP_RET_KILL_THREAD:
+        do_exit(SIGSYS);
+    case SECCOMP_RET_ERRNO:
+        syscall_set_return_value(current, current_pt_regs(),
+                                  -data, 0);
+        return -1;
+    /* ... */
+    }
+}
+```
+
+## Auditing seccomp actions
+
+```bash
+# Check process's current seccomp mode
+cat /proc/self/status | grep Seccomp
+# Seccomp: 2   (0=off, 1=strict, 2=filter)
+
+# List active seccomp filters (requires CAP_SYS_PTRACE)
+cat /proc/<pid>/seccomp_filter
+
+# See seccomp violations in audit log
+ausearch -m SECCOMP | head -20
+# type=SECCOMP msg=audit(1234.567:890): avc:  seccomp
+# sig=31 arch=c000003e syscall=62 compat=0 ip=0x7f... code=0x80000000
+
+# strace with seccomp
+strace -e seccomp ./myprogram
+```
+
+## Further reading
+
+- [LSM Framework](lsm.md) — MAC policies that run before seccomp
+- [Capabilities](capabilities.md) — Privilege reduction before seccomp
+- [BPF: Architecture](../bpf/bpf-overview.md) — BPF programs as seccomp filters
+- [Cgroups: Container Isolation](../cgroups/container-isolation.md) — seccomp in containers
+- `man 2 seccomp` — syscall documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -308,3 +308,8 @@ nav:
     - ext4: filesystems/ext4.md
     - tmpfs and ramfs: filesystems/tmpfs.md
     - btrfs: filesystems/btrfs.md
+  - Security:
+    - Getting Started: security/README.md
+    - LSM Framework: security/lsm.md
+    - Capabilities: security/capabilities.md
+    - seccomp BPF: security/seccomp.md


### PR DESCRIPTION
## Summary

- **LSM framework** (`lsm.md`): security_hook_list dispatch (call_int_hook, all-must-allow semantics), security_add_hooks registration with DEFINE_LSM, 200+ hook categories (file/inode/task/cred/network/IPC/BPF), SELinux (label model with user:role:type:level, selinux_inode_permission with avc_has_perm, audit log AVC messages, chcon/restorecon), AppArmor (path-based DFA matching, profile syntax, aa-status/complain mode)
- **Capabilities** (`capabilities.md`): all 40 capabilities with practical descriptions, 5 per-thread sets (effective/permitted/inheritable/bounding/ambient), kernel capable()/ns_capable() checks, /proc/self/status Cap* fields, capsh --decode, setcap/getcap for file capabilities (e/i/p flags), privilege dropping pattern (cap_clear + cap_set_flag + prctl PR_CAPBSET_DROP + setuid), PR_SET_NO_NEW_PRIVS, CAP_SYS_ADMIN overuse warning
- **seccomp BPF** (`seccomp.md`): struct seccomp_data layout, SECCOMP_RET_* priority ordering (KILL > TRAP > ERRNO > USER_NOTIF > TRACE > LOG > ALLOW), raw BPF filter example with arch check, libseccomp high-level API with conditional argument rules, Docker default profile (blocked syscalls list), SECCOMP_RET_USER_NOTIF supervisor pattern for rootless containers, kernel __seccomp_filter() dispatch, auditing via ausearch and /proc/status

Closes #318, #319, #320

## Test plan

- [ ] All 4 pages render correctly
- [ ] Cross-links to cgroups/, bpf/ work
- [ ] Code examples are valid C and shell