### PR TITLE
Add live patching and kexec documentation

### DIFF
--- a/docs/livepatch/README.md
+++ b/docs/livepatch/README.md
@@ -1,0 +1,35 @@
+# Live Patching and kexec
+
+> Updating a running kernel without rebooting
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Kernel Live Patching](klp.md) | KLP, struct klp_patch, ftrace redirection, consistency model |
+| [kexec](kexec.md) | kexec_load, machine_kexec, kdump integration, fast reboot |
+
+## Quick reference
+
+```bash
+# Check if live patching is supported
+grep CONFIG_LIVEPATCH /boot/config-$(uname -r)
+# CONFIG_LIVEPATCH=y
+
+# List active live patches
+cat /sys/kernel/livepatch/*/enabled
+
+# Apply a live patch (kernel module)
+insmod mypatch.ko
+cat /sys/kernel/livepatch/mypatch/enabled
+# 1 = active and consistent
+
+# Disable a live patch
+echo 0 > /sys/kernel/livepatch/mypatch/enabled
+
+# kexec: load a new kernel
+kexec -l /boot/vmlinuz --initrd=/boot/initrd.img --reuse-cmdline
+
+# Execute the loaded kernel (immediate, no POST)
+kexec -e
+```

--- a/docs/livepatch/kexec.md
+++ b/docs/livepatch/kexec.md
@@ -1,0 +1,257 @@
+# kexec
+
+> Boot a new kernel from within a running kernel, without hardware reset
+
+## What kexec does
+
+`kexec` loads a new kernel into memory and jumps to it directly, bypassing BIOS/UEFI POST and the bootloader:
+
+```
+Normal boot:      BIOS/UEFI → GRUB → kernel
+kexec boot:       running kernel → kexec_exec → new kernel
+                  (BIOS/POST skipped → 5-10 second faster reboot)
+```
+
+Primary uses:
+1. **Fast reboot**: upgrade kernel in seconds instead of minutes
+2. **kdump**: crash kernel boots capture kernel to save vmcore
+3. **A/B kernel updates**: atomically switch to a new kernel
+
+## kexec_load syscall
+
+```c
+/* kernel/kexec.c */
+/*
+ * kexec_load(entry, nr_segments, segments, flags)
+ *   entry:      entry point of new kernel
+ *   nr_segments: number of memory segments to load
+ *   segments:   array of kexec_segment structs
+ *   flags:      KEXEC_ON_CRASH=for kdump, KEXEC_ARCH=arch, etc.
+ */
+
+struct kexec_segment {
+    const void  __user *buf;   /* userspace buffer with segment data */
+    size_t               bufsz; /* size of buffer */
+    const void          *mem;  /* target physical address */
+    size_t               memsz; /* size at target */
+};
+```
+
+### kexec_file_load: signature-verified loading
+
+`kexec_file_load` takes a file descriptor instead of raw memory segments, enabling kernel image signature verification:
+
+```c
+/* kexec_file_load(kernel_fd, initrd_fd, cmdline_len, cmdline, flags) */
+int kexec_file_load(int kernel_fd,      /* open("/boot/vmlinuz", O_RDONLY) */
+                     int initrd_fd,      /* initrd file descriptor */
+                     unsigned long cmdline_len,
+                     const char __user *cmdline,
+                     unsigned long flags);
+```
+
+If `CONFIG_KEXEC_VERIFY_SIG=y`, the kernel image must be signed with a trusted key — useful for Secure Boot compatibility.
+
+## Machine kexec: the jump
+
+When `kexec -e` is run, `machine_kexec()` performs the actual handoff:
+
+```c
+/* arch/x86/kernel/machine_kexec_64.c */
+void machine_kexec(struct kimage *image)
+{
+    unsigned long page_list;
+    unsigned long reboot_code_buffer_phys;
+    void *reboot_code_buffer;
+
+    /* Disable interrupts */
+    local_irq_disable();
+
+    /* Stop all other CPUs */
+    machine_crash_nonpanic_core(NULL);
+
+    /* Copy identity-mapped page tables (kexec needs to access
+       the new kernel's pages which are at physical addresses) */
+    page_list = image->head & PAGE_MASK;
+
+    /* Jump to the relocation trampoline */
+    reboot_code_buffer = page_address(image->control_code_page);
+    relocate_kernel((unsigned long)page_list,
+                     reboot_code_buffer,
+                     image->start,
+                     image->preserve_context,
+                     image->arch.pgtable);
+}
+
+/* relocate_kernel (assembly): */
+/*   1. Switch to identity-mapped page tables */
+/*   2. Copy new kernel segments to their final locations */
+/*   3. Jump to new kernel entry point */
+```
+
+## kimage: the loaded kernel
+
+```c
+/* include/linux/kexec.h */
+struct kimage {
+    kimage_entry_t  head;            /* page list head */
+    kimage_entry_t *entry;           /* current position in page list */
+    kimage_entry_t *last_entry;      /* end of page list */
+
+    unsigned long    start;          /* entry point of new kernel */
+
+    struct page     *control_code_page; /* page for relocation code */
+    struct page     *swap_page;         /* temporary page for copying */
+
+    unsigned long    nr_segments;    /* number of loaded segments */
+    struct kexec_segment segment[KEXEC_SEGMENT_MAX]; /* up to 16 segments */
+
+    struct list_head control_pages;  /* pages used by kexec itself */
+    struct list_head dest_pages;     /* pages for new kernel */
+    struct list_head unusable_pages; /* pages that can't be used */
+
+    /* ... */
+    unsigned long    flags;
+    int              type;           /* KEXEC_TYPE_DEFAULT or KEXEC_TYPE_CRASH */
+};
+```
+
+## kdump integration
+
+kdump uses kexec to boot a capture kernel when the primary kernel crashes:
+
+```
+Primary kernel running
+    │ panic() / oops
+    ▼
+machine_crash_shutdown()
+    │ stop all CPUs
+    │ save registers
+    ▼
+machine_kexec(kexec_crash_image)
+    │
+    ▼
+Capture kernel boots
+    │ reads /proc/vmcore (primary kernel's memory)
+    ▼
+makedumpfile saves vmcore → reboot
+```
+
+The capture kernel is loaded into a reserved physical memory region (`crashkernel=256M`) during normal boot. The primary kernel never uses this region, so it's intact after a crash.
+
+```bash
+# Load kdump kernel at boot
+kexec -p /boot/vmlinuz-kdump \
+    --initrd=/boot/initrd-kdump.img \
+    --reuse-cmdline \
+    --append="irqpoll nr_cpus=1 reset_devices"
+
+# List loaded kernels
+cat /sys/kernel/kexec_crash_loaded
+# 1 = crash kernel loaded
+
+cat /sys/kernel/kexec_loaded
+# 0 = no normal kexec kernel loaded
+```
+
+## kexec userspace tool
+
+```bash
+# Load a kernel for kexec reboot
+kexec -l /boot/vmlinuz \
+    --initrd=/boot/initrd.img \
+    --reuse-cmdline       # use current boot cmdline
+
+# Load with explicit command line
+kexec -l /boot/vmlinuz \
+    --initrd=/boot/initrd.img \
+    --append="root=/dev/sda1 quiet"
+
+# Execute: jump to new kernel immediately
+kexec -e
+
+# Or: schedule for next reboot (via systemctl)
+systemctl kexec
+# runs kexec -e during shutdown
+
+# Load crash kernel
+kexec -p /boot/vmlinuz-crash \
+    --initrd=/boot/initrd-crash.img \
+    --append="1 irqpoll"
+
+# Unload crash kernel
+kexec -p -u
+```
+
+## kexec in the kernel
+
+### Shutdown sequence
+
+```c
+/* kernel/kexec_core.c */
+int kernel_kexec(void)
+{
+    int error = 0;
+
+    /* Execute pre-kexec notifiers */
+    error = blocking_notifier_call_chain(&reboot_notifier_list, SYS_RESTART, NULL);
+
+    /* Suspend filesystems and devices */
+    error = pm_notifier_call_chain(PM_SUSPEND_PREPARE);
+
+    kernel_restart_prepare(NULL);
+
+    /* Disable SMP: all other CPUs stopped */
+    migrate_to_reboot_cpu();
+    syscore_shutdown();
+
+    /* Jump to new kernel */
+    machine_kexec(kexec_image);
+
+    /* Should not return */
+    BUG();
+    return error;
+}
+```
+
+### Preserving EFI runtime services
+
+```c
+/* For EFI systems: preserve EFI runtime memory */
+if (efi_enabled(EFI_RUNTIME_SERVICES)) {
+    /* Mark EFI runtime regions as preserved */
+    /* New kernel can use EFI runtime services */
+}
+```
+
+## Observing kexec
+
+```bash
+# Check kexec support in kernel
+grep KEXEC /boot/config-$(uname -r)
+# CONFIG_KEXEC=y
+# CONFIG_KEXEC_FILE=y
+# CONFIG_KEXEC_VERIFY_SIG=y   (optional)
+
+# Memory reserved for kdump
+cat /proc/iomem | grep -i crash
+# 100000000-10fffffff : Crash kernel
+
+# Boot source detection: was this a kexec boot?
+cat /sys/kernel/kexec_loaded
+# After kexec reboot: bootloader may set ACPI table flag
+dmesg | grep -i kexec
+
+# Timing: kexec vs cold boot
+time systemctl kexec   # ~5 seconds
+# vs
+time reboot            # ~60 seconds (BIOS POST)
+```
+
+## Further reading
+
+- [kdump and crash](../debugging/kdump.md) — crash dump collection using kexec
+- [Kernel Live Patching](klp.md) — avoiding reboots entirely
+- [Power Management: System Suspend](../power/suspend.md) — PM notifiers in kexec path
+- `kernel/kexec_core.c`, `arch/x86/kernel/machine_kexec_64.c` — kexec core
+- `man 8 kexec` — userspace kexec tool

--- a/docs/livepatch/klp.md
+++ b/docs/livepatch/klp.md
@@ -1,0 +1,299 @@
+# Kernel Live Patching (KLP)
+
+> Applying security fixes and bug fixes to a running kernel without rebooting
+
+## What KLP does
+
+KLP redirects calls from the original (buggy) function to a replacement (patched) function at runtime, using ftrace's function entry hook:
+
+```
+Before patch:           After patch:
+  caller                  caller
+    │                       │
+    call orig_func          call orig_func
+                              │ (function entry hook)
+                              └─► NEW: jump to patched_func
+                                        │
+                                        └─► executes patch
+```
+
+The original function's first bytes are never modified. The ftrace hook at function entry branches to the replacement.
+
+## Architecture
+
+```c
+/* include/linux/livepatch.h */
+
+/* Describes one patched function */
+struct klp_func {
+    const char      *old_name;      /* name of function to patch */
+    void            *new_func;      /* replacement function */
+    unsigned long    old_sympos;    /* which occurrence (for duplicates) */
+    unsigned long    old_addr;      /* resolved at patch time */
+    struct kobject   kobj;
+    struct list_head node;
+    struct ftrace_ops fops;          /* ftrace hook for this function */
+    bool             nops;          /* no-op patch (for rollback testing) */
+    bool             patched;       /* currently active */
+    bool             transition;    /* in consistency transition */
+};
+
+/* A set of functions that form one complete patch */
+struct klp_patch {
+    struct module   *mod;           /* the live patch module */
+    struct klp_object *objs;        /* array of objects (modules/vmlinux) */
+    bool             enabled;
+    bool             forced;        /* forced (skipped consistency check) */
+    struct work_struct free_work;
+    struct completion finish;
+    struct kobject   kobj;
+    struct list_head list;
+};
+
+/* Functions grouped by the kernel module (or vmlinux) they patch */
+struct klp_object {
+    const char      *name;          /* NULL for vmlinux */
+    struct klp_func *funcs;         /* array of functions to patch */
+    struct module   *mod;           /* resolved target module */
+    struct kobject   kobj;
+    struct list_head node;
+    bool             dynamic;       /* for dynamically added funcs */
+};
+```
+
+## Writing a live patch module
+
+```c
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/livepatch.h>
+
+/* The replacement function */
+static int patched_vfs_read(struct file *file, char __user *buf,
+                             size_t count, loff_t *pos)
+{
+    /* New implementation with the bug fixed */
+    if (!file || !file->f_op)
+        return -EBADF;   /* was: NULL deref here */
+
+    /* Call the original after our check */
+    return klp_call_orig(file, buf, count, pos);
+    /* Or: re-implement entirely */
+}
+
+/* Patch descriptor */
+static struct klp_func funcs[] = {
+    {
+        .old_name = "vfs_read",
+        .new_func = patched_vfs_read,
+    },
+    {}  /* sentinel */
+};
+
+static struct klp_object objs[] = {
+    {
+        .name  = NULL,  /* NULL = patch vmlinux */
+        .funcs = funcs,
+    },
+    {}  /* sentinel */
+};
+
+static struct klp_patch patch = {
+    .mod  = THIS_MODULE,
+    .objs = objs,
+};
+
+static int __init livepatch_init(void)
+{
+    return klp_enable_patch(&patch);
+}
+
+static void __exit livepatch_exit(void)
+{
+    /* KLP modules are sticky by default — can only unload after disabling */
+}
+
+module_init(livepatch_init);
+module_exit(livepatch_exit);
+MODULE_INFO(livepatch, "Y");
+MODULE_LICENSE("GPL");
+```
+
+### Calling the original function
+
+```c
+/* klp_call_orig() works only when called from a live-patched function */
+/* It calls the unpatched version of the function */
+static int my_patched_func(...)
+{
+    /* Do pre-processing */
+    preprocess(args);
+
+    /* Call original */
+    int ret = klp_call_orig(args);
+
+    /* Do post-processing */
+    postprocess(ret);
+    return ret;
+}
+```
+
+## ftrace-based redirection
+
+KLP uses ftrace's `FTRACE_OPS_FL_SAVE_REGS` to redirect function calls:
+
+```c
+/* kernel/livepatch/patch.c */
+static void notrace klp_ftrace_handler(unsigned long ip,
+                                         unsigned long parent_ip,
+                                         struct ftrace_ops *fops,
+                                         struct ftrace_regs *fregs)
+{
+    struct klp_ops *ops;
+    struct klp_func *func;
+    int patch_state;
+
+    ops = container_of(fops, struct klp_ops, fops);
+
+    /* Find the active patch for this function */
+    func = list_first_or_null_rcu(&ops->func_stack, struct klp_func, stack_node);
+    if (!func)
+        return;
+
+    /* Check consistency: is this task in a safe state? */
+    patch_state = current->patch_state;
+    if (patch_state == KLP_UNDEFINED)
+        patch_state = current->patch_state = KLP_UNPATCHED;
+
+    if (func->transition) {
+        if (patch_state == KLP_UNPATCHED)
+            return;  /* task not yet transitioned */
+    }
+
+    /* Redirect: change IP to point to patched function */
+    klp_arch_set_pc(fregs, (unsigned long)func->new_func);
+}
+```
+
+## The consistency model
+
+KLP can't simply redirect calls immediately — a task might be in the middle of executing the old function. The **consistency model** ensures all tasks have transitioned before the patch is considered active:
+
+```
+State: KLP_UNPATCHED → (patch applied) → KLP_PATCHED
+
+For each task:
+  1. When task returns to userspace (schedule point), mark as KLP_PATCHED
+  2. Tasks already in kernel get KLP_PATCHED at their next schedule
+  3. Until all tasks are KLP_PATCHED, the patch is in "transition" state
+
+During transition:
+  - New task entries: use new (patched) function
+  - Tasks already running in old function: continue until they return
+  - Patch isn't "complete" until all tasks are transitioned
+```
+
+```bash
+# Check transition status
+cat /sys/kernel/livepatch/mypatch/transition
+# 1 = still transitioning (some tasks not yet patched)
+# 0 = complete
+
+# Force completion (skips consistency check — may be unsafe!)
+echo 1 > /sys/kernel/livepatch/mypatch/force
+```
+
+### Sleepy tasks
+
+A task blocked in `D` state (uninterruptible sleep) inside the old function will delay the transition. The kernel waits (with periodic wakeup attempts via `kick_all_cpus_sync()`):
+
+```bash
+# If transition is stuck: find who's blocking it
+cat /sys/kernel/livepatch/mypatch/transition
+# 1
+
+# Find tasks in the old function's call stack
+ps aux | grep ' D '  # uninterruptible sleep tasks
+cat /proc/<pid>/stack  # check if in the old function
+```
+
+## Shadow variables
+
+Shadow variables attach extra data to existing kernel objects without modifying their structure — useful when a patch needs to add state:
+
+```c
+/* Add a "magic" field to struct file without changing the struct */
+#define KLP_SHADOW_MAGIC 0xdeadbeef
+
+struct my_shadow_data {
+    u32 magic;
+    int new_state;
+};
+
+/* On first use: allocate and attach shadow data */
+struct my_shadow_data *data;
+data = klp_shadow_get_or_alloc(file,  /* attached to this object */
+                                 KLP_SHADOW_MAGIC,
+                                 sizeof(*data), GFP_KERNEL,
+                                 shadow_init_fn, NULL);
+data->new_state = 42;
+
+/* On subsequent uses: retrieve */
+data = klp_shadow_get(file, KLP_SHADOW_MAGIC);
+
+/* On cleanup (e.g., file close): free */
+klp_shadow_free(file, KLP_SHADOW_MAGIC, NULL);
+```
+
+Shadow data is stored in a global hash table keyed by (object pointer, ID).
+
+## Building a live patch
+
+```bash
+# Kernel build tree required
+make -C /lib/modules/$(uname -r)/build M=$(pwd) modules
+
+# Or: use kpatch-build (automated live patch creation)
+kpatch-build -t vmlinux fix.patch
+
+# Install
+insmod mypatch.ko
+lsmod | grep livepatch
+
+# Verify active
+cat /sys/kernel/livepatch/mypatch/enabled
+# 1
+```
+
+## Observing live patches
+
+```bash
+# All active patches
+for p in /sys/kernel/livepatch/*/; do
+    echo "Patch: $(basename $p)"
+    echo "  enabled: $(cat $p/enabled)"
+    echo "  transition: $(cat $p/transition)"
+done
+
+# Which functions are patched
+cat /sys/kernel/livepatch/*/objs/*/funcs/*/patched
+cat /sys/kernel/livepatch/*/objs/*/funcs/*/old_addr
+
+# Kernel taint from live patch
+cat /proc/sys/kernel/tainted
+# bit 11 set (KLP patch applied)
+
+# Verify with dmesg
+dmesg | grep livepatch
+# livepatch: enabling patch 'mypatch'
+# livepatch: 'mypatch': starting patching transition
+# livepatch: 'mypatch': patching complete
+```
+
+## Further reading
+
+- [kexec](kexec.md) — loading and booting a new kernel
+- [Kernel Modules](../modules/module-basics.md) — KLP uses the module system
+- [Tracing: ftrace](../tracing/ftrace.md) — ftrace function hooks used by KLP
+- `kernel/livepatch/` in the kernel tree — KLP implementation
+- `Documentation/livepatch/` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -350,6 +350,10 @@ nav:
     - Getting Started: crypto/README.md
     - Kernel Crypto API: crypto/crypto-api.md
     - dm-crypt and fscrypt: crypto/encryption.md
+  - Live Patching:
+    - Getting Started: livepatch/README.md
+    - Kernel Live Patching: livepatch/klp.md
+    - kexec: livepatch/kexec.md
   - Architecture:
     - ARM64:
       - Getting Started: arch/arm64/README.md


### PR DESCRIPTION
## Summary

- **Kernel Live Patching** (`livepatch/klp.md`): `struct klp_func`/`klp_object`/`klp_patch` full layout, ftrace `klp_ftrace_handler` with `klp_arch_set_pc` IP redirect, consistency model (KLP_UNPATCHED→KLP_PATCHED per-task transition), D-state blocking tasks detection, `klp_call_orig` for calling original function, shadow variables `klp_shadow_get_or_alloc` for adding state to existing objects, complete minimal live patch module with `MODULE_INFO(livepatch, "Y")`, `enabled`/`transition`/`force` sysfs, kpatch-build tooling
- **kexec** (`livepatch/kexec.md`): `kexec_load` with `kexec_segment` physical address layout, `kexec_file_load` for signature-verified loading, `machine_kexec` identity page table switch and `relocate_kernel` jump, `struct kimage` control/dest/unusable page management, kdump crash kernel in reserved `crashkernel=` region, `kernel_kexec` PM notifier + syscore shutdown sequence, EFI runtime preservation, userspace kexec tool options, fast reboot (~5s vs 60s cold)

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] Live Patching nav section renders
- [ ] Cross-links to kdump, modules, ftrace, power management resolve