### PR TITLE
Add SRCU and completions/wait queue documentation

### DIFF
--- a/docs/locking/completions.md
+++ b/docs/locking/completions.md
@@ -1,0 +1,289 @@
+# Completions and Wait Queues
+
+> Blocking synchronization: sleeping until an event occurs
+
+## struct completion
+
+`completion` is a simple one-shot synchronization primitive: one thread waits, another signals when done. It's simpler and safer than using `wait_queue_head_t` directly for this common pattern.
+
+```c
+#include <linux/completion.h>
+
+/* Declare and initialize */
+DECLARE_COMPLETION(my_completion);
+/* Or dynamically: */
+struct completion c;
+init_completion(&c);
+
+/* Waiter thread: block until signaled */
+wait_for_completion(&c);
+/* Execution continues here after signal */
+
+/* Signaler thread: wake up the waiter */
+complete(&c);
+/* After complete(), one waiter is woken */
+```
+
+### Completion variants
+
+```c
+/* Timed wait: return 0 on timeout, 1 on completion */
+unsigned long remaining = wait_for_completion_timeout(&c, jiffies + HZ);
+if (!remaining)
+    pr_err("Timed out waiting!\n");
+
+/* Interruptible wait: return -ERESTARTSYS if signal arrives */
+int ret = wait_for_completion_interruptible(&c);
+if (ret)
+    return ret;  /* interrupted */
+
+/* Interruptible with timeout */
+long ret = wait_for_completion_interruptible_timeout(&c, timeout);
+/* ret > 0: completed */
+/* ret == 0: timed out */
+/* ret < 0: interrupted */
+
+/* Wake all waiters (not just one) */
+complete_all(&c);
+
+/* Reinitialize after all waiters have woken */
+reinit_completion(&c);
+
+/* Check without blocking */
+if (completion_done(&c)) {
+    /* already signaled */
+}
+```
+
+### Completion with try_wait
+
+```c
+/* Non-blocking check: acquire if already signaled */
+if (try_wait_for_completion(&c)) {
+    /* Was already complete — no blocking */
+} else {
+    /* Not yet complete — would have blocked */
+}
+```
+
+## struct wait_queue_head_t
+
+`wait_queue_head_t` is the lower-level primitive that `completion` builds on. It supports:
+- Multiple waiters on the same event
+- Custom wake conditions
+- Exclusive vs non-exclusive wakeup
+- `poll()/select()/epoll` integration
+
+```c
+#include <linux/wait.h>
+
+/* Declare */
+DECLARE_WAIT_QUEUE_HEAD(my_wq);
+/* Or: */
+wait_queue_head_t wq;
+init_waitqueue_head(&wq);
+```
+
+## wait_event: the standard pattern
+
+`wait_event` combines the wait with a condition check:
+
+```c
+/* Waiter: sleep until condition is true */
+wait_event(wq, condition);
+/* condition is re-evaluated after every wakeup */
+
+/* Interruptible version */
+int ret = wait_event_interruptible(wq, condition);
+if (ret)
+    return ret;  /* -ERESTARTSYS: signal received */
+
+/* With timeout */
+long ret = wait_event_timeout(wq, condition, timeout_jiffies);
+/* ret > 0: condition met */
+/* ret == 0: timed out */
+
+/* With interruptible + timeout */
+long ret = wait_event_interruptible_timeout(wq, condition, timeout);
+```
+
+**The wake_up / wait_event contract**:
+
+```c
+/* Signaler: modify the condition variable, then wake */
+WRITE_ONCE(data_ready, true);
+wake_up(&wq);          /* wake one non-exclusive waiter */
+wake_up_all(&wq);      /* wake all waiters */
+wake_up_interruptible(&wq);  /* wake only interruptible waiters */
+```
+
+`wait_event` uses a loop:
+```c
+/* wait_event expansion (simplified): */
+for (;;) {
+    prepare_to_wait(&wq, &__wait, TASK_UNINTERRUPTIBLE);
+    if (condition)
+        break;
+    schedule();   /* sleep */
+}
+finish_wait(&wq, &__wait);
+```
+
+This correctly handles races: if the condition becomes true between the check and `schedule()`, the wake_up will have set the task state back to TASK_RUNNING.
+
+## Custom wait: prepare_to_wait / finish_wait
+
+For more complex patterns:
+
+```c
+DEFINE_WAIT(wait);
+
+prepare_to_wait(&wq, &wait, TASK_INTERRUPTIBLE);
+while (!condition) {
+    if (signal_pending(current)) {
+        /* Signal received */
+        break;
+    }
+    /* Drop any locks here before sleeping */
+    spin_unlock_irq(&lock);
+    schedule();
+    spin_lock_irq(&lock);
+    /* Recheck condition here */
+}
+finish_wait(&wq, &wait);
+```
+
+## Exclusive waiters
+
+Exclusive waiters are woken one at a time (thundering herd prevention):
+
+```c
+/* Add as exclusive waiter (only woken by wake_up, not wake_up_all) */
+prepare_to_wait_exclusive(&wq, &wait, TASK_INTERRUPTIBLE);
+
+/* wake_up: wakes exactly one exclusive waiter + all non-exclusive */
+wake_up(&wq);
+```
+
+Used for accept() on TCP listen sockets: only one of many waiting accept() calls needs to be woken when a connection arrives.
+
+## poll/select/epoll integration
+
+Drivers implement `poll` (or `->poll` in file_operations) using wait queues:
+
+```c
+/* In file_operations.poll or .f_poll: */
+static __poll_t mydev_poll(struct file *file, poll_table *wait)
+{
+    struct mydev *dev = file->private_data;
+    __poll_t mask = 0;
+
+    /* Register this file's wait queue with the poll table */
+    poll_wait(file, &dev->read_wq, wait);
+    poll_wait(file, &dev->write_wq, wait);
+
+    /* Check current state */
+    if (!kfifo_is_empty(&dev->recv_fifo))
+        mask |= EPOLLIN | EPOLLRDNORM;   /* data available to read */
+    if (!kfifo_is_full(&dev->send_fifo))
+        mask |= EPOLLOUT | EPOLLWRNORM;  /* space available to write */
+
+    return mask;
+}
+
+/* When data arrives: wake the wait queue */
+void mydev_data_arrived(struct mydev *dev)
+{
+    kfifo_put(&dev->recv_fifo, data);
+    wake_up_interruptible(&dev->read_wq);
+}
+```
+
+`poll_wait` adds the wait queue to the poll table so that epoll monitors it. When `wake_up` fires, epoll wakes the calling process.
+
+## wait_queue_entry: custom callbacks
+
+Advanced use: add a custom function to call on wakeup:
+
+```c
+/* Custom wait entry with callback */
+static int my_wakeup_func(struct wait_queue_entry *curr,
+                           unsigned mode, int wake_flags, void *key)
+{
+    struct mydata *data = container_of(curr, struct mydata, wait_entry);
+
+    /* Called in the waker's context (IRQ or process) */
+    /* Return 0 to continue waking other waiters, 1 to stop */
+
+    /* Schedule a task for later processing */
+    schedule_work(&data->work);
+    return 1;  /* don't wake the task directly */
+}
+
+struct wait_queue_entry wqe = {
+    .private = &mydata,
+    .func    = my_wakeup_func,
+    .flags   = 0,  /* or WQ_FLAG_EXCLUSIVE for exclusive */
+};
+
+add_wait_queue(&wq, &wqe);
+/* ... */
+remove_wait_queue(&wq, &wqe);
+```
+
+## Common patterns
+
+### Producer/consumer with wait queue
+
+```c
+struct ring_buffer {
+    u8               data[1024];
+    unsigned int     head, tail;
+    wait_queue_head_t not_empty;   /* consumers wait here */
+    wait_queue_head_t not_full;    /* producers wait here */
+    spinlock_t        lock;
+};
+
+/* Consumer */
+int rb_read(struct ring_buffer *rb, u8 *buf, size_t len)
+{
+    int ret;
+
+    spin_lock(&rb->lock);
+    ret = wait_event_interruptible_lock_irq(rb->not_empty,
+                                             !rb_is_empty(rb),
+                                             rb->lock);
+    if (ret) {
+        spin_unlock(&rb->lock);
+        return ret;  /* interrupted */
+    }
+
+    memcpy(buf, &rb->data[rb->tail], len);
+    rb->tail = (rb->tail + len) % sizeof(rb->data);
+    spin_unlock(&rb->lock);
+
+    wake_up(&rb->not_full);
+    return len;
+}
+
+/* Producer */
+int rb_write(struct ring_buffer *rb, const u8 *buf, size_t len)
+{
+    spin_lock(&rb->lock);
+    wait_event_interruptible_lock_irq(rb->not_full, !rb_is_full(rb), rb->lock);
+    memcpy(&rb->data[rb->head], buf, len);
+    rb->head = (rb->head + len) % sizeof(rb->data);
+    spin_unlock(&rb->lock);
+
+    wake_up(&rb->not_empty);
+    return len;
+}
+```
+
+## Further reading
+
+- [SRCU](srcu.md) — sleepable RCU with read-side blocking
+- [Mutex](mutex.md) — sleeping mutual exclusion
+- [IPC: Signals](../ipc/signals.md) — signal delivery to waiting tasks
+- [io_uring](../io-uring/io-uring-arch.md) — io_uring avoids wait queues entirely
+- `include/linux/wait.h` — full wait queue API

--- a/docs/locking/srcu.md
+++ b/docs/locking/srcu.md
@@ -1,0 +1,161 @@
+# SRCU: Sleepable RCU
+
+> RCU for read-side critical sections that may block or sleep
+
+## The problem with classic RCU
+
+Classic RCU (`rcu_read_lock`) has one key constraint: **no sleeping**. The reader must stay in its critical section without blocking:
+
+```c
+rcu_read_lock();
+p = rcu_dereference(global_ptr);
+/* Must not sleep here! No mutex, no blocking I/O */
+do_something(p);
+rcu_read_unlock();
+```
+
+This rules out many use cases: VFS operations (may take a lock), I/O, memory allocation with GFP_KERNEL, or any operation that might schedule.
+
+**SRCU** (Sleepable RCU) allows sleeping inside the read-side critical section. The trade-off: SRCU is more expensive than classic RCU (per-CPU counters instead of quiescent state detection).
+
+## SRCU usage
+
+```c
+#include <linux/srcu.h>
+
+/* Declare a per-module SRCU domain */
+DEFINE_SRCU(my_srcu);
+/* Or: */
+struct srcu_struct my_srcu;
+init_srcu_struct(&my_srcu);  /* dynamic initialization */
+
+/* ---- Read side ---- */
+int idx = srcu_read_lock(&my_srcu);
+/* CAN sleep here (mutex, wait_event, etc.) */
+p = srcu_dereference(global_ptr, &my_srcu);
+mutex_lock(&p->lock);     /* ← this is fine in SRCU */
+do_work(p);
+mutex_unlock(&p->lock);
+srcu_read_unlock(&my_srcu, idx);
+
+/* ---- Update side ---- */
+old = rcu_replace_pointer(global_ptr, new_ptr, 1);
+
+/* Wait for all current readers to complete */
+synchronize_srcu(&my_srcu);  /* may sleep (blocks) */
+/* Safe to free old */
+kfree(old);
+
+/* Asynchronous: */
+call_srcu(&my_srcu, &old->rcu, my_free_callback);
+```
+
+## struct srcu_struct
+
+```c
+/* include/linux/srcu.h */
+struct srcu_struct {
+    struct srcu_node    node[NUM_RCU_NODES];  /* expedited nodes */
+    struct srcu_node   *level[RCU_NUM_LVLS + 1]; /* node levels */
+    int                 srcu_size_state;       /* size of below */
+    struct mutex        srcu_cb_mutex;         /* callback serialization */
+    spinlock_t          lock;
+    struct mutex        srcu_gp_mutex;
+    unsigned int        srcu_idx;             /* current grace period idx */
+    bool                srcu_gp_running;
+    bool                srcu_gp_waiting;
+    struct srcu_data __percpu *sda;           /* per-CPU counters */
+    struct list_head    srcu_work_list;
+    struct delayed_work work;                 /* periodic grace period check */
+    struct lockdep_map  dep_map;
+    unsigned long       srcu_gp_seq;          /* grace period sequence */
+    unsigned long       srcu_gp_seq_needed;
+    unsigned long       srcu_gp_seq_needed_exp;
+};
+```
+
+### Per-CPU counters: the key difference
+
+Classic RCU tracks quiescent states globally. SRCU uses per-CPU counters that readers increment/decrement:
+
+```c
+/* srcu_read_lock: */
+int idx = srcu_read_lock(sp)
+    → this_cpu_inc(sp->sda->srcu_lock_count[idx & 1])
+    → return idx
+
+/* srcu_read_unlock: */
+srcu_read_unlock(sp, idx)
+    → this_cpu_inc(sp->sda->srcu_unlock_count[idx & 1])
+```
+
+A grace period completes when `srcu_lock_count[old_idx] == srcu_unlock_count[old_idx]` across all CPUs — meaning all readers that started before the grace period have finished.
+
+## Expedited SRCU
+
+`synchronize_srcu_expedited()` shortens the grace period by actively polling CPUs:
+
+```c
+/* Faster than synchronize_srcu but more CPU intensive */
+synchronize_srcu_expedited(&my_srcu);
+```
+
+Use for infrequent, latency-critical updates where waiting is unacceptable.
+
+## SRCU vs classic RCU
+
+| Feature | RCU | SRCU |
+|---------|-----|------|
+| Read-side overhead | barrier (near zero) | per-CPU counter increment |
+| Sleep in read-side | No | Yes |
+| Grace period | Async, natural quiescent states | Active polling of per-CPU counters |
+| Multiple domains | One global | One per-domain (struct srcu_struct) |
+| Typical use | Lock-free data structures | VFS, notifiers, module unload |
+| `call_rcu` equivalent | Yes | `call_srcu` |
+
+## Real-world uses of SRCU
+
+**VFS path lookup**: The kernel uses SRCU for namespaces where locks might be needed during the read-side:
+
+```c
+/* fs/namespace.c */
+/* SRCU for mount namespace protection */
+DEFINE_STATIC_SRCU(mount_lock);
+
+int path_mount(const char *dev_name, struct path *path, ...)
+{
+    int mnt_flags = 0;
+    int retval;
+
+    /* ... */
+    retval = do_mount(dev_name, path->dentry, type_page, flags, data_page);
+    /* ... */
+}
+```
+
+**Notifier chains**: Many kernel notifier chains use SRCU to allow sleeping callbacks.
+
+**Module unload**: SRCU allows holding a reference to a module while sleeping, preventing the module from being unloaded mid-operation.
+
+## Observing SRCU
+
+```bash
+# SRCU grace period statistics
+cat /sys/kernel/debug/rcu/rcudata
+
+# Lockdep: SRCU annotations appear in lockdep output
+# If a read-side critical section is too long:
+dmesg | grep "SRCU stall"
+# rcu: INFO: SRCU stall warning (5999ms)
+
+# Force an SRCU stall (for testing, requires CONFIG_RCU_STALL_COMMON)
+# echo 1 > /sys/kernel/debug/rcu/rcu_urgent_qs
+```
+
+## Further reading
+
+- [RCU](rcu.md) — classic RCU for non-sleeping read-side
+- [Mutex](mutex.md) — blocking mutual exclusion
+- [Completions and Wait Queues](completions.md) — blocking synchronization primitives
+- `kernel/rcu/srcutree.c` — SRCU implementation
+- `Documentation/RCU/Design/` in the kernel tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,6 +242,8 @@ nav:
       - Lockdep: locking/lockdep.md
       - Lock Contention Debugging: locking/lock-debugging.md
       - Futex Internals: locking/futex.md
+      - SRCU: locking/srcu.md
+      - Completions and Wait Queues: locking/completions.md
   - Interrupts:
     - Getting Started: interrupts/README.md
     - Fundamentals:


### PR DESCRIPTION
## Summary

- **SRCU** (`locking/srcu.md`): motivation (classic RCU no-sleep constraint), `DEFINE_SRCU`/`init_srcu_struct`, `srcu_read_lock` idx tracking, `srcu_dereference`, sleeping allowed in critical section, `synchronize_srcu`/`call_srcu`/`synchronize_srcu_expedited`, `struct srcu_struct` per-CPU `sda` counters with `srcu_lock_count`/`srcu_unlock_count` alternation, RCU vs SRCU comparison table, real-world uses (VFS, notifiers, module unload)
- **Completions and Wait Queues** (`locking/completions.md`): `DECLARE_COMPLETION`/`wait_for_completion`/`complete`, all timeout/interruptible/try_wait variants, `wait_queue_head_t` with `wait_event` condition-loop expansion, `wake_up`/`wake_up_all`/`wake_up_interruptible`, `prepare_to_wait`/`finish_wait` for lock-releasing patterns, exclusive waiters with `prepare_to_wait_exclusive`, `poll_wait`+`wake_up_interruptible` for epoll integration, custom `wait_queue_entry` with callback, producer/consumer ring buffer with `wait_event_interruptible_lock_irq`

## Test plan

- [ ] `mkdocs build` completes without warnings
- [ ] SRCU and Completions appear under Locking/Advanced in nav
- [ ] Cross-links to RCU, mutex, io_uring resolve