### PR TITLE
Add virtualization/KVM documentation

### DIFF
--- a/docs/virtualization/README.md
+++ b/docs/virtualization/README.md
@@ -1,0 +1,58 @@
+# Virtualization: KVM
+
+> Hardware-accelerated virtual machines in the Linux kernel
+
+## KVM architecture overview
+
+KVM (Kernel-based Virtual Machine) is a hypervisor built into the Linux kernel. It uses hardware virtualization extensions (Intel VT-x / AMD-V) to run virtual machines at near-native speed.
+
+```
+Host (Linux + KVM)
+┌─────────────────────────────────────────────────────────┐
+│  QEMU (userspace)                                        │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ VM process: manages devices, memory layout, VNC   │    │
+│  │  │                                                │    │
+│  │  │ ioctl(/dev/kvm, KVM_RUN)                      │    │
+│  └──│──────────────────────────────────────────────┘    │
+│     ▼                                                    │
+│  KVM kernel module                                       │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ vCPU thread: runs in VMX non-root mode            │    │
+│  │  ├── VM Entry: switch to guest (vmlaunch/vmresume)│    │
+│  │  ├── Guest runs (near-native speed)               │    │
+│  │  └── VM Exit: return to host on sensitive ops     │    │
+│  └──────────────────────────────────────────────────┘    │
+│                                                          │
+│  Hardware: Intel VT-x / AMD-V                           │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [KVM Architecture](kvm-arch.md) | /dev/kvm API, vCPU, VM exits, VMCS |
+| [Memory Virtualization](kvm-memory.md) | EPT/NPT, shadow paging, balloon, huge pages |
+| [virtio](virtio.md) | Paravirtualized I/O, virtqueue, vhost acceleration |
+
+## Quick reference
+
+```bash
+# Check KVM support
+lsmod | grep kvm
+# kvm_intel   or  kvm_amd
+# kvm
+
+ls /dev/kvm  # must exist
+
+# Check hardware virtualization
+grep -m1 -E "vmx|svm" /proc/cpuinfo
+
+# List running VMs (QEMU/KVM)
+virsh list --all
+qemu-img info disk.qcow2
+
+# VM memory usage
+virsh domstats --list-running --balloon
+```

--- a/docs/virtualization/kvm-arch.md
+++ b/docs/virtualization/kvm-arch.md
@@ -1,0 +1,272 @@
+# KVM Architecture
+
+> How the Linux kernel becomes a type-2 hypervisor
+
+## Intel VT-x: hardware virtualization basics
+
+Intel VT-x adds two new CPU operating modes:
+- **VMX root mode**: where the hypervisor (KVM) runs — full privilege
+- **VMX non-root mode**: where the guest OS runs — hardware-restricted
+
+The critical data structure is the **VMCS** (Virtual Machine Control Structure) — a per-vCPU hardware structure that stores guest and host state and controls when VM exits happen.
+
+```
+Host CPU (ring 0)                    VMCS
+    │                          ┌────────────────────┐
+    │                          │ Guest state area:  │
+    │  VMLAUNCH/VMRESUME ──────►  rip, rsp, cr3,    │
+    │                          │  cs, es, tr, ...   │
+    │  ◄─── VM Exit ──────────  ├────────────────────┤
+    │                          │ Host state area:   │
+    │                          │  (restored on exit)│
+    │                          ├────────────────────┤
+    │                          │ Control fields:    │
+    │                          │  - exit reasons    │
+    │                          │  - VMCS pointers   │
+    │                          │  - MSR bitmaps     │
+    │                          └────────────────────┘
+```
+
+## The /dev/kvm API
+
+KVM exposes its functionality through ioctls on `/dev/kvm`, `/dev/kvm/<vm>`, and `/dev/kvm/<vm>/<vcpu>`:
+
+```c
+#include <linux/kvm.h>
+#include <sys/ioctl.h>
+
+/* Step 1: Open the KVM API */
+int kvm_fd = open("/dev/kvm", O_RDWR);
+
+/* Step 2: Create a VM */
+int vm_fd = ioctl(kvm_fd, KVM_CREATE_VM, 0);
+
+/* Step 3: Set up memory */
+struct kvm_userspace_memory_region region = {
+    .slot            = 0,
+    .guest_phys_addr = 0x0,      /* guest physical address */
+    .memory_size     = 0x100000, /* 1MB */
+    .userspace_addr  = (uint64_t)mmap(NULL, 0x100000,
+                                       PROT_READ|PROT_WRITE,
+                                       MAP_PRIVATE|MAP_ANONYMOUS, -1, 0),
+};
+ioctl(vm_fd, KVM_SET_USER_MEMORY_REGION, &region);
+
+/* Step 4: Create a vCPU */
+int vcpu_fd = ioctl(vm_fd, KVM_CREATE_VCPU, 0);
+
+/* Step 5: Map the vCPU run structure */
+int vcpu_mmap_size = ioctl(kvm_fd, KVM_GET_VCPU_MMAP_SIZE, 0);
+struct kvm_run *run = mmap(NULL, vcpu_mmap_size,
+                           PROT_READ|PROT_WRITE, MAP_SHARED, vcpu_fd, 0);
+
+/* Step 6: Set initial vCPU state (registers) */
+struct kvm_regs regs = { .rip = 0x0, .rsp = 0x10000, .rflags = 0x2 };
+ioctl(vcpu_fd, KVM_SET_REGS, &regs);
+
+/* Step 7: Run the vCPU */
+while (1) {
+    ioctl(vcpu_fd, KVM_RUN, 0);  /* enters VMX non-root mode */
+
+    switch (run->exit_reason) {
+    case KVM_EXIT_HLT:
+        printf("Guest halted\n");
+        return 0;
+    case KVM_EXIT_IO:
+        /* Guest did I/O (in/out instruction) */
+        handle_io(run);
+        break;
+    case KVM_EXIT_MMIO:
+        /* Guest accessed unmapped MMIO region */
+        handle_mmio(run);
+        break;
+    case KVM_EXIT_INTERNAL_ERROR:
+        fprintf(stderr, "KVM internal error\n");
+        return 1;
+    }
+}
+```
+
+## VM exits and their causes
+
+A VM exit returns control from guest to host. Common exit reasons:
+
+```c
+/* include/uapi/linux/kvm.h — exit reasons */
+KVM_EXIT_IO              /* PMIO (in/out) instruction */
+KVM_EXIT_MMIO            /* memory-mapped I/O */
+KVM_EXIT_HYPERCALL       /* guest called hypercall (vmcall/vmmcall) */
+KVM_EXIT_DEBUG           /* debug event */
+KVM_EXIT_HLT             /* hlt instruction */
+KVM_EXIT_CPUID           /* cpuid instruction */
+KVM_EXIT_FAIL_ENTRY      /* VM entry failed */
+KVM_EXIT_EXCEPTION       /* exception in non-root mode */
+KVM_EXIT_INTR            /* signal received while in KVM_RUN */
+KVM_EXIT_SHUTDOWN        /* triple fault or machine check */
+KVM_EXIT_SET_TPR         /* TPR (task priority register) write */
+KVM_EXIT_TPR_ACCESS
+KVM_EXIT_NMI             /* NMI */
+KVM_EXIT_X86_RDMSR       /* RDMSR instruction */
+KVM_EXIT_X86_WRMSR       /* WRMSR instruction */
+KVM_EXIT_DIRTY_RING_FULL /* dirty page tracking ring full */
+KVM_EXIT_AP_RESET_HOLD   /* multiprocessor boot */
+```
+
+Frequency matters: frequent exits (like timer ticks, MMIO) are costly because they require switching CPU state. Hardware features like APICv, posted interrupts, and EPT reduce exits.
+
+## struct kvm and struct kvm_vcpu
+
+```c
+/* virt/kvm/kvm_main.c */
+struct kvm {
+    spinlock_t          mmu_lock;
+    struct mutex        slots_lock;
+    struct mutex        slots_arch_lock;
+
+    struct mm_struct   *mm;          /* userspace VM process mm */
+    unsigned long       nr_memslot_pages;
+    struct kvm_memslots *memslots[KVM_ADDRESS_SPACE_NUM];
+
+    struct kvm_vcpu    *vcpus[KVM_MAX_VCPUS];
+    atomic_t            online_vcpus;
+    int                 max_vcpus;
+    int                 created_vcpus;
+
+    struct list_head    vm_list;     /* link in kvm_list */
+    struct mutex        lock;
+    struct kvm_io_bus   *buses[KVM_NR_BUSES];
+    struct kvm_irq_routing_table *irq_routing;
+    struct hlist_head   irq_ack_notifier_list;
+
+    /* Memory management */
+    struct kvm_page_track_notifier_head *track_notifier_head;
+    atomic64_t          arch_flags;
+
+    struct kvm_arch     arch;        /* architecture-specific state */
+};
+
+struct kvm_vcpu {
+    struct kvm         *kvm;
+    int                 cpu;         /* physical CPU this vCPU ran on last */
+    int                 vcpu_id;
+    int                 vcpu_idx;
+
+    int                 srcu_idx;
+    int                 mode;        /* IN_GUEST_MODE, etc. */
+    u64                 requests;    /* pending requests bitmask */
+    unsigned long       guest_debug; /* debug flags */
+
+    int                 pre_pcpu;
+    struct list_head    blocked_vcpu_list;
+
+    struct mutex        mutex;
+    struct kvm_run     *run;         /* the mmap'd run structure */
+
+    int                 guest_fpu_loaded;
+    wait_queue_head_t   wq;          /* for blocking on halt */
+
+    struct kvm_vcpu_arch arch;       /* x86/arm64-specific state */
+    struct kvm_vcpu_stat stat;
+
+    /* Dirty ring for tracking modified guest pages */
+    struct kvm_dirty_ring dirty_ring;
+};
+```
+
+## The vCPU run loop
+
+```c
+/* arch/x86/kvm/x86.c: kvm_arch_vcpu_ioctl_run() */
+int kvm_arch_vcpu_ioctl_run(struct kvm_vcpu *vcpu)
+{
+    struct kvm_run *kvm_run = vcpu->run;
+
+    while (1) {
+        /* Process any pending work before entering guest */
+        if (kvm_request_pending(vcpu)) {
+            if (kvm_check_request(KVM_REQ_TLB_FLUSH, vcpu))
+                kvm_flush_tlb(vcpu);
+            /* ... handle other requests ... */
+        }
+
+        /* Inject interrupts if pending */
+        if (vcpu->arch.interrupt.injected)
+            vmx_inject_irq(vcpu);
+
+        /* VM Entry */
+        kvm_x86_ops.run(vcpu);   /* calls VMLAUNCH or VMRESUME */
+
+        /* VM Exit: handle the reason */
+        r = kvm_x86_ops.handle_exit(vcpu, exit_fastpath);
+
+        if (r <= 0)
+            break;  /* exit to userspace */
+
+        /* Continue in-kernel: handle exits that don't need QEMU */
+    }
+
+    return r;
+}
+```
+
+## Hypercalls: guest-to-host communication
+
+```c
+/* Guest: issue a hypercall */
+/* On x86: vmcall (Intel) or vmmcall (AMD) */
+static inline long kvm_hypercall(unsigned int nr, unsigned long p1,
+                                  unsigned long p2, unsigned long p3,
+                                  unsigned long p4)
+{
+    long ret;
+    asm volatile("vmcall"
+                 : "=a"(ret)
+                 : "a"(nr), "b"(p1), "c"(p2), "d"(p3), "S"(p4)
+                 : "memory");
+    return ret;
+}
+
+/* KVM hypercall numbers (include/uapi/linux/kvm_para.h) */
+KVM_HC_VAPIC_POLL_IRQ     /* poll for virtual APIC interrupt */
+KVM_HC_MMU_OP             /* MMU operation */
+KVM_HC_FEATURES           /* get KVM feature flags */
+KVM_HC_PPC_MAP_MAGIC_PAGE /* PowerPC */
+KVM_HC_KICK_CPU           /* kick another vCPU (IPI) */
+KVM_HC_CLOCK_PAIRING      /* time synchronization */
+KVM_HC_SEND_IPI           /* send IPI to bitmap of vCPUs */
+KVM_HC_SCHED_YIELD        /* yield to another vCPU */
+KVM_HC_MAP_GPA_RANGE      /* memory attribute notification */
+```
+
+## Observing KVM
+
+```bash
+# KVM stats per VM (requires debugfs)
+ls /sys/kernel/debug/kvm/
+# 42-0/  42-1/  ...  (vm_id-vcpu_id directories)
+
+cat /sys/kernel/debug/kvm/42-0/exits
+# Total: 12345678
+# mmio: 23456
+# io: 12345
+# halt: 100
+# irq_window: 5000
+
+# perf KVM stats
+perf kvm stat record -a sleep 10
+perf kvm stat report
+
+# KVM tracepoints
+ls /sys/kernel/tracing/events/kvm/
+echo 1 > /sys/kernel/tracing/events/kvm/kvm_exit/enable
+cat /sys/kernel/tracing/trace_pipe
+# bash-1234 [003] kvm_exit: reason EXTERNAL_INTERRUPT rip 0xffff...
+```
+
+## Further reading
+
+- [Memory Virtualization](kvm-memory.md) — EPT, shadow paging, balloon
+- [virtio](virtio.md) — I/O paravirtualization
+- [Memory Management: page tables](../mm/page-tables.md) — EPT builds on x86 paging
+- `virt/kvm/` in the kernel tree — KVM core implementation
+- `arch/x86/kvm/` — x86-specific KVM code

--- a/docs/virtualization/kvm-memory.md
+++ b/docs/virtualization/kvm-memory.md
@@ -1,0 +1,360 @@
+# Memory Virtualization
+
+> EPT, shadow paging, balloon driver, and huge pages for KVM guests
+
+## Two layers of address translation
+
+A guest OS thinks it controls physical memory. It doesn't — it controls *guest physical addresses* (GPA), which KVM translates to *host physical addresses* (HPA) using a second page table layer.
+
+```
+Guest virtual → Guest physical → Host physical
+      (guest CR3)       (EPT / shadow PT)
+
+Without hardware:  two separate walks, merged by software (shadow paging)
+With EPT/NPT:      hardware does a 2D walk automatically
+```
+
+## Extended Page Tables (EPT / NPT)
+
+Intel EPT (Extended Page Tables) and AMD NPT (Nested Page Tables) are the hardware mechanisms for GPA→HPA translation. They eliminate the need for shadow page tables on modern hardware.
+
+### EPT page walk
+
+The CPU walks both GCR3 (guest CR3) and the EPT pointer (EPTP) simultaneously:
+
+```
+Guest CR3 → PML4 → PDPT → PD → PT → GPA
+                                        │
+                           EPTP → EPT PML4 → EPT PDPT → EPT PD → EPT PT → HPA
+```
+
+For a 4-level guest walking a 4-level EPT, the hardware may touch up to 24 page table entries in the worst case (4 guest + 4×4 EPT walks).
+
+### struct kvm_mmu
+
+```c
+/* arch/x86/include/asm/kvm_host.h */
+struct kvm_mmu {
+    /* Page fault handler: invoked on GPA fault */
+    int (*page_fault)(struct kvm_vcpu *vcpu,
+                      struct kvm_page_fault *fault);
+
+    /* TLB flush */
+    void (*invlpg)(struct kvm_vcpu *vcpu, gva_t gva, hpa_t root_hpa);
+
+    /* Root (top-level EPT/shadow PT physical address) */
+    hpa_t                root_hpa;
+    gpa_t                root_pgd;
+    union kvm_mmu_page_role root_role;
+
+    /* GPA fault address from VMCS exit qualification */
+    gpa_t                gpa_available;
+
+    /* Shadow page table state */
+    struct kvm_mmu_page *pae_root;
+    struct kvm_mmu_root_info prev_roots[KVM_MMU_NUM_PREV_ROOTS];
+};
+```
+
+### EPT violation handling
+
+When a guest accesses memory with no EPT entry, the CPU triggers an EPT violation VM exit:
+
+```c
+/* arch/x86/kvm/mmu/mmu.c */
+static int handle_ept_violation(struct kvm_vcpu *vcpu)
+{
+    gpa_t gpa    = vmcs_read64(GUEST_PHYSICAL_ADDRESS);
+    u64   exit_qual = vmcs_readl(EXIT_QUALIFICATION);
+
+    /*
+     * exit_qual bits:
+     *   bit 0: read fault
+     *   bit 1: write fault
+     *   bit 2: fetch fault
+     *   bit 7: GPA in addr translation of GVA (not a direct access)
+     */
+
+    /* Look up or create the HPA mapping */
+    return kvm_mmu_page_fault(vcpu, gpa, error_code, NULL, 0);
+}
+
+static int kvm_mmu_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
+                               u64 error_code, ...)
+{
+    /* Try to resolve the fault by building EPT entries */
+    r = kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, error_code, false, &emulation_type);
+    if (r == RET_PF_INVALID) {
+        /* Emulate the access (e.g., MMIO to a device region) */
+        r = handle_mmio_page_fault(vcpu, cr2_or_gpa, is_present_gpte(error_code));
+    }
+    return r;
+}
+```
+
+### struct kvm_mmu_page (shadow pages)
+
+KVM tracks EPT/shadow pages via `struct kvm_mmu_page`. One struct per page table page:
+
+```c
+struct kvm_mmu_page {
+    struct list_head    link;          /* in kvm->arch.active_mmu_pages */
+    struct hlist_node   hash_link;     /* hash table by gfn */
+    struct list_head    lpage_disallowed_link;
+
+    bool                unsync;        /* sptes may be out of date */
+    u8                  mmu_valid_gen; /* generation counter */
+
+    gfn_t               gfn;          /* guest frame number this page maps */
+    union kvm_mmu_page_role role;      /* level, cr4_pae, access bits, ... */
+
+    u64                *spt;          /* the actual page table page (4096 bytes) */
+    gfn_t              *shadowed_translation; /* gfn for each spte */
+    struct kvm_rmap_head parent_ptes;  /* reverse map: who points here */
+
+    atomic_t            write_flooding_count;
+};
+```
+
+## Shadow paging (without EPT)
+
+On older hardware without EPT, KVM maintains **shadow page tables** that directly map GVA→HPA. The guest's CR3 points to the shadow page table, not its own.
+
+```
+Guest CR3 ──────────► Shadow PT (GVA → HPA, maintained by KVM)
+                              ▲
+Guest's own PT ──────────────┘
+(GVA → GPA, never loaded)
+```
+
+### The write-protection trap
+
+Shadow paging requires KVM to intercept every guest write to a page table:
+
+1. KVM write-protects all guest page table pages (set `EPT_PROT_WRITE = 0`)
+2. When guest tries to modify its own page table → EPT write fault → VM exit
+3. KVM emulates the write, updates both guest PT and shadow PT
+4. Resume guest
+
+This is costly for page-table-heavy workloads. EPT avoids this entirely.
+
+## Memory slots
+
+KVM maps guest physical memory in *slots* — contiguous GPA ranges backed by host userspace memory:
+
+```c
+/* include/linux/kvm_host.h */
+struct kvm_memory_slot {
+    struct hlist_node   id_node[2];
+    struct interval_tree_node hva_node[2];
+    struct rb_node      gfn_node[2];
+
+    gfn_t               base_gfn;   /* start GFN */
+    unsigned long       npages;     /* number of guest pages */
+    unsigned long      *dirty_bitmap;
+    struct kvm_arch_memory_slot arch;
+
+    unsigned long       userspace_addr; /* HVA of backing memory */
+    u32                 flags;          /* KVM_MEM_LOG_DIRTY_PAGES, etc. */
+    short               id;
+    u16                 as_id;
+};
+```
+
+A slot can be:
+- **Normal RAM**: backed by `mmap(MAP_ANONYMOUS)` memory in QEMU
+- **ROM**: read-only (bios, option ROM)
+- **MMIO**: no backing — triggers `KVM_EXIT_MMIO` on access
+
+## Dirty page tracking
+
+KVM can track which guest pages have been modified (used by live migration):
+
+```c
+/* Enable dirty tracking on a slot */
+struct kvm_userspace_memory_region region = {
+    .slot  = 0,
+    .flags = KVM_MEM_LOG_DIRTY_PAGES,  /* enables dirty bitmap */
+    /* ... */
+};
+ioctl(vm_fd, KVM_SET_USER_MEMORY_REGION, &region);
+
+/* Fetch and clear dirty bitmap (pauses guest writes during collection) */
+struct kvm_dirty_log log = {
+    .slot       = 0,
+    .dirty_bitmap = bitmap,
+};
+ioctl(vm_fd, KVM_GET_DIRTY_LOG, &log);
+```
+
+### Dirty ring (5.11+)
+
+The dirty ring is a faster alternative that avoids the bitmap scan:
+
+```c
+/* Kernel exports dirty GFNs to a per-vCPU ring */
+struct kvm_dirty_ring {
+    u32    dirty_index;   /* written by kernel */
+    u32    reset_index;   /* read/reset by VMM */
+    u32    size;
+    u32    soft_limit;
+    struct kvm_dirty_gfn *dirty_gfns; /* mmap'd ring */
+};
+
+struct kvm_dirty_gfn {
+    __u32 flags;
+    __u32 slot;
+    __u64 offset;  /* page offset within slot */
+};
+```
+
+The VMM polls the ring, processes dirty GFNs, and resets them. No bitmap scan needed — much faster for high-write-rate guests.
+
+## Balloon driver
+
+The balloon driver is a paravirtual mechanism for the host to reclaim memory from a guest without the guest noticing page table manipulations.
+
+```
+Host (KVM)              Guest (virtio-balloon driver)
+    │                           │
+    │  inflate request ─────────►
+    │  (need N pages back)      │
+    │                           │ allocate N pages from guest allocator
+    │                           │ add their GFNs to balloon page list
+    │                           │
+    │  guest tells host GPAs ◄──┘
+    │
+    │  host removes EPT entries for those GPAs
+    │  host can now use the physical memory for other guests
+    │
+    │  deflate request ──────────►
+    │  (guest can have pages back) │
+    │                              │ release pages back to guest allocator
+```
+
+### Balloon stats
+
+The guest can also report memory statistics to the host:
+
+```c
+/* drivers/virtio/virtio_balloon.c */
+static void update_balloon_stats(struct virtio_balloon *vb)
+{
+    unsigned long events[NR_VM_EVENT_ITEMS];
+    struct sysinfo i;
+
+    all_vm_events(events);
+    si_meminfo(&i);
+
+    update_stat(vb, VIRTIO_BALLOON_S_SWAP_IN,
+                pages_to_bytes(events[PSWPIN]));
+    update_stat(vb, VIRTIO_BALLOON_S_SWAP_OUT,
+                pages_to_bytes(events[PSWPOUT]));
+    update_stat(vb, VIRTIO_BALLOON_S_MAJFLT, events[PGMAJFAULT]);
+    update_stat(vb, VIRTIO_BALLOON_S_MINFLT, events[PGFAULT]);
+    update_stat(vb, VIRTIO_BALLOON_S_MEMFREE,
+                pages_to_bytes(i.freeram));
+    update_stat(vb, VIRTIO_BALLOON_S_MEMTOT,
+                pages_to_bytes(i.totalram));
+    update_stat(vb, VIRTIO_BALLOON_S_AVAIL,
+                pages_to_bytes(si_mem_available()));
+}
+```
+
+The host uses these stats to make inflation/deflation decisions intelligently (e.g., don't inflate if guest has no free memory).
+
+## Huge pages for guests
+
+Using huge pages in the EPT improves TLB efficiency. KVM can map a 2MB or 1GB GPA range with a single EPT entry.
+
+### Transparent huge pages (THP) for guest memory
+
+QEMU typically allocates guest RAM with `mmap(MAP_ANONYMOUS)`. With THP enabled, the host kernel may promote guest pages to huge pages automatically, and KVM will use 2MB EPT entries:
+
+```bash
+# On host: allow THP for anonymous memory
+echo always > /sys/kernel/mm/transparent_hugepage/enabled
+
+# Check if guest pages are backed by hugepages
+grep -i huge /proc/$(pgrep qemu)/smaps | head
+# AnonHugePages: 1234567 kB
+```
+
+### hugetlbfs-backed guest memory
+
+For guaranteed huge pages with no THP pressure, QEMU can use hugetlbfs:
+
+```bash
+# Allocate 512 x 2MB hugepages (1GB total) on host
+echo 512 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+
+# Start QEMU with hugetlbfs memory
+qemu-system-x86_64 \
+    -m 1G \
+    -mem-path /dev/hugepages \
+    -mem-prealloc \
+    ...
+```
+
+When EPT maps these, every 2MB of guest physical memory uses one EPT leaf entry instead of 512. Fewer TLB misses → better guest performance for memory-intensive workloads.
+
+### KVM large page handling
+
+```c
+/* arch/x86/kvm/mmu/mmu.c */
+static int kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu,
+                                    struct kvm_page_fault *fault)
+{
+    struct kvm_memory_slot *slot = fault->slot;
+    kvm_pfn_t mask;
+    int level;
+
+    /*
+     * Walk from the maximum possible level (1GB) down to 4KB.
+     * Use the largest level where:
+     *   1. The GPA range is aligned
+     *   2. The HPA range is backed by a huge page
+     */
+    for (level = KVM_MAX_HUGEPAGE_LEVEL; level > PG_LEVEL_4K; level--) {
+        mask = KVM_PAGES_PER_HPAGE(level) - 1;
+        if (fault->addr & (mask << PAGE_SHIFT))
+            continue;  /* not aligned for this level */
+        if (!kvm_is_transparent_hugepage(fault->pfn & ~mask))
+            continue;  /* host page not huge */
+        fault->goal_level = level;
+        return 0;
+    }
+    return 0;
+}
+```
+
+## Observing guest memory
+
+```bash
+# EPT violations per vCPU (VM exits due to missing EPT entries)
+cat /sys/kernel/debug/kvm/*/ept_violations
+
+# Guest TLB flush requests
+cat /sys/kernel/debug/kvm/*/tlb_flush
+
+# Guest huge pages
+cat /sys/kernel/debug/kvm/*/nx_lpage_splits
+
+# Host sees guest RSS as the QEMU process
+cat /proc/$(pgrep qemu)/status | grep VmRSS
+
+# Check EPT is active
+grep ept /sys/module/kvm_intel/parameters/
+# ept:Y   (or N if disabled)
+
+# Force EPT off for testing (requires shadow paging fallback)
+modprobe kvm_intel ept=0
+```
+
+## Further reading
+
+- [KVM Architecture](kvm-arch.md) — /dev/kvm API, vCPU run loop
+- [virtio](virtio.md) — paravirtual I/O, balloon transport
+- [Memory Management: page tables](../mm/page-tables.md) — host-side page tables
+- [Memory Management: THP](../mm/thp.md) — huge page promotion KVM uses
+- `arch/x86/kvm/mmu/` in the kernel tree — EPT/shadow page table implementation

--- a/docs/virtualization/virtio.md
+++ b/docs/virtualization/virtio.md
@@ -1,0 +1,351 @@
+# virtio
+
+> Paravirtualized I/O for KVM guests
+
+## Why paravirtualization?
+
+Emulating real hardware (e.g., Intel e1000 NIC, IDE disk) inside QEMU works but is slow: every device register access by the guest causes a VM exit, QEMU decodes the access, updates emulated state, and returns. This happens thousands of times per packet.
+
+virtio replaces emulated hardware registers with a shared-memory protocol. The guest knows it's in a VM and cooperates — far fewer VM exits, much higher throughput.
+
+```
+Emulated hardware path:
+  Guest write → VM exit → QEMU decode → emulate register → VM resume
+  (per I/O register access)
+
+virtio path:
+  Guest fills ring buffer → notify host (one VM exit per batch)
+  Host processes batch → notifies guest
+```
+
+## virtio architecture
+
+```
+Guest kernel                          Host (QEMU / vhost)
+┌────────────────────────────┐        ┌────────────────────────────┐
+│  virtio-net / virtio-blk   │        │  virtio-net backend        │
+│  device driver             │        │  (QEMU or vhost-net)       │
+│           │                │        │           ▲                │
+│    virtqueue (vring)        │        │    virtqueue (vring)        │
+│    ┌──────────────────┐    │        │    ┌──────────────────┐    │
+│    │ desc  table      │◄───┼────────┼───►│ desc  table      │    │
+│    │ avail ring       │    │        │    │ avail ring       │    │
+│    │ used  ring       │    │        │    │ used  ring       │    │
+│    └──────────────────┘    │        │    └──────────────────┘    │
+│           │                │        │                            │
+│    kick (PCI notify)  ─────┼────────┼──► process descriptors    │
+│    ◄─── interrupt ─────────┼────────┼─── add to used ring       │
+└────────────────────────────┘        └────────────────────────────┘
+```
+
+## The virtqueue / vring
+
+A virtqueue is a split ring buffer with three regions in shared memory:
+
+```c
+/* include/uapi/linux/virtio_ring.h */
+
+/* One descriptor: points to a buffer segment */
+struct vring_desc {
+    __virtio64 addr;   /* physical address (GPA) of buffer */
+    __virtio32 len;    /* buffer length */
+    __virtio16 flags;  /* VRING_DESC_F_NEXT | VRING_DESC_F_WRITE | VRING_DESC_F_INDIRECT */
+    __virtio16 next;   /* index of next descriptor (if NEXT flag set) */
+};
+
+/* Available ring: driver (guest) adds here, device (host) reads */
+struct vring_avail {
+    __virtio16 flags;  /* VRING_AVAIL_F_NO_INTERRUPT: suppress interrupts */
+    __virtio16 idx;    /* where driver will put next entry */
+    __virtio16 ring[]; /* descriptor chain head indices */
+};
+
+/* Used ring: device (host) adds here, driver (guest) reads */
+struct vring_used_elem {
+    __virtio32 id;     /* index of used descriptor chain */
+    __virtio32 len;    /* bytes written (for reads; 0 for writes) */
+};
+
+struct vring_used {
+    __virtio16 flags;  /* VRING_USED_F_NO_NOTIFY: suppress kicks */
+    __virtio16 idx;    /* where device will put next entry */
+    struct vring_used_elem ring[];
+};
+```
+
+### virtqueue lifecycle
+
+```
+Guest (driver side):                   Host (device side):
+
+1. Allocate descriptors:
+   desc[0].addr = buf_gpa
+   desc[0].len  = 1500
+   desc[0].flags = VRING_DESC_F_WRITE
+
+2. Post to available ring:
+   avail.ring[avail.idx] = 0 (desc #0)
+   wmb()
+   avail.idx++
+
+3. Kick the host:
+   iowrite16(queue_idx, notify_addr)
+   → VM exit (PCI MMIO write)
+
+                                       4. Host sees avail.idx changed
+                                          Read desc[0] → DMA into buf
+
+                                       5. Host posts to used ring:
+                                          used.ring[used.idx] = {0, 1500}
+                                          used.idx++
+                                          send interrupt to guest
+
+6. Guest interrupt handler:
+   while (last_used != used.idx) {
+       process used.ring[last_used]
+       last_used++
+   }
+```
+
+### Descriptor chaining
+
+Large buffers (e.g., a 64KB network packet with header + payload) can be represented as a chain:
+
+```
+desc[0]: header   → flags = NEXT, next = 1
+desc[1]: payload  → flags = WRITE, next = 0  (end of chain)
+```
+
+The host reads desc[0], follows `next` to desc[1], processes both as one logical buffer.
+
+## virtio-net
+
+```c
+/* drivers/net/virtio_net.c */
+struct virtnet_info {
+    struct virtio_device    *vdev;
+    struct virtqueue        *cvq;           /* control virtqueue */
+    struct net_device       *dev;
+    struct send_queue       *sq;            /* one per TX queue */
+    struct receive_queue    *rq;            /* one per RX queue */
+    unsigned int            max_queue_pairs;
+
+    /* Offload features negotiated with host */
+    bool                    mergeable_rx_bufs;
+    bool                    has_rss;
+};
+
+/* TX path: enqueue packet */
+static int xmit_skb(struct send_queue *sq, struct sk_buff *skb)
+{
+    struct virtio_net_hdr_mrg_rxbuf *hdr;
+    const unsigned char *dest = ((struct ethhdr *)skb->data)->h_dest;
+    struct virtnet_info *vi = sq->vq->vdev->priv;
+    int num_sg;
+
+    /* Prepend virtio_net header */
+    hdr = skb_push(skb, vi->hdr_len);
+    memset(hdr, 0, vi->hdr_len);
+
+    /* If TSO/checksum offload: set flags in hdr */
+    if (skb->ip_summed == CHECKSUM_PARTIAL) {
+        hdr->hdr.flags   = VIRTIO_NET_HDR_F_NEEDS_CSUM;
+        hdr->hdr.csum_offset = skb->csum_offset;
+        hdr->hdr.csum_start  = skb_checksum_start_offset(skb);
+    }
+
+    /* Build scatter-gather list from skb frags */
+    num_sg = skb_to_sgvec(skb, sq->sg, 0, skb->len);
+
+    return virtqueue_add_outbuf(sq->vq, sq->sg, num_sg, skb, GFP_ATOMIC);
+}
+```
+
+### virtio-net header
+
+```c
+/* include/uapi/linux/virtio_net.h */
+struct virtio_net_hdr {
+    __u8  flags;       /* VIRTIO_NET_HDR_F_NEEDS_CSUM, etc. */
+    __u8  gso_type;    /* VIRTIO_NET_HDR_GSO_TCPV4/6, etc. */
+    __le16 hdr_len;    /* ethernet+IP+TCP header length */
+    __le16 gso_size;   /* max segment size for GSO */
+    __le16 csum_start; /* offset to start of checksum */
+    __le16 csum_offset;/* offset within csum_start to place checksum */
+};
+```
+
+This header lets the host/guest negotiate hardware offloads: checksum, segmentation (TSO), receive-side coalescing (LRO).
+
+## virtio-blk
+
+```c
+/* include/uapi/linux/virtio_blk.h */
+struct virtio_blk_req {
+    __virtio32 type;    /* VIRTIO_BLK_T_IN / T_OUT / T_FLUSH / T_DISCARD */
+    __virtio32 ioprio;
+    __virtio64 sector;  /* 512-byte sector number */
+};
+
+/* A complete I/O request descriptor chain:
+   [0] virtio_blk_req header  (device-readable)
+   [1] data buffer            (device-writable for read, device-readable for write)
+   [2] status byte            (device-writable: 0=success, 1=error, 2=unsupported) */
+```
+
+### Why virtio-blk is fast
+
+- One virtqueue per vCPU (multi-queue support)
+- Guest batches multiple requests before kicking
+- Host processes full batch, posts all completions
+- With `VIRTIO_BLK_F_FLUSH`: explicit flush ordering
+
+## Feature negotiation
+
+virtio devices negotiate features before use:
+
+```c
+/* Guest reads host-supported features */
+u64 host_features = vdev->config->get_features(vdev);
+
+/* Guest decides what it wants */
+u64 guest_features = 0;
+if (host_features & (1ULL << VIRTIO_NET_F_CSUM))
+    guest_features |= (1ULL << VIRTIO_NET_F_CSUM);   /* checksum offload */
+if (host_features & (1ULL << VIRTIO_NET_F_MRG_RXBUF))
+    guest_features |= (1ULL << VIRTIO_NET_F_MRG_RXBUF); /* mergeable RX */
+if (host_features & (1ULL << VIRTIO_F_RING_PACKED))
+    guest_features |= (1ULL << VIRTIO_F_RING_PACKED); /* packed ring layout */
+
+/* Write accepted features back */
+vdev->config->finalize_features(vdev);
+```
+
+Key feature bits:
+```c
+VIRTIO_F_VERSION_1         /* modern virtio (mandatory for new devices) */
+VIRTIO_F_RING_PACKED       /* packed ring layout (avoids avail/used split) */
+VIRTIO_F_IN_ORDER          /* host completes requests in order */
+VIRTIO_NET_F_CSUM          /* checksum offload */
+VIRTIO_NET_F_HOST_TSO4     /* TCP segmentation offload (IPv4) */
+VIRTIO_NET_F_MRG_RXBUF     /* mergeable receive buffers */
+VIRTIO_NET_F_RSS           /* receive-side scaling (multi-queue) */
+VIRTIO_BLK_F_SEG_MAX       /* max segments per request */
+VIRTIO_BLK_F_SIZE_MAX      /* max segment size */
+VIRTIO_BLK_F_DISCARD       /* TRIM/discard support */
+VIRTIO_BLK_F_WRITE_ZEROES  /* write-zeroes command */
+```
+
+## vhost-net: kernel-space acceleration
+
+vhost-net moves the virtio-net backend from QEMU userspace into the kernel, eliminating the QEMU → host kernel round trip for each packet.
+
+```
+Without vhost-net:
+  Guest → VM exit → KVM → wake QEMU → QEMU reads vring →
+  QEMU writes to TAP fd → kernel TAP → network
+
+With vhost-net:
+  Guest → VM exit → KVM → vhost worker (kernel thread) →
+  reads vring → writes to TAP directly (no QEMU in data path)
+```
+
+### vhost kernel internals
+
+```c
+/* drivers/vhost/net.c */
+struct vhost_net {
+    struct vhost_dev dev;           /* owns vhost worker thread */
+    struct vhost_net_virtqueue vqs[VHOST_NET_VQ_MAX];
+    /* ... */
+};
+
+struct vhost_dev {
+    struct mm_struct *mm;           /* guest mm for GPA→HVA translation */
+    struct mutex mutex;
+    struct vhost_virtqueue **vqs;
+    int nvqs;
+    struct task_struct *worker;     /* kernel thread doing I/O */
+    /* ... */
+};
+
+/* vhost worker: polls virtqueue, processes TX/RX */
+static void handle_tx(struct vhost_net *net)
+{
+    struct vhost_net_virtqueue *nvq = &net->vqs[VHOST_NET_VQ_TX];
+    struct vhost_virtqueue *vq = &nvq->vq;
+
+    /* Read from guest avail ring */
+    while ((head = vhost_get_vq_desc(vq, ...)) != vq->num) {
+        /* GPA → HVA translation using guest mm */
+        /* write to socket / TAP fd */
+        vhost_add_used(vq, head, 0);
+    }
+    vhost_signal(&net->dev, vq);  /* interrupt guest */
+}
+```
+
+### vhost-user: userspace vhost
+
+vhost-user moves the backend to a separate userspace process (e.g., DPDK, OVS) using a Unix socket for control and shared memory for the rings:
+
+```
+Guest (KVM) ──► vring (shared memory) ◄── vhost-user process (DPDK/OVS)
+                 ▲
+          eventfd for kick/interrupt
+```
+
+Used by Open vSwitch + DPDK for line-rate switching without kernel involvement.
+
+## virtio-mmio vs PCI transport
+
+virtio devices are exposed over two transports:
+
+| Transport | Usage | Discovery |
+|-----------|-------|-----------|
+| PCI | x86 VMs, standard | PCI config space scan |
+| MMIO | ARM/embedded VMs, containers | Device tree / ACPI |
+
+```bash
+# In a Linux guest: see virtio devices
+lspci | grep -i virtio
+# 00:01.0 Ethernet controller: Red Hat, Inc. Virtio network device
+# 00:02.0 SCSI storage controller: Red Hat, Inc. Virtio block device
+
+# Or via virtio-mmio:
+cat /proc/device-tree/virtio_mmio@*/compatible
+# virtio,mmio
+```
+
+## Observing virtio performance
+
+```bash
+# In guest: virtio-net stats
+ethtool -S eth0 | grep -E "queue|vq"
+
+# virtio-blk device statistics
+cat /sys/block/vda/stat
+
+# vhost-net stats (on host)
+cat /proc/net/dev   # TAP interface throughput
+
+# Kick/interrupt frequency (low = batching, high = latency-sensitive)
+cat /sys/kernel/debug/virtio*/virtqueue*/avail_idx
+cat /sys/kernel/debug/virtio*/virtqueue*/used_idx
+
+# perf: vhost worker CPU usage
+perf top -p $(pgrep vhost)
+
+# Interrupt coalescing: check if interrupts are suppressed
+# (VRING_AVAIL_F_NO_INTERRUPT tells host not to interrupt guest)
+```
+
+## Further reading
+
+- [KVM Architecture](kvm-arch.md) — VM exits, hypercalls
+- [Memory Virtualization](kvm-memory.md) — EPT, balloon driver
+- `drivers/virtio/` in the kernel tree — virtio core bus
+- `drivers/net/virtio_net.c` — virtio-net driver
+- `drivers/block/virtio_blk.c` — virtio-blk driver
+- `drivers/vhost/` — vhost-net kernel backend
+- virtio specification: https://docs.oasis-open.org/virtio/virtio/v1.2/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -313,3 +313,8 @@ nav:
     - LSM Framework: security/lsm.md
     - Capabilities: security/capabilities.md
     - seccomp BPF: security/seccomp.md
+  - Virtualization:
+    - Getting Started: virtualization/README.md
+    - KVM Architecture: virtualization/kvm-arch.md
+    - Memory Virtualization: virtualization/kvm-memory.md
+    - virtio: virtualization/virtio.md


### PR DESCRIPTION
## Summary

- **KVM Architecture** (`kvm-arch.md`): Intel VT-x/VMCS, `/dev/kvm` ioctl API with full working example, VM exit reasons, `struct kvm`/`kvm_vcpu` internals, vCPU run loop, hypercalls, debugfs observability
- **Memory Virtualization** (`kvm-memory.md`): EPT/NPT two-level address translation, `struct kvm_mmu`/`kvm_mmu_page`, shadow paging write-protection trap, memory slots, dirty bitmap + dirty ring (5.11+), balloon driver inflation/deflation/stats, huge pages (THP and hugetlbfs)
- **virtio** (`virtio.md`): vring split-ring protocol (`vring_desc`/`vring_avail`/`vring_used`), descriptor chaining, virtio-net (TX path, `virtio_net_hdr`, offloads), virtio-blk, feature negotiation, vhost-net kernel acceleration, vhost-user/DPDK, PCI vs MMIO transport

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] All cross-links between `kvm-arch.md`, `kvm-memory.md`, and `virtio.md` resolve
- [ ] mkdocs.yml Virtualization section renders in nav