### PR TITLE
Add IOMMU and DMA API documentation

### DIFF
--- a/docs/iommu/README.md
+++ b/docs/iommu/README.md
@@ -1,0 +1,51 @@
+# IOMMU and DMA
+
+> Hardware address translation and memory protection for devices
+
+## Why IOMMU?
+
+Without an IOMMU, a DMA-capable device can access any physical memory — a compromised network card can read or overwrite kernel memory. The IOMMU sits between the PCIe bus and physical memory, translating device I/O virtual addresses (IOVAs) to physical addresses and enforcing access permissions.
+
+```
+Without IOMMU:
+  Device → physical memory (unrestricted)
+
+With IOMMU:
+  Device → IOVA → IOMMU translation → physical memory
+                  (checked against per-domain page tables)
+```
+
+Beyond security, the IOMMU enables:
+- **IOVA remapping**: devices with < 64-bit address buses can DMA to high memory
+- **Scatter-gather flattening**: discontiguous physical pages appear contiguous to the device
+- **Device passthrough (VFIO)**: safely assign physical devices to VMs
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [IOMMU Architecture](iommu-arch.md) | Intel VT-d, AMD-Vi, iommu_domain, IOMMU groups, VFIO |
+| [DMA API](dma-api.md) | dma_alloc_coherent, dma_map_single/sg, swiotlb, IOVA allocation |
+
+## Quick reference
+
+```bash
+# Check if IOMMU is active
+dmesg | grep -i iommu | head -20
+# DMAR: IOMMU enabled
+# AMD-Vi: device isolation enabled
+
+# List IOMMU groups (devices that share address space)
+ls /sys/kernel/iommu_groups/
+for g in /sys/kernel/iommu_groups/*/devices/*; do echo "$g"; done
+
+# Enable IOMMU at boot (kernel parameter)
+# Intel: intel_iommu=on
+# AMD:   amd_iommu=on
+# Both:  iommu=pt (passthrough — no translation, just groups)
+
+# VFIO: bind a device for VM passthrough
+echo "8086 1521" | sudo tee /sys/bus/pci/drivers/vfio-pci/new_id
+echo "0000:01:00.0" | sudo tee /sys/bus/pci/devices/0000:01:00.0/driver/unbind
+echo "0000:01:00.0" | sudo tee /sys/bus/pci/drivers/vfio-pci/bind
+```

--- a/docs/iommu/dma-api.md
+++ b/docs/iommu/dma-api.md
@@ -1,0 +1,301 @@
+# DMA API
+
+> Programming devices for memory access: coherent and streaming DMA
+
+## Why a DMA API?
+
+DMA programming is architecture-dependent:
+- x86 with IOMMU: allocate IOVA, program device with IOVA
+- x86 without IOMMU: device uses physical addresses directly
+- ARM with non-coherent cache: must flush/invalidate cache around DMA
+- 32-bit DMA-capable device on 64-bit system: addresses must be < 4GB
+
+The DMA API abstracts all of this. Device drivers use one API regardless of architecture, IOMMU presence, or device addressing limitations.
+
+## Setting up a device for DMA
+
+Before using DMA, a driver declares the device's addressing capability:
+
+```c
+/* Set the DMA mask: device can address 64-bit addresses */
+if (dma_set_mask_and_coherent(dev, DMA_BIT_MASK(64))) {
+    /* Fall back to 32-bit if 64-bit not supported */
+    if (dma_set_mask_and_coherent(dev, DMA_BIT_MASK(32))) {
+        dev_err(dev, "No suitable DMA mask\n");
+        return -ENODEV;
+    }
+}
+```
+
+`DMA_BIT_MASK(n)` creates a mask of `n` bits. Setting a 32-bit mask means the device cannot DMA above 4GB — the kernel must ensure DMA buffers are allocated below 4GB.
+
+## Coherent DMA
+
+Coherent (or "consistent") DMA allocates memory that is both CPU-accessible and device-accessible without explicit cache management. The CPU and device always see the same data.
+
+```c
+/* Allocate coherent DMA buffer */
+dma_addr_t dma_handle;
+void *cpu_addr = dma_alloc_coherent(dev,
+                                     size,         /* bytes */
+                                     &dma_handle,  /* device-visible address */
+                                     GFP_KERNEL);
+if (!cpu_addr)
+    return -ENOMEM;
+
+/* cpu_addr: CPU-side virtual address */
+/* dma_handle: address to program into device registers */
+device_set_dma_addr(dev, dma_handle);
+
+/* Use the buffer (no cache management needed) */
+memset(cpu_addr, 0, size);
+/* Device can read this immediately */
+
+/* Free when done */
+dma_free_coherent(dev, size, cpu_addr, dma_handle);
+```
+
+**How it works under the hood:**
+- x86 with cache-coherent bus: `dma_alloc_coherent` → `alloc_pages` + IOMMU mapping
+- ARM non-coherent: `dma_alloc_coherent` → `alloc_pages` + mark as uncached (`pgprot_noncached`)
+- No IOMMU: `dma_alloc_coherent` → `alloc_pages` restricted to DMA zone (< 4GB if 32-bit mask)
+
+## Streaming DMA (map/unmap)
+
+Streaming DMA is for existing buffers that are transferred once. The CPU writes data, hands it to the device, then takes it back.
+
+### Single buffer
+
+```c
+/* DMA direction: */
+/* DMA_TO_DEVICE:     CPU → device (write DMA) */
+/* DMA_FROM_DEVICE:   device → CPU (read DMA)  */
+/* DMA_BIDIRECTIONAL: both */
+
+/* Map before transfer */
+dma_addr_t dma_handle = dma_map_single(dev,
+                                        cpu_addr,      /* kernel virtual address */
+                                        size,
+                                        DMA_TO_DEVICE);
+if (dma_mapping_error(dev, dma_handle)) {
+    dev_err(dev, "DMA mapping failed\n");
+    return -ENOMEM;
+}
+
+/* Program the device with dma_handle */
+device_write(dev, dma_handle, size);
+
+/* Wait for DMA to complete (device signals via interrupt) */
+wait_for_completion(&transfer_done);
+
+/* Unmap after transfer */
+dma_unmap_single(dev, dma_handle, size, DMA_TO_DEVICE);
+
+/* Now CPU can read/modify the buffer again */
+```
+
+**What happens at map/unmap:**
+- With IOMMU: allocate IOVA, create IOMMU mapping
+- Without IOMMU, coherent cache: mapping is a no-op (physical == device address)
+- Without IOMMU, non-coherent cache: `map` flushes CPU cache; `unmap` invalidates CPU cache
+
+### Scatter-gather
+
+Real I/O often involves discontiguous memory (e.g., page-aligned skb fragments, bio pages):
+
+```c
+#include <linux/dma-mapping.h>
+#include <linux/scatterlist.h>
+
+struct scatterlist sg[4];
+sg_init_table(sg, 4);
+sg_set_page(&sg[0], page0, PAGE_SIZE, 0);
+sg_set_page(&sg[1], page1, PAGE_SIZE, 0);
+sg_set_page(&sg[2], page2, 512,       0);
+
+/* Map all entries at once */
+int nents = dma_map_sg(dev, sg, 3, DMA_TO_DEVICE);
+if (!nents) {
+    /* mapping failed */
+    return -ENOMEM;
+}
+
+/* Program device: iterate mapped entries */
+for_each_sg(sg, s, nents, i) {
+    dma_addr_t addr = sg_dma_address(s);
+    unsigned int len = sg_dma_len(s);
+    device_add_descriptor(dev, addr, len);
+}
+
+/* Wait for completion, then unmap */
+dma_unmap_sg(dev, sg, 3, DMA_TO_DEVICE);
+```
+
+With an IOMMU, `dma_map_sg` can coalesce adjacent pages into a single IOVA range — the device sees one contiguous buffer even though physical memory is fragmented.
+
+## IOVA allocation
+
+With an IOMMU, each streaming DMA map requires an IOVA allocation:
+
+```c
+/* drivers/iommu/dma-iommu.c */
+static dma_addr_t iommu_dma_map_page(struct device *dev, struct page *page,
+                                      unsigned long offset, size_t size,
+                                      enum dma_data_direction dir,
+                                      unsigned long attrs)
+{
+    struct iommu_domain *domain = iommu_get_dma_domain(dev);
+    struct iommu_dma_cookie *cookie = domain->iova_cookie;
+    struct iova_domain *iovad = &cookie->iovad;
+
+    /* Allocate an IOVA (I/O virtual address range) */
+    dma_addr_t iova = iommu_dma_alloc_iova(domain, size, dma_get_mask(dev), dev);
+    if (!iova)
+        return DMA_MAPPING_ERROR;
+
+    /* Create IOMMU page table entry: IOVA → physical page */
+    phys_addr_t phys = page_to_phys(page) + offset;
+    if (iommu_map(domain, iova, phys, size, prot, GFP_ATOMIC)) {
+        iommu_dma_free_iova(cookie, iova, size, NULL);
+        return DMA_MAPPING_ERROR;
+    }
+
+    return iova;
+}
+```
+
+The IOVA allocator uses a red-black tree of free ranges and a cached allocator for same-size allocations.
+
+## swiotlb: bounce buffers
+
+When a device cannot address certain memory (e.g., 32-bit device, memory > 4GB), the kernel must **bounce** DMA through a buffer in addressable memory:
+
+```
+Bounce buffer mechanism:
+  1. Device needs to DMA to high memory (> 4GB, but device is 32-bit)
+  2. swiotlb allocates a buffer in low memory (< 4GB)
+  3. For writes (DMA_TO_DEVICE):  CPU copies data to bounce buffer first
+  4. Device DMAs from bounce buffer
+  5. For reads (DMA_FROM_DEVICE): Device DMAs to bounce buffer, then CPU copies out
+
+  High memory buffer ──[CPU copy]──► bounce buffer ──[DMA]──► device
+```
+
+```c
+/* kernel/dma/swiotlb.c */
+phys_addr_t swiotlb_tbl_map_single(struct device *dev,
+                                     phys_addr_t orig_addr,
+                                     size_t mapping_size,
+                                     size_t alloc_size,
+                                     unsigned int alloc_align_mask,
+                                     enum dma_data_direction dir,
+                                     unsigned long attrs)
+{
+    struct io_tlb_mem *mem = dev->dma_io_tlb_mem;
+    /* Find a free slot in the swiotlb pool */
+    index = find_slots(dev, mem, orig_addr, alloc_size, alloc_align_mask);
+    tlb_addr = slot_addr(mem->start, index);
+
+    /* Copy data to bounce buffer for DMA_TO_DEVICE */
+    if (!(attrs & DMA_ATTR_SKIP_CPU_SYNC) &&
+        (dir == DMA_TO_DEVICE || dir == DMA_BIDIRECTIONAL))
+        swiotlb_bounce(dev, tlb_addr, mapping_size, DMA_TO_DEVICE);
+
+    return tlb_addr;
+}
+```
+
+```bash
+# swiotlb pool size (set at boot with swiotlb= parameter)
+dmesg | grep "software IO TLB"
+# software IO TLB: mapped [mem 0x...] (64MB)
+
+# swiotlb usage
+cat /sys/kernel/debug/swiotlb/io_tlb_nslabs    # total slots
+cat /sys/kernel/debug/swiotlb/io_tlb_used      # currently used
+```
+
+## DMA pools
+
+For small, frequently allocated DMA buffers (e.g., descriptor rings), use a DMA pool to avoid fragmentation:
+
+```c
+#include <linux/dmapool.h>
+
+/* Create a pool of 64-byte DMA-coherent buffers, 64-byte aligned */
+struct dma_pool *pool = dma_pool_create("my_descriptors", dev,
+                                         64,   /* size */
+                                         64,   /* alignment */
+                                         0);   /* boundary (0 = no boundary) */
+
+/* Allocate from pool */
+dma_addr_t dma_handle;
+void *vaddr = dma_pool_alloc(pool, GFP_KERNEL, &dma_handle);
+
+/* Use the descriptor */
+setup_descriptor(vaddr, dma_handle);
+
+/* Return to pool */
+dma_pool_free(pool, vaddr, dma_handle);
+
+/* Destroy pool (frees all underlying coherent memory) */
+dma_pool_destroy(pool);
+```
+
+## Observing DMA
+
+```bash
+# DMA memory zones (for no-IOMMU systems)
+cat /proc/zoneinfo | grep -A5 "Node 0, zone  DMA"
+
+# IOVA allocator statistics
+cat /sys/kernel/debug/iommu/iova
+
+# Check if swiotlb is in use (active remapping)
+cat /sys/kernel/debug/swiotlb/io_tlb_used
+
+# DMA API debugging (catch unmapped accesses, misuse)
+# Requires CONFIG_DMA_API_DEBUG=y in kernel config
+echo 1 > /sys/kernel/debug/dma-api/disabled  # re-enable
+cat /sys/kernel/debug/dma-api/error_count
+cat /sys/kernel/debug/dma-api/dump
+
+# Tracepoints: DMA map/unmap
+echo 1 > /sys/kernel/tracing/events/dma_fence/enable
+```
+
+## Device tree DMA binding (ARM/embedded)
+
+On ARM SoCs, device tree specifies DMA capabilities:
+
+```dts
+/* Device tree source */
+dma-controller@40400000 {
+    compatible = "arm,pl330";
+    reg = <0x40400000 0x1000>;
+    #dma-cells = <1>;
+};
+
+ethernet@e0100000 {
+    compatible = "cdns,macb";
+    reg = <0xe0100000 0x1000>;
+    dmas = <&dma_controller 0>,   /* TX DMA channel */
+           <&dma_controller 1>;   /* RX DMA channel */
+    dma-names = "tx", "rx";
+};
+```
+
+```c
+/* Driver: request DMA channels from device tree */
+priv->dma_tx = dma_request_chan(dev, "tx");
+priv->dma_rx = dma_request_chan(dev, "rx");
+```
+
+## Further reading
+
+- [IOMMU Architecture](iommu-arch.md) — IOMMU hardware and domains
+- [Memory Management: DMA zones](../mm/dma.md) — DMA zone in the buddy allocator
+- [Memory Management: Device Coherency](../mm/device-coherency.md) — cache coherency
+- [Device Drivers: platform driver](../drivers/platform-driver.md) — devm_request_mem_region
+- `include/linux/dma-mapping.h` — DMA API declarations
+- `Documentation/core-api/dma-api.rst` — full DMA API reference

--- a/docs/iommu/iommu-arch.md
+++ b/docs/iommu/iommu-arch.md
@@ -1,0 +1,257 @@
+# IOMMU Architecture
+
+> Intel VT-d, AMD-Vi, iommu_domain, and device passthrough
+
+## Hardware implementations
+
+### Intel VT-d (Virtualization Technology for Directed I/O)
+
+Intel VT-d places a remapping hardware unit (DMAR unit) on the root complex. Each DMAR unit manages a segment of the PCIe bus:
+
+```
+CPU ──► System Agent ──► DMAR Unit ──► PCIe Root Port ──► Device
+                              │
+                         Page Tables
+                         (IOVA → HPA)
+                              │
+                         Access Control
+                         (read/write/execute bits)
+```
+
+The DMAR unit uses a two-level structure:
+1. **Root table** (indexed by bus number)
+2. **Context table** (indexed by device/function)
+3. Each context entry points to the device's **IOMMU page tables**
+
+```c
+/* drivers/iommu/intel/iommu.c */
+struct intel_iommu {
+    void __iomem    *reg;        /* MMIO registers */
+    u64              cap;        /* capability register */
+    u64              ecap;       /* extended capability */
+    /* ... */
+    struct root_entry *root_entry; /* root table (bus indexed) */
+    int              seq_id;
+    struct iommu_device iommu_dev;
+};
+```
+
+### AMD-Vi (AMD I/O Virtualization)
+
+AMD uses a single system-wide Device Table (indexed by 16-bit device ID = bus+dev+fn). Each entry points to the device's page table and control flags:
+
+```c
+/* drivers/iommu/amd/amd_iommu_types.h */
+struct dev_table_entry {
+    u64 data[4];
+    /*
+     * Bits define:
+     *   [0]    TV: translation valid
+     *   [1]    HaddrRange: host address range (4K pages)
+     *   [8:11] Mode: page table levels
+     *   [51:12] PTP: page table pointer
+     *   [62]   IR: interrupt remap enable
+     *   [63]   IW: interrupt remap write enable
+     */
+};
+```
+
+## The IOMMU subsystem
+
+The kernel abstracts both implementations behind a common API in `drivers/iommu/`.
+
+### struct iommu_domain
+
+An `iommu_domain` represents an isolated address space. One or more devices are attached to a domain; they share the same IOVA→PA translation.
+
+```c
+/* include/linux/iommu.h */
+struct iommu_domain {
+    unsigned            type;      /* IOMMU_DOMAIN_UNMANAGED / BLOCKED / IDENTITY / DMA */
+    const struct iommu_domain_ops *ops;
+    unsigned long       pgsize_bitmap; /* supported page sizes */
+    struct iommu_domain_geometry geometry;  /* IOVA range constraints */
+    struct iommu_dma_cookie *iova_cookie;   /* IOVA allocator state */
+    /* ... */
+};
+
+struct iommu_domain_ops {
+    int  (*attach_dev)(struct iommu_domain *domain, struct device *dev);
+    void (*detach_dev)(struct iommu_domain *domain, struct device *dev);
+
+    int  (*map_pages)(struct iommu_domain *domain, unsigned long iova,
+                      phys_addr_t paddr, size_t pgsize, size_t pgcount,
+                      int prot, gfp_t gfp, size_t *mapped);
+    size_t (*unmap_pages)(struct iommu_domain *domain, unsigned long iova,
+                           size_t pgsize, size_t pgcount,
+                           struct iommu_iotlb_gather *iotlb_gather);
+
+    phys_addr_t (*iova_to_phys)(struct iommu_domain *domain, dma_addr_t iova);
+    /* ... */
+};
+```
+
+### Domain types
+
+```c
+/* IOMMU_DOMAIN_BLOCKED: all access denied (default) */
+/* IOMMU_DOMAIN_IDENTITY: IOVA == PA (passthrough) */
+/* IOMMU_DOMAIN_UNMANAGED: driver manages mappings */
+/* IOMMU_DOMAIN_DMA: kernel DMA layer manages mappings */
+/* IOMMU_DOMAIN_DMA_FQ: DMA with flush queue for deferred TLB invalidation */
+```
+
+For normal DMA: `IOMMU_DOMAIN_DMA` — the kernel's DMA API manages IOVA allocation and mapping automatically.
+
+## IOMMU groups
+
+An IOMMU group is the smallest set of devices that the IOMMU can isolate from each other. Devices in the same group must share a domain — you cannot give them independent address spaces.
+
+Why groups? PCIe peer-to-peer transactions: a PCIe bridge may allow devices behind it to DMA to each other, bypassing the IOMMU. The kernel groups these devices to prevent false isolation.
+
+```bash
+# A typical system: most devices get their own group
+# PCIe root ports and their children may be grouped
+ls /sys/kernel/iommu_groups/
+# 0  1  2  3  ... 25  ...
+
+# Group 0: Intel audio device
+ls /sys/kernel/iommu_groups/0/devices/
+# 0000:00:1f.3
+
+# Group 12: discrete GPU (may include audio function)
+ls /sys/kernel/iommu_groups/12/devices/
+# 0000:01:00.0   (GPU)
+# 0000:01:00.1   (GPU HDMI audio)
+```
+
+## VFIO: device passthrough to VMs
+
+VFIO (Virtual Function I/O) uses the IOMMU to safely pass a physical device to a VM (KVM) or userspace driver.
+
+```
+VM guest
+  │  writes to virtual device MMIO
+  ▼
+KVM VFIO handler
+  │
+  ▼
+VFIO container (an IOMMU domain)
+  │  guest physical address → IOVA mapping
+  ▼
+IOMMU page tables
+  │  IOVA → host physical address
+  ▼
+physical device
+```
+
+### VFIO usage
+
+```c
+/* Userspace VFIO API */
+#include <linux/vfio.h>
+
+/* 1. Open the VFIO container */
+int container = open("/dev/vfio/vfio", O_RDWR);
+
+/* 2. Open the IOMMU group */
+int group = open("/dev/vfio/12", O_RDWR);  /* group 12 */
+ioctl(group, VFIO_GROUP_SET_CONTAINER, &container);
+
+/* 3. Enable IOMMU on the container */
+ioctl(container, VFIO_SET_IOMMU, VFIO_TYPE1_IOMMU);
+
+/* 4. Open the device */
+int device = ioctl(group, VFIO_GROUP_GET_DEVICE_FD, "0000:01:00.0");
+
+/* 5. Map guest memory into IOMMU domain */
+struct vfio_iommu_type1_dma_map dma_map = {
+    .argsz = sizeof(dma_map),
+    .flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE,
+    .vaddr = (uint64_t)guest_ram,     /* HVA */
+    .iova  = 0x0,                     /* guest physical base */
+    .size  = guest_ram_size,
+};
+ioctl(container, VFIO_IOMMU_MAP_DMA, &dma_map);
+
+/* Now: device can DMA to guest memory at IOVA 0..guest_ram_size */
+/* The IOMMU prevents the device from accessing other host memory */
+```
+
+## SR-IOV: virtual functions
+
+SR-IOV (Single Root I/O Virtualization) creates multiple PCIe **virtual functions** (VFs) from a single physical function (PF). Each VF gets its own PCIe configuration space and can be independently assigned to a VM.
+
+```bash
+# Enable VFs on a NIC (e.g., create 4 VFs)
+echo 4 | sudo tee /sys/bus/pci/devices/0000:01:00.0/sriov_numvfs
+
+# Each VF gets its own PCI address
+lspci | grep "Virtual Function"
+# 0000:01:10.0 Ethernet controller: Intel ... Virtual Function
+# 0000:01:10.2 ...
+
+# Assign a VF to a VM via VFIO
+echo "0000:01:10.0" > /sys/bus/pci/devices/0000:01:10.0/driver/unbind
+echo "8086 154c" > /sys/bus/pci/drivers/vfio-pci/new_id
+```
+
+## IOMMU TLB management
+
+The IOMMU has its own TLB (IOTLB) that caches IOVA→PA translations. After unmapping, the kernel must flush the IOTLB:
+
+```c
+/* drivers/iommu/iommu.c */
+void iommu_iotlb_gather_add_page(struct iommu_domain *domain,
+                                  struct iommu_iotlb_gather *gather,
+                                  unsigned long iova, size_t size)
+{
+    /* Accumulate unmapped ranges */
+    if (gather->start > iova)
+        gather->start = iova;
+    if (gather->end < iova + size)
+        gather->end   = iova + size;
+    gather->pgsize = size;
+}
+
+/* Flush accumulated ranges (batch for efficiency) */
+void iommu_iotlb_sync(struct iommu_domain *domain,
+                       struct iommu_iotlb_gather *iotlb_gather)
+{
+    if (domain->ops->iotlb_sync)
+        domain->ops->iotlb_sync(domain, iotlb_gather);
+    iommu_iotlb_gather_init(iotlb_gather);
+}
+```
+
+Deferred flushing (flush queue) amortizes IOTLB invalidation cost by batching unmap operations.
+
+## Observing the IOMMU
+
+```bash
+# DMAR faults (device violated IOMMU policy)
+dmesg | grep DMAR
+# DMAR: [DMA Write] Request device [01:00.0] fault addr 7f000000
+# DMAR: [fault reason 02] Present bit in context entry is clear
+
+# IOMMU statistics
+cat /sys/kernel/debug/iommu/intel/iommu_perf_stats
+
+# AMD-Vi statistics
+cat /sys/kernel/debug/iommu/amd/amd_iommu_stats
+
+# IOVA allocator state
+cat /sys/kernel/debug/iommu/iova
+
+# Test IOMMU isolation (VFIO test)
+modprobe vfio-pci
+```
+
+## Further reading
+
+- [DMA API](dma-api.md) — kernel driver DMA programming
+- [Memory Management: DMA](../mm/dma.md) — DMA zones and device coherency
+- [Memory Management: Device Coherency](../mm/device-coherency.md) — cache coherency with devices
+- [Virtualization: KVM Memory](../virtualization/kvm-memory.md) — EPT complements IOMMU for VMs
+- `drivers/iommu/` in the kernel tree — IOMMU subsystem
+- `Documentation/userspace-api/iommu.rst` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -328,3 +328,7 @@ nav:
     - Timekeeping and Clocksources: time/timekeeping.md
     - hrtimers: time/hrtimers.md
     - POSIX Timers and timerfd: time/posix-timers.md
+  - IOMMU and DMA:
+    - Getting Started: iommu/README.md
+    - IOMMU Architecture: iommu/iommu-arch.md
+    - DMA API: iommu/dma-api.md


### PR DESCRIPTION
## Summary

- **IOMMU Architecture** (`iommu-arch.md`): Intel VT-d (DMAR units, root/context tables), AMD-Vi (device table layout), `struct iommu_domain` with ops and all domain types, IOMMU groups and PCIe peer-to-peer isolation, VFIO passthrough with complete userspace ioctl API (container→group→device→DMA map), SR-IOV VF creation, IOTLB batch flushing
- **DMA API** (`dma-api.md`): `dma_set_mask_and_coherent`, coherent DMA (`dma_alloc_coherent` behavior per architecture), streaming DMA (`dma_map_single`, direction semantics, cache flush implications), scatter-gather with `dma_map_sg` and IOMMU coalescing, IOVA allocation internals (`iommu_dma_map_page`), swiotlb bounce buffers with slot mechanism, `dma_pool` for descriptor rings, device tree DMA bindings

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] IOMMU and DMA nav section renders
- [ ] Cross-links to mm/dma, mm/device-coherency, virtualization/kvm-memory resolve