### PR TITLE
Add ARM64 architecture documentation

### DIFF
--- a/docs/arch/arm64/README.md
+++ b/docs/arch/arm64/README.md
@@ -1,0 +1,47 @@
+# ARM64 Architecture
+
+> Exception levels, memory model, and ARM-specific kernel internals
+
+## Why ARM64?
+
+ARM64 (AArch64) is the dominant architecture for:
+- Mobile (Android, iOS)
+- Embedded and IoT (Raspberry Pi, NXP, TI)
+- Servers (AWS Graviton, Ampere Altra)
+- Laptops (Apple Silicon, Qualcomm Snapdragon X)
+
+Understanding ARM64-specific behavior is essential for kernel work on these platforms.
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Exception Model](exception-model.md) | EL0-EL3, VBAR_EL1, syndrome registers, GIC |
+| [Memory Model](memory-model.md) | Weak ordering, barriers, load-acquire/store-release, LDAR/STLR |
+
+## ARM64 vs x86 key differences
+
+| Feature | x86-64 | ARM64 |
+|---------|--------|-------|
+| Memory ordering | TSO (total store order) | Weak (RVWMO relaxed) |
+| Privilege levels | ring 0-3 | EL0-EL3 |
+| Interrupt controller | APIC | GIC (Generic Interrupt Controller) |
+| System registers | MSR/RDMSR | MRS/MSR instructions |
+| SIMD | SSE/AVX | NEON / SVE / SME |
+| Page sizes | 4K/2M/1G | 4K/16K/64K base + 2M/1G huge |
+| TLB shootdown | IPI to other CPUs | TLBI broadcast via DSB |
+
+## Quick reference
+
+```bash
+# CPU features on ARM64
+cat /proc/cpuinfo | grep Features
+# Features: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics ...
+
+# ARM64-specific system registers (via perf or MSR equivalent)
+# Read CNTVCT_EL0 (virtual counter — ARM equivalent of RDTSC)
+# mrs x0, CNTVCT_EL0
+
+# Exception level of running code
+# EL0 = userspace, EL1 = kernel, EL2 = hypervisor, EL3 = secure monitor
+```

--- a/docs/arch/arm64/exception-model.md
+++ b/docs/arch/arm64/exception-model.md
@@ -1,0 +1,303 @@
+# ARM64 Exception Model
+
+> Exception levels, interrupt handling, and the GIC
+
+## Exception Levels
+
+ARM64 defines four exception levels (EL0-EL3), roughly analogous to x86 protection rings but more hierarchical:
+
+```
+EL3: Secure Monitor (TrustZone firmware, e.g., ARM Trusted Firmware)
+  │
+EL2: Hypervisor (KVM runs here)
+  │
+EL1: OS Kernel (Linux kernel runs here)
+  │
+EL0: User space (applications)
+```
+
+Key properties:
+- **EL0**: unprivileged, can only access user-accessible system registers
+- **EL1**: kernel mode, full access to kernel address space and EL1 system registers
+- **EL2**: hypervisor mode, can trap and emulate EL1 operations
+- **EL3**: most privileged, manages secure/non-secure world transitions (TrustZone)
+
+The Linux kernel runs at EL1. KVM runs at EL1 (host kernel) but switches guests to EL1/EL0 using EL2 primitives via the VHE (Virtualization Host Extension, ARMv8.1+) or a separate EL2 stub.
+
+## Exception types
+
+ARM64 has four categories of exceptions:
+
+| Category | Description | Examples |
+|----------|-------------|---------|
+| **Synchronous** | Caused by the current instruction | SVC, data abort, instruction abort, undefined |
+| **IRQ** | External interrupt (normal priority) | Device interrupts |
+| **FIQ** | Fast interrupt (high priority, EL3 only) | Secure world interrupts |
+| **SError** | Asynchronous system error | Bus errors, DRAM ECC |
+
+## Exception vectors: VBAR_EL1
+
+When an exception occurs, the CPU jumps to an entry in the **vector table**, pointed to by `VBAR_EL1` (Vector Base Address Register for EL1):
+
+```
+VBAR_EL1 base
+  + 0x000: Synchronous, current EL with SP_EL0
+  + 0x080: IRQ, current EL with SP_EL0
+  + 0x100: FIQ, current EL with SP_EL0
+  + 0x180: SError, current EL with SP_EL0
+  + 0x200: Synchronous, current EL with SP_ELx
+  + 0x280: IRQ, current EL with SP_ELx        ← kernel IRQ from EL1
+  + 0x300: FIQ, current EL with SP_ELx
+  + 0x380: SError, current EL with SP_ELx
+  + 0x400: Synchronous, lower EL (AArch64)    ← syscall / fault from EL0
+  + 0x480: IRQ, lower EL (AArch64)            ← IRQ while in userspace
+  + 0x500: FIQ, lower EL (AArch64)
+  + 0x580: SError, lower EL (AArch64)
+  + 0x600: Synchronous, lower EL (AArch32)    ← 32-bit compat
+  ...
+```
+
+### Linux vector table
+
+```asm
+/* arch/arm64/kernel/entry.S */
+    .align  11
+SYM_CODE_START(vectors)
+    kernel_ventry   1, t, 64, sync    /* Synchronous EL1t (SP_EL0) */
+    kernel_ventry   1, t, 64, irq     /* IRQ EL1t */
+    kernel_ventry   1, t, 64, fiq     /* FIQ EL1t */
+    kernel_ventry   1, t, 64, error   /* Error EL1t */
+
+    kernel_ventry   1, h, 64, sync    /* Synchronous EL1h (SP_ELx) */
+    kernel_ventry   1, h, 64, irq     /* IRQ EL1h */
+    kernel_ventry   1, h, 64, fiq     /* FIQ EL1h */
+    kernel_ventry   1, h, 64, error   /* Error EL1h */
+
+    kernel_ventry   0, t, 64, sync    /* Synchronous EL0 64-bit */
+    kernel_ventry   0, t, 64, irq     /* IRQ EL0 64-bit */
+    kernel_ventry   0, t, 64, fiq     /* FIQ EL0 64-bit */
+    kernel_ventry   0, t, 64, error   /* Error EL0 64-bit */
+
+    kernel_ventry   0, t, 32, sync    /* Synchronous EL0 32-bit */
+    kernel_ventry   0, t, 32, irq     /* IRQ EL0 32-bit */
+    kernel_ventry   0, t, 32, fiq     /* FIQ EL0 32-bit */
+    kernel_ventry   0, t, 32, error   /* Error EL0 32-bit */
+SYM_CODE_END(vectors)
+```
+
+## Syndrome registers: ESR_EL1
+
+When a synchronous exception occurs, `ESR_EL1` (Exception Syndrome Register) identifies the cause:
+
+```c
+/* arch/arm64/include/asm/esr.h */
+
+/* ESR_EL1 bits: */
+/* [31:26] EC: Exception Class */
+#define ESR_ELx_EC_SHIFT    26
+#define ESR_ELx_EC_MASK     (0x3FUL << ESR_ELx_EC_SHIFT)
+
+/* Exception classes: */
+#define ESR_ELx_EC_UNKNOWN  0x00  /* Unknown reason */
+#define ESR_ELx_EC_SVC64   0x15  /* SVC instruction (EL0 → EL1, 64-bit) */
+#define ESR_ELx_EC_IABT_LOW 0x20  /* Instruction abort from lower EL */
+#define ESR_ELx_EC_IABT_CUR 0x21  /* Instruction abort from current EL */
+#define ESR_ELx_EC_DABT_LOW 0x24  /* Data abort from lower EL */
+#define ESR_ELx_EC_DABT_CUR 0x25  /* Data abort from current EL */
+#define ESR_ELx_EC_SOFTSTP_LOW 0x32 /* Software step (debug) from lower EL */
+
+/* [24] IL: Instruction Length (0=16-bit, 1=32-bit) */
+/* [23:0] ISS: Instruction-Specific Syndrome */
+/* For data aborts, ISS includes: DFSC (fault status code), WnR (write), SRT (register) */
+```
+
+### Fault status codes (DFSC)
+
+```c
+/* Data fault status codes in ESR_EL1.ISS.DFSC */
+#define ESR_ELx_FSC_TYPE    0x3C
+#define ESR_ELx_FSC_EXTABT  0x10  /* External abort */
+#define ESR_ELx_FSC_SERROR  0x11  /* Async SError abort */
+#define ESR_ELx_FSC_ACCESS  0x08  /* Access flag fault */
+#define ESR_ELx_FSC_FAULT   0x04  /* Translation fault (page not present) */
+#define ESR_ELx_FSC_PERM    0x0C  /* Permission fault */
+
+/* Level bits [1:0]: */
+/* 0b00 = level 0 (PGD), 0b01 = level 1, 0b10 = level 2, 0b11 = level 3 (PTE) */
+```
+
+### Linux fault handling
+
+```c
+/* arch/arm64/mm/fault.c */
+static int __kprobes do_mem_abort(unsigned long far, unsigned long esr,
+                                   struct pt_regs *regs)
+{
+    const struct fault_info *inf = esr_to_fault_info(esr);
+
+    if (!inf->fn(far, esr, regs))
+        return 0;
+
+    /* Unhandled fault */
+    arm64_notify_die(inf->name, regs, esr, far);
+    return 0;
+}
+
+/* ESR EC → handler dispatch */
+static const struct fault_info fault_info[] = {
+    { do_bad,           SIGKILL, 0,                   "ttbr address size fault" },
+    /* ... */
+    { do_translation_fault, SIGSEGV, SEGV_MAPERR,     "level 3 translation fault" },
+    { do_page_fault,    SIGSEGV, SEGV_MAPERR,          "level 3 translation fault" },
+    { do_page_fault,    SIGSEGV, SEGV_ACCERR,          "level 3 permission fault"  },
+};
+```
+
+## Syscall entry (SVC)
+
+On ARM64, system calls use the `SVC #0` instruction (Supervisor Call):
+
+```asm
+/* Userspace syscall: */
+mov x8, #__NR_write    /* syscall number in x8 */
+mov x0, #1             /* fd = 1 (stdout) */
+mov x1, x_buf          /* buffer address */
+mov x2, x_len          /* length */
+svc #0                 /* trap to EL1 */
+/* returns in x0 */
+```
+
+The kernel SVC handler:
+
+```asm
+/* arch/arm64/kernel/entry.S */
+SYM_CODE_START(el0t_64_sync_handler)
+    /* Save all registers */
+    kernel_entry 0, 64
+
+    mrs     x22, esr_el1        /* read exception syndrome */
+    lsr     x24, x22, #ESR_ELx_EC_SHIFT  /* extract EC */
+
+    /* EC = 0x15 means SVC from 64-bit EL0 */
+    cmp     x24, #ESR_ELx_EC_SVC64
+    b.eq    el0_svc
+
+    /* Other exception types */
+    b       el0_sync_handler
+SYM_CODE_END(el0t_64_sync_handler)
+```
+
+```c
+/* arch/arm64/kernel/syscall.c */
+static void el0_svc_common(struct pt_regs *regs, int scno,
+                             int sc_nr, const syscall_fn_t syscall_table[])
+{
+    /* Apply syscall tracing (seccomp, ptrace) */
+    invoke_syscall(regs, scno, sc_nr, syscall_table);
+}
+```
+
+The syscall number is in `x8`, arguments in `x0-x5`, and the return value goes into `x0`.
+
+## GIC: Generic Interrupt Controller
+
+ARM systems use the GIC (Generic Interrupt Controller) for interrupt management, not the x86 APIC.
+
+```
+Peripheral ──► GIC Distributor (shared)
+                    │
+                    ├──► CPU Interface 0 (CPU 0)
+                    ├──► CPU Interface 1 (CPU 1)
+                    └──► CPU Interface N (CPU N)
+                              │
+                          IRQ line to CPU core
+```
+
+### GIC interrupt types
+
+```c
+/* GIC interrupt IDs */
+/* 0-15:   SGI (Software Generated Interrupts) — IPIs */
+/* 16-31:  PPI (Private Peripheral Interrupts) — per-CPU (timers, PMU) */
+/* 32+:    SPI (Shared Peripheral Interrupts) — shared across CPUs */
+/* 8192+:  LPI (Locality-specific Peripheral Interrupts) — MSI for PCIe */
+```
+
+### Linux GIC driver
+
+```c
+/* drivers/irqchip/irq-gic-v3.c */
+static struct irq_chip gic_chip = {
+    .name                   = "GICv3",
+    .irq_mask               = gic_mask_irq,
+    .irq_unmask             = gic_unmask_irq,
+    .irq_eoi                = gic_eoi_irq,
+    .irq_set_type           = gic_set_type,
+    .irq_set_affinity       = gic_set_affinity,   /* CPU affinity */
+    .irq_retrigger          = gic_retrigger,
+    .irq_get_irqchip_state  = gic_irq_get_irqchip_state,
+    .irq_set_irqchip_state  = gic_irq_set_irqchip_state,
+};
+
+/* EOI (End of Interrupt): acknowledge to GIC when done */
+static void gic_eoi_irq(struct irq_data *d)
+{
+    gic_write_eoir(gic_irq(d));  /* EOIR1_EL1: write IRQ number to EOI */
+}
+```
+
+### IPIs on ARM64
+
+ARM64 IPIs (for TLB shootdown, function calls, rescheduling) use GIC SGIs:
+
+```c
+/* arch/arm64/kernel/smp.c */
+static void smp_send_reschedule(int cpu)
+{
+    smp_cross_call(cpumask_of(cpu), IPI_RESCHEDULE);
+}
+
+void arch_send_call_function_ipi_mask(const struct cpumask *mask)
+{
+    smp_cross_call(mask, IPI_CALL_FUNC);
+}
+
+/* smp_cross_call → GIC SGI → IPI_RESCHEDULE/IPI_CALL_FUNC handler */
+```
+
+## System registers
+
+ARM64 system registers are accessed with `MRS`/`MSR` instructions:
+
+```asm
+/* Read current EL */
+mrs x0, CurrentEL          /* bits [3:2] = EL */
+lsr x0, x0, #2             /* shift to get 0/1/2/3 */
+
+/* Read virtual counter (vDSO uses this instead of syscall) */
+mrs x0, CNTVCT_EL0
+
+/* Read Thread ID register (TLS base) */
+mrs x0, TPIDR_EL0
+
+/* Enable/disable interrupts */
+msr daifclr, #2            /* clear IRQ mask bit = enable IRQs */
+msr daifset, #2            /* set IRQ mask bit = disable IRQs */
+```
+
+In the kernel (using C):
+
+```c
+/* arch/arm64/include/asm/sysreg.h */
+u64 cntvct = read_sysreg(cntvct_el0);   /* virtual counter */
+write_sysreg(ttbr0_val, ttbr0_el1);     /* page table base */
+```
+
+## Further reading
+
+- [Memory Model](memory-model.md) — ARM64 weak ordering and barriers
+- [Memory Management: page tables](../../mm/page-tables.md) — ARM64 page table format
+- [Interrupts: Interrupt Handling Overview](../../interrupts/interrupts.md) — generic interrupt framework
+- [Virtualization: KVM Architecture](../../virtualization/kvm-arch.md) — KVM on ARM64 (EL2)
+- `arch/arm64/kernel/` in the kernel tree — ARM64 exception handlers
+- ARM Architecture Reference Manual (ARM DDI 0487)

--- a/docs/arch/arm64/memory-model.md
+++ b/docs/arch/arm64/memory-model.md
@@ -1,0 +1,294 @@
+# ARM64 Memory Model
+
+> Weak ordering, barriers, and atomic operations on ARM64
+
+## ARM64 is weakly ordered
+
+Unlike x86 (which has TSO — Total Store Order, nearly sequentially consistent), ARM64 has a **weakly ordered** memory model. The hardware may reorder loads and stores for performance:
+
+```
+// ARM64: these operations may be REORDERED by hardware:
+STR x1, [x2]     // store to address x2
+LDR x3, [x4]     // load from address x4
+// CPU may execute the load before the store
+```
+
+This matters for lock-free algorithms and any code that synchronizes between threads without using explicit atomic operations.
+
+## What ARM64 guarantees
+
+1. **Single-copy atomicity**: A naturally-aligned load or store of a single register is atomic (the value is either fully written or not written).
+
+2. **Program order for dependent accesses**: If load A is used to compute the address of load B, B observes the effects of A (data-dependent ordering).
+
+3. **No guarantees for independent accesses**: Stores and loads to unrelated addresses can be observed in any order by other CPUs.
+
+## Memory barrier instructions
+
+ARM64 provides three barrier instructions:
+
+### DMB: Data Memory Barrier
+
+Ensures memory accesses before the barrier are visible before accesses after it:
+
+```asm
+DMB SY      /* full system, all types: LD after LD, LD after ST, ST after LD, ST after ST */
+DMB ST      /* only STores after STores (and STores after loads) */
+DMB LD      /* only LoaDs after LoaDs (and loads after stores) */
+DMB ISH     /* inner shareable: affects all CPUs in the same shareability domain */
+DMB ISHST   /* inner shareable, stores only */
+DMB ISHLD   /* inner shareable, loads only */
+DMB NSH     /* non-shareable: only this PE */
+DMB OSH     /* outer shareable */
+```
+
+`SY` (full system) is most conservative. `ISH` is typical for SMP kernels.
+
+### DSB: Data Synchronization Barrier
+
+Stronger than DMB: not only are memory accesses ordered, but **the barrier stalls the pipeline** until all prior memory accesses are complete:
+
+```asm
+DSB SY      /* wait until all memory accesses complete, full system */
+DSB ISH     /* same but inner shareable only */
+DSB ST      /* wait until all stores complete */
+```
+
+Use DSB when you need to know memory accesses have *completed* (not just ordered) — e.g., before modifying page tables that the MMU might be walking, or before a cache maintenance operation takes effect.
+
+### ISB: Instruction Synchronization Barrier
+
+Flushes the instruction pipeline:
+
+```asm
+ISB
+```
+
+Use ISB after:
+- Writing to system registers that affect instruction execution (e.g., SCTLR_EL1)
+- Self-modifying code
+- Changing the instruction cache attributes
+
+Without ISB, the CPU might have already fetched and decoded instructions past the system register write.
+
+## Load-acquire and Store-release
+
+ARM64 provides special atomic load/store variants that include ordering semantics:
+
+```asm
+LDAR x0, [x1]    /* Load-Acquire: no loads or stores after this can be
+                    reordered before it */
+
+STLR x0, [x1]    /* Store-Release: no loads or stores before this can be
+                    reordered after it */
+
+LDAPR x0, [x1]   /* Load-Acquire RCpc: weaker acquire — only prevents
+                    subsequent loads from moving before, not stores */
+```
+
+These implement the C11/C++11 `memory_order_acquire` and `memory_order_release` semantics efficiently — no explicit DMB needed.
+
+```c
+/* C equivalent of LDAR/STLR */
+/* LDAR x0, [x1] == */  atomic_load_explicit(ptr, memory_order_acquire);
+/* STLR x0, [x1] == */  atomic_store_explicit(ptr, val, memory_order_release);
+```
+
+## Exclusive load/store (atomics)
+
+ARM64 atomics use a load-link/store-conditional (LL/SC) mechanism:
+
+```asm
+/* Compare-and-swap loop: old_val → new_val at [addr] */
+.loop:
+    LDXR  w0, [x1]        /* Load eXclusive: mark addr as exclusive */
+    CMP   w0, w3           /* compare with expected */
+    B.NE  .fail
+    STXR  w4, w2, [x1]    /* Store eXclusive: write new value */
+    CBNZ  w4, .loop        /* if store failed (exclusive lost), retry */
+    /* success */
+.fail:
+    /* w0 has the actual value */
+```
+
+ARMv8.1 adds **Large System Extensions (LSE)** — single-instruction atomics that avoid the retry loop:
+
+```asm
+/* ARMv8.1 LSE: atomic compare-and-swap */
+CAS  w0, w2, [x1]    /* if [x1]==w0, write w2; w0 = old value */
+CASAL w0, w2, [x1]   /* CAS with acquire-release semantics */
+
+/* Atomic add */
+LDADD x0, x1, [x2]  /* [x2] += x1; x0 = old [x2] */
+STADD x0, [x1]       /* [x1] += x0; no return value */
+
+/* Atomic swap */
+SWP x0, x1, [x2]    /* x0 = [x2]; [x2] = x1 */
+```
+
+LSE atomics are preferred on systems with many cores — they generate a single bus transaction rather than potentially many retry loops.
+
+## Linux kernel barrier macros on ARM64
+
+The kernel provides architecture-independent macros that map to ARM64 instructions:
+
+```c
+/* include/asm-generic/barrier.h (mapped to arch/arm64 in asm/barrier.h) */
+
+smp_mb()    /* full memory barrier:   DMB ISH  */
+smp_rmb()   /* read memory barrier:   DMB ISHLD */
+smp_wmb()   /* write memory barrier:  DMB ISHST */
+
+smp_store_release(p, v)   /* STLR: store + release */
+smp_load_acquire(p)        /* LDAR: load + acquire */
+
+/* Data dependency barrier (weaker — relies on data dependency ordering) */
+smp_read_barrier_depends()  /* no-op on ARM64: data dep ordering is guaranteed */
+
+/* Compiler barriers (prevent compiler reordering, no CPU barrier) */
+barrier()   /* asm volatile("" ::: "memory") */
+READ_ONCE(x)    /* load, prevent compiler optimizations */
+WRITE_ONCE(x,v) /* store, prevent compiler optimizations */
+```
+
+### When to use which
+
+```c
+/* Lock: acquire semantics — nothing after the lock can move before it */
+spin_lock() → smp_load_acquire or DMB ISH + LDAR
+
+/* Unlock: release semantics — nothing before the unlock can move after it */
+spin_unlock() → STLR or DMB ISH + STR
+
+/* RCU read side: data dependency is sufficient on ARM64 */
+rcu_dereference(p)  /* READ_ONCE + smp_read_barrier_depends (noop on ARM64) */
+
+/* Producer/consumer lockless queue */
+/* Producer: */
+WRITE_ONCE(item->data, value);
+smp_wmb();                     /* ensure data visible before index */
+WRITE_ONCE(queue->tail, new_tail);
+
+/* Consumer: */
+tail = smp_load_acquire(&queue->tail);  /* load tail with acquire */
+data = READ_ONCE(item->data);           /* data visible after acquire load */
+```
+
+## Page table barriers
+
+A common ARM64 specific need: after modifying a page table entry, you must ensure the store is visible to the MMU before the TLB invalidation instruction:
+
+```asm
+/* Write new PTE */
+STR x0, [x1]          /* store new page table entry */
+DSB ISH                /* wait for store to complete */
+/* TLB invalidate */
+TLBI VAE1IS, x2        /* invalidate TLB entry, inner shareable */
+DSB ISH                /* wait for TLB invalidation */
+ISB                    /* ensure subsequent instructions use new mappings */
+```
+
+In the kernel:
+
+```c
+/* arch/arm64/include/asm/tlbflush.h */
+static inline void flush_tlb_page(struct vm_area_struct *vma,
+                                    unsigned long uaddr)
+{
+    unsigned long addr = __TLBI_VADDR(uaddr, ASID(vma->vm_mm));
+    dsb(ishst);             /* DSB ISH ST — wait for page table stores */
+    __tlbi(vale1is, addr);  /* TLBI by address, inner shareable */
+    dsb(ish);               /* DSB ISH — wait for TLB invalidation */
+}
+```
+
+## Acquire/Release in the kernel: spinlock
+
+```asm
+/* arch/arm64/include/asm/spinlock.h */
+/* Ticket spinlock acquire: */
+arch_spin_lock:
+    PRFM    PSTL1KEEP, [x0]   /* prefetch for write */
+.again:
+    LDAXR   w2, [x0]          /* load-exclusive + acquire */
+    /* Check if our ticket == serving number */
+    ...
+    CBNZ    w3, .wait
+    STXR    w3, w1, [x0]      /* store-exclusive */
+    CBNZ    w3, .again
+    RET
+
+/* Spinlock release: just store, store-release ordering */
+arch_spin_unlock:
+    STLR    w1, [x0]          /* store-release: all prior accesses visible */
+    RET
+```
+
+## Weak memory model bugs
+
+Common patterns that work on x86 (TSO) but **fail on ARM64**:
+
+### Missing barrier in producer/consumer
+
+```c
+/* WRONG on ARM64: */
+struct item {
+    int ready;    /* offset 0 */
+    int data;     /* offset 4 */
+};
+
+/* Thread A (producer): */
+item->data  = 42;
+item->ready = 1;    /* ARM64 may reorder: ready=1 visible before data=42 */
+
+/* Thread B (consumer): */
+while (!item->ready);   /* spin */
+use(item->data);        /* may see data=0 because no barrier! */
+
+/* RIGHT: */
+WRITE_ONCE(item->data, 42);
+smp_wmb();              /* DMB ISHST: ensure data visible before ready */
+WRITE_ONCE(item->ready, 1);
+
+/* Consumer: */
+while (!smp_load_acquire(&item->ready)); /* LDAR: acquire ordering */
+use(READ_ONCE(item->data));
+```
+
+### Missing dsb after page table update
+
+```c
+/* WRONG: CPU may start walking old page tables after set_pte */
+set_pte(ptep, new_pte);
+flush_tlb_page(vma, addr);  /* TLB flush without DSB — MMU might not see new PTE */
+
+/* RIGHT (done by the kernel automatically): */
+set_pte(ptep, new_pte);
+dsb(ishst);                 /* ensure PTE store visible */
+flush_tlb_page(vma, addr);
+```
+
+## Observing memory ordering issues
+
+```bash
+# Run litmus tests (memory model validation)
+# ARM provides litmus7 tool for testing actual hardware behavior
+
+# LKMM (Linux Kernel Memory Model) verification
+# https://github.com/torvalds/linux/tree/master/tools/memory-model
+
+# Enable CONFIG_KCSAN for compile-time race detection
+# KCSAN instruments memory accesses and checks for data races
+
+# Detect issues with lockdep + KCSAN
+dmesg | grep "data-race"
+```
+
+## Further reading
+
+- [Exception Model](exception-model.md) — ARM64 exception levels and GIC
+- [Locking: Atomic Operations and Memory Barriers](../../locking/atomics.md) — kernel atomic API
+- [Locking: RCU](../../locking/rcu.md) — how RCU uses barriers
+- [Memory Management: page tables](../../mm/page-tables.md) — page table barrier requirements
+- ARM Architecture Reference Manual — B2: The AArch64 Application Level Memory Model
+- `Documentation/memory-barriers.txt` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -344,3 +344,8 @@ nav:
     - Getting Started: crypto/README.md
     - Kernel Crypto API: crypto/crypto-api.md
     - dm-crypt and fscrypt: crypto/encryption.md
+  - Architecture:
+    - ARM64:
+      - Getting Started: arch/arm64/README.md
+      - Exception Model: arch/arm64/exception-model.md
+      - Memory Model: arch/arm64/memory-model.md


### PR DESCRIPTION
## Summary

- **Exception Model** (`arch/arm64/exception-model.md`): EL0-EL3 hierarchy with TrustZone/KVM placement, all 16 VBAR_EL1 vector table entries (sync/IRQ/FIQ/SError × EL1t/EL1h/EL0-64/EL0-32), ESR_EL1 syndrome decoding (EC shift/mask, exception classes table, DFSC fault level bits), Linux `fault_info[]` dispatch, SVC #0 syscall with x8/x0-x5/x0 calling convention, GIC Distributor+CPU Interface hierarchy, interrupt types SGI/PPI/SPI/LPI, `gic_chip` eoi/mask/affinity, ARM64 IPI via GIC SGI, `MRS`/`MSR` system register access
- **Memory Model** (`arch/arm64/memory-model.md`): Weak vs x86 TSO ordering, DMB/DSB/ISB with all domain suffixes (SY/ISH/ISHST/ISHLD/OSH/NSH), LDAR/STLR/LDAPR acquire-release semantics, LL/SC LDXR/STXR retry loop, ARMv8.1 LSE single-instruction atomics (CAS/CASAL/LDADD/SWP), Linux `smp_mb/wmb/rmb/load_acquire/store_release` mapping, DSB+TLBI page table update sequence, spinlock LDAXR+STLR implementation, common ARM64 bugs (missing `smp_wmb` in producer/consumer, missing DSB after PTE update)

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] Architecture/ARM64 nav section renders
- [ ] Cross-links to locking/atomics, mm/page-tables, interrupts, virtualization resolve