### PR TITLE
Add kernel debugging documentation

### DIFF
--- a/docs/debugging/README.md
+++ b/docs/debugging/README.md
@@ -1,0 +1,50 @@
+# Kernel Debugging
+
+> Tools and techniques for debugging the Linux kernel
+
+## Debugging approaches
+
+```
+Problem type                  Best tool
+────────────────────────────────────────────────────────────
+Kernel crash (already happened) kdump + crash
+Live kernel, single machine     kgdb over serial/netconsole
+Memory corruption               KASAN, KFENCE, SLUB debug
+Race conditions                 lockdep, KCSAN
+Crashes with no debugger        Oops analysis, addr2line
+Performance                     perf, ftrace, BPF
+Logic bugs in drivers           dynamic debug, pr_debug
+Boot failures                   early_printk, earlyprintk=ttyS0
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [KGDB](kgdb.md) | Live kernel debugging with GDB over serial or network |
+| [kdump and crash](kdump.md) | Capturing and analyzing kernel crash dumps |
+| [Oops analysis](oops-analysis.md) | Reading oops output, addr2line, decode_stacktrace |
+
+## Quick reference
+
+```bash
+# Trigger an oops on demand (testing)
+echo c > /proc/sysrq-trigger
+
+# Enable SysRq
+echo 1 > /proc/sys/kernel/sysrq
+
+# Common SysRq keys:
+# Alt+SysRq+t: dump all tasks
+# Alt+SysRq+m: memory info
+# Alt+SysRq+l: backtrace all CPUs
+# Alt+SysRq+b: reboot
+# Alt+SysRq+c: crash (for kdump testing)
+
+# Panic on oops (useful for kdump testing)
+echo 1 > /proc/sys/kernel/panic_on_oops
+echo 5 > /proc/sys/kernel/panic          # reboot 5s after panic
+
+# kernel.org decode
+./scripts/decode_stacktrace.sh vmlinux < oops.txt
+```

--- a/docs/debugging/kdump.md
+++ b/docs/debugging/kdump.md
@@ -1,0 +1,258 @@
+# kdump and crash
+
+> Capturing and analyzing kernel crash dumps
+
+## How kdump works
+
+kdump uses `kexec` to pre-load a second "capture kernel" into a reserved region of memory. When the primary kernel crashes (panic), it hands control to the capture kernel via kexec. The capture kernel boots, saves the first kernel's memory (the "vmcore") to disk, and reboots.
+
+```
+Normal operation:
+  Primary kernel runs
+  Capture kernel pre-loaded at reserved address (e.g., 0x100000000)
+  ────────────────────────────────────────────────
+Crash:
+  Primary kernel panics
+  kexec jumps to capture kernel entry point
+  ────────────────────────────────────────────────
+Capture kernel:
+  Boots with crashkernel= memory
+  Mounts root filesystem
+  /proc/vmcore: primary kernel's memory accessible here
+  makedumpfile saves compressed vmcore to /var/crash/
+  System reboots
+```
+
+## Setup
+
+### Step 1: Reserve memory for capture kernel
+
+Add to kernel boot parameters:
+
+```bash
+# /etc/default/grub (or equivalent)
+GRUB_CMDLINE_LINUX="crashkernel=256M"
+# Reserve 256MB for the capture kernel at a high address
+
+# For systems with > 4GB RAM (common):
+crashkernel=256M,high   # prefer high memory
+crashkernel=64M,low     # also reserve 64MB in low memory (for DMA)
+
+# Regenerate grub config
+sudo update-grub
+sudo reboot
+```
+
+```bash
+# Verify reservation after boot
+cat /proc/cmdline | grep crashkernel
+dmesg | grep "crashkernel"
+# crashkernel: memory value: 0x10000000 at 0x100000000
+```
+
+### Step 2: Install and configure kdump
+
+```bash
+# Debian/Ubuntu
+sudo apt install kdump-tools
+
+# RHEL/Fedora
+sudo dnf install kexec-tools
+
+# Start kdump service (loads capture kernel via kexec)
+sudo systemctl enable --now kdump
+
+# Verify kdump is ready
+sudo kdump-config show
+# DUMP_MODE:        kdump
+# USE_KDUMP:        1
+# KDUMP_SYSCTL:     kernel.panic_on_oops=1
+# current state:    ready to kdump
+```
+
+### Step 3: Test kdump
+
+```bash
+# Force a crash to test (writes crash dump then reboots)
+echo 1 > /proc/sys/kernel/sysrq
+echo c > /proc/sysrq-trigger
+
+# After reboot: check /var/crash/
+ls /var/crash/
+# 202601301234/  vmcore  vmcore-dmesg.txt
+```
+
+## Analyzing a crash dump with crash
+
+The `crash` tool is the standard way to analyze vmcore files:
+
+```bash
+# Install crash
+sudo apt install crash   # Debian/Ubuntu
+sudo dnf install crash   # RHEL
+
+# Open the crash dump
+crash /usr/lib/debug/boot/vmlinux-$(uname -r) /var/crash/*/vmcore
+# Or with a kernel debuginfo package:
+crash /path/to/vmlinux vmcore
+```
+
+### crash command reference
+
+Once inside crash:
+
+```
+crash> help          # list all commands
+
+# System information
+crash> sys           # kernel version, panic string, uptime
+# KERNEL: /usr/lib/debug/.../vmlinux
+# DUMPFILE: vmcore  [PARTIAL DUMP]
+# CPUS: 8
+# DATE: Mon Jan 30 12:34:56 2026
+# UPTIME: 2 days, 03:21:45
+# PANIC: "general protection fault, maybe for address..."
+
+# The panic message and task
+crash> bt            # backtrace of the crashing task
+crash> bt -a         # backtraces of all tasks
+crash> bt <pid>      # backtrace of specific task
+
+# Process information
+crash> ps            # process list (like ps aux)
+crash> ps -t         # thread list
+crash> task <pid>    # full task_struct of a process
+crash> files <pid>   # open files of a process
+
+# Memory inspection
+crash> rd address 16          # read 16 words at address
+crash> wr address value       # write (modify vmcore — dangerous)
+crash> kmem -i                # memory info
+crash> kmem -z                # zone info
+crash> kmem -s                # slab info
+
+# Kernel structures
+crash> struct task_struct <address>      # pretty-print struct
+crash> p variable_name                   # print variable
+crash> p *((struct inode *)0xffff..)    # dereference pointer
+
+# Modules
+crash> mod                    # list modules
+crash> mod -s mymodule /path/to/mymodule.ko  # load module symbols
+
+# Virtual memory
+crash> vm <pid>               # VMAs of process
+crash> pte <address>          # page table entry
+crash> vtop <virtual>         # virtual→physical translation
+
+# Log
+crash> log                    # kernel ring buffer from vmcore
+crash> log -m                 # include timestamp prefix
+```
+
+### Reading the backtrace
+
+```
+crash> bt
+PID: 1234   TASK: ffff888012345678  CPU: 3   COMMAND: "myapp"
+ #0 [ffff8880abcd0000] machine_kexec at ffffffff81064180
+ #1 [ffff8880abcd0058] __crash_kexec at ffffffff8112e943
+ #2 [ffff8880abcd0120] crash_kexec at ffffffff8112ea8c
+ #3 [ffff8880abcd0138] oops_end at ffffffff810512e1
+ #4 [ffff8880abcd0160] no_context at ffffffff81065e28
+ #5 [ffff8880abcd01b0] __bad_area_nosemaphore at ffffffff81066037
+ #6 [ffff8880abcd0200] bad_area_nosemaphore at ffffffff81066167
+ #7 [ffff8880abcd0210] do_user_addr_fault at ffffffff81066b8e
+ #8 [ffff8880abcd0280] exc_page_fault at ffffffff8106765f
+ #9 [ffff8880abcd02a0] asm_exc_page_fault at ffffffff81c00b62
+    RIP: 0033:0x7f1234abcd00   RSP: 0018:ffff8880abcd0300   EFLAGS: 00010246
+    RAX: 0000000000000000  RBX: ffff888001234567  RCX: 0000000000000000
+```
+
+Each frame shows: frame number, kernel stack address, function name, source address.
+
+### Inspecting the crashing code
+
+```
+# Find the faulting instruction
+crash> dis -l ffffffff81066b8e     # disassemble with source lines
+# do_user_addr_fault():
+# /build/linux/arch/x86/mm/fault.c: 1402
+# 0xffffffff81066b80: mov    (%rbx),%rax    ← NULL deref here
+# 0xffffffff81066b83: test   %rax,%rax
+
+# Print the faulting variable
+crash> p my_struct->field
+
+# Find what module a function belongs to
+crash> sym ffffffffc0a01234
+# ffffffffc0a01234 (t) mymodule_function [mymodule]
+```
+
+## makedumpfile
+
+Raw vmcore files can be very large (equal to physical RAM). `makedumpfile` compresses and filters them:
+
+```bash
+# Create compressed dump, excluding zero pages and free pages
+makedumpfile -c -d 31 /proc/vmcore /var/crash/dump
+
+# Compression levels: -d N where bits mean:
+# bit 0 (1): zero pages
+# bit 1 (2): cache pages
+# bit 2 (4): cache private
+# bit 3 (8): user-space pages
+# bit 4 (16): free pages
+# 31 = all of the above
+
+# For later analysis on a different machine:
+makedumpfile --dump-dmesg /proc/vmcore dmesg.txt
+```
+
+## pstore: persistent storage across reboots
+
+For embedded systems or when full kdump is impractical, pstore saves the kernel console log and oops backtraces to persistent storage (ACPI APEI, NVRAM, MTD flash, ramoops):
+
+```bash
+# ramoops: reserve RAM region that survives kexec
+# (add to boot parameters)
+ramoops.mem_address=0x8f000000 ramoops.mem_size=0x100000
+
+# After crash/reboot, read saved logs:
+ls /sys/fs/pstore/
+# dmesg-ramoops-0   (console output before crash)
+# console-ramoops-0
+
+cat /sys/fs/pstore/dmesg-ramoops-0
+
+# Erase after reading
+echo 1 > /sys/fs/pstore/dmesg-ramoops-0/erase
+```
+
+## Observing panic behavior
+
+```bash
+# Control what happens on panic
+cat /proc/sys/kernel/panic
+# 0 = hang (default)
+# N > 0 = reboot after N seconds
+# N < 0 = reboot immediately
+echo 10 > /proc/sys/kernel/panic
+
+# Panic on any oops (not just fatal ones)
+echo 1 > /proc/sys/kernel/panic_on_oops
+
+# Panic on soft lockup (hung task watchdog)
+echo 1 > /proc/sys/kernel/softlockup_panic
+
+# Hung task timeout (panic after N seconds of task stuck)
+echo 120 > /proc/sys/kernel/hung_task_timeout_secs
+```
+
+## Further reading
+
+- [Oops analysis](oops-analysis.md) — reading oops without crash tool
+- [KGDB](kgdb.md) — live kernel debugging
+- [Memory Management: KASAN](../mm/kasan.md) — catching use-after-free before crashes
+- [Memory Management: KFENCE](../mm/kfence.md) — lightweight memory error detection
+- `Documentation/admin-guide/kdump/kdump.rst` in the kernel tree

--- a/docs/debugging/kgdb.md
+++ b/docs/debugging/kgdb.md
@@ -1,0 +1,247 @@
+# KGDB: Kernel GDB Debugger
+
+> Live debugging of a running kernel with GDB
+
+## Overview
+
+KGDB allows debugging a live kernel using GDB as the front-end. The kernel halts at breakpoints and exposes a GDB remote protocol stub over a serial port or netconsole. A second machine (or a VM host) runs GDB.
+
+```
+Target machine (running kernel to debug)
+  │
+  │  kgdb serial/network transport
+  │
+  ▼
+Host machine (running GDB)
+  gdb vmlinux
+  (gdb) target remote /dev/ttyS0
+```
+
+For single-machine debugging, KGDB over a VM's virtual serial port is the most practical setup.
+
+## Kernel configuration
+
+```bash
+# Required kernel config options:
+CONFIG_KGDB=y
+CONFIG_KGDB_SERIAL_CONSOLE=y   # kgdboc: KGDB over console
+CONFIG_KGDB_KDB=y              # optional: built-in KDB shell
+CONFIG_FRAME_POINTER=y         # reliable stack traces
+CONFIG_DEBUG_INFO=y            # symbol information in vmlinux
+CONFIG_GDB_SCRIPTS=y           # GDB python scripts for kernel types
+```
+
+## Setting up the connection
+
+### Over serial (physical or VM)
+
+```bash
+# Target: configure kgdb to use serial port ttyS0 at 115200 baud
+# At boot (kernel parameter):
+console=ttyS0,115200 kgdboc=ttyS0,115200
+
+# Or at runtime (if kernel supports it):
+echo ttyS0,115200 > /sys/module/kgdboc/parameters/kgdboc
+
+# Trigger entry into the debugger:
+echo g > /proc/sysrq-trigger
+# Or: send SysRq-g over serial: Alt+SysRq+g
+# Or: hit a breakpoint
+```
+
+```bash
+# Host: connect GDB
+gdb vmlinux
+(gdb) set serial baud 115200
+(gdb) target remote /dev/ttyS0
+# Remote debugging using /dev/ttyS0
+# (gdb) ...
+```
+
+### Over network (kgdboe)
+
+kgdboe (KGDB over Ethernet) uses the netpoll framework:
+
+```bash
+# Target: kgdboe configuration
+# Format: @target_ip/interface,@host_ip
+insmod kgdb_nmi.ko
+echo "g" > /proc/sysrq-trigger  # (after kgdboe setup)
+# Or at boot:
+kgdboe=@192.168.1.10/eth0,@192.168.1.1
+
+# Host: use GDB with UDP
+# (requires agent-proxy or similar)
+```
+
+For most use cases, serial is simpler and more reliable.
+
+## Basic GDB commands for kernel debugging
+
+Once connected:
+
+```
+# Show kernel version info
+(gdb) info threads
+(gdb) thread apply all bt    # backtrace all threads
+
+# Inspect current task
+(gdb) p $lx_current()        # current task_struct (requires GDB scripts)
+(gdb) lx-ps                  # list all processes (GDB script)
+
+# Stack trace
+(gdb) bt
+(gdb) bt full                # with local variables
+
+# Navigate frames
+(gdb) up
+(gdb) down
+(gdb) frame 3
+
+# Inspect variables
+(gdb) p variable_name
+(gdb) p *ptr
+(gdb) p *(struct task_struct*)0xffff888012345678
+
+# Memory inspection
+(gdb) x/16x address          # 16 hex words
+(gdb) x/s address            # string
+(gdb) x/i address            # disassemble
+
+# Continue
+(gdb) c                      # continue execution
+(gdb) s                      # single step (into)
+(gdb) n                      # next (over)
+(gdb) finish                 # run until function return
+```
+
+## Breakpoints
+
+```
+# Software breakpoint (INT3 on x86)
+(gdb) break function_name
+(gdb) break kernel/sched/core.c:1234
+(gdb) break *0xffffffff81234567   # by address
+
+# Conditional breakpoint
+(gdb) break schedule if current->pid == 1234
+
+# Hardware watchpoint: break when memory is written
+(gdb) watch *address           # break on write
+(gdb) rwatch *address          # break on read
+(gdb) awatch *address          # break on read or write
+
+# Example: catch when a specific inode is modified
+(gdb) watch -l inode->i_count
+
+# List and manage breakpoints
+(gdb) info breakpoints
+(gdb) disable 2
+(gdb) delete 2
+```
+
+## GDB scripts for kernel
+
+The kernel ships Python-based GDB scripts (`scripts/gdb/`) that add kernel-specific commands:
+
+```
+# Load scripts (automatic if CONFIG_GDB_SCRIPTS=y and .gdbinit configured)
+(gdb) source /path/to/kernel/scripts/gdb/vmlinux-gdb.py
+
+# Kernel-specific commands:
+(gdb) lx-version          # kernel version string
+(gdb) lx-ps              # process list (like ps)
+(gdb) lx-dmesg           # kernel ring buffer
+(gdb) lx-lsmod           # loaded modules
+(gdb) lx-mounts          # mounted filesystems
+(gdb) lx-iomem           # /proc/iomem equivalent
+(gdb) lx-symbols         # load module symbols
+
+# Pretty-printers: struct task_struct, list_head, etc.
+(gdb) p $lx_per_cpu("runqueues", 0)  # runqueue of CPU 0
+(gdb) p $lx_current()               # current task
+(gdb) $lx_container_of(ptr, "struct task_struct", "mm")
+```
+
+## Debugging a kernel module
+
+Modules are loaded at runtime at unknown addresses. You must load their symbols into GDB:
+
+```bash
+# On target: find where module is loaded
+cat /proc/modules | grep mymodule
+# mymodule 16384 0 - Live 0xffffffffc0a00000
+
+# Or via sysfs
+cat /sys/module/mymodule/sections/.text
+cat /sys/module/mymodule/sections/.data
+```
+
+```
+# In GDB: add symbols at the reported address
+(gdb) add-symbol-file mymodule.ko 0xffffffffc0a00000
+
+# Or use lx-symbols to load all modules automatically
+(gdb) lx-symbols /lib/modules/$(uname -r)/
+```
+
+## KDB: the built-in kernel debugger
+
+KDB (`CONFIG_KGDB_KDB=y`) provides a simpler text-based debugger that runs entirely on the target, without needing a second machine:
+
+```bash
+# Enter KDB: press Alt+SysRq+g or trigger a panic
+# Or at a breakpoint
+
+# KDB prompt:
+[0]kdb> help
+[0]kdb> ps              # process list
+[0]kdb> bt              # backtrace current task
+[0]kdb> btp <pid>       # backtrace specific task
+[0]kdb> md 0xffff888012345678 16   # memory dump
+[0]kdb> mm address value           # memory modify
+[0]kdb> bp function_name           # set breakpoint
+[0]kdb> go                         # continue
+[0]kdb> dmesg                      # print ring buffer
+[0]kdb> lsmod                      # list modules
+```
+
+## Common debugging scenarios
+
+### Debugging a kernel oops
+
+```bash
+# After an oops, the system may or may not be still running
+# If still running (non-fatal oops), enter kgdb and:
+(gdb) bt           # see where we are
+(gdb) frame 5      # go to the faulting frame
+(gdb) p *ptr       # inspect the null/invalid pointer
+(gdb) list         # show source around crash point
+```
+
+### Race condition debugging
+
+```bash
+# Breakpoint with a counter (hit on 100th call)
+(gdb) break kmalloc
+(gdb) ignore 1 99        # skip first 99 hits
+```
+
+### Inspecting scheduler state
+
+```bash
+(gdb) break __schedule
+(gdb) c
+# At breakpoint:
+(gdb) p *current         # current task
+(gdb) p *current->mm     # current mm_struct
+(gdb) p runqueue_of_cpu(0)  # runqueue
+```
+
+## Further reading
+
+- [kdump and crash](kdump.md) — post-mortem crash analysis
+- [Oops analysis](oops-analysis.md) — decoding oops without a debugger
+- [Kernel Modules](../modules/module-basics.md) — loading module debug symbols
+- [Tracing: ftrace](../tracing/ftrace.md) — lighter-weight alternative to breakpoints
+- `Documentation/dev-tools/kgdb.rst` in the kernel tree

--- a/docs/debugging/oops-analysis.md
+++ b/docs/debugging/oops-analysis.md
@@ -1,0 +1,260 @@
+# Kernel Oops Analysis
+
+> Reading oops output, decoding addresses, and finding the bug
+
+## What is a kernel oops?
+
+A **kernel oops** is a non-fatal kernel error — the kernel detected an inconsistency (usually a NULL pointer dereference, bad memory access, or BUG()) but can keep running (though the offending task is killed). A **kernel panic** is a fatal oops or a situation where the kernel cannot safely continue.
+
+## Anatomy of an oops message
+
+```
+[  123.456789] BUG: kernel NULL pointer dereference, address: 0000000000000018
+[  123.456790] #PF: supervisor read access in kernel mode
+[  123.456791] #PF: error_code(0x0000) - not-present page
+[  123.456792] PGD 0 P4D 0
+[  123.456793] Oops: 0000 [#1] PREEMPT SMP NOPTI
+```
+
+Breaking down the first line:
+- `BUG: kernel NULL pointer dereference` — the fault type
+- `address: 0x18` — the virtual address that caused the fault (0x18 = offset 24 in a struct)
+
+The error code `0000`:
+- Bit 0 = 0: page not present (vs protection fault)
+- Bit 1 = 0: read (vs write)
+- Bit 2 = 0: kernel mode (vs user mode)
+
+```
+[  123.456794] CPU: 3 PID: 1234 Comm: myapp Tainted: G  --------- -  5.19.0 #1
+[  123.456795] Hardware name: QEMU Standard PC, BIOS rel-1.16.0
+[  123.456796] RIP: 0010:mydriver_write+0x34/0xb0 [mydriver]
+```
+
+- `CPU: 3` — which CPU was running
+- `PID: 1234 Comm: myapp` — the task that triggered the oops
+- `Tainted: G` — kernel taint flags (G = proprietary module loaded)
+- `RIP: 0010:` — instruction pointer, `0010` = kernel code segment
+- `mydriver_write+0x34/0xb0` — function + offset / function size
+
+### Taint flags
+
+```
+G — proprietary module
+P — forced module load (bad signature)
+S — SMP unsafe module
+M — machine check exception
+B — bad page
+U — user (userspace explicitly loaded)
+D — died (OOPS has been recorded, tainted from now on)
+A — ACPI table overridden
+W — warning (taint on WARN())
+C — staging driver loaded
+I — ACPI workaround applied
+T — live patched
+```
+
+## Register dump
+
+```
+[  123.456797] RSP: 0018:ffffc900012c7d28 EFLAGS: 00010246
+[  123.456798] RAX: 0000000000000000 RBX: ffff888012345678 RCX: 0000000000000040
+[  123.456799] RDX: 0000000000000001 RSI: 00007fff12345678 RDI: ffff888087654321
+[  123.456800] RBP: ffffc900012c7d60 R08: 0000000000000000 R09: 0000000000000000
+[  123.456801] R10: 0000000000000000 R11: 0000000000000246 R12: ffff888087654321
+[  123.456802] R13: ffff888012345678 R14: 0000000000000040 R15: 00007fff12345678
+[  123.456803] FS:  00007f1234567890(0000) GS:ffff88813fc00000(0000) knlGS:0000000000000000
+[  123.456804] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[  123.456805] CR2: 0000000000000018 CR3: 000000010a234000 CR4: 00000000003506e0
+```
+
+Key registers for diagnosis:
+- `RIP` — where the crash happened
+- `CR2` — the faulting address (for page faults)
+- `RAX = 0` — often the NULL pointer that was dereferenced
+- `RBX`, `R12-15` — often hold struct pointers; can reveal the data structure
+
+**The offset trick**: `CR2 = 0x18 = 24`. A struct member at offset 24 from a NULL pointer. Count struct fields to identify which member was accessed.
+
+## Stack trace
+
+```
+[  123.456806] Call Trace:
+[  123.456807]  <TASK>
+[  123.456808]  mydriver_write+0x34/0xb0 [mydriver]
+[  123.456809]  vfs_write+0xb5/0x2a0
+[  123.456810]  ksys_write+0x67/0xe0
+[  123.456811]  __x64_sys_write+0x1d/0x30
+[  123.456812]  do_syscall_64+0x3b/0x80
+[  123.456813]  entry_SYSCALL_64_after_hwframe+0x63/0xcd
+[  123.456814]  </TASK>
+```
+
+Read from top (most recent) to bottom (oldest call). The crash happened in `mydriver_write` at offset `0x34` within the function.
+
+## addr2line: finding the source line
+
+Given the faulting address, find the exact source line:
+
+```bash
+# Method 1: addr2line with vmlinux
+addr2line -e /usr/lib/debug/vmlinux ffffffff81234567
+# /build/linux/drivers/mydriver/mydriver.c:245
+
+# With function name:
+addr2line -e vmlinux -f ffffffff81234567
+# mydriver_write
+# /build/linux/drivers/mydriver/mydriver.c:245
+
+# Method 2: for a module (needs unstripped .ko)
+addr2line -e mydriver.ko 0x34   # offset within the module
+# /path/to/mydriver.c:245
+```
+
+## decode_stacktrace.sh
+
+The kernel ships a script that resolves all addresses in a stack trace:
+
+```bash
+# Pipe the oops through decode_stacktrace
+./scripts/decode_stacktrace.sh /path/to/vmlinux /path/to/kernel/source < oops.txt
+
+# Or with modules:
+./scripts/decode_stacktrace.sh vmlinux . mydriver.ko < oops.txt
+```
+
+Output resolves each `function+0xNN/0xNN` to `function (file.c:line)`.
+
+## objdump: disassembling around the crash
+
+```bash
+# Disassemble the function that crashed
+objdump -d --start-address=0xffffffff81234500 --stop-address=0xffffffff81234600 vmlinux
+
+# For a module:
+objdump -d mydriver.ko | grep -A 30 "<mydriver_write>"
+```
+
+The crash was at offset `0x34` in `mydriver_write`:
+
+```
+0000000000000000 <mydriver_write>:
+   0: push %rbp
+   1: mov %rsp,%rbp
+  ...
+  34: mov 0x18(%rax),%rdx    ← crash here: rax was NULL, accessing offset 0x18
+  38: test %rdx,%rdx
+```
+
+This tells us: `%rax` was NULL, and the code tried to read member at offset 0x18 from it.
+
+## Common oops patterns
+
+### NULL pointer dereference
+
+```
+BUG: kernel NULL pointer dereference, address: 0000000000000018
+RIP: mydriver_write+0x34/0xb0
+RAX: 0000000000000000
+```
+
+Diagnosis: `RAX = 0` (the NULL pointer). Offset `0x18` tells you which field. Look at the struct at that offset.
+
+```c
+/* If the struct is: */
+struct mydev {
+    spinlock_t lock;      /* offset 0 */
+    void *private;        /* offset 8 */
+    struct device *dev;   /* offset 16 = 0x10 */
+    int refcount;         /* offset 24 = 0x18 ← this field */
+};
+/* Reading offset 0x18 = reading mydev->refcount from a NULL mydev* */
+```
+
+### Use-after-free
+
+```
+BUG: KASAN: use-after-free in mydriver_read+0x45/0x100
+Read of size 8 at addr ffff888012345678 by task myapp/1234
+Freed by task 5678:
+  kfree+0x...
+  mydriver_cleanup+0x...
+Allocated by task 1234:
+  kmalloc+0x...
+  mydriver_probe+0x...
+```
+
+KASAN shows exactly where the memory was allocated and freed — invaluable for race conditions.
+
+### Stack overflow
+
+```
+BUG: stack guard page was hit at 0000000012345678 (stack is 0xffff888012340000..0xffff888012348000)
+kernel stack overflow (page fault): 0000 [#1] PREEMPT SMP
+```
+
+Kernel stacks are typically 8-16KB. Deep recursion (e.g., deep VFS recursion with overlayfs) can overflow them.
+
+### Soft lockup
+
+```
+watchdog: BUG: soft lockup - CPU#3 stuck for 22s!
+Modules linked in: ...
+CPU: 3 PID: 5678 Comm: kworker/3:1
+Call Trace:
+  <IRQ>
+  do_something_slow+0x123/0x456
+```
+
+The CPU hasn't scheduled in 20+ seconds. Usually: holding a spinlock too long, or a tight loop without `cond_resched()`.
+
+### RCU stall
+
+```
+rcu: INFO: rcu_sched self-detected stall on CPU 2 (...)
+rcu:     3-second stall for cpumask={2} (t=...
+rcu: rcu_sched kthread starved for ...ms
+```
+
+An RCU read-side critical section has been held for too long, or the RCU grace period is stalled. Often caused by holding a lock while preemption is disabled for an extended time.
+
+## BUG() and WARN()
+
+```c
+/* In kernel code: force an oops at a specific point */
+BUG();                      /* always: oops + stack trace */
+BUG_ON(condition);          /* conditional */
+
+WARN();                     /* log + stack trace, but continue */
+WARN_ON(condition);
+WARN_ON_ONCE(condition);    /* print only once */
+WARN_ONCE(condition, fmt);
+```
+
+`WARN` is useful for detecting unexpected conditions without crashing the system. Check `dmesg` for `WARNING:` lines even if the system seems fine.
+
+## netconsole: capture oops over the network
+
+For headless servers where you can't see the serial console:
+
+```bash
+# Load netconsole (or configure as module)
+modprobe netconsole netconsole=@192.168.1.10/eth0,@192.168.1.1/00:11:22:33:44:55
+# Format: @src_ip/src_dev,@dst_ip/dst_mac
+
+# On the receiving machine:
+nc -ulp 6666   # listen on default netconsole port
+
+# Or with dynamic netconsole:
+echo "192.168.1.10/eth0,6666,192.168.1.1,6666,00:11:22:33:44:55" > \
+    /sys/kernel/debug/netconsole/target1/enabled
+```
+
+## Further reading
+
+- [kdump and crash](kdump.md) — automated crash dump collection
+- [KGDB](kgdb.md) — live kernel debugging
+- [Memory Management: KASAN](../mm/kasan.md) — memory error detection
+- [Memory Management: KFENCE](../mm/kfence.md) — lightweight production memory checking
+- [Tracing: kprobes](../tracing/kprobes-tracepoints.md) — probing without crashing
+- `scripts/decode_stacktrace.sh` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -332,3 +332,8 @@ nav:
     - Getting Started: iommu/README.md
     - IOMMU Architecture: iommu/iommu-arch.md
     - DMA API: iommu/dma-api.md
+  - Kernel Debugging:
+    - Getting Started: debugging/README.md
+    - KGDB: debugging/kgdb.md
+    - kdump and crash: debugging/kdump.md
+    - Oops Analysis: debugging/oops-analysis.md


### PR DESCRIPTION
## Summary

- **KGDB** (`kgdb.md`): Serial and netconsole transport setup, kernel config requirements, complete GDB session example, GDB kernel Python scripts (lx-ps/lx-dmesg/lx-lsmod/lx-symbols), module symbol loading with sysfs addresses, KDB built-in debugger commands, common scenarios (oops debugging, race detection with ignore N, scheduler state inspection)
- **kdump** (`kdump.md`): kexec two-kernel mechanism diagram, `crashkernel=` reservation, kdump-tools setup, `crash` tool full command reference (bt/ps/task/files/kmem/struct/vm/pte/log/mod), backtrace reading guide, makedumpfile with compression levels, pstore/ramoops for embedded systems, panic behavior tuning knobs
- **Oops analysis** (`oops-analysis.md`): Oops header anatomy (fault type, PF error code bits), taint flag table, register dump reading (CR2 faulting address, NULL pointer identification, struct offset trick), call trace format, addr2line and decode_stacktrace.sh, objdump disassembly at crash offset, common patterns (NULL deref, KASAN use-after-free, stack overflow, soft lockup, RCU stall), BUG()/WARN() macros, netconsole for headless capture

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] Kernel Debugging nav section renders
- [ ] Cross-links to KASAN, KFENCE, tracing sections resolve