### PR TITLE
Add advanced MM documentation: MGLRU and memory tiering

### DIFF
--- a/docs/mm/memory-tiering.md
+++ b/docs/mm/memory-tiering.md
@@ -1,0 +1,263 @@
+# Memory Tiering
+
+> Managing heterogeneous memory: DRAM, CXL, PMEM, and HBM
+
+## Why memory tiering?
+
+Modern servers increasingly have multiple memory types with different performance characteristics:
+
+| Memory type | Bandwidth | Latency | Capacity | Cost |
+|-------------|-----------|---------|----------|------|
+| HBM (on-package) | 1+ TB/s | ~10ns | 32-128GB | High |
+| DDR5 DRAM | 50-100 GB/s | ~80ns | 256GB-4TB | Medium |
+| CXL memory | 30-50 GB/s | ~200ns | 1-16TB | Lower |
+| PMEM (Optane) | 20-40 GB/s | ~300ns | 1-8TB | Lowest |
+
+The kernel must:
+1. **Identify** which memory node belongs to which tier
+2. **Place** hot pages on fast memory, cold pages on slow memory
+3. **Promote** cold pages that become hot
+4. **Demote** hot pages that go cold (under memory pressure)
+
+## Memory tiers
+
+```c
+/* include/linux/memory-tiers.h */
+struct memory_tier {
+    struct list_head    list;
+    struct list_head    memory_types;  /* memory types (NUMA nodes) in this tier */
+    int                 adistance;     /* abstract distance: lower = faster */
+    struct device       dev;
+};
+
+/* Default tier assignments: */
+/* DRAM: adistance = DRAM_ADISTANCE (200) */
+/* CXL:  adistance = CXL_ADISTANCE  (300) */
+/* PMEM: adistance = PMEM_ADISTANCE  (400) */
+```
+
+### Tier discovery
+
+```bash
+# View memory tiers
+cat /sys/devices/virtual/memory_tiering/memory_tierN/adistance
+# 200   ← DRAM tier
+
+# NUMA nodes and their tier assignment
+for node in /sys/devices/system/node/node*/; do
+    echo -n "$(basename $node): "
+    cat "$node/memory_tier" 2>/dev/null || echo "none"
+done
+
+# numactl: shows memory nodes
+numactl --hardware
+# available: 4 nodes (0-3)
+# node 0 cpus: 0-15
+# node 0 size: 256000 MB     ← DRAM
+# node 2 cpus:               ← no CPUs: CXL or PMEM memory node
+# node 2 size: 512000 MB
+```
+
+## Page demotion
+
+When fast memory is under pressure, the kernel demotes cold pages to slow memory nodes:
+
+```c
+/* mm/migrate.c */
+int migrate_pages_to_node(struct list_head *pagelist, int node,
+                           enum migrate_mode mode)
+{
+    /* Move pages from list to the specified NUMA node */
+    return migrate_pages(pagelist, alloc_migration_target_page,
+                          NULL, node, mode, MR_DEMOTION);
+}
+
+/* mm/vmscan.c: kswapd demotes when fast memory is low */
+static bool demote_page_list(struct list_head *demote_pages,
+                              struct pglist_data *pgdat)
+{
+    int target_nid = next_demotion_node(pgdat->node_id);
+    if (target_nid == NUMA_NO_NODE)
+        return false;  /* no slower tier available */
+
+    return migrate_pages_to_node(demote_pages, target_nid, MIGRATE_ASYNC) == 0;
+}
+```
+
+```bash
+# Monitor page demotions
+cat /proc/vmstat | grep pgdemote
+# pgdemote_kswapd   12345   ← pages demoted by kswapd
+# pgdemote_direct   678     ← pages demoted during direct reclaim
+```
+
+## Page promotion
+
+When a page on slow memory is frequently accessed, NUMA Balancing or the tier migration daemon can promote it to fast memory:
+
+```c
+/* mm/numa_balancing.c */
+static int numa_migrate_preferred(struct task_struct *p)
+{
+    unsigned long interval = msecs_to_jiffies(task_scan_period(p));
+    /* Migrate pages used by this task to the task's preferred NUMA node */
+    /* If preferred node is in a faster tier, this is a promotion */
+}
+```
+
+### Explicit promotion via memory_tier sysfs
+
+```bash
+# Set a page's NUMA node migration policy
+numactl --preferred=0 myprogram  # prefer DRAM (node 0)
+
+# Move all pages of a process to DRAM
+numactl --membind=0 --pid=1234 migrate
+
+# Check current page placement
+numastat -p <pid>
+# Per-node memory use of process:
+# N0      N1      N2      N3
+# 512.0   128.0   0.0     1024.0  (MB)
+```
+
+## Tiered memory allocation
+
+The kernel allocates from faster tiers first, falling back to slower:
+
+```c
+/* mm/page_alloc.c */
+static struct page *get_page_from_freelist(gfp_t gfp_mask, unsigned int order,
+                                            int alloc_flags,
+                                            const struct alloc_context *ac)
+{
+    struct zoneref *z;
+    struct zone *zone;
+
+    /* Zonelist is ordered: faster memory zones listed first */
+    for_next_zone_zonelist_nodemask(zone, z, ac->zonelist, ac->highest_zoneidx,
+                                    ac->nodemask) {
+        /* Try to allocate from this zone */
+        page = rmqueue(ac->preferred_zoneref->zone, zone, order,
+                        gfp_mask, alloc_flags, ac->migratetype);
+        if (page)
+            return page;
+    }
+    return NULL;
+}
+```
+
+The zonelist order is set by `build_zonelists()` which considers NUMA distance. With memory tiers, CXL memory at distance 300 is listed after DRAM at distance 200.
+
+## CXL (Compute Express Link) memory
+
+CXL is a PCIe-based memory expansion standard that allows attaching DRAM at higher latency than on-package DDR:
+
+```bash
+# Check CXL devices
+ls /sys/bus/cxl/devices/
+# mem0  mem1  (CXL memory devices)
+
+# CXL memory region
+cat /sys/bus/cxl/devices/mem0/size
+
+# Binding CXL memory to a NUMA node
+# (done by firmware/BIOS, then exposed as NUMA node N)
+cat /sys/devices/system/node/node2/memory_tier
+# memory_tier2    ← CXL assigned to tier 2
+```
+
+## PMEM (Persistent Memory)
+
+Optane DIMM and future persistent memory devices:
+
+```bash
+# ndctl: NVDIMM control
+ndctl list
+# [{
+#   "dev":"namespace0.0",
+#   "mode":"fsdax",
+#   "size":549755813888,
+#   "sector_size":512
+# }]
+
+# Mount PMEM as DAX (direct access, no page cache)
+mount -o dax /dev/pmem0 /mnt/pmem
+
+# Use PMEM as a memory tier (volatile, no persistence)
+# Configure via kernel boot parameter:
+# memmap=4G!4G  ← use 4G starting at 4G as PMEM (emulate with DRAM)
+```
+
+## NUMA migration policies
+
+```bash
+# System-wide NUMA migration policy
+cat /proc/sys/kernel/numa_balancing
+# 1 = enabled
+
+# Per-process migration control
+cat /proc/<pid>/numa_maps | head -5
+# 7f1234560000 default anon=4 dirty=4 N0=4 kernelpagesize_kB=4
+#                                     ^^^ all pages on NUMA node 0
+
+# Force pages to specific node
+numactl --membind=2 ./myapp  # allocate from node 2 (CXL)
+
+# Check page NUMA placement
+cat /proc/<pid>/numa_maps | awk '{print $2}' | sort | uniq -c
+```
+
+## Hot page detection for promotion
+
+The kernel uses PTE access bits and page fault sampling to identify hot pages on slow tiers:
+
+```c
+/* mm/numa_balancing.c — NUMA balancing fault handler */
+static int do_numa_page(struct vm_fault *vmf)
+{
+    struct page *page = vmf->page;
+    int current_nid = page_to_nid(page);
+    int target_nid  = numa_migrate_prep(page, vmf, vmf->address,
+                                         current_nid, &flags);
+
+    if (target_nid != current_nid) {
+        /* Target is in faster tier: promote this page */
+        migrate_misplaced_page(page, vmf, target_nid);
+    }
+    return 0;
+}
+```
+
+## Observing memory tiering
+
+```bash
+# Memory tier statistics
+cat /sys/kernel/debug/memory_tiering/
+
+# Promotion/demotion rates
+watch -n 1 'grep -E "pgpromote|pgdemote" /proc/vmstat'
+
+# Per-tier allocation stats
+cat /sys/devices/system/node/node*/vmstat | grep -E "nr_free|nr_active|nr_inactive"
+
+# Numastat: per-node allocation stats
+numastat
+# Per-node process memory usage:
+#                     Node 0    Node 2
+#            Huge         0         0
+#          Heap       1234.5   456.7
+#           Stack        2.1      0.0
+
+# CXL bandwidth monitoring
+perf stat -e uncore_imc/data_reads/,uncore_imc/data_writes/ -a sleep 5
+```
+
+## Further reading
+
+- [NUMA](numa.md) — NUMA topology fundamentals
+- [CXL Memory Tiering](cxl-memory-tiering.md) — CXL-specific details
+- [Page Reclaim](reclaim.md) — how demotion integrates with reclaim
+- [MGLRU](mglru.md) — generation-based LRU, key for identifying cold pages
+- `mm/memory-tiers.c` in the kernel tree — tier management
+- `Documentation/admin-guide/mm/memory-tiers.rst` in the kernel tree

--- a/docs/mm/mglru.md
+++ b/docs/mm/mglru.md
@@ -1,0 +1,190 @@
+# MGLRU: Multi-Generation LRU
+
+> A generational page reclaim algorithm for better working set detection
+
+## The problem with classic LRU
+
+The classic LRU (Least Recently Used) page reclaim uses two lists per memory zone: **active** and **inactive**. Pages migrate between them based on access. The fundamental problems:
+
+1. **The scan cost**: To find reclaimable pages, the reclaimer walks the inactive list. If the inactive list is full of hot pages (false negatives), it wastes CPU time.
+2. **One-time access pollution**: A large `dd` or `tar` operation reads every file once, thrashing the active list with cold pages.
+3. **No temporal locality**: Classic LRU treats a page accessed 1 second ago the same as one accessed 1 year ago.
+
+## MGLRU's generational model
+
+MGLRU (Multi-Generation LRU, merged in 6.1) divides pages into **generations**. Each generation represents pages that became hot at roughly the same time. The oldest generation is evicted first:
+
+```
+Generation 0 (oldest): pages not accessed since earliest timestamp
+Generation 1:          pages accessed in the second-oldest period
+...
+Generation N (newest): recently accessed pages
+
+Reclaim: evict from generation 0 first → if empty, evict generation 1 → ...
+Age: promote pages to the newest generation when accessed
+```
+
+Typical number of generations: 4. Each generation is ~seconds to minutes of activity.
+
+## Key data structures
+
+```c
+/* mm/vmscan.c (6.1+) */
+
+/* Per-node, per-type (anon/file) LRU state */
+struct lru_gen_folio {
+    /* Min/max generation counters */
+    unsigned long max_seq;          /* newest generation */
+    unsigned long min_seq[ANON_AND_FILE]; /* oldest non-empty generation */
+
+    /* Per-generation page counts */
+    long          nr_pages[MAX_NR_GENS][ANON_AND_FILE][MAX_NR_ZONES];
+
+    /* Bloom filter for faster refault detection */
+    unsigned long *filters[NR_BLOOM_FILTERS];
+    atomic_long_t  nr_evicted[ANON_AND_FILE];
+    atomic_long_t  nr_refaulted[ANON_AND_FILE];
+    atomic_long_t  protected[NR_HIST_GENS][ANON_AND_FILE][NR_BIRTH_MARKS];
+};
+
+/* Per-folio generation tracking embedded in folio flags */
+/* gen = folio_lru_gen(folio): which generation this folio is in */
+```
+
+## Aging: scanning for hot pages
+
+**Aging** walks page tables to find recently accessed pages and promote them to the newest generation:
+
+```c
+/* mm/vmscan.c */
+static bool walk_mm(struct lruvec *lruvec, struct mm_struct *mm,
+                     struct lru_gen_walk_control *lwc)
+{
+    struct lru_gen_mm_walk walk = {
+        .lruvec = lruvec,
+        .seq    = min_seq(lruvec, ANON_AND_FILE),
+        /* ... */
+    };
+
+    /* Walk all VMAs, checking PTE accessed bits */
+    walk_page_range(mm, 0, ULONG_MAX, &lru_gen_mm_walk_ops, &walk);
+    return walk.force_scan;
+}
+```
+
+The accessed bit in PTEs tells the kernel which pages have been touched since the last aging pass. Pages with the accessed bit set are promoted to the newest generation; those without are left in their old generation (and will be evicted sooner).
+
+## Eviction: reclaiming old generations
+
+**Eviction** reclaims pages from the oldest generation:
+
+```c
+/* mm/vmscan.c */
+static long evict_folios(struct lruvec *lruvec, struct scan_control *sc,
+                          swp_entry_t *swpent)
+{
+    int type = get_type_to_scan(lruvec, sc, &tier);
+    long nr_to_scan = get_nr_to_scan(lruvec, sc, can_age, type);
+    long nr_reclaimed = 0;
+
+    /* Get the oldest generation */
+    unsigned long min_seq = READ_ONCE(lrugen->min_seq[type]);
+
+    /* Collect folios from the oldest generation */
+    isolate_folios(lruvec, sc, type, min_seq, &list);
+
+    /* Try to reclaim them (writeback, swap, or just free) */
+    nr_reclaimed = reclaim_pages(&list);
+
+    /* If min generation is now empty, advance min_seq */
+    if (!nr_pages_in_gen(lruvec, type, min_seq))
+        WRITE_ONCE(lrugen->min_seq[type], min_seq + 1);
+
+    return nr_reclaimed;
+}
+```
+
+## Working set protection: refault detection
+
+MGLRU detects when evicted pages are immediately faulted back in (**refaults**), indicating the working set was violated. It uses a Bloom filter:
+
+1. When a page is evicted, its fingerprint is added to the Bloom filter
+2. When a page is faulted in, MGLRU checks if it was recently evicted
+3. If yes: the page is placed in a **protected generation** — older than the newest but protected from immediate eviction
+
+```c
+/* Refault detection */
+static bool lru_gen_test_recent(struct lruvec *lruvec, bool file,
+                                 struct folio *folio, ...)
+{
+    struct lru_gen_folio *lrugen = &lruvec->lrugen;
+    /* Check Bloom filter: was this folio recently evicted? */
+    return test_bloom_filter(lrugen, lrugen->min_seq[file], folio);
+}
+```
+
+## Comparison: classic LRU vs MGLRU
+
+| Aspect | Classic LRU | MGLRU |
+|--------|-------------|-------|
+| Data structure | active + inactive lists | 4 generation lists |
+| Reclaim target | scan inactive list | evict oldest generation |
+| Access tracking | active/inactive promotion | PTE accessed bit scan |
+| Working set detection | refault distance approximation | Bloom filter per generation |
+| Streaming reads | pollutes active list | one-time accesses stay in old gen |
+| Memory overhead | 2 list_head per folio | generation counters + Bloom filter |
+
+## Configuration
+
+```bash
+# MGLRU is enabled by default in 6.1+
+cat /sys/kernel/mm/lru_gen/enabled
+# 0x0007  ← bitmask: 1=enabled, 2=mglru, 4=aging
+
+# Enable/disable components
+echo 0 > /sys/kernel/mm/lru_gen/enabled    # disable MGLRU (use classic LRU)
+echo 0x0007 > /sys/kernel/mm/lru_gen/enabled  # enable all
+
+# Min LRU generations (default 2)
+cat /sys/kernel/mm/lru_gen/min_ttl_ms
+# 0  ← no minimum lifetime
+
+# Set minimum time a generation stays before eviction
+echo 1000 > /sys/kernel/mm/lru_gen/min_ttl_ms  # protect pages for 1s
+
+# Number of generations: controlled by MAX_NR_GENS (compile-time, usually 4)
+```
+
+## Observing MGLRU
+
+```bash
+# Generation distribution per node/memcg/zone
+cat /sys/kernel/debug/lru_gen
+
+# Output format:
+# memcg    N    lruvec    aged anon  0  1  2  3
+#                         evicted anon 0 1 2 3
+#                         aged file  0  1  2  3
+#                         evicted file 0 1 2 3
+
+# Memory pressure stats
+cat /proc/vmstat | grep -E "pgpromote|pgdemote|lru_gen"
+# pgpromote_success 12345    ← pages promoted to newer generation
+# pgdemote_kswapd 67890      ← pages demoted (aged into older generation)
+
+# Refault rate (working set violations)
+cat /proc/vmstat | grep pgrefault
+# pgrefault 1234
+
+# perf: track LRU events
+perf stat -e vmscan:mm_vmscan_lru_isolate -a sleep 5
+```
+
+## Further reading
+
+- [Page Reclaim](reclaim.md) — overall reclaim framework
+- [Reclaim Throttling](reclaim-throttling.md) — memory pressure signaling
+- [Swap](swap.md) — where anon pages go when evicted
+- [Page Cache](page-cache.md) — file-backed page lifecycle
+- `mm/vmscan.c` in the kernel tree — MGLRU implementation
+- `Documentation/admin-guide/mm/multigen_lru.rst` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - Caching & Reclaim:
       - Page Cache: mm/page-cache.md
       - Page Reclaim: mm/reclaim.md
+      - MGLRU: mm/mglru.md
       - Reclaim Throttling: mm/reclaim-throttling.md
       - Zone Reclaim Policy: mm/zone-reclaim.md
       - Shrinker API: mm/shrinker.md
@@ -109,6 +110,7 @@ nav:
       - RCU in Memory Management: mm/rcu-mm.md
       - TLB Optimization: mm/tlb-optimization.md
       - CXL Memory Tiering: mm/cxl-memory-tiering.md
+      - Memory Tiering: mm/memory-tiering.md
       - vrealloc: mm/vrealloc.md
     - Memory Cgroups:
       - Container Memory Limits: mm/container-memory-limits.md


### PR DESCRIPTION
## Summary

- **MGLRU** (`mm/mglru.md`): classic LRU limitations (scan cost, streaming pollution, no temporal locality), generational model with aging/eviction phases, `struct lru_gen_folio` with max_seq/min_seq/nr_pages per-generation-per-type-per-zone arrays, `walk_mm` PTE accessed bit scan for aging, `evict_folios` oldest-gen reclaim with min_seq advancement, Bloom filter refault detection for working set protection, MGLRU vs classic LRU comparison table, `/sys/kernel/mm/lru_gen/` configuration
- **Memory Tiering** (`mm/memory-tiering.md`): HBM/DRAM/CXL/PMEM bandwidth-latency-capacity table, `struct memory_tier` with adistance hierarchy, `demote_page_list` → `migrate_pages_to_node` for pressure-driven demotion, NUMA balancing `do_numa_page` for fault-driven promotion, zonelist ordering for faster-first allocation, CXL ndctl setup, PMEM DAX mount, `numastat`/`pgdemote_kswapd`/`pgpromote_success` observability

## Test plan

- [ ] `mkdocs build` completes without warnings  
- [ ] MGLRU appears under Caching & Reclaim, Memory Tiering under Advanced
- [ ] Cross-links to reclaim, swap, NUMA, CXL tiering resolve