### PR TITLE
Add scheduler advanced documentation: load balancing and EAS

### DIFF
--- a/docs/sched/eas.md
+++ b/docs/sched/eas.md
@@ -1,0 +1,274 @@
+# Energy-Aware Scheduling (EAS)
+
+> Minimizing energy consumption on heterogeneous CPU topologies
+
+## Motivation
+
+On ARM big.LITTLE and Intel hybrid (P+E core) CPUs, different cores have different performance *and* energy characteristics:
+
+```
+ARM big.LITTLE:
+  "big" cores (A76):   high performance, high power
+  "LITTLE" cores (A55): low performance, low power
+
+Intel Alder Lake:
+  P-cores (Golden Cove): high performance, high power
+  E-cores (Gracemont):   lower performance, lower power
+```
+
+A compute-intensive task should run on a big/P-core. An idle background task should park on a LITTLE/E-core. EAS makes this decision based on an energy model of the hardware.
+
+## Energy model
+
+The energy model describes the power consumption of each CPU at different utilization levels:
+
+```c
+/* include/linux/energy_model.h */
+struct em_perf_state {
+    unsigned long frequency;  /* kHz */
+    unsigned long power;      /* mW */
+    unsigned long cost;       /* power * max_freq / frequency (normalized) */
+    unsigned long flags;
+};
+
+struct em_perf_domain {
+    struct em_perf_state   *table;      /* performance states (P-states) */
+    int                     nr_perf_states;
+    unsigned long           cpus;       /* cpumask of CPUs in this domain */
+    struct device          *dev;
+};
+```
+
+The energy model is registered by cpufreq drivers or device tree:
+
+```c
+/* drivers/cpufreq/cpufreq-dt.c (or ARM firmware) */
+em_dev_register_perf_domain(cpu_dev, nr_states, &em_cb, cpumask, milliwatts);
+
+/* em_cb.active_power(dev, freq, power) — power at given frequency */
+/* em_cb.get_cost(dev, freq, cost) — optional: pre-compute cost */
+```
+
+## CPU capacity
+
+EAS models each CPU's maximum compute capacity (normalized to 1024):
+
+```c
+/* Maximum capacity: fastest CPU = 1024 */
+/* Each CPU has capacity_orig based on its max frequency */
+
+/* arch/arm64/kernel/topology.c */
+static void update_cpu_capacity(unsigned int cpu)
+{
+    unsigned long capacity = SCHED_CAPACITY_SCALE;  /* 1024 */
+
+    /* Scale by frequency ratio vs max CPU in system */
+    capacity *= per_cpu(cpu_scale, cpu);
+    capacity >>= SCHED_CAPACITY_SHIFT;
+
+    set_capacity_scale(cpu, capacity);
+}
+```
+
+A LITTLE core running at 1.0 GHz vs a big core at 2.5 GHz might have capacity 400 vs 1024.
+
+## find_energy_efficient_cpu
+
+The core EAS function selects the CPU that minimizes total system energy:
+
+```c
+/* kernel/sched/fair.c */
+static int find_energy_efficient_cpu(struct task_struct *p, int prev_cpu)
+{
+    struct cpumask *pd_cpus;
+    struct em_perf_domain *pd;
+    long prev_delta = LONG_MAX, best_delta = LONG_MAX;
+    unsigned long p_util_cfs = task_util_est(p);
+    int best_energy_cpu = prev_cpu;
+
+    /* For each performance domain (group of CPUs sharing frequency): */
+    for_each_perf_domain(pd) {
+        pd_cpus = em_span_cpus(pd);
+
+        if (!cpumask_intersects(sched_domain_span(sd), pd_cpus))
+            continue;
+
+        /* Find the most energy-efficient CPU in this domain */
+        for_each_cpu_and(cpu, pd_cpus, sched_domain_span(sd)) {
+            long energy_delta = compute_energy(pd, cpu, p, prev_cpu);
+
+            /* Does placing p on cpu reduce total energy? */
+            if (cpu == prev_cpu)
+                prev_delta = energy_delta;
+            else if (energy_delta < best_delta) {
+                best_delta    = energy_delta;
+                best_energy_cpu = cpu;
+            }
+        }
+    }
+
+    /* Only switch if energy saving exceeds migration cost threshold (6%) */
+    if ((prev_delta - best_delta) * 1024 > prev_delta * 6)
+        return best_energy_cpu;
+
+    return prev_cpu;  /* stay on previous CPU */
+}
+```
+
+## compute_energy
+
+Energy estimation for placing a task on a specific CPU:
+
+```c
+/* kernel/sched/energy.c */
+static long compute_energy(struct em_perf_domain *pd, int cpu,
+                             struct task_struct *p, int prev_cpu)
+{
+    struct em_perf_state *ps;
+    unsigned long util_sum = 0;
+
+    /* Sum utilization of all tasks that will be on CPUs in this domain */
+    for_each_cpu(cpu_iter, em_span_cpus(pd)) {
+        unsigned long util = cpu_util_next(cpu_iter, p, cpu);
+        util_sum += util;
+    }
+
+    /* Find the performance state (P-state) needed to sustain util_sum */
+    ps = em_pd_get_efficient_state(pd, util_sum, ..., pd->nr_perf_states);
+
+    /* Energy = power * time
+       Normalized: cost = power * max_freq / freq
+       energy ≈ cost * util_sum */
+    return em_cpu_energy(pd, ps, util_sum, ...);
+}
+```
+
+## Capacity-aware wakeup
+
+Before EAS runs its full energy computation, a simpler capacity check prevents placing a task on a CPU that's already saturated:
+
+```c
+/* Only run EAS if system is not overutilized */
+static bool sched_energy_enabled(void)
+{
+    static u64 last_check;
+    u64 now;
+
+    /* Check if any CPU is overutilized */
+    if (READ_ONCE(overutilized))
+        return false;
+
+    return true;
+}
+
+/* Per-CPU: is this CPU's capacity sufficient? */
+static inline bool cpu_overutilized(int cpu)
+{
+    return !fits_capacity(cpu_util(cpu), capacity_of(cpu));
+}
+```
+
+When the system is overutilized (some CPU at 100%), EAS falls back to the regular load balancer — energy optimization doesn't help when you're already maxed out.
+
+## Schedutil + EAS interaction
+
+EAS determines *which* CPU; schedutil determines *which frequency*:
+
+```
+1. EAS: place task on CPU that minimizes total system energy
+2. schedutil: set frequency of that CPU based on utilization
+   (freq = max_freq * util / capacity)
+3. cpufreq driver: select actual P-state or HWP hint
+```
+
+```bash
+# EAS is only enabled if schedutil governor is active
+cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+# schedutil  ← EAS active
+# ondemand   ← EAS disabled (falls back to load balancing)
+```
+
+## Observing EAS
+
+```bash
+# Check if EAS is active
+dmesg | grep -i "energy"
+# sched: EAS: Energy Model successfully initialized
+
+# CPU capacities
+cat /sys/devices/system/cpu/cpu*/cpu_capacity
+# 512 512 512 512 1024 1024 1024 1024
+# (LITTLE cores at 512, big cores at 1024)
+
+# Energy model per-domain
+cat /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state
+
+# Task placement: which core type is each task using?
+ps aux --sort=-%cpu | head -10
+# Then check CPU affinity:
+taskset -cp <pid>
+
+# perf: energy events
+perf stat -e power/energy-pkg/,power/energy-cores/ sleep 10
+
+# Trace EAS decisions
+echo 1 > /sys/kernel/tracing/events/sched/sched_find_energy_efficient_cpu/enable
+cat /sys/kernel/tracing/trace_pipe
+
+# Force a task to LITTLE cores only (for testing)
+taskset -cp 0-3 <pid>  # pin to CPUs 0-3 (LITTLE cores)
+```
+
+## big.LITTLE Linux support
+
+```bash
+# Check asymmetric CPU topology
+cat /sys/devices/system/cpu/cpu*/topology/physical_package_id
+cat /sys/devices/system/cpu/cpu*/cpu_capacity
+
+# ARM's sysfs for cluster info
+cat /sys/devices/system/cpu/cpufreq/policy*/cpuinfo_max_freq
+
+# Current energy model
+for cpu in /sys/devices/system/cpu/cpu*/; do
+    echo -n "$cpu: capacity "
+    cat "$cpu/cpu_capacity" 2>/dev/null || echo "N/A"
+done
+```
+
+## Thermal pressure
+
+When a CPU is thermally throttled, its capacity is temporarily reduced. EAS accounts for this:
+
+```c
+/* kernel/sched/thermal-pressure.c */
+void arch_update_thermal_pressure(const struct cpumask *cpus,
+                                   unsigned long capped_frequency)
+{
+    unsigned long max_freq, thermal_pressure;
+
+    max_freq = per_cpu(freq_factor, cpu) * arch_max_freq_scale;
+
+    /* thermal_pressure = capacity loss due to throttling */
+    thermal_pressure = max_freq - capped_frequency;
+    thermal_pressure = div_u64(thermal_pressure << SCHED_CAPACITY_SHIFT,
+                                max_freq);
+
+    /* Reduce effective capacity */
+    WRITE_ONCE(per_cpu(thermal_pressure, cpu), thermal_pressure);
+}
+```
+
+```bash
+# Current thermal pressure per CPU
+cat /sys/devices/system/cpu/cpu*/thermal_throttle/throttle_count
+```
+
+## Further reading
+
+- [Load Balancing](load-balancing.md) — cross-CPU task migration
+- [cpufreq: P-states](../power/cpufreq.md) — frequency selection, schedutil
+- [Scheduler: EEVDF](eevdf.md) — per-CPU scheduling policy
+- [Scheduler Domains](sched-domains.md) — topology construction for EAS
+- `kernel/sched/fair.c` — `find_energy_efficient_cpu`
+- `Documentation/scheduler/sched-energy.rst` in the kernel tree

--- a/docs/sched/load-balancing.md
+++ b/docs/sched/load-balancing.md
@@ -1,0 +1,313 @@
+# Load Balancing
+
+> How the scheduler distributes tasks across CPUs
+
+## Why load balancing is hard
+
+Load balancing must trade off:
+- **Throughput**: spread tasks evenly to use all CPUs
+- **Cache affinity**: a task recently on CPU A has hot cache — migrating it to B is expensive
+- **NUMA locality**: migrating across NUMA nodes is more expensive than across cores
+- **Topology awareness**: don't migrate across P-cores/E-cores on hybrid CPUs
+
+The Linux scheduler uses a **hierarchical scheduling domain** topology to navigate these trade-offs.
+
+## Scheduling domains and groups
+
+```
+System topology (example: 2-socket NUMA, 4 cores each, 2-way SMT):
+
+NUMA domain
+├── MC (multicore) domain — socket 0
+│   ├── SMT group: {cpu0, cpu4}   (physical core 0)
+│   ├── SMT group: {cpu1, cpu5}   (physical core 1)
+│   ├── SMT group: {cpu2, cpu6}   (physical core 2)
+│   └── SMT group: {cpu3, cpu7}   (physical core 3)
+└── MC domain — socket 1
+    ├── SMT group: {cpu8, cpu12}
+    ...
+```
+
+Each scheduling domain has parameters controlling when to balance:
+
+```c
+/* include/linux/sched/topology.h */
+struct sched_domain {
+    struct sched_domain __rcu *parent; /* up to NUMA domain */
+    struct sched_domain __rcu *child;  /* down to SMT domain */
+    struct sched_group  *groups;       /* circular list of groups */
+
+    unsigned long       min_interval;  /* balance interval at min load */
+    unsigned long       max_interval;  /* balance interval at max load */
+    unsigned int        busy_factor;   /* extra balance when busy */
+
+    int                 balance_interval; /* current interval */
+    unsigned int        nr_balance_failed; /* consecutive failed balances */
+
+    unsigned long       last_balance;  /* jiffies of last balance */
+
+    int                 span_weight;   /* number of CPUs this domain covers */
+    cpumask_var_t       span;          /* CPUs in this domain */
+
+    /* Flags controlling behavior */
+    unsigned int        flags;
+    /* SD_LOAD_BALANCE: participate in balancing */
+    /* SD_BALANCE_NEWIDLE: balance when CPU goes idle */
+    /* SD_BALANCE_EXEC: balance on exec() */
+    /* SD_BALANCE_FORK: balance on fork() */
+    /* SD_WAKE_AFFINE: try to wake on current CPU */
+    /* SD_ASYM_PACKING: use SD for asymmetric packing (E-core/P-core) */
+    /* SD_NUMA: NUMA domain */
+};
+```
+
+## Periodic load balancing
+
+Every CPU runs `load_balance()` periodically (via the scheduler tick):
+
+```c
+/* kernel/sched/fair.c */
+static int load_balance(int this_cpu, struct rq *this_rq,
+                         struct sched_domain *sd, enum cpu_idle_type idle,
+                         int *continue_balancing)
+{
+    struct lb_env env = {
+        .sd             = sd,
+        .dst_cpu        = this_cpu,
+        .dst_rq         = this_rq,
+        .idle           = idle,
+        .loop_break     = SCHED_NR_MIGRATE_BREAK,
+        .cpus           = cpus,
+        .fbq_type       = all,
+        .tasks          = LIST_HEAD_INIT(env.tasks),
+    };
+
+    /* Find the busiest group in this scheduling domain */
+    struct sched_group *group = find_busiest_group(&env);
+    if (!group)
+        goto out_balanced;
+
+    /* Find the busiest runqueue in the busiest group */
+    struct rq *busiest = find_busiest_queue(&env, group);
+    if (!busiest)
+        goto out_balanced;
+
+    env.src_cpu = busiest->cpu;
+    env.src_rq  = busiest;
+
+    /* Move tasks from busiest to this_rq */
+    ld_moved = move_tasks(&env);
+
+    return ld_moved;
+}
+```
+
+## Load metric: PELT
+
+The scheduler uses **PELT** (Per-Entity Load Tracking) to measure each task's load contribution. PELT tracks an exponentially weighted moving average of CPU utilization:
+
+```
+util_avg = util_avg * decay + new_util * (1 - decay)
+```
+
+The decay factor is set so that history older than 32ms has < 1% weight.
+
+```c
+/* kernel/sched/pelt.c */
+static u32 accumulate_sum(u64 delta, struct sched_avg *sa,
+                           unsigned long load, unsigned long runnable,
+                           int running)
+{
+    u32 contrib = (u32)delta;  /* delta since last update */
+
+    /* Geometric series sum for accumulated utilization */
+    if (delta < 1024) {
+        contrib = div_u64(delta * sa->period_contrib + (contrib << 10),
+                          1024);
+    } else {
+        sa->util_sum = (sa->util_sum >> 1) + (running << (SCHED_CAPACITY_SHIFT - 1));
+    }
+    return contrib;
+}
+```
+
+## struct lb_env: the balancing context
+
+```c
+/* kernel/sched/sched.h */
+struct lb_env {
+    struct sched_domain *sd;         /* domain being balanced */
+
+    struct rq           *src_rq;     /* source runqueue (busiest) */
+    int                  src_cpu;
+
+    int                  dst_cpu;    /* destination CPU */
+    struct rq           *dst_rq;
+
+    struct cpumask      *dst_grpmask; /* CPUs in destination group */
+    int                  new_dst_cpu;
+
+    enum cpu_idle_type   idle;       /* NEW_IDLE / NO_IDLE / NEWLY_IDLE */
+
+    long                 imbalance;  /* load imbalance to fix */
+    struct cpumask      *cpus;       /* eligible CPUs */
+
+    unsigned int         flags;
+    unsigned int         loop;
+    unsigned int         loop_break;
+    unsigned int         loop_max;
+
+    enum fbq_type        fbq_type;   /* filter type: all/regular/remote/base */
+    enum migration_type  migration_type;
+
+    struct list_head     tasks;      /* tasks to migrate */
+};
+```
+
+## newidle_balance: when CPU goes idle
+
+When a CPU has no tasks, it immediately tries to pull work from a busier CPU:
+
+```c
+/* kernel/sched/fair.c */
+static int newidle_balance(struct rq *this_rq, struct rq_flags *rf)
+{
+    unsigned long next_balance = jiffies + HZ;
+    int this_cpu = this_rq->cpu;
+    u64 t0, t1, curr_cost = 0;
+    struct sched_domain *sd;
+    int pulled_task = 0;
+
+    update_blocked_averages(this_cpu);
+
+    rcu_read_lock();
+    for_each_domain(this_cpu, sd) {
+        int continue_balancing = 1;
+
+        if (this_rq->avg_idle < curr_cost + sd->avg_scan_cost ||
+            !READ_ONCE(sd->nohz_idle))
+            break;
+
+        if (sd->flags & SD_BALANCE_NEWIDLE) {
+            pulled_task = load_balance(this_cpu, this_rq, sd,
+                                        CPU_NEWLY_IDLE, &continue_balancing);
+        }
+
+        if (pulled_task || this_rq->nr_running > 0)
+            break;
+    }
+    rcu_read_unlock();
+
+    return pulled_task;
+}
+```
+
+`avg_idle` tracks average idle duration. If the CPU is expected to be idle for less time than the scan cost, it skips balancing — not worth the cache pollution.
+
+## Wakeup balancing: select_task_rq_fair
+
+When a task wakes up, the scheduler selects which CPU to place it on:
+
+```c
+/* kernel/sched/fair.c */
+static int select_task_rq_fair(struct task_struct *p, int prev_cpu,
+                                int wake_flags)
+{
+    int sync = (wake_flags & WF_SYNC) && !(current->flags & PF_EXITING);
+    struct sched_domain *tmp, *sd = NULL;
+    int cpu = smp_processor_id();
+    int new_cpu = prev_cpu;
+    int want_affine = 0;
+
+    /* SD_WAKE_AFFINE: try to wake on current CPU (good for producer/consumer) */
+    rcu_read_lock();
+    for_each_domain(cpu, tmp) {
+        if (want_affine && (tmp->flags & SD_WAKE_AFFINE) &&
+            cpumask_test_cpu(prev_cpu, sched_domain_span(tmp))) {
+            /* Wake affine: check if current CPU is a good choice */
+            if (wake_affine(tmp, p, cpu, prev_cpu, sync))
+                new_cpu = cpu;
+            break;
+        }
+        if (tmp->flags & sd_flag)
+            sd = tmp;
+    }
+
+    /* Find idlest CPU in the selected domain */
+    if (sd)
+        new_cpu = find_idlest_cpu(sd, p, cpu, prev_cpu, sd_flag);
+
+    rcu_read_unlock();
+    return new_cpu;
+}
+```
+
+**Wake affine**: if task B always wakes after task A (producer/consumer), schedule B on the same or nearby CPU to share cache lines.
+
+## Misfit tasks on asymmetric CPUs
+
+On big.LITTLE / hybrid CPUs (ARM big.LITTLE, Intel hybrid P+E cores), a task is "misfit" if it demands more capacity than its current CPU provides:
+
+```c
+/* kernel/sched/fair.c */
+static bool task_fits_capacity(struct task_struct *p, long capacity)
+{
+    return fits_capacity(task_util(p), capacity);
+}
+
+static inline bool fits_capacity(unsigned long util, unsigned long capacity)
+{
+    /* 80% threshold: task fits if util < 80% of CPU capacity */
+    return util < capacity_of(smp_processor_id()) * 4 / 5;
+}
+
+/* Misfit migration: triggered by nohz_balance_kick */
+static void check_misfit_status(struct rq *rq, struct sched_domain *sd)
+{
+    if (rq->misfit_task_load &&
+        (rq->curr->nr_cpus_allowed == 1 ||
+         !task_fits_capacity(rq->curr, rq->cpu_capacity))) {
+        sd->balance_interval = 1;  /* balance immediately */
+    }
+}
+```
+
+## Observing load balancing
+
+```bash
+# Runqueue lengths per CPU
+watch -n 1 'cat /proc/schedstat | awk "NR%2==0{cpu++; print \"cpu\"cpu, \$9}"'
+
+# Load balancing statistics
+cat /proc/schedstat | head -5
+# version 15
+# timestamp 123456789
+# cpu0 0 0 0 0 0 0 0 0 0   ← various fields
+# domain0 00000003 lb_count lb_balanced lb_failed ...
+
+# perf: scheduling events
+perf stat -e sched:sched_migrate_task,sched:sched_wakeup -a sleep 5
+
+# Trace task migrations
+echo 1 > /sys/kernel/tracing/events/sched/sched_migrate_task/enable
+cat /sys/kernel/tracing/trace_pipe
+# myapp-1234 [002] sched_migrate_task: comm=myapp pid=1234 prio=120 orig_cpu=2 dest_cpu=5
+
+# Scheduling domain topology
+cat /proc/sys/kernel/sched_domain/cpu0/domain0/name
+# MC
+cat /proc/sys/kernel/sched_domain/cpu0/domain1/name
+# NUMA
+
+# PELT utilization signal for each task
+cat /proc/<pid>/sched | grep -i util
+```
+
+## Further reading
+
+- [EAS: Energy-Aware Scheduling](eas.md) — energy-optimal CPU selection on heterogeneous hardware
+- [Scheduler: EEVDF](eevdf.md) — per-CPU task selection
+- [Scheduler: Scheduling Domains](sched-domains.md) — domain construction
+- [Memory Management: NUMA](../mm/numa.md) — NUMA topology and load balancing
+- `kernel/sched/fair.c` — CFS/EEVDF and load balancing
+- `kernel/sched/topology.c` — domain construction

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,9 @@ nav:
       - cpuset: sched/cpuset.md
       - Scheduling Domains: sched/sched-domains.md
       - CPU Affinity: sched/cpu-affinity.md
+    - Advanced:
+      - Load Balancing: sched/load-balancing.md
+      - Energy-Aware Scheduling: sched/eas.md
     - Debugging & Observability:
       - Scheduler Statistics: sched/schedstat.md
       - Scheduler Tracing: sched/sched-tracing.md


### PR DESCRIPTION
## Summary

- **Load Balancing** (`sched/load-balancing.md`): scheduling domain hierarchy (SMT→MC→NUMA), `struct sched_domain` flags (SD_LOAD_BALANCE, SD_WAKE_AFFINE, SD_ASYM_PACKING), `load_balance()` with `find_busiest_group`/`find_busiest_queue`, PELT exponential decay math, `struct lb_env` context, `newidle_balance` with `avg_idle` scan-cost gating, `select_task_rq_fair` wake-affine for producer/consumer, misfit task detection for big.LITTLE/hybrid CPUs, `schedstat`/`sched_migrate_task` tracepoint observability
- **Energy-Aware Scheduling** (`sched/eas.md`): `struct em_perf_domain`/`em_perf_state` energy model registration, CPU capacity normalization to 1024, `find_energy_efficient_cpu` with 6% migration threshold, `compute_energy` P-state lookup via `em_pd_get_efficient_state`, overutilized fallback to regular load balancer, schedutil+EAS interaction, thermal pressure accounting with `arch_update_thermal_pressure`, big.LITTLE capacity observation

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] Scheduler Advanced subsection appears in nav
- [ ] Cross-links to cpufreq/schedutil, NUMA, sched-domains resolve