### PR TITLE
Add advanced networking documentation

### DIFF
--- a/docs/net/container-networking.md
+++ b/docs/net/container-networking.md
@@ -1,0 +1,256 @@
+# Container Networking
+
+> How Docker, Kubernetes, and container runtimes implement network isolation
+
+## The building blocks
+
+Container networking is built from three Linux primitives:
+
+1. **Network namespaces** — isolated network stacks (interfaces, routes, iptables)
+2. **veth pairs** — virtual Ethernet cable connecting two namespaces
+3. **Linux bridge** — software switch connecting veth pairs
+
+```
+Host network namespace                 Container namespace
+┌─────────────────────────┐            ┌──────────────────────┐
+│  eth0 (physical)         │            │  eth0 (veth1's peer) │
+│  docker0 (bridge)        │            │  10.0.0.2/24         │
+│  ├── veth0 (10.0.0.1)   │════════════│  (sees only this)    │
+│  └── veth2              │════════════│                      │
+│  iptables MASQUERADE     │            └──────────────────────┘
+└─────────────────────────┘
+```
+
+## veth pairs
+
+A veth pair is two virtual interfaces connected back-to-back. Packets sent to one end emerge from the other:
+
+```bash
+# Create a veth pair
+ip link add veth0 type veth peer name veth1
+
+# veth0 stays in host namespace
+# veth1 is moved to container's network namespace
+ip link set veth1 netns <container_pid>
+
+# Configure both ends
+ip addr add 10.0.0.1/24 dev veth0
+ip link set veth0 up
+
+# Inside container:
+nsenter -t <container_pid> -n ip addr add 10.0.0.2/24 dev veth1
+nsenter -t <container_pid> -n ip link set veth1 up
+nsenter -t <container_pid> -n ip route add default via 10.0.0.1
+```
+
+### veth in the kernel
+
+```c
+/* drivers/net/veth.c */
+struct veth_priv {
+    struct net_device __rcu *peer;      /* the other end */
+    atomic64_t               dropped;
+    struct veth_rq          *rq;        /* RX queues */
+    unsigned int             requested_headroom;
+    bool                     rx_notify_masked;
+    struct ptr_ring         *xdp_ring;  /* XDP ring buffer */
+};
+
+/* TX: just deliver to the peer's RX */
+static netdev_tx_t veth_xmit(struct sk_buff *skb, struct net_device *dev)
+{
+    struct veth_priv *rcv_priv, *priv = netdev_priv(dev);
+    struct net_device *rcv;
+
+    rcv = rcu_dereference(priv->peer);
+    if (!rcv)
+        goto drop;
+
+    /* Deliver directly to peer's softirq RX path */
+    if (veth_forward_skb(rcv, skb, rq, use_napi) == NET_RX_DROP) {
+        /* ... */
+    }
+    return NETDEV_TX_OK;
+}
+```
+
+No actual hardware involved — packets cross from one namespace to another via `netif_rx()`.
+
+## Linux bridge
+
+The bridge acts as a software L2 switch. veth host-side interfaces are attached as bridge ports:
+
+```bash
+# Create a bridge (docker0 equivalent)
+ip link add docker0 type bridge
+ip addr add 172.17.0.1/16 dev docker0
+ip link set docker0 up
+
+# Attach veth host-sides to the bridge
+ip link set veth0 master docker0
+ip link set veth2 master docker0
+
+# Now: containers connected to docker0 can communicate with each other
+# and through the host's routing table
+```
+
+### Bridge forwarding
+
+```c
+/* net/bridge/br_forward.c */
+/* When a frame arrives on a bridge port: */
+void br_forward(const struct net_bridge_port *to, struct sk_buff *skb,
+                bool local_rcv, bool local_orig)
+{
+    /* Look up destination MAC in FDB (forwarding database) */
+    struct net_bridge_fdb_entry *dst = br_fdb_find_rcu(to->br, dest, vid);
+    if (dst) {
+        /* Unicast: forward to specific port */
+        __br_forward(dst->dst, skb, local_orig);
+    } else {
+        /* Unknown unicast: flood to all ports */
+        br_flood(to->br, skb, BR_PKT_UNICAST, local_rcv, local_orig);
+    }
+}
+```
+
+The bridge maintains a MAC→port forwarding database (FDB), learning from incoming packets. `bridge fdb show` displays it.
+
+## NAT / masquerade
+
+Containers need to reach the internet. The host NATs outgoing traffic:
+
+```bash
+# iptables NAT masquerade (what Docker adds)
+iptables -t nat -A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
+
+# nftables equivalent
+nft add rule ip nat POSTROUTING ip saddr 172.17.0.0/16 oif != "docker0" masquerade
+```
+
+When container `172.17.0.2` sends to `8.8.8.8`:
+1. Packet leaves container via `eth0` → veth → bridge → host routing
+2. Host sees source `172.17.0.2` → matches MASQUERADE rule
+3. Connection tracking records the mapping: `172.17.0.2:54321 → host_ip:RANDOM`
+4. Source IP rewritten to host IP
+5. Reply comes back to host IP → conntrack → translated back → forwarded to container
+
+## Port publishing
+
+```bash
+# Docker: map host port 8080 → container port 80
+docker run -p 8080:80 nginx
+
+# Translates to iptables rules:
+iptables -t nat -A PREROUTING -p tcp --dport 8080 -j DNAT --to-destination 172.17.0.2:80
+iptables -t filter -A DOCKER -d 172.17.0.2 -p tcp --dport 80 -j ACCEPT
+```
+
+## Overlay networks (VXLAN)
+
+For multi-host container networking (Kubernetes, Docker Swarm), overlay networks encapsulate container traffic in UDP/VXLAN:
+
+```
+Node 1 (10.0.0.1)                    Node 2 (10.0.0.2)
+Container A (192.168.0.1)            Container B (192.168.0.2)
+   │                                        │
+   veth                                     veth
+   │                                        │
+   VTEP (VXLAN Tunnel Endpoint)             VTEP
+   │  encapsulate in UDP/VXLAN              │  decapsulate
+   │  outer: 10.0.0.1→10.0.0.2             │
+   └────────── physical network ────────────┘
+```
+
+```bash
+# Create a VXLAN overlay (Flannel/Calico/Cilium do this automatically)
+ip link add vxlan0 type vxlan id 100 \
+    local 10.0.0.1 \
+    remote 10.0.0.2 \
+    dstport 4789
+
+ip link set vxlan0 up
+ip addr add 192.168.0.1/24 dev vxlan0
+
+# Add a route for container B
+ip route add 192.168.0.2/32 via 10.0.0.2 dev vxlan0
+```
+
+### VXLAN in the kernel
+
+```c
+/* drivers/net/vxlan/vxlan_core.c */
+static netdev_tx_t vxlan_xmit(struct sk_buff *skb, struct net_device *dev)
+{
+    struct vxlan_dev *vxlan = netdev_priv(dev);
+
+    /* Look up VTEP for destination */
+    struct vxlan_fdb *f = vxlan_find_mac(vxlan, eth_hdr(skb)->h_dest, vni);
+
+    /* Encapsulate: inner Ethernet frame → VXLAN header → UDP → outer IP */
+    vxlan_encap_bypass(skb, vxlan, dst, vni, ...);
+    udp_tunnel_xmit_skb(vxlan->vn4_sock, rt, skb,
+                         src, remote_ip, ...);
+    return NETDEV_TX_OK;
+}
+```
+
+## Network policies (iptables vs eBPF)
+
+Traditional container firewalling uses iptables rules inserted by the runtime. For thousands of pods, this becomes a bottleneck (O(n) rule traversal):
+
+```bash
+# kube-proxy (traditional): thousands of iptables rules
+iptables -L -n | wc -l
+# 5000+  ← one rule per service endpoint
+
+# Cilium (eBPF-based): O(1) BPF map lookup
+# No iptables at all — policy enforced via XDP/TC BPF hooks
+bpf_redirect_map(&cilium_lb4_backends, backend_id, 0)
+```
+
+Cilium and other eBPF-based CNI plugins (Calico with eBPF, Flannel with VXLAN-on-eBPF) replace iptables with BPF maps — constant-time lookups regardless of rule count.
+
+## Observing container networking
+
+```bash
+# List all network namespaces
+lsns -t net
+
+# Enter a container's network namespace
+ip netns exec <ns_name> ip addr show
+# or
+nsenter -t <container_pid> -n ip addr show
+
+# Show veth peer relationship
+ip link show | grep -A1 "veth"
+# Or:
+for dev in /sys/class/net/veth*; do
+    peer_idx=$(cat "$dev/ifindex")  # wrong — it's actually iflink
+    echo "$(basename $dev) → peer ifindex $(cat $dev/iflink)"
+done
+
+# Bridge FDB (MAC learning table)
+bridge fdb show dev docker0
+
+# Watch packet flow through the bridge
+tcpdump -i docker0 -n
+
+# NAT connection tracking
+conntrack -L -p tcp | head -20
+
+# Per-veth stats
+ip -s link show veth0
+
+# VXLAN tunnel stats
+ip -s link show vxlan0
+```
+
+## Further reading
+
+- [Netfilter Architecture](netfilter.md) — iptables/nftables hooks
+- [Connection Tracking](conntrack.md) — NAT state tracking
+- [XDP](xdp.md) — eBPF networking acceleration
+- [AF_XDP](af-xdp.md) — zero-copy userspace packet processing
+- [Cgroups: Namespaces](../cgroups/namespaces.md) — network namespace internals
+- [Cgroups: Container Isolation](../cgroups/container-isolation.md) — full container setup

--- a/docs/net/ktls.md
+++ b/docs/net/ktls.md
@@ -1,0 +1,253 @@
+# Kernel TLS (kTLS)
+
+> In-kernel TLS record layer for zero-copy HTTPS
+
+## The problem kTLS solves
+
+Traditionally, TLS runs entirely in userspace (OpenSSL):
+
+```
+Application → plaintext → OpenSSL encrypt → ciphertext → write() syscall → kernel → NIC
+```
+
+This means:
+- Every TLS record copy: user buffer → kernel socket buffer
+- `sendfile()` doesn't work: data must pass through userspace for encryption
+- TLS offload to NIC requires kernel involvement anyway
+
+kTLS moves the TLS record layer into the kernel:
+
+```
+Application → plaintext → write()/sendfile() → kernel TLS encrypt → NIC
+```
+
+Benefits:
+- `sendfile()` works for TLS: zero-copy file → TLS → NIC
+- NIC TLS offload: kernel can push crypto to hardware
+- Lower CPU usage for TLS-heavy workloads (nginx, envoy)
+
+## ULP: Upper Layer Protocol
+
+kTLS is implemented as a ULP (Upper Layer Protocol) — a socket layer that intercepts send/receive between the application and TCP:
+
+```
+Application
+    │ write()/sendmsg()
+    ▼
+[ULP layer: TLS record framing + encryption]
+    │
+    ▼
+TCP layer
+    │
+    ▼
+NIC
+```
+
+## Setting up kTLS
+
+kTLS setup is done after the TLS handshake completes (e.g., via OpenSSL):
+
+```c
+#include <linux/tls.h>
+
+/* After SSL_accept()/SSL_connect() completes: */
+
+/* Step 1: Enable kTLS ULP on the socket */
+setsockopt(sockfd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
+
+/* Step 2: Get the symmetric keys negotiated by the handshake
+   (OpenSSL exposes these via SSL_get_current_cipher, SSL_CTX_set_keylog_callback,
+    or via the ktls OpenSSL engine) */
+
+/* Step 3: Configure TX crypto info */
+struct tls12_crypto_info_aes_gcm_128 crypto_info;
+crypto_info.info.version     = TLS_1_3_VERSION;  /* or TLS_1_2_VERSION */
+crypto_info.info.cipher_type = TLS_CIPHER_AES_GCM_128;
+memcpy(crypto_info.iv,  tx_iv,  sizeof(crypto_info.iv));
+memcpy(crypto_info.key, tx_key, sizeof(crypto_info.key));
+memcpy(crypto_info.salt, tx_salt, sizeof(crypto_info.salt));
+memcpy(crypto_info.rec_seq, tx_seq, sizeof(crypto_info.rec_seq));
+
+setsockopt(sockfd, SOL_TLS, TLS_TX, &crypto_info, sizeof(crypto_info));
+
+/* Step 4: Configure RX crypto info (optional — for in-kernel decrypt) */
+/* ... similar with rx_key/iv/seq ... */
+setsockopt(sockfd, SOL_TLS, TLS_RX, &crypto_info, sizeof(crypto_info));
+
+/* Now: write()/sendfile() automatically encrypts as TLS records */
+sendfile(sockfd, file_fd, NULL, file_size);
+/* ↑ Zero-copy: file pages → NIC with TLS encryption, no userspace copy */
+```
+
+## Supported cipher suites
+
+```c
+/* include/uapi/linux/tls.h */
+TLS_CIPHER_AES_GCM_128
+TLS_CIPHER_AES_GCM_256
+TLS_CIPHER_AES_CCM_128
+TLS_CIPHER_CHACHA20_POLY1305
+
+TLS_1_2_VERSION
+TLS_1_3_VERSION
+```
+
+## kTLS in the kernel
+
+```c
+/* net/tls/tls_sw.c: TLS software implementation */
+
+/* TX path: intercept sendmsg */
+static int tls_sw_sendmsg(struct sock *sk, struct msghdr *msg, size_t size)
+{
+    struct tls_context *tls_ctx = tls_get_ctx(sk);
+    struct tls_sw_context_tx *ctx = tls_sw_ctx_tx(tls_ctx);
+
+    /* Gather plaintext into a TLS record (up to 16KB) */
+    while (msg_data_left(msg)) {
+        /* Copy plaintext into record buffer */
+        copied = sk_msg_memcopy_from_iter(sk, &msg->msg_iter,
+                                           msg, try_to_copy);
+
+        /* When record is full or MSG_EOM: encrypt and send */
+        if (full_record || eor) {
+            rc = tls_push_record(sk, msg->msg_flags, record_type);
+        }
+    }
+    return copied;
+}
+
+static int tls_push_record(struct sock *sk, int flags, unsigned char record_type)
+{
+    struct tls_context *ctx = tls_get_ctx(sk);
+
+    /* Build TLS record header */
+    /* Encrypt with AEAD: plaintext → ciphertext + auth tag */
+    rc = tls_do_encryption(sk, ctx, ctx->sw_tx, aead_req, data_len, i);
+
+    /* Hand encrypted record to TCP */
+    return tls_push_sg(sk, ctx, &sg_array[0], 0, flags);
+}
+```
+
+## NIC TLS offload
+
+For hardware that supports TLS offload, kTLS can push crypto to the NIC:
+
+```
+Without NIC offload:    CPU encrypts → NIC sends ciphertext
+With NIC offload:       CPU sends plaintext → NIC encrypts and sends
+```
+
+```c
+/* net/tls/tls_device.c */
+static int tls_device_push_pending_record(struct sock *sk, int flags)
+{
+    struct tls_context *ctx = tls_get_ctx(sk);
+    struct tls_offload_context_tx *offload_ctx = tls_offload_ctx_tx(ctx);
+
+    /* The NIC driver registers tls_dev_add/del operations */
+    /* TCP segment is sent with TLS metadata (seqno, record seq) */
+    /* NIC encrypts in hardware */
+    return tls_push_sg(sk, ctx, NULL, 0, flags);
+}
+```
+
+NIC TLS offload support: Mellanox ConnectX-5/6, Intel E810, some Chelsio NICs.
+
+```bash
+# Enable NIC TLS offload (requires driver support)
+ethtool -K eth0 tls-hw-tx-offload on
+ethtool -K eth0 tls-hw-rx-offload on
+
+# Check offload status
+ethtool -k eth0 | grep tls
+# tls-hw-tx-offload: on
+# tls-hw-rx-offload: on
+```
+
+## Zero-copy sendfile for HTTPS
+
+The primary use case for kTLS is zero-copy file serving:
+
+```c
+/* HTTPS server serving static files with kTLS */
+int setup_ktls_server(int sockfd, SSL *ssl)
+{
+    /* After handshake: install kTLS */
+    setsockopt(sockfd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
+    /* ... install TX crypto info from SSL ... */
+}
+
+void serve_file(int sockfd, const char *path)
+{
+    int fd = open(path, O_RDONLY);
+    struct stat st;
+    fstat(fd, &st);
+
+    /* Zero-copy: page cache → TLS encryption → NIC */
+    /* No copy to userspace buffer needed */
+    sendfile(sockfd, fd, NULL, st.st_size);
+    close(fd);
+}
+```
+
+Traditional HTTPS flow:
+```
+disk → page cache → read() → user buffer → SSL_write() → OpenSSL encrypt → write() → kernel → NIC
+        (4 copies)
+```
+
+kTLS + sendfile flow:
+```
+disk → page cache → sendfile() → kTLS encrypt → NIC
+        (1 copy, or 0 with DMA)
+```
+
+## RX path: in-kernel decrypt
+
+When `TLS_RX` is configured, reads are decrypted in the kernel:
+
+```c
+/* Application: */
+char buf[4096];
+int n = read(sockfd, buf, sizeof(buf));
+/* buf contains decrypted plaintext — TLS record layer handled by kernel */
+
+/* Optionally: control messages for record type */
+struct msghdr msg;
+char cmsg_buf[CMSG_SPACE(sizeof(unsigned char))];
+/* ... */
+recvmsg(sockfd, &msg, 0);
+/* CMSG with SOL_TLS, TLS_GET_RECORD_TYPE: check for alerts, handshake msgs */
+```
+
+## Observing kTLS
+
+```bash
+# Check if kTLS is active on a socket
+ss -tinHp | grep -i tls
+
+# TLS statistics
+cat /proc/net/tls_stat
+# TlsCurrTxSw        5       # sockets using SW TX
+# TlsCurrRxSw        3       # sockets using SW RX
+# TlsCurrTxDevice    2       # sockets using NIC TX offload
+# TlsTxSoftware      12345   # total SW TX records
+# TlsDecryptError    0       # authentication failures
+
+# Per-socket TLS info (requires ss from iproute2 >= 5.9)
+ss -tinH --tcp state established
+
+# nginx kTLS config
+# nginx.conf: ssl_sendfile on;  (uses sendfile with kTLS)
+```
+
+## Further reading
+
+- [TCP Implementation](tcp.md) — socket layer kTLS integrates with
+- [Network Device and NAPI](napi.md) — NIC TLS offload reception
+- [Crypto: Kernel Crypto API](../crypto/crypto-api.md) — AEAD used for TLS records
+- [io_uring: Operations](../io-uring/io-uring-ops.md) — io_uring send_zc with kTLS
+- `net/tls/` in the kernel tree — kTLS implementation
+- `Documentation/networking/tls.rst` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,6 +215,9 @@ nav:
       - XDP (eXpress Data Path): net/xdp.md
       - AF_XDP Sockets: net/af-xdp.md
       - TC and qdisc: net/tc-qdisc.md
+    - Advanced:
+      - Container Networking: net/container-networking.md
+      - Kernel TLS (kTLS): net/ktls.md
     - Debugging & Observability:
       - Network Debugging with ss and ip: net/net-debugging.md
       - Network Tracing: net/net-tracing.md


### PR DESCRIPTION
## Summary

- **Container Networking** (`container-networking.md`): veth pair creation and `veth_xmit` direct-to-peer-RX delivery, Linux bridge FDB MAC learning with `br_forward`/`br_flood`, iptables MASQUERADE NAT with conntrack DNAT port publishing, VXLAN overlay with `vxlan_xmit` UDP encapsulation (Flannel/Calico pattern), eBPF CNI (Cilium O(1) BPF map lookup vs iptables O(n)), `lsns`/`nsenter`/`bridge fdb`/`conntrack` observability
- **Kernel TLS** (`ktls.md`): ULP socket layer intercept, kTLS setup with `TCP_ULP`+`TLS_TX`/`TLS_RX` after handshake, `tls_sw_sendmsg` record framing and `tls_push_record` AEAD encryption, NIC TLS offload path (`tls_device.c`) with ethtool enable, zero-copy sendfile path comparison (4 copies traditional vs 0-1 with kTLS), RX decrypt with `TLS_GET_RECORD_TYPE` cmsg, `/proc/net/tls_stat` counters

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] Advanced section appears under Networking in nav
- [ ] Cross-links to conntrack, netfilter, XDP, crypto resolve