### PR TITLE
Add power management documentation

### DIFF
--- a/docs/power/README.md
+++ b/docs/power/README.md
@@ -1,0 +1,59 @@
+# Power Management
+
+> CPU frequency scaling, device runtime power, and system suspend in the Linux kernel
+
+## The power management stack
+
+```
+User space (udev, systemd, powertop)
+    │
+    ▼
+sysfs / /sys/devices/.../power/  /sys/devices/system/cpu/cpu*/cpufreq/
+    │
+    ▼
+PM core (drivers/base/power/)
+    ├── Runtime PM:  device active/suspended lifecycle
+    ├── System PM:   suspend/hibernate state machine
+    └── Wakeup:      wakeup_source tracking
+    │
+    ▼
+cpufreq subsystem (drivers/cpufreq/)
+    ├── Governor:    schedutil / ondemand / powersave / performance
+    └── Driver:      intel_pstate / acpi-cpufreq / cppc_cpufreq
+    │
+    ▼
+Hardware: ACPI P-states, HWP (Hardware P-state), C-states, ARM DVFS
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [cpufreq](cpufreq.md) | P-states, governors, schedutil, intel_pstate, HWP |
+| [Runtime PM](runtime-pm.md) | dev_pm_ops, pm_runtime_get/put, power domains |
+| [System Suspend](suspend.md) | suspend-to-RAM, hibernate, wakeup sources, PM notifiers |
+
+## Quick reference
+
+```bash
+# Current CPU frequency scaling
+cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq
+
+# Change governor (all CPUs)
+echo schedutil | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+
+# Device runtime PM status
+cat /sys/bus/pci/devices/*/power/runtime_status
+# active / suspended / error
+
+# System suspend states available
+cat /sys/power/state
+# freeze mem disk
+
+# Suspend to RAM
+echo mem | sudo tee /sys/power/state
+
+# Who is blocking suspend?
+cat /sys/kernel/debug/wakeup_sources
+```

--- a/docs/power/cpufreq.md
+++ b/docs/power/cpufreq.md
@@ -1,0 +1,283 @@
+# cpufreq: CPU Frequency Scaling
+
+> P-states, governors, and hardware-coordinated frequency management
+
+## Why CPU frequency scaling?
+
+Modern CPUs can run at different voltage-frequency operating points called **P-states** (performance states). Lower frequency = lower voltage = less power. The kernel's cpufreq subsystem selects the operating point based on current load.
+
+```
+P0 (max turbo): 4.5 GHz, 1.4V  — high throughput, high power
+P1 (base):      3.5 GHz, 1.2V  — sustained all-core
+P2:             2.5 GHz, 1.0V
+...
+Pn (minimum):   0.8 GHz, 0.7V  — idle, minimal power
+```
+
+## Architecture
+
+```
+cpufreq core (drivers/cpufreq/cpufreq.c)
+    │
+    ├── Governor (policy): schedutil / ondemand / performance / powersave
+    │       decides target frequency based on utilization
+    │
+    └── Driver (hardware): intel_pstate / acpi-cpufreq / cppc_cpufreq
+            programs the actual hardware MSRs / ACPI commands
+```
+
+## struct cpufreq_policy
+
+```c
+/* include/linux/cpufreq.h */
+struct cpufreq_policy {
+    /* CPUs sharing this policy (e.g., SMT siblings or all cores on a die) */
+    cpumask_var_t   cpus;
+    cpumask_var_t   related_cpus;
+
+    unsigned int    shared_type;   /* CPUFREQ_SHARED_TYPE_ALL/ANY/HW */
+
+    unsigned int    cpu;           /* managing CPU */
+    struct clk     *clk;
+
+    struct cpufreq_cpuinfo cpuinfo; /* min/max freq, transition latency */
+
+    unsigned int    min;     /* current policy min (kHz) */
+    unsigned int    max;     /* current policy max (kHz) */
+    unsigned int    cur;     /* current frequency */
+    unsigned int    suspend_freq;
+
+    unsigned int    policy;  /* CPUFREQ_POLICY_PERFORMANCE or _POWERSAVE */
+    unsigned int    last_policy;
+
+    struct cpufreq_governor *governor;
+    void            *governor_data;
+
+    struct cpufreq_driver *driver;
+
+    struct freq_qos_request *min_freq_req;
+    struct freq_qos_request *max_freq_req;
+};
+```
+
+## Governors
+
+A governor observes CPU utilization and selects a target frequency.
+
+### schedutil (recommended, 4.7+)
+
+schedutil integrates with the scheduler's per-CPU utilization tracking. It's called directly from the scheduler path when utilization changes — no polling needed.
+
+```c
+/* drivers/cpufreq/schedutil.c */
+static void sugov_update_single_freq(struct update_util_data *hook, u64 time,
+                                      unsigned int flags)
+{
+    struct sugov_cpu *sg_cpu = container_of(hook, struct sugov_cpu, update_util);
+    struct sugov_policy *sg_policy = sg_cpu->sg_policy;
+    unsigned int cached_freq = sg_policy->cached_raw_freq;
+    unsigned int next_f;
+
+    /* Get utilization signal from scheduler */
+    sugov_get_util(sg_cpu);
+    sugov_iowait_apply(sg_cpu, time);
+
+    /* Map utilization → target frequency */
+    next_f = get_next_freq(sg_policy, sg_cpu->util, sg_cpu->max);
+
+    /* Apply rate limiting (don't change too often) */
+    if (!sugov_update_next_freq(sg_policy, time, next_f))
+        return;
+
+    sugov_fast_switch(sg_policy, time, next_f);
+}
+
+static unsigned int get_next_freq(struct sugov_policy *sg_policy,
+                                   unsigned long util, unsigned long max)
+{
+    struct cpufreq_policy *policy = sg_policy->policy;
+    unsigned int freq = arch_scale_freq_invariant() ?
+                        policy->cpuinfo.max_freq : policy->cur;
+
+    /*
+     * Scale: freq = max_freq * (util / max)
+     * With 25% margin for responsiveness: util * 1.25
+     */
+    util = map_util_perf(util);
+    freq = map_util_freq(util, freq, max);
+
+    if (freq == sg_policy->cached_raw_freq && !sg_policy->need_freq_update)
+        return sg_policy->next_freq;
+
+    sg_policy->cached_raw_freq = freq;
+    return cpufreq_driver_resolve_freq(policy, freq);
+}
+```
+
+### ondemand
+
+Polls CPU idle time periodically (default 10ms), scales frequency proportionally to non-idle fraction:
+
+```
+target_freq = max_freq * (non_idle_time / sample_time)
+```
+
+Slower to react than schedutil (polling vs event-driven), but simpler and still widely used.
+
+### performance / powersave
+
+Static governors: always select the maximum (performance) or minimum (powersave) frequency in the policy range. No utilization sampling at all.
+
+```bash
+# Use performance governor for latency-critical workloads
+echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+
+# Use powersave for battery/thermal savings
+echo powersave | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+```
+
+## cpufreq drivers
+
+### acpi-cpufreq
+
+Uses ACPI _PCT (performance control) and _PSS (P-state supported) objects to enumerate and switch P-states. The OS writes to MSR_IA32_PERF_CTL:
+
+```c
+/* drivers/cpufreq/acpi-cpufreq.c */
+static void drv_write(struct acpi_cpufreq_data *data,
+                       const struct cpumask *mask, u32 val)
+{
+    /* Write target P-state to performance control MSR */
+    wrmsr_on_cpus(mask, MSR_IA32_PERF_CTL, val);
+}
+```
+
+### intel_pstate
+
+Intel's native driver for Sandy Bridge and later. It bypasses the traditional governor hierarchy for CPUs with HWP (Hardware P-state control, Broadwell+):
+
+```
+Without HWP: intel_pstate governor → write PERF_CTL MSR every ~10ms
+With HWP:    intel_pstate sets HWP_{MIN,MAX,DESIRED,EPP} once
+             hardware manages frequency autonomously
+```
+
+```c
+/* drivers/cpufreq/intel_pstate.c */
+static void intel_pstate_hwp_set(unsigned int cpu)
+{
+    struct cpudata *cpu_data = all_cpu_data[cpu];
+    int max, min, desired, epp;
+
+    max     = cpu_data->max_perf_ratio;
+    min     = cpu_data->min_perf_ratio;
+    desired = 0;  /* let hardware decide between min and max */
+    epp     = cpu_data->epp_policy; /* Energy Performance Preference */
+
+    /* Pack into HWP_REQUEST MSR */
+    wrmsrl_on_cpu(cpu, MSR_HWP_REQUEST,
+        HWP_MIN_PERF(min) | HWP_MAX_PERF(max) |
+        HWP_DESIRED_PERF(desired) | HWP_ENERGY_PERF_PREFERENCE(epp));
+}
+```
+
+#### Energy Performance Preference (EPP)
+
+EPP is a hint to the hardware about the performance/power tradeoff:
+
+| EPP value | Hint | Typical use |
+|-----------|------|-------------|
+| 0 | performance | latency-critical |
+| 128 | balance_performance | default |
+| 192 | balance_power | |
+| 255 | power | battery saving |
+
+```bash
+# Read/write EPP for CPU 0
+cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+# balance_performance
+
+echo performance | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+```
+
+### ARM / cppc_cpufreq
+
+ARM servers use ACPI CPPC (Collaborative Processor Performance Control) for firmware-assisted frequency scaling. Similar to HWP: the OS writes desired performance, firmware adjusts clocks.
+
+## Frequency QoS (Quality of Service)
+
+Devices and drivers can impose constraints on CPU frequency via the frequency QoS API:
+
+```c
+#include <linux/pm_qos.h>
+
+/* Request minimum frequency of 1 GHz for a latency-sensitive device */
+struct freq_qos_request req;
+freq_qos_add_request(&policy->constraints, &req,
+                     FREQ_QOS_MIN, 1000000 /* kHz */);
+
+/* Later: remove constraint */
+freq_qos_remove_request(&req);
+```
+
+Constraints from multiple requestors are combined (highest min / lowest max wins).
+
+## C-states: idle power
+
+Separate from P-states, C-states are CPU idle states (when there's no work):
+
+| C-state | Name | Wake latency | Power saved |
+|---------|------|-------------|-------------|
+| C0 | Active | 0 | none |
+| C1 | Halt | ~1µs | low |
+| C1E | Enhanced halt | ~1µs | moderate |
+| C3 | Sleep | ~100µs | high |
+| C6 | Deep power down | ~200µs | highest |
+| C10 | Modern standby | ~10ms | maximum |
+
+The cpuidle subsystem selects C-states. The governor (`menu` or `teo`) predicts next wakeup time and picks the deepest C-state with acceptable latency.
+
+```bash
+# C-state statistics per CPU
+grep . /sys/devices/system/cpu/cpu0/cpuidle/state*/name
+grep . /sys/devices/system/cpu/cpu0/cpuidle/state*/usage
+grep . /sys/devices/system/cpu/cpu0/cpuidle/state*/time  # microseconds
+
+# Prevent deep C-states (latency-sensitive workloads)
+# Set latency QoS: max allowed exit latency in µs
+echo 100 | sudo tee /dev/cpu_dma_latency  # hold fd open
+```
+
+## Observing cpufreq
+
+```bash
+# Current frequencies (all CPUs)
+grep MHz /proc/cpuinfo
+
+# Frequency transition statistics
+cat /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state
+# 800000   12345678   (freq_kHz  time_in_10ms_units)
+# 1000000  8765432
+# 2400000  1234567
+
+cat /sys/devices/system/cpu/cpu0/cpufreq/stats/total_trans
+
+# turbostat: per-CPU P-state and C-state distribution
+sudo turbostat --interval 5
+
+# perf: CPU frequency events
+perf stat -e power/energy-pkg/,power/energy-cores/ sleep 10
+
+# trace frequency transitions
+echo 1 > /sys/kernel/tracing/events/power/cpu_frequency/enable
+cat /sys/kernel/tracing/trace_pipe
+# kworker/0:1-42 [000] cpu_frequency: state=2400000 cpu_id=0
+```
+
+## Further reading
+
+- [Runtime PM](runtime-pm.md) — device-level power management
+- [System Suspend](suspend.md) — system-wide power states
+- [Scheduler: EEVDF](../sched/eevdf.md) — schedutil integrates with scheduler utilization
+- `drivers/cpufreq/` in the kernel tree — governor and driver implementations
+- `Documentation/admin-guide/pm/cpufreq.rst` in the kernel tree

--- a/docs/power/runtime-pm.md
+++ b/docs/power/runtime-pm.md
@@ -1,0 +1,346 @@
+# Runtime PM
+
+> Device-level power management: suspending idle devices while the system runs
+
+## What is Runtime PM?
+
+Runtime PM allows individual devices to enter low-power states while the rest of the system continues running. A GPU can be powered off when no display is attached; a USB device can be suspended when idle; a PCIe NIC can cut power to its PHY between bursts.
+
+```
+System running (S0)
+├── CPU: P-state varies with load
+├── GPU:  [active] → [runtime suspended] after 2 seconds idle
+├── NVMe: [active] → [runtime suspended] after 1 second idle
+├── USB:  [runtime suspended] (nothing plugged in)
+└── NIC:  [active]
+```
+
+## PM callbacks: struct dev_pm_ops
+
+Every driver can register power management callbacks:
+
+```c
+/* include/linux/pm.h */
+struct dev_pm_ops {
+    /* System sleep: called on system suspend/resume */
+    int (*prepare)(struct device *dev);
+    void (*complete)(struct device *dev);
+    int (*suspend)(struct device *dev);
+    int (*resume)(struct device *dev);
+    int (*freeze)(struct device *dev);    /* hibernate snapshot */
+    int (*thaw)(struct device *dev);
+    int (*poweroff)(struct device *dev);
+    int (*restore)(struct device *dev);
+
+    /* Runtime PM: called when device idles or resumes */
+    int (*runtime_suspend)(struct device *dev);
+    int (*runtime_resume)(struct device *dev);
+    int (*runtime_idle)(struct device *dev);
+};
+```
+
+A driver registers them with:
+
+```c
+static const struct dev_pm_ops mydriver_pm_ops = {
+    SET_SYSTEM_SLEEP_PM_OPS(mydriver_suspend, mydriver_resume)
+    SET_RUNTIME_PM_OPS(mydriver_runtime_suspend,
+                       mydriver_runtime_resume,
+                       mydriver_runtime_idle)
+};
+
+static struct platform_driver mydriver = {
+    .driver = {
+        .name   = "mydriver",
+        .pm     = &mydriver_pm_ops,
+    },
+    /* ... */
+};
+```
+
+## Usage counting: get and put
+
+The core of Runtime PM is a **usage counter**. The device stays active while the counter is > 0; it may be suspended when it reaches 0.
+
+```c
+#include <linux/pm_runtime.h>
+
+/* Increment usage count and wait for device to become active.
+   If device is suspended, resumes it first. */
+int ret = pm_runtime_get_sync(dev);
+if (ret < 0) {
+    /* Device could not be resumed — return error */
+    return ret;
+}
+
+/* ... use the device ... */
+
+/* Decrement usage count. If count reaches 0, idle callback fires.
+   The device MAY be suspended asynchronously after this. */
+pm_runtime_put(dev);
+
+/* Or: decrement and schedule suspend immediately */
+pm_runtime_put_autosuspend(dev);
+```
+
+The difference between `pm_runtime_put` variants:
+
+| Function | Behavior |
+|----------|---------- |
+| `pm_runtime_put_sync` | Suspends synchronously if count reaches 0 |
+| `pm_runtime_put` | Schedules async suspend if count reaches 0 |
+| `pm_runtime_put_autosuspend` | Suspends after autosuspend delay |
+| `pm_runtime_put_noidle` | Decrements but does not trigger suspend |
+
+## Autosuspend
+
+Autosuspend adds a configurable delay before suspension. This prevents thrashing when a device is briefly idle between bursts of activity:
+
+```c
+/* In probe: enable autosuspend with 2-second delay */
+pm_runtime_set_autosuspend_delay(dev, 2000 /* ms */);
+pm_runtime_use_autosuspend(dev);
+pm_runtime_enable(dev);
+
+/* Mark the device as initially active (since probe just brought it up) */
+pm_runtime_get_noresume(dev);
+pm_runtime_set_active(dev);
+pm_runtime_put_autosuspend(dev);
+```
+
+The autosuspend delay is also exported to userspace:
+
+```bash
+# Read/write autosuspend delay for a device (ms, -1 = disabled)
+cat /sys/bus/usb/devices/1-1/power/autosuspend_delay_ms
+echo 1000 | sudo tee /sys/bus/usb/devices/1-1/power/autosuspend_delay_ms
+```
+
+## Runtime PM state machine
+
+```
+           pm_runtime_enable()
+                   │
+                   ▼
+              [RPM_ACTIVE]
+              usage_count > 0
+                   │
+         pm_runtime_put() → count=0
+                   │
+                   ▼
+              [RPM_IDLE]
+         idle callback fires
+                   │
+    idle CB returns 0 → pm_runtime_suspend()
+                   │
+                   ▼
+           [RPM_SUSPENDING]
+      runtime_suspend() callback
+                   │
+                   ▼
+           [RPM_SUSPENDED]
+                   │
+         pm_runtime_get_sync()
+                   │
+                   ▼
+           [RPM_RESUMING]
+      runtime_resume() callback
+                   │
+                   ▼
+              [RPM_ACTIVE]
+```
+
+### The idle callback
+
+The idle callback is called when usage count reaches 0. It decides whether to actually suspend:
+
+```c
+static int mydriver_runtime_idle(struct device *dev)
+{
+    struct mydata *priv = dev_get_drvdata(dev);
+
+    /* Don't suspend if there's pending work */
+    if (!list_empty(&priv->pending_list))
+        return -EBUSY;  /* don't suspend */
+
+    /* Let PM core call runtime_suspend */
+    return pm_runtime_autosuspend(dev);
+    /* or: return 0 (PM core will call runtime_suspend immediately) */
+}
+```
+
+## struct device power fields
+
+```c
+/* include/linux/pm.h */
+struct dev_pm_info {
+    pm_message_t        power_state;    /* current power state */
+    unsigned int        can_wakeup:1;   /* device can generate wakeup events */
+    unsigned int        async_suspend:1;
+    bool                in_dpm_list:1;
+
+    /* Runtime PM fields */
+    struct timer_list   suspend_timer;  /* autosuspend timer */
+    unsigned long       timer_expires;
+    struct work_struct  work;
+
+    wait_queue_head_t   wait_queue;
+    struct hrtimer      suspend_timer_hr;
+
+    atomic_t            usage_count;    /* get/put counter */
+    atomic_t            child_count;    /* children that are active */
+
+    unsigned int        disable_depth;  /* depth of pm_runtime_disable() calls */
+    int                 runtime_error;
+
+    int                 last_status;    /* RPM_ACTIVE/SUSPENDED/etc. */
+
+    enum rpm_status     runtime_status; /* current runtime PM state */
+    int                 runtime_usage;
+};
+```
+
+## Power domains
+
+A power domain is a hardware block that can be independently powered off. Multiple devices may share a domain — the domain stays on until all devices in it are suspended.
+
+```c
+/* drivers/base/power/domain.c */
+struct generic_pm_domain {
+    struct dev_pm_domain domain;    /* embedded — has dev_pm_ops */
+    struct list_head      gpd_list_node;
+
+    const char           *name;
+    atomic_t              sd_count;  /* number of active subdomains */
+    enum gpd_status       status;    /* GPD_STATE_ACTIVE/POWER_OFF */
+
+    unsigned int          device_count;
+    unsigned int          suspended_count;
+    unsigned int          prepared_count;
+
+    struct list_head      master_links; /* parent domains */
+    struct list_head      slave_links;  /* child domains */
+    struct list_head      dev_list;     /* devices in this domain */
+
+    int (*power_off)(struct generic_pm_domain *domain);
+    int (*power_on)(struct generic_pm_domain *domain);
+};
+```
+
+### genpd usage (ARM SoC example)
+
+```c
+/* SoC power domain setup (in platform code or device tree) */
+static struct generic_pm_domain gpu_pd = {
+    .name      = "gpu",
+    .power_off = gpu_domain_power_off,
+    .power_on  = gpu_domain_power_on,
+};
+
+/* Attach a device to the domain */
+pm_genpd_add_device(&gpu_pd, &gpu_dev);
+
+/* Now: when all devices in gpu_pd are runtime-suspended,
+   power_off() is called automatically */
+```
+
+## Runtime PM in interrupt context
+
+`pm_runtime_get_sync` may sleep (to wait for resume). This is not allowed in interrupt context. Use the non-blocking variant:
+
+```c
+/* In interrupt handler: try to get, but don't sleep */
+ret = pm_runtime_get_if_active(dev, true);
+if (!ret) {
+    /* Device is suspended, can't use it now — schedule work */
+    schedule_work(&priv->deferred_work);
+    return IRQ_HANDLED;
+}
+
+/* Device is active */
+handle_interrupt(dev);
+pm_runtime_put(dev);
+return IRQ_HANDLED;
+```
+
+## Observing Runtime PM
+
+```bash
+# Runtime PM status for all PCI devices
+for d in /sys/bus/pci/devices/*/; do
+    echo -n "$d: "
+    cat "$d/power/runtime_status" 2>/dev/null || echo "N/A"
+done
+
+# Usage count and autosuspend
+cat /sys/bus/pci/devices/0000:00:02.0/power/runtime_usage
+cat /sys/bus/pci/devices/0000:00:02.0/power/autosuspend_delay_ms
+
+# Enable runtime PM for a device (some drivers require userspace enable)
+echo auto | sudo tee /sys/bus/usb/devices/1-1/power/control
+echo on   | sudo tee /sys/bus/usb/devices/1-1/power/control  # disable
+
+# PM tracepoints
+echo 1 > /sys/kernel/tracing/events/rpm/enable
+cat /sys/kernel/tracing/trace_pipe
+# mydriver 0000:01:00.0: rpm_suspend flags 0x4
+# mydriver 0000:01:00.0: rpm_suspended flags 0x4
+
+# powertop shows device runtime PM activity
+sudo powertop --html=powertop.html
+```
+
+## Common pitfalls
+
+### Forgetting pm_runtime_enable
+
+```c
+/* WRONG: runtime PM is disabled by default */
+static int mydriver_probe(struct platform_device *pdev)
+{
+    /* ... setup ... */
+    /* missing: pm_runtime_enable(&pdev->dev) */
+    return 0;
+}
+/* pm_runtime_get_sync will always return -EACCES */
+```
+
+### Not balancing get/put
+
+```c
+/* WRONG: skipping put on error path */
+static int mydriver_do_io(struct device *dev)
+{
+    pm_runtime_get_sync(dev);
+    if (error_condition)
+        return -EIO;  /* leaked get! usage_count never decremented */
+    pm_runtime_put(dev);
+    return 0;
+}
+
+/* RIGHT: always put */
+static int mydriver_do_io(struct device *dev)
+{
+    int ret;
+    pm_runtime_get_sync(dev);
+    ret = do_actual_io(dev);
+    pm_runtime_put(dev);
+    return ret;
+}
+```
+
+### Calling get_sync in atomic context
+
+```c
+/* WRONG: pm_runtime_get_sync may sleep */
+spin_lock_irqsave(&lock, flags);
+pm_runtime_get_sync(dev);  /* may sleep! BUG */
+```
+
+## Further reading
+
+- [cpufreq](cpufreq.md) — CPU-level frequency/voltage scaling
+- [System Suspend](suspend.md) — system-wide sleep states
+- [Device Drivers: platform driver](../drivers/platform-driver.md) — devm_ and probe flow
+- `drivers/base/power/` in the kernel tree — runtime PM core
+- `Documentation/power/runtime_pm.rst` in the kernel tree

--- a/docs/power/suspend.md
+++ b/docs/power/suspend.md
@@ -1,0 +1,340 @@
+# System Suspend and Hibernate
+
+> System-wide power states: suspend-to-RAM, hibernate, and the PM state machine
+
+## Sleep states
+
+Linux supports multiple system-level sleep states, described by ACPI S-states and the kernel's internal model:
+
+| Kernel state | ACPI | Description |
+|---|---|---|
+| `freeze` | S0 (idle) | Freeze user processes, suspend devices. CPU stays powered. Very fast resume. |
+| `standby` | S1 | Shallow sleep. CPU powered down but state retained. |
+| `mem` | S3 | **Suspend-to-RAM (STR)**. All state in DRAM, rest powered off. Common laptop sleep. |
+| `disk` | S4 | **Hibernate (STD)**. Memory image written to swap/file, power completely off. |
+
+```bash
+# Check which states are available
+cat /sys/power/state
+# freeze mem disk
+
+# Enter suspend-to-RAM
+echo mem | sudo tee /sys/power/state
+```
+
+## The suspend state machine
+
+```
+/sys/power/state write "mem"
+        │
+        ▼
+kernel/power/suspend.c: pm_suspend()
+        │
+        ├─ 1. Sync filesystems
+        │
+        ├─ 2. Freeze userspace processes
+        │      freeze_processes() — send SIGSTOP-equivalent,
+        │      wait for all tasks to reach safe point
+        │
+        ├─ 3. Suspend devices (reverse probe order)
+        │      dpm_suspend_start() → each driver's .suspend callback
+        │      (deepest devices in tree suspended first)
+        │
+        ├─ 4. Disable non-boot CPUs (CPU hotplug)
+        │
+        ├─ 5. Suspend syscore (timers, IRQ chips, clocksource)
+        │      syscore_suspend() — last things before hardware off
+        │
+        ├─ 6. Enter hardware sleep
+        │      acpi_suspend_enter() or platform-specific
+        │      ──────────────── ASLEEP ────────────────
+        │
+        └─ 7. Resume (reverse order):
+               syscore_resume()
+               Enable CPUs
+               dpm_resume_end() → each driver's .resume callback
+               Thaw processes
+```
+
+## PM notifiers
+
+Notifiers allow subsystems to react to suspend/resume events:
+
+```c
+#include <linux/suspend.h>
+
+static int mysubsys_pm_notify(struct notifier_block *nb,
+                               unsigned long action, void *data)
+{
+    switch (action) {
+    case PM_SUSPEND_PREPARE:
+        /* About to suspend: flush caches, stop background work */
+        flush_workqueue(mysubsys_wq);
+        break;
+    case PM_POST_SUSPEND:
+        /* Resumed: restart background work */
+        queue_delayed_work(mysubsys_wq, &mysubsys_work, HZ);
+        break;
+    case PM_HIBERNATION_PREPARE:
+        break;
+    case PM_POST_HIBERNATION:
+        break;
+    case PM_RESTORE_PREPARE:   /* before loading hibernate image */
+        break;
+    case PM_POST_RESTORE:
+        break;
+    }
+    return NOTIFY_OK;
+}
+
+static struct notifier_block mysubsys_pm_nb = {
+    .notifier_call = mysubsys_pm_notify,
+};
+
+/* Register */
+register_pm_notifier(&mysubsys_pm_nb);
+
+/* Unregister */
+unregister_pm_notifier(&mysubsys_pm_nb);
+```
+
+## Device suspend callbacks
+
+The full driver PM callback sequence for system suspend:
+
+```
+dpm_prepare()      → driver .prepare()         (optional; prepare for suspend)
+dpm_suspend()      → driver .suspend()          (save state, stop DMA)
+dpm_suspend_late() → driver .suspend_late()     (last operations before power off)
+dpm_suspend_noirq()→ driver .suspend_noirq()    (IRQs disabled; final operations)
+─────────────── hardware suspended ───────────────
+dpm_resume_noirq() → driver .resume_noirq()     (IRQs still disabled)
+dpm_resume_early() → driver .resume_early()     (restore critical state)
+dpm_resume()       → driver .resume()           (full restore)
+dpm_complete()     → driver .complete()         (post-resume cleanup)
+```
+
+For most drivers, only `.suspend` and `.resume` need implementation. The `_noirq` and `_late/_early` variants are for hardware that requires very late/early access.
+
+### Minimal suspend implementation
+
+```c
+static int mydriver_suspend(struct device *dev)
+{
+    struct mydata *priv = dev_get_drvdata(dev);
+
+    /* Stop hardware operations */
+    mydriver_stop_hw(priv);
+
+    /* Save registers that hardware won't retain */
+    priv->saved_config = readl(priv->base + CONFIG_REG);
+    priv->saved_irq_mask = readl(priv->base + IRQ_MASK_REG);
+
+    /* Disable clocks/power */
+    clk_disable_unprepare(priv->clk);
+
+    return 0;
+}
+
+static int mydriver_resume(struct device *dev)
+{
+    struct mydata *priv = dev_get_drvdata(dev);
+    int ret;
+
+    /* Re-enable clocks/power */
+    ret = clk_prepare_enable(priv->clk);
+    if (ret)
+        return ret;
+
+    /* Restore saved registers */
+    writel(priv->saved_config,   priv->base + CONFIG_REG);
+    writel(priv->saved_irq_mask, priv->base + IRQ_MASK_REG);
+
+    /* Reinitialize hardware */
+    mydriver_init_hw(priv);
+
+    return 0;
+}
+
+/* Shared PM ops using the SET_ macros */
+static const struct dev_pm_ops mydriver_pm_ops = {
+    SET_SYSTEM_SLEEP_PM_OPS(mydriver_suspend, mydriver_resume)
+    SET_RUNTIME_PM_OPS(mydriver_runtime_suspend,
+                       mydriver_runtime_resume, NULL)
+};
+```
+
+## Wakeup sources
+
+A **wakeup source** is a hardware event that can wake the system from sleep. Common wakeup sources: keyboard, touchpad, NIC (Wake-on-LAN), RTC alarm, USB.
+
+```c
+/* Driver: register a wakeup source */
+static int mydriver_probe(struct platform_device *pdev)
+{
+    struct mydata *priv;
+    /* ... */
+
+    device_init_wakeup(&pdev->dev, true);  /* this device can wake the system */
+
+    /* Configure hardware to assert wakeup interrupt during suspend */
+    /* ... */
+    return 0;
+}
+
+/* Before suspend: arm the wakeup interrupt */
+static int mydriver_suspend(struct device *dev)
+{
+    if (device_may_wakeup(dev))
+        enable_irq_wake(priv->irq);  /* route IRQ as wakeup source */
+    /* ... */
+}
+
+static int mydriver_resume(struct device *dev)
+{
+    if (device_may_wakeup(dev))
+        disable_irq_wake(priv->irq);
+    /* ... */
+}
+```
+
+### Wakeup source tracking
+
+```c
+#include <linux/wakeup_reason.h>
+
+/* The kernel tracks active wakeup sources */
+struct wakeup_source {
+    const char           *name;
+    struct list_head      entry;
+    spinlock_t            lock;
+    struct wake_irq      *wakeirq;
+    struct timer_list     timer;
+    unsigned long         timer_expires;
+    ktime_t               total_time;
+    ktime_t               max_time;
+    ktime_t               last_time;
+    ktime_t               start_prevent_time;
+    ktime_t               prevent_sleep_time;
+    unsigned long         event_count;
+    unsigned long         active_count;
+    unsigned long         relax_count;
+    unsigned long         expire_count;
+    unsigned long         wakeup_count;
+    struct device        *dev;
+    bool                  active:1;
+    bool                  autosleep_enabled:1;
+};
+```
+
+```bash
+# Which wakeup sources are active (blocking suspend)?
+cat /sys/kernel/debug/wakeup_sources
+# name          active_count  event_count  wakeup_count  expire_count  active_since  total_time  max_time  last_change  prevent_suspend_time
+# NETLINK       0             1234         0             0             0             0           0         12345        0
+# battery       1             5678         1             0             12345         67890       12345     67890        12345
+
+# Which IRQs can wake the system?
+cat /proc/interrupts | grep -i wake
+
+# Last wakeup reason (after resume)
+cat /sys/kernel/debug/suspend_stats
+```
+
+## Hibernate (suspend-to-disk)
+
+Hibernation saves the entire memory image to disk, then powers off. On resume, the image is read back and execution continues exactly where it left off.
+
+```
+echo disk | sudo tee /sys/power/state
+```
+
+### Hibernate state machine
+
+```
+1. Freeze processes
+2. Create memory snapshot (swsusp_save):
+   - Walk all pages, copy to free pages or swap
+   - The "hibernation image" = all in-use memory pages
+3. Write image to swap partition or hibernation file
+4. Power off
+─────────── powered off ──────────
+5. Boot
+6. Bootloader detects hibernate flag in ACPI
+7. Kernel: check /sys/power/resume device
+8. Read image from swap
+9. swsusp_restore: overwrite running kernel pages
+10. Resume execution at hibernation point
+```
+
+### Configuring hibernate destination
+
+```bash
+# Use a specific swap partition
+echo /dev/sda2 | sudo tee /sys/power/resume
+
+# Or a swap file (requires offset)
+echo offset=$(swap-offset /swapfile) | sudo tee /sys/power/resume_offset
+echo /dev/sda1 | sudo tee /sys/power/resume  # device containing swapfile
+
+# Check current hibernate device
+cat /sys/power/resume
+```
+
+## Freeze (s2idle / S0ix)
+
+Modern laptops use **s2idle** (suspend-to-idle, sometimes called S0ix or "connected standby"). Unlike S3, the CPU stays in a very shallow sleep state, allowing:
+
+- Bluetooth/WiFi to stay connected
+- Background tasks to run at reduced rate
+- Faster wake time (~1 second vs ~3 seconds for S3)
+
+```bash
+# Force s2idle (ignore platform S3 support)
+echo s2idle | sudo tee /sys/power/mem_sleep
+
+# Or prefer S3 if available
+echo deep | sudo tee /sys/power/mem_sleep
+
+cat /sys/power/mem_sleep
+# s2idle [deep]   (brackets = current selection)
+```
+
+## Diagnosing suspend failures
+
+```bash
+# Verbose suspend logging
+echo 1 | sudo tee /sys/power/pm_debug_messages
+echo 1 | sudo tee /sys/power/pm_print_times
+
+# After failed suspend attempt
+dmesg | grep -E "PM:|suspend|freeze" | tail -50
+
+# Which device failed to suspend?
+dmesg | grep "error during suspend"
+
+# Time each driver's suspend callback takes
+cat /sys/kernel/debug/suspend_stats
+# success: 42
+# fail: 2
+# failed_freeze: 0
+# failed_prepare: 0
+# failed_suspend: 1       ← driver failed here
+# failed_suspend_noirq: 0
+
+# Enable PM tracepoints for detailed timeline
+echo 1 > /sys/kernel/tracing/events/power/device_pm_callback_start/enable
+echo 1 > /sys/kernel/tracing/events/power/device_pm_callback_end/enable
+cat /sys/kernel/tracing/trace_pipe > /tmp/suspend_trace &
+echo mem | sudo tee /sys/power/state
+# Ctrl-C background cat, examine /tmp/suspend_trace
+```
+
+## Further reading
+
+- [cpufreq](cpufreq.md) — CPU frequency scaling
+- [Runtime PM](runtime-pm.md) — device-level power management
+- [Device Drivers: platform driver](../drivers/platform-driver.md) — dev_pm_ops integration
+- [Interrupts: Timers](../interrupts/timers.md) — RTC alarm as wakeup source
+- `kernel/power/` in the kernel tree — suspend/hibernate core
+- `Documentation/admin-guide/pm/` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -318,3 +318,8 @@ nav:
     - KVM Architecture: virtualization/kvm-arch.md
     - Memory Virtualization: virtualization/kvm-memory.md
     - virtio: virtualization/virtio.md
+  - Power Management:
+    - Getting Started: power/README.md
+    - cpufreq and P-states: power/cpufreq.md
+    - Runtime PM: power/runtime-pm.md
+    - System Suspend: power/suspend.md


### PR DESCRIPTION
## Summary

- **cpufreq** (`cpufreq.md`): P-states, `struct cpufreq_policy`, governors (schedutil with `get_next_freq` utilization→frequency mapping, ondemand, performance/powersave), intel_pstate with HWP and EPP table, acpi-cpufreq, ARM cppc, frequency QoS API, C-states with cpuidle governors, turbostat and perf observability
- **Runtime PM** (`runtime-pm.md`): `struct dev_pm_ops` full callback table, usage count get/put variants table, autosuspend with delay, RPM state machine diagram, `struct generic_pm_domain` power domains, non-blocking get for interrupt context, common pitfalls (missing enable, unbalanced get/put, sleeping in atomic)
- **System Suspend** (`suspend.md`): All sleep states (freeze/standby/mem/disk), full suspend state machine, PM notifiers with all action codes, device callback sequence (prepare→suspend→suspend_late→suspend_noirq and reverse), minimal suspend implementation, wakeup sources with `struct wakeup_source`, hibernate image creation/restore, s2idle vs S3, suspend failure diagnostics with tracepoints

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] Power Management nav section appears correctly
- [ ] Cross-links to drivers, scheduler, and interrupts sections resolve