### PR TITLE
Add crypto subsystem documentation

### DIFF
--- a/docs/crypto/README.md
+++ b/docs/crypto/README.md
@@ -1,0 +1,55 @@
+# Crypto Subsystem
+
+> Cryptographic algorithms, kernel key management, and storage encryption
+
+## The crypto stack
+
+```
+User space:    openssl / libgcrypt / kernel keyctl
+                         │
+      ┌──────────────────┼───────────────────────┐
+      │                  │                        │
+  AF_ALG socket     kernel keyring           dm-crypt / fscrypt
+  (access kernel    (key storage)            (disk/file encryption)
+   crypto from       struct key
+   userspace)             │
+      │                   │
+      └──────────┬─────────┘
+                 │
+         Kernel Crypto API
+         (crypto/*)
+         struct crypto_alg
+         ┌──────────────────────────────┐
+         │ SKCIPHER  AEAD  HASH  AKCIPHER│
+         │ (AES-XTS) (AES-GCM) (SHA-256)│
+         └──────────────────────────────┘
+                 │
+         Hardware acceleration
+         Intel AES-NI / QAT / ARM CE
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Kernel Crypto API](crypto-api.md) | struct crypto_alg, SKCIPHER, AEAD, hash, hardware offload |
+| [dm-crypt and fscrypt](encryption.md) | Block-level and file-level encryption, keyring integration |
+
+## Quick reference
+
+```bash
+# List available crypto algorithms
+cat /proc/crypto
+
+# Check if AES-NI is available
+grep aes /proc/cpuinfo
+
+# Test crypto performance
+cryptsetup benchmark
+# Testing 128 bit cipher AES-XTS... 1234.5 MiB/s
+
+# Key management
+keyctl show           # show process keyrings
+keyctl add user mykey "mysecret" @u
+keyctl search @u user mykey
+```

--- a/docs/crypto/crypto-api.md
+++ b/docs/crypto/crypto-api.md
@@ -1,0 +1,304 @@
+# Kernel Crypto API
+
+> Symmetric ciphers, AEAD, hash functions, and hardware acceleration
+
+## Overview
+
+The Linux kernel crypto API provides a unified interface to cryptographic operations. Callers request a transform by name (e.g., `"gcm(aes)"`, `"sha256"`) and the subsystem selects the best available implementation — software fallback or hardware accelerator.
+
+## struct crypto_alg
+
+Every cryptographic algorithm registers a `struct crypto_alg`:
+
+```c
+/* include/linux/crypto.h */
+struct crypto_alg {
+    struct list_head    cra_list;
+    struct list_head    cra_users;
+
+    u32                 cra_flags;      /* CRYPTO_ALG_TYPE_* */
+    unsigned int        cra_blocksize;  /* cipher block size */
+    unsigned int        cra_ctxsize;    /* size of transform context */
+    unsigned int        cra_alignmask; /* required alignment */
+
+    int                 cra_priority;  /* higher = preferred (e.g., AES-NI > software) */
+    atomic_t            cra_refcnt;
+
+    char                cra_name[CRYPTO_MAX_ALG_NAME];    /* "aes", "sha256", ... */
+    char                cra_driver_name[CRYPTO_MAX_ALG_NAME]; /* "aes-aesni", ... */
+
+    const struct crypto_type *cra_type;
+
+    union {
+        struct ablkcipher_alg  ablkcipher;
+        struct blkcipher_alg   blkcipher;
+        struct cipher_alg      cipher;
+        struct compress_alg    compress;
+    } cra_u;
+
+    int (*cra_init)(struct crypto_tfm *tfm);
+    void (*cra_exit)(struct crypto_tfm *tfm);
+    void (*cra_destroy)(struct crypto_alg *alg);
+
+    struct module          *cra_module;
+};
+```
+
+## SKCIPHER: symmetric ciphers
+
+SKCIPHER (synchronous key cipher) is the API for symmetric block ciphers like AES-CBC, AES-XTS, ChaCha20:
+
+```c
+#include <crypto/skcipher.h>
+
+/* Allocate a cipher transform */
+struct crypto_skcipher *tfm = crypto_alloc_skcipher("xts(aes)", 0, 0);
+if (IS_ERR(tfm)) {
+    pr_err("Failed to allocate xts(aes): %ld\n", PTR_ERR(tfm));
+    return PTR_ERR(tfm);
+}
+
+/* Set key (XTS needs 2x key: data key + tweak key) */
+u8 key[64];  /* 32 bytes data + 32 bytes tweak = AES-256-XTS */
+get_random_bytes(key, sizeof(key));
+crypto_skcipher_setkey(tfm, key, sizeof(key));
+
+/* Allocate a request (holds per-operation state) */
+struct skcipher_request *req = skcipher_request_alloc(tfm, GFP_KERNEL);
+
+/* Set up scatter-gather I/O */
+struct scatterlist sg;
+sg_init_one(&sg, plaintext_buf, buflen);
+
+/* IV for XTS: sector number */
+u8 iv[16] = { 0 };  /* sector 0 */
+skcipher_request_set_crypt(req, &sg, &sg, buflen, iv);
+
+/* Encrypt in-place (synchronous) */
+int ret = crypto_skcipher_encrypt(req);
+
+/* Decrypt */
+skcipher_request_set_crypt(req, &sg, &sg, buflen, iv);
+ret = crypto_skcipher_decrypt(req);
+
+/* Cleanup */
+skcipher_request_free(req);
+crypto_free_skcipher(tfm);
+```
+
+### Common cipher names
+
+```
+"cbc(aes)"          AES-CBC (128/192/256 bit key)
+"xts(aes)"          AES-XTS (disk encryption)
+"ctr(aes)"          AES-CTR (stream cipher mode)
+"gcm(aes)"          AES-GCM (AEAD — see below)
+"chacha20"          ChaCha20 stream cipher
+"chacha20poly1305"  ChaCha20-Poly1305 (AEAD)
+"ecb(aes)"          AES-ECB (avoid — deterministic)
+```
+
+## AEAD: authenticated encryption
+
+AEAD (Authenticated Encryption with Associated Data) provides confidentiality AND integrity in one operation. AES-GCM is the most common kernel AEAD:
+
+```c
+#include <crypto/aead.h>
+
+struct crypto_aead *tfm = crypto_alloc_aead("gcm(aes)", 0, 0);
+
+/* Key (128, 192, or 256 bits for AES) */
+u8 key[32];  /* AES-256-GCM */
+crypto_aead_setkey(tfm, key, sizeof(key));
+
+/* Authentication tag length: 16 bytes = 128-bit tag */
+crypto_aead_setauthsize(tfm, 16);
+
+struct aead_request *req = aead_request_alloc(tfm, GFP_KERNEL);
+
+/* Layout in scatter-gather:
+   [associated data (AAD)] [plaintext/ciphertext] [auth tag (on encrypt)]
+
+   assoclen = length of AAD
+   cryptlen = length of plaintext (encrypt) or ciphertext+tag (decrypt) */
+
+struct scatterlist src[2], dst[2];
+sg_init_one(&src[0], aad, aadlen);        /* associated data */
+sg_init_one(&src[1], plaintext, ptlen);    /* plaintext */
+sg_init_one(&dst[0], aad, aadlen);        /* pass-through AAD */
+sg_init_one(&dst[1], ciphertext, ptlen + 16); /* ciphertext + 16-byte tag */
+
+u8 iv[12];   /* 96-bit IV recommended for GCM */
+get_random_bytes(iv, sizeof(iv));
+
+aead_request_set_crypt(req, src, dst, ptlen, iv);
+aead_request_set_ad(req, aadlen);
+
+/* Encrypt: outputs ciphertext + 16-byte authentication tag */
+ret = crypto_aead_encrypt(req);
+
+/* Decrypt: verifies tag, returns -EBADMSG if authentication fails */
+aead_request_set_crypt(req, src, dst, ptlen + 16, iv);
+aead_request_set_ad(req, aadlen);
+ret = crypto_aead_decrypt(req);
+if (ret == -EBADMSG)
+    pr_err("Authentication failed — data corrupted or tampered\n");
+```
+
+## Hash functions
+
+```c
+#include <crypto/hash.h>
+
+/* Simple SHA-256 hash */
+struct crypto_shash *tfm = crypto_alloc_shash("sha256", 0, 0);
+
+SHASH_DESC_ON_STACK(desc, tfm);  /* allocate desc on stack */
+desc->tfm = tfm;
+
+u8 digest[32];
+crypto_shash_init(desc);
+crypto_shash_update(desc, data, datalen);
+crypto_shash_final(desc, digest);
+
+/* Or: one-shot */
+crypto_shash_digest(desc, data, datalen, digest);
+
+crypto_free_shash(tfm);
+```
+
+### HMAC
+
+```c
+struct crypto_shash *tfm = crypto_alloc_shash("hmac(sha256)", 0, 0);
+crypto_shash_setkey(tfm, hmac_key, keylen);
+
+SHASH_DESC_ON_STACK(desc, tfm);
+desc->tfm = tfm;
+
+u8 mac[32];
+crypto_shash_digest(desc, message, msglen, mac);
+```
+
+## Asynchronous (ahash) API
+
+For large data or hardware offload, use the async hash API:
+
+```c
+struct crypto_ahash *tfm = crypto_alloc_ahash("sha256", 0, 0);
+struct ahash_request *req = ahash_request_alloc(tfm, GFP_KERNEL);
+
+struct scatterlist sg;
+sg_init_one(&sg, data, datalen);
+ahash_request_set_crypt(req, &sg, digest, datalen);
+
+/* Complete callback for async operation */
+ahash_request_set_callback(req, CRYPTO_TFM_REQ_MAY_BACKLOG,
+                            my_hash_complete, &completion);
+
+ret = crypto_ahash_digest(req);
+if (ret == -EINPROGRESS)
+    wait_for_completion(&completion);  /* hardware processing */
+```
+
+## Hardware acceleration
+
+The crypto subsystem automatically uses hardware accelerators when available. The `cra_priority` field determines selection:
+
+| Priority | Implementation |
+|----------|---------------|
+| 4001 | Intel QAT hardware |
+| 800  | Intel AES-NI + PCLMULQDQ |
+| 300  | Generic C implementation |
+
+```bash
+# See which implementation is selected
+cat /proc/crypto | grep -A 10 "name.*gcm"
+# name         : gcm(aes)
+# driver       : gcm_base(ctr(aes-aesni),ghash-clmulni-intel)
+# module       : kernel
+# priority     : 800     ← AES-NI selected
+
+# Force software implementation (for testing)
+modprobe tcrypt mode=1  # run crypto test suite
+```
+
+### Intel AES-NI
+
+AES-NI adds hardware instructions for AES rounds. The kernel implementation uses them via SIMD (SSE/AVX) register operations:
+
+```c
+/* arch/x86/crypto/aesni-intel_glue.c */
+static int aesni_skcipher_encrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher *tfm = crypto_skcipher_reqtfm(req);
+    struct crypto_aes_ctx *ctx = aes_ctx(crypto_skcipher_ctx(tfm));
+
+    /* Kernel must save/restore SIMD registers around these calls */
+    if (!crypto_simd_usable())
+        return crypto_skcipher_encrypt_fallback(req);
+
+    kernel_fpu_begin();   /* save FPU state */
+    aesni_cbc_enc(ctx, dst, src, len, iv);  /* AESENC instruction */
+    kernel_fpu_end();     /* restore FPU state */
+    return 0;
+}
+```
+
+`kernel_fpu_begin()` is relatively expensive (saves ~512 bytes of SIMD state), so AES-NI is most beneficial for large buffers.
+
+## AF_ALG: userspace access to kernel crypto
+
+AF_ALG sockets expose kernel crypto to userspace without copying data to/from kernel buffers:
+
+```c
+/* Userspace: use kernel AES-GCM via AF_ALG socket */
+int sockfd = socket(AF_ALG, SOCK_SEQPACKET, 0);
+
+struct sockaddr_alg sa = {
+    .salg_family = AF_ALG,
+    .salg_type   = "aead",
+    .salg_name   = "gcm(aes)",
+};
+bind(sockfd, (struct sockaddr *)&sa, sizeof(sa));
+
+/* Set key */
+setsockopt(sockfd, SOL_ALG, ALG_SET_KEY, key, sizeof(key));
+setsockopt(sockfd, SOL_ALG, ALG_SET_AEAD_AUTHSIZE, NULL, 16);
+
+/* Accept returns operation fd */
+int opfd = accept(sockfd, NULL, 0);
+
+/* Encrypt via sendmsg/recvmsg */
+struct cmsghdr cmsg;
+/* ... set IV, AD length in ancillary data ... */
+sendmsg(opfd, &msg, 0);
+recvmsg(opfd, &msg_out, 0);
+```
+
+## Observing the crypto subsystem
+
+```bash
+# All registered algorithms with priority
+cat /proc/crypto
+
+# Crypto test suite (requires CONFIG_CRYPTO_TEST)
+modprobe tcrypt mode=1   # test all algorithms
+modprobe tcrypt mode=200 # benchmark AES
+# testing AES-128-ECB encryption
+#  128 bit key:  1234.5 MB/s
+
+# Hardware utilization (QAT example)
+cat /sys/kernel/debug/qat_*/fw_counters
+
+# CPU cycles for crypto (perf)
+perf stat -e instructions,cycles cryptsetup benchmark
+```
+
+## Further reading
+
+- [dm-crypt and fscrypt](encryption.md) — using kernel crypto for storage
+- [BPF: verifier](../bpf/bpf-verifier.md) — BPF crypto helpers
+- [Security: seccomp](../security/seccomp.md) — restricting crypto syscalls
+- `crypto/` in the kernel tree — algorithm implementations
+- `Documentation/crypto/` in the kernel tree

--- a/docs/crypto/encryption.md
+++ b/docs/crypto/encryption.md
@@ -1,0 +1,311 @@
+# dm-crypt and fscrypt
+
+> Block-level and file-level encryption in Linux
+
+## Two encryption layers
+
+Linux provides encryption at two levels:
+
+| Layer | Subsystem | What's encrypted | Key granularity |
+|-------|-----------|-----------------|-----------------|
+| Block device | dm-crypt | Entire partition/disk | One key per volume |
+| Filesystem | fscrypt | Individual files/dirs | Per-file or per-directory keys |
+
+dm-crypt is transparent to the filesystem; fscrypt is transparent to applications but per-file.
+
+## dm-crypt: block-level encryption
+
+dm-crypt is a device mapper target that transparently encrypts reads and writes using the kernel crypto API.
+
+```
+Application → read/write /dev/mapper/myvolume
+                              │
+                         dm-crypt layer
+                         (AES-XTS decrypt/encrypt)
+                              │
+                         /dev/sda2 (ciphertext on disk)
+```
+
+### LUKS: Linux Unified Key Setup
+
+LUKS is the standard format for dm-crypt volumes. It stores encrypted key material in a header, allowing multiple passphrases to unlock the same volume:
+
+```bash
+# Create a LUKS volume
+cryptsetup luksFormat /dev/sda2
+# Enter passphrase
+
+# Open (decrypt) the volume
+cryptsetup luksOpen /dev/sda2 myvolume
+# /dev/mapper/myvolume now exists
+
+# Use it like any block device
+mkfs.ext4 /dev/mapper/myvolume
+mount /dev/mapper/myvolume /mnt/secure
+
+# Close (re-encrypt the volume key, remove device)
+umount /mnt/secure
+cryptsetup luksClose myvolume
+```
+
+### dm-crypt internals
+
+```c
+/* drivers/md/dm-crypt.c */
+struct crypt_config {
+    struct dm_dev       *dev;           /* backing block device */
+    sector_t             start;
+
+    /* Per-CPU I/O work queues */
+    struct workqueue_struct *io_queue;
+    struct workqueue_struct *crypt_queue;
+
+    /* Crypto transform */
+    struct crypto_skcipher **tfms;      /* one per CPU for parallelism */
+    unsigned int          tfms_count;
+
+    /* IV generator */
+    struct iv_operations  *iv_gen_ops;  /* ESSIV, plain64, benbi, ... */
+    char                  iv_mode[CRYPTO_MAX_ALG_NAME];
+
+    unsigned long long    iv_offset;    /* sector number offset for IV */
+    unsigned int          iv_size;
+
+    char                  cipher_string[CRYPTO_MAX_ALG_NAME];
+
+    struct crypt_iv_operations *iv_gen_private;
+};
+
+/* Each I/O is processed in a crypt_io */
+struct dm_crypt_io {
+    struct crypt_config    *cc;
+    struct bio             *base_bio;
+    u8                     *integrity_metadata;
+
+    struct work_struct      work;   /* submitted to crypt_queue */
+
+    struct convert_context  ctx;    /* current conversion state */
+    atomic_t                io_pending;
+    blk_status_t            error;
+    sector_t                sector;
+};
+```
+
+### AES-XTS: why not CBC?
+
+dm-crypt uses AES-XTS (XEX-based tweaked-codebook mode with ciphertext stealing) rather than AES-CBC for disk encryption:
+
+**CBC weakness for disk encryption**: In CBC, sector 1 always encrypts to the same ciphertext for a given key (the IV is derived from the sector number). An attacker can detect which sectors have identical plaintext. AES-XTS uses a tweak derived from the physical sector number, making each sector's encryption unique.
+
+```
+AES-XTS(key, sector_num, plaintext) → ciphertext
+
+Tweak = AES_encrypt(key2, sector_num)
+For each 16-byte block i in the sector:
+  ciphertext[i] = AES_encrypt(key1, plaintext[i] XOR tweak_i) XOR tweak_i
+  tweak_{i+1}   = GF(2^128) multiplication of tweak_i
+```
+
+### IV generation
+
+dm-crypt supports several IV modes:
+
+```c
+/* IV modes (selected by the cipher string): */
+
+/* plain/plain64: IV = sector number */
+/* "aes-cbc-plain64" */
+
+/* essiv: IV = encrypt(sector_num) with SHA256 of volume key */
+/* Prevents watermarking attacks against CBC */
+/* "aes-cbc-essiv:sha256" */
+
+/* Standard for new volumes: */
+/* "aes-xts-plain64" — sector number as 64-bit LE integer */
+```
+
+## dm-integrity: authenticated block storage
+
+dm-integrity adds a per-sector checksum to detect data corruption:
+
+```bash
+# Create an integrity device (adds 4-byte CRC per 512-byte sector)
+cryptsetup open --type integrity /dev/sda2 myintegrity
+# Or combine with dm-crypt for authenticated encryption:
+cryptsetup luksFormat --integrity hmac-sha256 /dev/sda2
+```
+
+## fscrypt: filesystem-level encryption
+
+fscrypt is built into ext4, f2fs, and ubifs. It encrypts file contents and filenames, with keys stored in the kernel keyring.
+
+```
+Directory with encryption policy:
+  /encrypted/
+  ├── Afvd3kLm (encrypted filename → real: "secret.txt")
+  └── Bxyz9pQr (encrypted filename → real: "notes.md")
+
+Reading a file:
+  open("/encrypted/Afvd3kLm") → page cache miss
+  → read block from disk (ciphertext)
+  → fscrypt_decrypt_pagecache_blocks()
+  → AES-256-XTS with per-file derived key
+  → return plaintext
+```
+
+### Setting up fscrypt
+
+```bash
+# Requires CONFIG_FS_ENCRYPTION=y and an fscrypt-capable filesystem
+
+# Generate a master key (256 bits)
+keyctl new_session
+fscryptctl generate-key > master.key
+
+# Add master key to filesystem
+fscryptctl add-key /mnt/myfs < master.key
+# Key identifier: 0123456789abcdef0123456789abcdef
+
+# Set encryption policy on a directory
+fscryptctl set-policy 0123456789abcdef0123456789abcdef /mnt/myfs/private/
+# Now all files created under /mnt/myfs/private/ are encrypted
+
+# After unmounting and remounting without the key:
+# filenames appear as ciphertext, content unreadable
+```
+
+### Key hierarchy
+
+fscrypt derives per-file keys from the master key using HKDF-SHA512:
+
+```
+Master key (256 bit)
+      │
+      │ HKDF-SHA512(master_key, "fscrypt\0" || context || nonce)
+      ▼
+Per-file key (256 bit, unique per inode)
+      │
+      │ AES-256-XTS
+      ▼
+Encrypted content
+```
+
+The nonce stored in the inode is unique per file, ensuring different keys for files with identical content.
+
+### fscrypt policies
+
+```c
+/* include/uapi/linux/fscrypt.h */
+struct fscrypt_policy_v2 {
+    __u8 version;                       /* FSCRYPT_POLICY_V2 = 2 */
+    __u8 contents_encryption_mode;      /* FSCRYPT_MODE_AES_256_XTS */
+    __u8 filenames_encryption_mode;     /* FSCRYPT_MODE_AES_256_CTS */
+    __u8 flags;                         /* FSCRYPT_POLICY_FLAGS_PAD_* */
+    __u8 log2_data_unit_size;           /* 0 = filesystem block size */
+    __u8 __reserved[3];
+    __u8 master_key_identifier[FSCRYPT_KEY_IDENTIFIER_SIZE]; /* 16 bytes */
+};
+
+/* Encryption modes: */
+FSCRYPT_MODE_AES_256_XTS   /* for file contents (recommended) */
+FSCRYPT_MODE_AES_256_CTS   /* for filenames */
+FSCRYPT_MODE_AES_128_CBC   /* legacy */
+FSCRYPT_MODE_ADIANTUM      /* for low-power devices (no AES-NI) */
+```
+
+### fscrypt in the kernel
+
+```c
+/* fs/crypto/crypto.c */
+int fscrypt_decrypt_pagecache_blocks(struct folio *folio, size_t len,
+                                      size_t offs)
+{
+    const struct inode *inode = folio->mapping->host;
+    const unsigned int du_bits = inode->i_crypt_info->ci_data_unit_bits;
+    const unsigned int du_size = 1U << du_bits;
+    u64 index = ((u64)folio->index << (PAGE_SHIFT - du_bits)) + (offs >> du_bits);
+    unsigned int i;
+
+    for (i = offs; i < offs + len; i += du_size, index++) {
+        /* Derive IV from file offset (sector number equivalent) */
+        u64 lblk_num = index;  /* logical block number */
+
+        /* Decrypt using per-file key */
+        fscrypt_crypt_block(inode, FS_DECRYPT, lblk_num,
+                            folio_page(folio, i >> PAGE_SHIFT), ...);
+    }
+    return 0;
+}
+```
+
+## Kernel keyring integration
+
+Both dm-crypt (via cryptsetup) and fscrypt store key material in the kernel keyring:
+
+```bash
+# View current keyring
+keyctl show @s         # session keyring
+keyctl show @u         # user keyring
+keyctl show @us        # user-session keyring
+
+# Add a dm-crypt volume key to the keyring
+keyctl add logon cryptsetup:0123456789abcdef <key_data> @s
+
+# Add an fscrypt master key
+keyctl add logon fscrypt:0123456789abcdef <key_data> @s
+
+# Key types used:
+# "user": arbitrary user data
+# "logon": kernel-only (cannot be read back by userspace)
+# "keyring": a keyring itself (can hold other keys)
+# "encrypted": encrypted with a master key
+```
+
+```c
+/* Kernel: look up a key */
+struct key *key = request_key(&key_type_logon, "fscrypt:...", NULL);
+const struct user_key_payload *ukp = user_key_payload_locked(key);
+memcpy(master_key, ukp->data, ukp->datalen);
+key_put(key);
+```
+
+## Observing encryption
+
+```bash
+# dm-crypt status
+cryptsetup status myvolume
+# /dev/mapper/myvolume is active and is in use.
+#   type:    LUKS2
+#   cipher:  aes-xts-plain64
+#   keysize: 512 bits     (256 data + 256 tweak for XTS)
+#   key location: dm-crypt
+#   device:  /dev/sda2
+
+# LUKS header info
+cryptsetup luksDump /dev/sda2
+
+# fscrypt status
+fscryptctl get-policy /mnt/myfs/private/
+# Encryption policy for /mnt/myfs/private/:
+#   Policy version: 2
+#   Master key identifier: 0123456789abcdef0123456789abcdef
+#   Contents encryption mode: AES-256-XTS
+#   Filenames encryption mode: AES-256-CTS
+
+# Performance
+cryptsetup benchmark
+# Tests common cipher/mode combinations
+
+# Block layer stats (I/O through dm-crypt)
+cat /sys/block/dm-0/stat
+```
+
+## Further reading
+
+- [Kernel Crypto API](crypto-api.md) — AES-XTS and AEAD internals
+- [Memory Management: DMA](../mm/dma.md) — DMA for hardware crypto engines
+- [Security: Capabilities](../security/capabilities.md) — `CAP_SYS_ADMIN` for dm setup
+- [Block Layer: bio and request](../block/bio-request.md) — bio processing through dm-crypt
+- `drivers/md/dm-crypt.c` — dm-crypt implementation
+- `fs/crypto/` — fscrypt implementation
+- `man 8 cryptsetup` — LUKS management

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -337,3 +337,7 @@ nav:
     - KGDB: debugging/kgdb.md
     - kdump and crash: debugging/kdump.md
     - Oops Analysis: debugging/oops-analysis.md
+  - Crypto:
+    - Getting Started: crypto/README.md
+    - Kernel Crypto API: crypto/crypto-api.md
+    - dm-crypt and fscrypt: crypto/encryption.md


### PR DESCRIPTION
## Summary

- **Kernel Crypto API** (`crypto-api.md`): `struct crypto_alg` layout with priority-based selection, SKCIPHER API with AES-XTS encrypt/decrypt scatter-gather example, AEAD AES-GCM with associated data and `-EBADMSG` auth failure, HMAC with `hmac(sha256)`, async `ahash_request` for hardware offload, Intel AES-NI with `kernel_fpu_begin()` SIMD save/restore, AF_ALG socket for userspace access, `/proc/crypto` observability
- **dm-crypt and fscrypt** (`encryption.md`): dm-crypt as device mapper target, LUKS2 header format and cryptsetup workflow, `crypt_config`/`dm_crypt_io` internals, AES-XTS tweak construction and why it's better than CBC for disk encryption, IV generation modes (plain64/essiv), dm-integrity for authenticated storage; fscrypt with HKDF-SHA512 key derivation per inode, `fscrypt_policy_v2` with Adiantum for low-power devices, `fscrypt_decrypt_pagecache_blocks` page cache path, kernel keyring with `logon` key type

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] Crypto nav section renders
- [ ] Cross-links to block layer, mm/dma, security sections resolve