### PR TITLE
Add time subsystem documentation

### DIFF
--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -1,0 +1,65 @@
+# Time Subsystem
+
+> Timekeeping, clocksources, and timers in the Linux kernel
+
+## The time stack
+
+```
+User space
+  clock_gettime(CLOCK_MONOTONIC)     timer_create()     timerfd_create()
+        │                                  │                   │
+        ▼                                  ▼                   ▼
+  vDSO (userspace page, no syscall)   POSIX timers        timerfd
+        │                                  │                   │
+        └──────────────┬───────────────────┘                   │
+                       ▼                                       │
+             Timekeeping core                                   │
+             (kernel/time/timekeeping.c)                        │
+             struct timekeeper                                  │
+                       │                                        │
+             ┌─────────┴──────────┐                            │
+             ▼                    ▼                             │
+       Clocksource           Clockevent                        │
+       (read counter)        (program interrupt)               │
+       TSC / HPET            HPET / LAPIC / ARM              hrtimer
+                                    │                           │
+                              tick_device                  hrtimer_cpu_base
+                              tick_sched                        │
+                                    │                           │
+                             Scheduler tick              High-res callback
+                             NOHZ idle                   (on clockevent IRQ)
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Timekeeping](timekeeping.md) | clocksources, TSC, NTP, struct timekeeper, vDSO |
+| [hrtimers](hrtimers.md) | High-resolution timers, CLOCK_MONOTONIC/REALTIME, timer slack |
+| [POSIX timers](posix-timers.md) | timer_create, clock_nanosleep, timerfd, epoll integration |
+
+## Quick reference
+
+```bash
+# Available clocksources (current in brackets)
+cat /sys/devices/system/clocksource/clocksource0/available_clocksource
+# tsc-early tsc hpet acpi_pm
+
+cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+# tsc
+
+# TSC frequency
+dmesg | grep "TSC.*MHz"
+# tsc: Detected 3600.000 MHz processor
+
+# Timer resolution
+clock_getres(CLOCK_MONOTONIC) → 1 ns on most x86 systems
+
+# hrtimer mode
+dmesg | grep "hrtimer"
+# Switched to high resolution mode on CPU 0
+
+# System time offset (NTP)
+timedatectl
+# NTP synchronized: yes
+```

--- a/docs/time/hrtimers.md
+++ b/docs/time/hrtimers.md
@@ -1,0 +1,237 @@
+# hrtimers
+
+> High-resolution timers: nanosecond-precision kernel timers
+
+## The two timer systems
+
+Linux has two timer implementations:
+
+| System | Precision | Data structure | Typical use |
+|--------|-----------|---------------|-------------|
+| **timer_list** (classic) | ~1/HZ (1–10ms) | Per-CPU hashed wheels | Timeout detection, network retransmit |
+| **hrtimer** | ~nanosecond | Per-CPU red-black tree | sleep(), audio, network pacing, real-time |
+
+The classic wheel is O(1) but coarse. hrtimers use a sorted red-black tree; the soonest expiry is at the tree minimum and programs the hardware clockevent directly.
+
+## struct hrtimer
+
+```c
+/* include/linux/hrtimer.h */
+struct hrtimer {
+    struct timerqueue_node  node;     /* rb_node + expiry time */
+    ktime_t                 _softexpires; /* earliest expiry */
+    enum hrtimer_restart  (*function)(struct hrtimer *); /* callback */
+    struct hrtimer_clock_base *base;  /* clock base this timer belongs to */
+    u8                      state;    /* HRTIMER_STATE_INACTIVE/ENQUEUED */
+    u8                      is_rel;   /* relative timer? */
+    u8                      is_soft;  /* softirq delivery? */
+    u8                      is_hard;  /* hardirq delivery? */
+};
+
+struct hrtimer_cpu_base {
+    raw_spinlock_t           lock;
+    unsigned int             cpu;
+    unsigned int             active_bases;  /* bitmask of active clock bases */
+    unsigned int             clock_was_set_seq;
+    unsigned int             hres_active:1; /* high-res mode enabled */
+    ktime_t                  expires_next;  /* next clockevent expiry */
+    struct hrtimer          *running;       /* currently executing timer */
+    struct hrtimer_clock_base clock_base[HRTIMER_MAX_CLOCK_BASES];
+};
+```
+
+## Clock bases
+
+Each CPU has separate timer queues per clock ID:
+
+```c
+/* HRTIMER_BASE_* indices into hrtimer_cpu_base.clock_base[] */
+HRTIMER_BASE_MONOTONIC        /* CLOCK_MONOTONIC */
+HRTIMER_BASE_REALTIME         /* CLOCK_REALTIME */
+HRTIMER_BASE_BOOTTIME         /* CLOCK_BOOTTIME (includes suspend) */
+HRTIMER_BASE_TAI              /* CLOCK_TAI */
+HRTIMER_BASE_MONOTONIC_SOFT   /* CLOCK_MONOTONIC, softirq delivery */
+HRTIMER_BASE_REALTIME_SOFT    /* CLOCK_REALTIME, softirq delivery */
+HRTIMER_BASE_BOOTTIME_SOFT    /* CLOCK_BOOTTIME, softirq delivery */
+HRTIMER_BASE_TAI_SOFT         /* CLOCK_TAI, softirq delivery */
+```
+
+Soft delivery timers fire in softirq context (lower latency jitter); hard delivery fires directly in the hardirq context of the clockevent interrupt.
+
+## Using hrtimers
+
+### Kernel driver example
+
+```c
+#include <linux/hrtimer.h>
+#include <linux/ktime.h>
+
+struct mydev {
+    struct hrtimer poll_timer;
+    /* ... */
+};
+
+/* Callback: called when timer fires */
+static enum hrtimer_restart mydev_timer_cb(struct hrtimer *timer)
+{
+    struct mydev *dev = container_of(timer, struct mydev, poll_timer);
+
+    /* Do work */
+    mydev_poll(dev);
+
+    /* Rearm for 10ms from now */
+    hrtimer_forward_now(timer, ms_to_ktime(10));
+    return HRTIMER_RESTART;  /* reschedule */
+
+    /* Or: return HRTIMER_NORESTART to stop */
+}
+
+static int mydev_probe(struct platform_device *pdev)
+{
+    struct mydev *dev = devm_kzalloc(&pdev->dev, sizeof(*dev), GFP_KERNEL);
+
+    /* Initialize timer (does not start it) */
+    hrtimer_init(&dev->poll_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+    dev->poll_timer.function = mydev_timer_cb;
+
+    /* Start: fire 10ms from now */
+    hrtimer_start(&dev->poll_timer, ms_to_ktime(10), HRTIMER_MODE_REL);
+
+    return 0;
+}
+
+static void mydev_remove(struct platform_device *pdev)
+{
+    struct mydev *dev = platform_get_drvdata(pdev);
+    hrtimer_cancel(&dev->poll_timer);  /* cancel and wait for callback */
+}
+```
+
+### Timer modes
+
+```c
+/* Absolute: fire at specific time */
+hrtimer_start(&timer, ktime_set(1735689600, 0), HRTIMER_MODE_ABS);
+
+/* Relative: fire N nanoseconds from now */
+hrtimer_start(&timer, ns_to_ktime(5000000), HRTIMER_MODE_REL);
+
+/* Pinned to current CPU (don't migrate on CPU hotplug) */
+hrtimer_start(&timer, ns_to_ktime(5000000), HRTIMER_MODE_REL_PINNED);
+
+/* Soft (softirq context): */
+hrtimer_start(&timer, ns_to_ktime(5000000), HRTIMER_MODE_REL_SOFT);
+```
+
+## High-resolution mode
+
+On boot, the kernel operates in **low-resolution mode** where timer interrupts fire at HZ rate (100–1000/s). When the first hrtimer device is detected, the system switches to **high-resolution mode**:
+
+```c
+/* kernel/time/hrtimer.c */
+static void hrtimer_switch_to_hres(void)
+{
+    if (tick_init_highres()) {
+        pr_warn("Could not switch to high resolution mode on CPU %d\n",
+                smp_processor_id());
+        return;
+    }
+    /* Reprogram clockevent to fire at exact timer expiry */
+    __hrtimer_run_queues(base, now, flags, HRTIMER_ACTIVE_HARD);
+    tick_setup_sched_timer();
+}
+```
+
+After switching:
+- The scheduler tick is implemented via an hrtimer (no longer a fixed-rate interrupt)
+- Timer resolution is limited only by hardware latency (~100ns typical)
+- `NOHZ` (tickless idle) can skip ticks entirely when CPU is idle
+
+```bash
+dmesg | grep "high resolution"
+# Switched to high resolution mode on CPU 0
+```
+
+## NOHZ: tickless operation
+
+With `CONFIG_NO_HZ_IDLE` (default), when all runqueue tasks sleep and no hrtimers are pending soon, the tick stops entirely:
+
+```
+CPU goes idle:
+  1. Calculate next hrtimer expiry
+  2. Program clockevent for that time
+  3. Enter C-state
+  4. Wake on clockevent (or external IRQ)
+  5. Process any expired hrtimers
+  6. Resume scheduler
+```
+
+With `CONFIG_NO_HZ_FULL` (for real-time/HPC), ticks also stop for CPUs with only one running task — eliminating ~1000 interrupts/second of OS noise.
+
+```bash
+# Check NOHZ status
+cat /sys/devices/system/cpu/cpu0/cpuidle/state*/name
+dmesg | grep nohz
+
+# See idle time per CPU
+cat /proc/stat | awk 'NR>1 && /cpu[0-9]/ {print $1, "idle:", $5}'
+```
+
+## Timer slack
+
+`nanosleep` and similar calls can be coalesced with nearby wakeups to reduce power consumption. The kernel applies a **slack** — allowed slippage past the requested time:
+
+```c
+/* Userspace: set timer slack for current thread */
+prctl(PR_SET_TIMERSLACK, 50000 /* ns */);
+
+/* In kernel: clock_nanosleep honors slack */
+hrtimer_sleeper_start_expires(&t, HRTIMER_MODE_ABS | HRTIMER_MODE_SOFT);
+```
+
+The default slack is `CONFIG_HZ`-dependent (typically ~50µs). Setting slack=0 disables coalescing — useful for real-time tasks that need precise wakeup.
+
+```bash
+# View timer slack for a process
+cat /proc/<pid>/timerslack_ns
+```
+
+## hrtimer vs timer_list
+
+When to use each:
+
+| Use case | Use |
+|----------|-----|
+| Timeouts (network, locks, wait_for_completion) | `timer_list` — cheaper, less precision needed |
+| Periodic work with precise interval | `hrtimer` |
+| `schedule_timeout` / `msleep` | Both (msleep uses hrtimer internally since 4.10) |
+| Real-time audio/video pacing | `hrtimer` with `HRTIMER_MODE_ABS` |
+| Watchdog timers | `timer_list` |
+
+## Observing hrtimers
+
+```bash
+# All active hrtimers in the system
+cat /proc/timer_list
+
+# hrtimer interrupt latency (how late timers fire)
+# Use cyclictest for real-time latency measurement
+cyclictest -p 99 -t 1 -m -n
+
+# perf: timer events
+perf stat -e hrtimer:hrtimer_start,hrtimer:hrtimer_expire_entry sleep 5
+
+# Trace hrtimer activity
+echo 1 > /sys/kernel/tracing/events/timer/hrtimer_start/enable
+echo 1 > /sys/kernel/tracing/events/timer/hrtimer_expire_entry/enable
+cat /sys/kernel/tracing/trace_pipe
+# kworker/0:1 [000] hrtimer_start: hrtimer=0xffff... function=tick_sched_timer expires=...
+```
+
+## Further reading
+
+- [Timekeeping](timekeeping.md) — clocksources, NTP, vDSO
+- [POSIX timers](posix-timers.md) — user-facing timer APIs
+- [Interrupts: Timers](../interrupts/timers.md) — timer_list wheel and workqueue timers
+- [Scheduler: EEVDF](../sched/eevdf.md) — scheduler tick via hrtimer
+- `kernel/time/hrtimer.c` — hrtimer implementation

--- a/docs/time/posix-timers.md
+++ b/docs/time/posix-timers.md
@@ -1,0 +1,297 @@
+# POSIX Timers and timerfd
+
+> User-facing timer APIs: timer_create, clock_nanosleep, and timerfd
+
+## POSIX timer APIs
+
+POSIX defines a portable timer interface built on arbitrary clock IDs:
+
+```c
+#include <signal.h>
+#include <time.h>
+
+/* Create a timer */
+timer_t timerid;
+struct sigevent sev = {
+    .sigev_notify = SIGEV_SIGNAL,   /* notify via signal */
+    .sigev_signo  = SIGRTMIN,       /* which signal */
+};
+timer_create(CLOCK_MONOTONIC, &sev, &timerid);
+
+/* Arm it: first expiry at 100ms, then repeat every 50ms */
+struct itimerspec its = {
+    .it_value    = { .tv_sec = 0, .tv_nsec = 100000000 }, /* 100ms */
+    .it_interval = { .tv_sec = 0, .tv_nsec =  50000000 }, /* 50ms repeat */
+};
+timer_settime(timerid, 0 /* relative */, &its, NULL);
+
+/* Query current state */
+struct itimerspec cur;
+timer_gettime(timerid, &cur);
+
+/* Delete */
+timer_delete(timerid);
+```
+
+### Notification modes
+
+```c
+/* sigev_notify options: */
+
+/* Deliver signal (default) */
+sev.sigev_notify = SIGEV_SIGNAL;
+sev.sigev_signo  = SIGRTMIN + 1;
+
+/* Create a new thread for each expiry */
+sev.sigev_notify            = SIGEV_THREAD;
+sev.sigev_notify_function   = my_callback;
+sev.sigev_notify_attributes = NULL;
+
+/* Send signal to specific thread */
+sev.sigev_notify            = SIGEV_THREAD_ID;
+sev.sigev_signo             = SIGRTMIN;
+sev._sigev_un._tid          = gettid();  /* specific thread */
+
+/* No notification (query manually with timer_gettime) */
+sev.sigev_notify = SIGEV_NONE;
+```
+
+## clock_nanosleep
+
+`clock_nanosleep` suspends the calling thread until an absolute or relative time:
+
+```c
+struct timespec req, rem;
+
+/* Relative sleep: 10ms */
+req.tv_sec  = 0;
+req.tv_nsec = 10000000;
+clock_nanosleep(CLOCK_MONOTONIC, 0, &req, &rem);
+
+/* Absolute sleep: wake at a specific monotonic time */
+struct timespec now, abs;
+clock_gettime(CLOCK_MONOTONIC, &now);
+abs.tv_sec  = now.tv_sec;
+abs.tv_nsec = now.tv_nsec + 5000000;  /* 5ms from now */
+if (abs.tv_nsec >= 1000000000L) {
+    abs.tv_sec++;
+    abs.tv_nsec -= 1000000000L;
+}
+/* TIMER_ABSTIME: don't wake early due to signal if abs time hasn't passed */
+clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &abs, NULL);
+```
+
+The absolute form is important for precise periodic loops — avoids drift from relative sleep accumulation.
+
+### Precise periodic loop
+
+```c
+/* Common pattern: audio/video callback at fixed period */
+static void run_periodic(long period_ns)
+{
+    struct timespec next;
+    clock_gettime(CLOCK_MONOTONIC, &next);
+
+    while (running) {
+        /* Do work */
+        do_work();
+
+        /* Advance to next period (absolute time, no drift) */
+        next.tv_nsec += period_ns;
+        if (next.tv_nsec >= 1000000000L) {
+            next.tv_sec++;
+            next.tv_nsec -= 1000000000L;
+        }
+        clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next, NULL);
+    }
+}
+```
+
+## timerfd
+
+`timerfd_create` returns a file descriptor that becomes readable when the timer expires. This enables integrating timers with `epoll` and `select` — no signals needed.
+
+```c
+#include <sys/timerfd.h>
+#include <sys/epoll.h>
+
+/* Create a timerfd */
+int tfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+
+/* Arm: fire every 100ms */
+struct itimerspec its = {
+    .it_value    = { .tv_nsec = 100000000 },
+    .it_interval = { .tv_nsec = 100000000 },
+};
+timerfd_settime(tfd, 0, &its, NULL);
+
+/* Integrate with epoll */
+int epfd = epoll_create1(EPOLL_CLOEXEC);
+struct epoll_event ev = { .events = EPOLLIN, .data.fd = tfd };
+epoll_ctl(epfd, EPOLL_CTL_ADD, tfd, &ev);
+
+/* Event loop */
+while (1) {
+    struct epoll_event events[8];
+    int n = epoll_wait(epfd, events, 8, -1);
+
+    for (int i = 0; i < n; i++) {
+        if (events[i].data.fd == tfd) {
+            uint64_t expirations;
+            read(tfd, &expirations, sizeof(expirations));
+            /* expirations = number of times timer fired since last read
+               (can be > 1 if we're behind) */
+            handle_timer(expirations);
+        }
+    }
+}
+```
+
+### timerfd_settime flags
+
+```c
+/* Absolute time */
+timerfd_settime(tfd, TFD_TIMER_ABSTIME, &its, NULL);
+
+/* Cancel on clock changes (CLOCK_REALTIME) */
+timerfd_settime(tfd, TFD_TIMER_CANCEL_ON_SET, &its, NULL);
+/* Returns ECANCELED on read after clock was set */
+```
+
+## Kernel implementation
+
+### POSIX timers in the kernel
+
+```c
+/* kernel/time/posix-timers.c */
+struct k_itimer {
+    struct list_head    list;       /* per-process list */
+    struct hlist_node   t_hash;     /* hash table node */
+    spinlock_t          it_lock;
+
+    const struct k_clock *kclock;   /* clock operations */
+    clockid_t            it_clock;
+    timer_t              it_id;
+
+    int                  it_overrun;     /* missed expirations */
+    int                  it_overrun_last;
+
+    int                  it_requeue_pending;
+    int                  it_sigev_notify;
+    ktime_t              it_interval;   /* reload interval */
+    struct signal_struct *it_signal;
+    union {
+        struct pid         *it_pid;
+        struct task_struct *it_process;
+    };
+    struct sigqueue      *sigq;         /* pre-allocated signal */
+
+    union {
+        struct {
+            struct hrtimer  timer;   /* hrtimer backing this POSIX timer */
+        } real;
+        struct cpu_timer_list   cpu;  /* CPU time timers */
+    } it;
+};
+```
+
+Each `timer_create()` allocates a `k_itimer` backed by an `hrtimer`. When the hrtimer fires, it queues the signal.
+
+### timerfd in the kernel
+
+```c
+/* fs/timerfd.c */
+struct timerfd_ctx {
+    union {
+        struct hrtimer      tmr;   /* backing hrtimer */
+        struct alarm        alarm; /* for CLOCK_REALTIME_ALARM */
+    } t;
+    ktime_t             tintv;     /* interval */
+    ktime_t             moffs;     /* MONOTONIC offset at creation */
+    wait_queue_head_t   wqh;       /* epoll/select wait queue */
+    u64                 ticks;     /* expired count */
+    int                 clockid;
+    short               expired;   /* pending reads */
+    short               settime_flags;
+    struct rcu_head     rcu;
+    struct list_head    clist;
+    spinlock_t          cancel_lock;
+    bool                might_cancel;
+};
+
+/* hrtimer callback: wake epoll waiters */
+static enum hrtimer_restart timerfd_tmrproc(struct hrtimer *htmr)
+{
+    struct timerfd_ctx *ctx = container_of(htmr, struct timerfd_ctx, t.tmr);
+
+    spin_lock(&ctx->wqh.lock);
+    ctx->ticks++;
+    wake_up_locked_poll(&ctx->wqh, EPOLLIN);
+    spin_unlock(&ctx->wqh.lock);
+
+    return ctx->tintv ? HRTIMER_RESTART : HRTIMER_NORESTART;
+}
+```
+
+## Overruns
+
+When a periodic timer fires faster than you consume it, expirations accumulate:
+
+```c
+/* timer_create: check overruns */
+struct itimerspec its;
+timer_gettime(timerid, &its);
+int overruns = timer_getoverrun(timerid);
+/* overruns > 0: missed this many expirations */
+
+/* timerfd: read returns accumulated count */
+uint64_t count;
+ssize_t sz = read(tfd, &count, sizeof(count));
+if (count > 1)
+    fprintf(stderr, "Behind by %llu expirations\n", count - 1);
+```
+
+Overruns happen when:
+- Handler takes longer than the period
+- System is loaded; scheduling latency > period
+- Thread was blocked (sleeping, waiting for I/O)
+
+## Choosing the right API
+
+| Scenario | Use |
+|----------|-----|
+| Simple sleep | `clock_nanosleep` |
+| Periodic work, signal-based | `timer_create(SIGEV_SIGNAL)` |
+| Event loop (epoll/select) | `timerfd_create` |
+| Real-time periodic thread | `clock_nanosleep(TIMER_ABSTIME)` |
+| Timeout on I/O | `timerfd` + `epoll` |
+| Kernel driver timer | `hrtimer` |
+
+## Observing POSIX timers
+
+```bash
+# Active timers for a process
+cat /proc/<pid>/timers
+# ID: 0
+# signal: 34 /...
+# notify: signal/pid.12345
+# ClockID: 1 (CLOCK_MONOTONIC)
+
+# timerfd shows up as an anonymous inode in lsof
+lsof -p <pid> | grep timerfd
+
+# perf: timer system calls
+perf trace -e timer_create,clock_nanosleep -p <pid>
+
+# Tracepoints: POSIX timer events
+echo 1 > /sys/kernel/tracing/events/timer/hrtimer_start/enable
+echo 1 > /sys/kernel/tracing/events/syscalls/sys_enter_timer_settime/enable
+```
+
+## Further reading
+
+- [hrtimers](hrtimers.md) — kernel timer implementation backing POSIX timers
+- [Timekeeping](timekeeping.md) — clock IDs and their semantics
+- [IPC: Signals](../ipc/signals.md) — signal delivery for `SIGEV_SIGNAL` timers
+- [io_uring: Operations](../io-uring/io-uring-ops.md) — `IORING_OP_TIMEOUT` for ring-based timers
+- `man 2 timerfd_create`, `man 2 clock_nanosleep`, `man 7 time`

--- a/docs/time/timekeeping.md
+++ b/docs/time/timekeeping.md
@@ -1,0 +1,262 @@
+# Timekeeping and Clocksources
+
+> How the kernel tracks time: TSC, HPET, clocksources, and NTP
+
+## Two abstractions: clocksource and clockevent
+
+The kernel splits time hardware into two roles:
+
+| Abstraction | Role | Examples |
+|-------------|------|---------|
+| **clocksource** | Free-running counter to *read* elapsed time | TSC, HPET, ACPI PM timer |
+| **clockevent** | Programmable device to *generate* interrupts at a future time | LAPIC timer, HPET, ARM generic timer |
+
+A clocksource is polled; a clockevent fires interrupts. Both are needed: the clocksource provides nanosecond-resolution reads; the clockevent drives the scheduler tick and hrtimers.
+
+## struct clocksource
+
+```c
+/* include/linux/clocksource.h */
+struct clocksource {
+    u64             (*read)(struct clocksource *cs);  /* read hardware counter */
+    u64             mask;          /* bitmask for counter width */
+    u32             mult;          /* counter→nanoseconds multiplier */
+    u32             shift;         /* fractional shift for mult */
+    u64             max_idle_ns;   /* max time without a read (for wrap detection) */
+    u32             maxadj;        /* max adjustment to mult */
+    u64             max_cycles;    /* max counter delta before overflow */
+    const char     *name;
+    int             rating;        /* quality: 1=bad, 100=good, 400=ideal (TSC) */
+    /* ... */
+};
+
+/* TSC clocksource (arch/x86/kernel/tsc.c) */
+static struct clocksource clocksource_tsc = {
+    .name           = "tsc",
+    .rating         = 300,
+    .read           = read_tsc,   /* rdtsc */
+    .mask           = CLOCKSOURCE_MASK(64),
+    .flags          = CLOCK_SOURCE_IS_CONTINUOUS | CLOCK_SOURCE_MUST_VERIFY,
+    /* mult/shift calibrated at boot */
+};
+```
+
+### Counter → nanoseconds conversion
+
+The `mult` and `shift` fields avoid division in the hot path:
+
+```c
+/*
+ * ns = (cycles * mult) >> shift
+ *
+ * mult is computed so that:
+ *   (10^9 * 2^shift) / frequency = mult
+ */
+static inline u64 clocksource_cyc2ns(u64 cycles, u32 mult, u32 shift)
+{
+    return ((u64) cycles * mult) >> shift;
+}
+```
+
+For a 3.6 GHz TSC: `mult ≈ 1175`, `shift = 22`. Each call to `clock_gettime` does one `rdtsc` + one multiply + one shift — no division, no lock.
+
+## struct timekeeper
+
+The timekeeper holds the current time state and is updated on every tick and NTP adjustment:
+
+```c
+/* kernel/time/timekeeping.c */
+struct timekeeper {
+    struct tk_read_base  tkr_mono;   /* CLOCK_MONOTONIC */
+    struct tk_read_base  tkr_raw;    /* CLOCK_MONOTONIC_RAW (no NTP) */
+
+    u64                  xtime_sec;    /* seconds component of wall time */
+    unsigned long        ktime_sec;    /* CLOCK_MONOTONIC seconds */
+
+    struct timespec64    wall_to_monotonic; /* offset between REALTIME and MONOTONIC */
+    ktime_t              offs_real;    /* offset: monotonic → realtime */
+    ktime_t              offs_boot;    /* offset: monotonic → boottime (adds suspend time) */
+    ktime_t              offs_tai;     /* offset: monotonic → TAI */
+
+    s32                  tai_offset;   /* TAI - UTC (leap seconds) */
+    unsigned int         clock_was_set_seq; /* incremented on settimeofday */
+};
+
+struct tk_read_base {
+    struct clocksource  *clock;
+    u64                  mask;
+    u64                  cycle_last;   /* last read counter value */
+    u64                  mult;         /* adjusted mult (NTP modifies this) */
+    u32                  shift;
+    u64                  xtime_nsec;   /* accumulated nanoseconds (fractional) */
+    ktime_t              base;         /* nanoseconds base */
+    u64                  base_real;
+};
+```
+
+### Clock IDs
+
+| Clock ID | Description | Affected by |
+|----------|-------------|------------|
+| `CLOCK_REALTIME` | Wall clock (UTC) | settimeofday, NTP jumps |
+| `CLOCK_MONOTONIC` | Monotonically increasing from boot | NTP rate adjustment only; never jumps |
+| `CLOCK_MONOTONIC_RAW` | Like MONOTONIC but no NTP adjustment | Nothing — pure hardware |
+| `CLOCK_BOOTTIME` | Like MONOTONIC but includes suspend time | Nothing |
+| `CLOCK_TAI` | International Atomic Time (no leap seconds) | Leap second offset only |
+| `CLOCK_PROCESS_CPUTIME_ID` | Process CPU time | |
+| `CLOCK_THREAD_CPUTIME_ID` | Thread CPU time | |
+
+```c
+struct timespec64 ts;
+clock_gettime(CLOCK_MONOTONIC, &ts);  /* nanosecond precision */
+clock_gettime(CLOCK_REALTIME, &ts);   /* wall clock */
+```
+
+## TSC: Time Stamp Counter
+
+The TSC is the primary clocksource on x86. It's a 64-bit counter incremented every CPU cycle.
+
+### TSC calibration
+
+At boot, the kernel calibrates the TSC frequency against a known-good reference (HPET, PIT, or ACPI PM timer):
+
+```c
+/* arch/x86/kernel/tsc.c */
+static unsigned long pit_calibrate_tsc(u32 latch, unsigned long ms, int loopmin)
+{
+    u64 tsc, t1, t2, delta;
+    unsigned long tscmin, tscmax;
+
+    /* Program PIT channel 2 for a known interval */
+    outb((inb(0x61) & ~0x02) | 0x01, 0x61);
+
+    /* Measure TSC ticks in that interval */
+    t1 = get_cycles();
+    /* ... wait for PIT ... */
+    t2 = get_cycles();
+
+    delta = t2 - t1;
+    /* delta / ms = TSC frequency in kHz */
+    return delta / ms;
+}
+```
+
+### TSC invariance
+
+Modern CPUs have an **invariant TSC** (`CPUID[0x80000007] bit 8`) that runs at a fixed rate regardless of P-states or C-states. This makes TSC a reliable clocksource even on laptops with frequency scaling.
+
+```bash
+# Check invariant TSC support
+grep "constant_tsc nonstop_tsc" /proc/cpuinfo
+```
+
+Without invariant TSC, TSC drifts when the CPU frequency changes — unreliable for timekeeping.
+
+## NTP: adjusting the clock
+
+NTP runs in userspace (ntpd/chronyd) but applies corrections to the kernel clock via `adjtimex(2)`:
+
+```c
+/* Userspace NTP daemon calls: */
+struct timex tx = {
+    .modes  = ADJ_FREQUENCY | ADJ_OFFSET,
+    .freq   = ppm_scaled,   /* frequency error in scaled PPM */
+    .offset = offset_ns,    /* time offset in nanoseconds */
+};
+adjtimex(&tx);
+```
+
+The kernel applies the frequency correction by adjusting the clocksource `mult` value:
+
+```
+new_mult = orig_mult + (freq_error * orig_mult) / NSEC_PER_SEC
+```
+
+This makes the counter-to-nanosecond conversion run slightly faster or slower without any visible jumps.
+
+### NTP phase-locked loop (PLL)
+
+```c
+/* kernel/time/ntp.c */
+static void ntp_update_frequency(void)
+{
+    u64 second_length = (u64)(tick_usec * NSEC_PER_USEC * USER_HZ)
+                        << NTP_SCALE_SHIFT;
+
+    second_length += time_freq;   /* accumulated frequency correction */
+
+    /* Adjust clocksource mult to correct rate */
+    tick_length_base = second_length;
+}
+```
+
+## vDSO: time without a syscall
+
+`clock_gettime(CLOCK_MONOTONIC)` is the most-called libc function. The kernel optimizes it via the **vDSO** (virtual dynamic shared object) — a read-only page mapped into every process that contains the timekeeping fast path.
+
+```c
+/* lib/vdso/gettimeofday.c — runs in userspace without syscall */
+static __always_inline int
+do_hres(const struct vdso_data *vd, clockid_t clk, struct __kernel_timespec *ts)
+{
+    const struct vdso_timestamp *vdso_ts = &vd->basetime[clk];
+    u64 cycles, last, sec, ns;
+    u32 seq;
+
+    do {
+        /* Seqlock: read until consistent (no concurrent writer) */
+        seq = vdso_read_begin(vd);
+
+        /* Read hardware counter (userspace RDTSC or CNTVCT_EL0 on ARM) */
+        cycles = vdso_read_counter(vd);
+
+        /* cycles_since_last * mult >> shift = nanoseconds delta */
+        ns  = vdso_ts->nsec;
+        last = vd->cycle_last;
+        ns += clocksource_delta(cycles, last, vd->mask) * vd->mult >> vd->shift;
+        sec = vdso_ts->sec;
+    } while (vdso_read_retry(vd, seq));
+
+    ts->tv_sec  = sec;
+    ts->tv_nsec = ns;
+    return 0;
+}
+```
+
+The vDSO page is updated by the kernel on every tick. User reads are entirely in userspace — no ring transitions, no TLB misses to kernel pages.
+
+## Observing timekeeping
+
+```bash
+# Current clocksource and available alternatives
+cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+cat /sys/devices/system/clocksource/clocksource0/available_clocksource
+
+# Force a different clocksource (for testing/debugging)
+echo hpet | sudo tee /sys/devices/system/clocksource/clocksource0/current_clocksource
+
+# TSC frequency and stability
+dmesg | grep -E "TSC|tsc"
+# tsc: Detected 3600.000 MHz processor
+# tsc: Detected 3600.000 MHz TSC
+# clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x...
+
+# NTP synchronization status
+timedatectl show | grep NTP
+chronyc tracking
+
+# Time namespace (containers may have their own offset)
+# /proc/<pid>/timens_offsets shows MONOTONIC/BOOTTIME offsets
+
+# Kernel time debugging
+cat /proc/timer_list | head -50
+```
+
+## Further reading
+
+- [hrtimers](hrtimers.md) — high-resolution timer implementation
+- [POSIX timers](posix-timers.md) — timer_create, timerfd
+- [System Calls: entry path](../syscalls/syscall-entry.md) — vDSO seqlock implementation
+- [Scheduler: CFS](../sched/cfs.md) — scheduler tick drives timekeeping
+- `kernel/time/timekeeping.c` — timekeeper implementation
+- `arch/x86/kernel/tsc.c` — TSC clocksource

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -323,3 +323,8 @@ nav:
     - cpufreq and P-states: power/cpufreq.md
     - Runtime PM: power/runtime-pm.md
     - System Suspend: power/suspend.md
+  - Time:
+    - Getting Started: time/README.md
+    - Timekeeping and Clocksources: time/timekeeping.md
+    - hrtimers: time/hrtimers.md
+    - POSIX Timers and timerfd: time/posix-timers.md


### PR DESCRIPTION
## Summary

- **Timekeeping** (`timekeeping.md`): clocksource vs clockevent distinction, `struct clocksource` with mult/shift counter→ns conversion, `struct timekeeper` with all clock IDs table (REALTIME/MONOTONIC/RAW/BOOTTIME/TAI), TSC invariance check, NTP PLL with `adjtimex` frequency correction, vDSO seqlock fast path (`do_hres` with userspace RDTSC), clocksource sysfs observability
- **hrtimers** (`hrtimers.md`): timer_list vs hrtimer comparison table, `struct hrtimer`/`hrtimer_cpu_base`, all 8 clock bases (4 hard + 4 soft), `HRTIMER_MODE_*` variants, complete kernel driver example with `hrtimer_forward_now`, high-resolution mode switch, NOHZ idle/full tickless, timer slack and `PR_SET_TIMERSLACK`, cyclictest for latency measurement
- **POSIX timers** (`posix-timers.md`): `timer_create` with all `sigev_notify` modes (SIGNAL/THREAD/THREAD_ID/NONE), absolute `clock_nanosleep` for drift-free periodic loops, `timerfd_create` with full epoll integration, `timerfd_settime` flags (ABSTIME/CANCEL_ON_SET), kernel `k_itimer`→hrtimer chain, `timerfd_ctx` with `timerfd_tmrproc` wakeup, overrun detection, API selection table

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] Time nav section renders correctly
- [ ] Cross-links to syscalls (vDSO), scheduler, interrupts, and IPC resolve