### PR TITLE
Add I/O Patterns section: direct I/O and async I/O evolution

### DIFF
--- a/docs/io/README.md
+++ b/docs/io/README.md
@@ -1,0 +1,39 @@
+# I/O Patterns
+
+> Direct I/O, asynchronous I/O, and the evolution from AIO to io_uring
+
+## I/O interface landscape
+
+```
+Application I/O interfaces:
+
+read()/write()          — synchronous, buffered (page cache)
+mmap()                  — memory-mapped I/O (page cache backed)
+O_DIRECT                — synchronous, bypasses page cache
+POSIX AIO               — async, user-thread-based (glibc)
+Linux AIO               — async kernel, but limited to O_DIRECT
+io_uring                — modern async I/O for everything
+epoll + non-blocking    — async for network/pipes (not files)
+```
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Direct I/O](direct-io.md) | O_DIRECT, alignment requirements, DIO path, mmap comparison |
+| [Async I/O evolution](async-io.md) | POSIX AIO, Linux AIO limitations, io_uring advantages |
+
+## Quick reference
+
+```bash
+# Check if filesystem supports O_DIRECT
+open("file", O_RDONLY | O_DIRECT)
+# EINVAL if not supported (tmpfs, procfs, etc.)
+
+# Linux AIO submit
+io_submit(ctx, 1, iocbs)   # blocking submit
+io_getevents(ctx, 1, 1, events, timeout)  # wait for completion
+
+# io_uring submit
+io_uring_submit(ring)      # lock-free, may need 0 syscalls with SQPOLL
+```

--- a/docs/io/async-io.md
+++ b/docs/io/async-io.md
@@ -1,0 +1,297 @@
+# Async I/O Evolution
+
+> From POSIX AIO to Linux AIO to io_uring
+
+## The problem with synchronous I/O
+
+Synchronous `read()`/`write()` block the calling thread until data is transferred. For high-throughput servers this means either:
+- Many threads (each blocking on I/O) — high memory cost, context switch overhead
+- Non-blocking I/O with `epoll` — works for sockets, but **epoll does not work for regular files** (they are always "ready")
+
+The goal of async I/O: submit I/O, do other work, collect results when ready.
+
+## POSIX AIO (glibc userspace)
+
+POSIX AIO (`aio_read`, `aio_write`) is the standard API — but the Linux glibc implementation fakes it with threads:
+
+```c
+#include <aio.h>
+
+struct aiocb cb = {
+    .aio_fildes = fd,
+    .aio_buf    = buf,
+    .aio_nbytes = 4096,
+    .aio_offset = 0,
+    /* Notify via signal: */
+    .aio_sigevent = {
+        .sigev_notify = SIGEV_SIGNAL,
+        .sigev_signo  = SIGUSR1,
+    },
+};
+
+/* Submit async read */
+aio_read(&cb);
+
+/* ... do other work ... */
+
+/* Check completion */
+int err = aio_error(&cb);
+if (err == 0) {
+    ssize_t n = aio_return(&cb);  /* bytes transferred */
+}
+
+/* Or: wait for all */
+const struct aiocb *list[] = { &cb };
+aio_suspend(list, 1, NULL);
+```
+
+**The problem**: glibc implements POSIX AIO using a thread pool. Each `aio_read()` submits work to a worker thread that calls `pread()` synchronously. This adds:
+- Thread creation/teardown overhead
+- Memory per thread (stack)
+- Context switches to the worker thread and back
+- No kernel bypass — still goes through the kernel per-thread
+
+## Linux Kernel AIO
+
+Linux added native async I/O in 2.6 (`io_submit`, `io_getevents`). Unlike POSIX AIO, this runs in the kernel — no threads.
+
+```c
+#include <linux/aio_abi.h>
+#include <sys/syscall.h>
+
+/* Setup: create an AIO context */
+aio_context_t ctx = 0;
+io_setup(128, &ctx);  /* max 128 in-flight ops */
+
+/* Prepare an iocb */
+struct iocb cb = {
+    .aio_lio_opcode = IORING_OP_READ,  /* IOCB_CMD_PREAD */
+    .aio_fildes     = fd,
+    .aio_buf        = (uint64_t)buf,
+    .aio_nbytes     = 4096,
+    .aio_offset     = 0,
+};
+struct iocb *cbs[] = { &cb };
+
+/* Submit */
+io_submit(ctx, 1, cbs);
+
+/* Wait for completion */
+struct io_event events[1];
+struct timespec timeout = { .tv_sec = 1 };
+int n = io_getevents(ctx, 1, 1, events, &timeout);
+if (n == 1) {
+    printf("result: %ld\n", events[0].res);
+}
+
+io_destroy(ctx);
+```
+
+### Linux AIO limitations
+
+Linux AIO was designed specifically for `O_DIRECT` I/O. It has serious limitations:
+
+| Limitation | Details |
+|-----------|---------|
+| **O_DIRECT only** | Buffered I/O submits synchronously even with `io_submit` |
+| **No network sockets** | Only block/file I/O, not sockets or pipes |
+| **io_submit can block** | On buffered files or full submission ring |
+| **No fixed buffers** | Each op requires mapping/unmapping user buffers |
+| **No chaining** | Can't express "read A, then write B" without round-tripping to userspace |
+| **No fsync** | `IOCB_CMD_FSYNC` exists but rarely works async |
+
+The result: Linux AIO only helps databases already using `O_DIRECT`. It does not solve the general async I/O problem.
+
+### Kernel path for Linux AIO
+
+```c
+/* fs/aio.c */
+long io_submit(aio_context_t ctx_id, long nr, struct iocb __user **iocbpp)
+{
+    struct kioctx *ctx = lookup_ioctx(ctx_id);
+
+    for (i = 0; i < nr; i++) {
+        struct iocb __user *user_iocb = iocbpp[i];
+        ret = io_submit_one(ctx, user_iocb, &tmp, compat);
+    }
+}
+
+static int io_submit_one(struct kioctx *ctx, struct iocb __user *user_iocb, ...)
+{
+    struct aio_kiocb *req = aio_get_req(ctx);
+
+    switch (iocb.aio_lio_opcode) {
+    case IOCB_CMD_PREAD:
+        ret = aio_read(&req->rw, &iocb, false, compat);
+        /* For O_DIRECT: submits bio and returns immediately */
+        /* For buffered: may block right here in io_submit! */
+        break;
+    case IOCB_CMD_PWRITE:
+        ret = aio_write(&req->rw, &iocb, false, compat);
+        break;
+    }
+}
+```
+
+## io_uring: solving the problem properly
+
+`io_uring` (merged in Linux 5.1, 2019) addresses all Linux AIO limitations. It uses two shared-memory ring buffers between kernel and userspace:
+
+```
+Userspace                    Kernel
+   │                            │
+   │  SQ ring (submissions)     │
+   │  ┌─────────────────────┐   │
+   │  │ SQE SQE SQE SQE ... │──▶│ io_uring_enter()
+   │  └─────────────────────┘   │     ↓
+   │                         submits I/O
+   │  CQ ring (completions)      │
+   │  ┌─────────────────────┐   │
+   │  │ CQE CQE CQE CQE ... │◀──│ kernel writes completions
+   │  └─────────────────────┘   │
+```
+
+No locking needed: SQ tail is written by userspace, SQ head by kernel; CQ tail by kernel, CQ head by userspace.
+
+### Basic io_uring usage
+
+```c
+#include <liburing.h>
+
+struct io_uring ring;
+io_uring_queue_init(128, &ring, 0);
+
+/* Submit a read */
+struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+io_uring_prep_read(sqe, fd, buf, 4096, offset);
+sqe->user_data = 42;  /* tag to identify completion */
+
+io_uring_submit(&ring);
+
+/* Wait for completion */
+struct io_uring_cqe *cqe;
+io_uring_wait_cqe(&ring, &cqe);
+printf("read %d bytes (tag=%llu)\n", cqe->res, cqe->user_data);
+io_uring_cqe_seen(&ring, cqe);
+
+io_uring_queue_exit(&ring);
+```
+
+### io_uring vs Linux AIO
+
+| Feature | Linux AIO | io_uring |
+|---------|-----------|---------|
+| Buffered I/O | Blocks in submit | Truly async |
+| Network sockets | No | Yes (recv/send/accept/connect) |
+| Fixed buffers | No | Yes (zero-copy after register) |
+| Request chaining | No | Yes (IOSQE_IO_LINK) |
+| Polled I/O (no IRQ) | No | Yes (IORING_SETUP_IOPOLL) |
+| Kernel thread submit | No | Yes (IORING_SETUP_SQPOLL) |
+| fsync | Partial | Yes |
+| Splice/tee | No | Yes |
+| openat/statx/unlinkat | No | Yes |
+| Zero syscalls | No | Yes (with SQPOLL) |
+
+### io_uring SQPOLL: zero-syscall I/O
+
+With `IORING_SETUP_SQPOLL`, a kernel thread polls the SQ ring:
+
+```c
+struct io_uring_params params = {
+    .flags = IORING_SETUP_SQPOLL,
+    .sq_thread_idle = 2000,  /* ms before kernel thread sleeps */
+};
+io_uring_queue_init_params(128, &ring, &params);
+
+/* Now io_uring_submit() is optional — kernel polls for new SQEs */
+struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+io_uring_prep_read(sqe, fd, buf, 4096, 0);
+io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+
+/* No syscall needed if kernel thread is still polling: */
+io_uring_submit(&ring);  /* may return without syscall */
+```
+
+Useful for NVMe with polled queues (`IORING_SETUP_IOPOLL` + `IORING_SETUP_SQPOLL`): latency of 50-100µs with zero syscalls.
+
+### io_uring request chaining
+
+```c
+/* Chain: read file → write to socket, only if read succeeds */
+struct io_uring_sqe *read_sqe = io_uring_get_sqe(&ring);
+io_uring_prep_read(read_sqe, file_fd, buf, 4096, 0);
+io_uring_sqe_set_flags(read_sqe, IOSQE_IO_LINK);  /* link to next */
+
+struct io_uring_sqe *send_sqe = io_uring_get_sqe(&ring);
+io_uring_prep_send(send_sqe, sock_fd, buf, 4096, 0);
+/* No IOSQE_IO_LINK: end of chain */
+
+io_uring_submit(&ring);
+/* Kernel executes read, then send (if read succeeded) */
+```
+
+### io_uring kernel internals
+
+```c
+/* io_uring/io_uring.c */
+static int io_read(struct io_kiocb *req, unsigned int issue_flags)
+{
+    struct io_rw *rw = io_kiocb_to_cmd(req, struct io_rw);
+    struct kiocb *kiocb = &rw->kiocb;
+
+    /* Try inline (non-blocking first): */
+    ret = io_iter_do_read(rw, &iter);
+
+    if (ret == -EAGAIN) {
+        /* Would block: punt to io-wq thread pool */
+        if (issue_flags & IO_URING_F_NONBLOCK)
+            return -EAGAIN;
+        /* Or: submit to async worker */
+        io_req_task_work_add(req);
+    }
+    /* Complete inline if data was in page cache */
+    io_req_set_res(req, ret, 0);
+    return IOU_OK;
+}
+```
+
+io_uring first attempts the operation inline (non-blocking). If it would block, it falls back to a `io-wq` worker thread (similar to a kernel thread pool but cheaper than POSIX AIO's userspace threads).
+
+## epoll limitations for file I/O
+
+For completeness: `epoll` does not solve async file I/O:
+
+```c
+/* This does NOT work for regular files: */
+int fd = open("file.dat", O_RDONLY | O_NONBLOCK);
+int epfd = epoll_create1(0);
+
+struct epoll_event ev = { .events = EPOLLIN, .data.fd = fd };
+epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev);
+
+/* epoll_wait will return immediately: files are always "ready" */
+epoll_wait(epfd, events, 10, -1);
+/* read() still blocks if data isn't in page cache */
+```
+
+Regular files always appear ready to epoll because the VFS has no mechanism to notify when a page cache miss resolves. Only sockets and pipes have genuine readiness semantics.
+
+## Choosing the right async I/O
+
+| Scenario | Recommendation |
+|----------|---------------|
+| O_DIRECT database I/O | io_uring (or Linux AIO for legacy) |
+| Network + file I/O together | io_uring |
+| High-throughput NVMe | io_uring + IOPOLL + SQPOLL |
+| Portable POSIX code | POSIX AIO (accepts the thread overhead) |
+| Socket-only server | epoll + non-blocking sockets |
+| Buffered file I/O, simple | Sync read/write + thread pool |
+
+## Further reading
+
+- [Direct I/O](direct-io.md) — O_DIRECT, alignment requirements
+- [io_uring: Architecture](../io-uring/io-uring-arch.md) — ring setup, SQE/CQE layout
+- [io_uring: Operations](../io-uring/io-uring-ops.md) — full operation reference
+- `io_uring/io_uring.c` — io_uring core
+- `fs/aio.c` — Linux AIO implementation
+- [io_uring.pdf](https://kernel.dk/io_uring.pdf) — Jens Axboe's design paper

--- a/docs/io/direct-io.md
+++ b/docs/io/direct-io.md
@@ -1,0 +1,188 @@
+# Direct I/O
+
+> O_DIRECT: bypassing the page cache for predictable I/O latency
+
+## What O_DIRECT does
+
+By default, `read()` and `write()` go through the **page cache** — the kernel reads disk data into DRAM pages and serves reads from there. Writes go to dirty pages, which are flushed asynchronously.
+
+O_DIRECT bypasses the page cache:
+
+```
+Buffered I/O:
+  write() → page cache (dirty page) → [async] → disk
+  read()  ← page cache ← [lazy] ← disk
+
+O_DIRECT:
+  write() → disk (synchronous, no page cache)
+  read()  ← disk (synchronous, no page cache)
+```
+
+## Why use O_DIRECT?
+
+**Databases (PostgreSQL, MySQL InnoDB, Oracle)**: Databases implement their own buffer pool. Routing I/O through both the database buffer and the OS page cache wastes DRAM. O_DIRECT gives the database full control:
+
+```
+Without O_DIRECT:
+  DB buffer (8GB) + OS page cache (partial duplication) = wasted RAM
+
+With O_DIRECT:
+  DB buffer (8GB) = all RAM goes to the database
+```
+
+**Predictable latency**: Page cache writeback can cause surprising latency spikes when dirty pages are flushed. O_DIRECT writes complete when the data reaches the drive.
+
+**NUMA-aware memory**: O_DIRECT allows passing NUMA-local buffers to the kernel, avoiding cache effects across NUMA nodes.
+
+## Alignment requirements
+
+O_DIRECT has strict alignment requirements. Violating them returns `EINVAL`:
+
+```c
+#define SECTOR_SIZE 512    /* minimum for most drives */
+#define BLOCK_SIZE  4096   /* filesystem block size */
+
+/* All three must be aligned to logical block size (usually 512B or 4096B): */
+/* 1. File offset */
+/* 2. Buffer address */
+/* 3. Transfer length */
+
+/* Correct: 4096-byte aligned everything */
+void *buf;
+posix_memalign(&buf, 4096, 4096);   /* 4096-byte aligned buffer */
+
+int fd = open("file", O_RDWR | O_DIRECT);
+pread(fd, buf, 4096, 0);    /* offset=0, len=4096 → OK */
+pread(fd, buf, 4096, 512);  /* offset=512, len=4096 → EINVAL on many FS */
+pread(fd, buf, 512, 0);     /* len=512 → may work (if blksize=512) */
+```
+
+### Checking the required alignment
+
+```c
+#include <sys/ioctl.h>
+#include <linux/fs.h>
+
+int blksz;
+ioctl(fd, BLKSSZGET, &blksz);   /* logical block size */
+/* or */
+struct stat st;
+fstat(fd, &st);
+/* st.st_blksize = preferred I/O block size */
+
+/* For block devices: */
+ioctl(fd, BLKPBSZGET, &blksz);  /* physical block size (may be 4096) */
+```
+
+## O_DIRECT in the kernel
+
+```c
+/* fs/read_write.c */
+static ssize_t do_loop_readv_writev(struct file *filp, struct iov_iter *iter,
+                                     loff_t *ppos, int type, rwf_t flags)
+{
+    /* O_DIRECT path for block-aligned I/O */
+    if (filp->f_flags & O_DIRECT) {
+        return filp->f_op->read_iter(kiocb, iter);
+        /* → generic_file_direct_write → filemap_write_and_wait_range +
+             filp->f_mapping->a_ops->direct_IO */
+    }
+    /* ... buffered path ... */
+}
+
+/* Per-filesystem direct_IO implementation: */
+/* ext4_direct_IO → iomap_dio_rw → bio submission */
+static ssize_t ext4_direct_IO(struct kiocb *iocb, struct iov_iter *iter)
+{
+    struct inode *inode = iocb->ki_filp->f_mapping->host;
+    size_t count = iov_iter_count(iter);
+
+    /* Must flush dirty pages in range (coherency: page cache may have newer data) */
+    ret = filemap_write_and_wait_range(inode->i_mapping, offset,
+                                        offset + count - 1);
+    if (ret)
+        return ret;
+
+    /* Submit DIO: goes directly to the block layer */
+    return iomap_dio_rw(iocb, iter, &ext4_iomap_ops,
+                         &ext4_dio_write_ops, 0, 0, 0);
+}
+```
+
+## iomap DIO: modern direct I/O path
+
+Since 4.10, most filesystems use the `iomap` layer for direct I/O:
+
+```c
+/* fs/iomap/direct-io.c */
+ssize_t iomap_dio_rw(struct kiocb *iocb, struct iov_iter *iter,
+                      const struct iomap_ops *ops,
+                      const struct iomap_dio_ops *dops,
+                      unsigned int dio_flags,
+                      void *private, size_t done_before)
+{
+    struct iomap_dio *dio;
+
+    /* Map file blocks to physical addresses */
+    while (iov_iter_count(iter)) {
+        ret = iomap_apply(inode, pos, count, flags, ops, dio,
+                           iomap_dio_iter);
+    }
+
+    /* Wait for all bios to complete (sync DIO) */
+    if (!is_sync_kiocb(iocb))
+        return -EIOCBQUEUED;  /* async: caller will wait */
+
+    wait_for_completion_io(&dio->done);
+    return dio->size;
+}
+```
+
+## O_DIRECT vs mmap
+
+| Aspect | O_DIRECT | mmap |
+|--------|----------|------|
+| Page cache | Bypassed | Used |
+| Zero-copy | With DMA (buffer directly addressed) | Copy from page cache |
+| Random access | `pread(fd, buf, len, offset)` | `memcpy(buf, mmap_ptr + offset, len)` |
+| CPU cost | Syscall per I/O | After fault: load instructions |
+| Alignment | Strict sector alignment | None (page granularity) |
+| Scatter-gather | `preadv(fd, iov, n, offset)` | Natural (pointer arithmetic) |
+| Typical use | Databases | Search engines, key-value stores |
+
+## O_DSYNC and O_SYNC: write durability
+
+```c
+/* O_SYNC: fsync() after every write (metadata + data durable) */
+int fd = open("file", O_WRONLY | O_SYNC);
+
+/* O_DSYNC: only data durable (no metadata sync for performance) */
+int fd = open("file", O_WRONLY | O_DSYNC);
+
+/* fsync() manually: flush buffered writes to disk */
+write(fd, data, len);
+fsync(fd);  /* or fdatasync(fd) for data only */
+```
+
+## O_DIRECT performance tips
+
+```c
+/* Use io_uring with IORING_OP_READ_FIXED for best O_DIRECT performance */
+/* Register buffers once: */
+struct iovec iov[1] = {{ .iov_base = buf, .iov_len = BUF_SIZE }};
+io_uring_register_buffers(ring, iov, 1);
+
+/* Submit with registered buffer (no per-op mapping) */
+struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+io_uring_prep_read_fixed(sqe, fd, buf, BUF_SIZE, offset, 0);
+io_uring_submit(ring);
+```
+
+## Further reading
+
+- [Async I/O evolution](async-io.md) — AIO, io_uring for O_DIRECT
+- [io_uring: Operations](../io-uring/io-uring-ops.md) — IORING_OP_READ_FIXED
+- [Block Layer: bio and request](../block/bio-request.md) — bio submission from DIO
+- [Memory Management: page cache](../mm/page-cache.md) — what O_DIRECT bypasses
+- `fs/iomap/direct-io.c` — modern DIO implementation
+- `Documentation/filesystems/dax.txt` — DAX for PMEM

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -300,6 +300,10 @@ nav:
     - Signals: ipc/signals.md
     - Pipes and FIFOs: ipc/pipes.md
     - Shared Memory and Semaphores: ipc/shared-memory.md
+  - I/O Patterns:
+    - Getting Started: io/README.md
+    - Direct I/O: io/direct-io.md
+    - Async I/O Evolution: io/async-io.md
   - io_uring:
     - Getting Started: io-uring/README.md
     - Architecture and Rings: io-uring/io-uring-arch.md


### PR DESCRIPTION
## Summary

- **Direct I/O** (`docs/io/direct-io.md`): O_DIRECT page cache bypass, strict alignment requirements (offset/buffer/length must be sector-aligned), EINVAL behaviour, `ioctl BLKSSZGET` to query block size, `ext4_direct_IO → iomap_dio_rw` kernel path, O_DIRECT vs mmap comparison table, O_DSYNC/O_SYNC durability semantics, io_uring `IORING_OP_READ_FIXED` for best performance
- **Async I/O Evolution** (`docs/io/async-io.md`): POSIX AIO glibc thread-pool implementation and its overhead, Linux Kernel AIO (`io_submit`/`io_getevents`) with O_DIRECT-only limitation and blocking `io_submit` on buffered files, `io_uring` solving all AIO limitations with SQPOLL (zero-syscall), request chaining (`IOSQE_IO_LINK`), `IORING_SETUP_IOPOLL`, why epoll cannot handle regular files
- **I/O Patterns README** (`docs/io/README.md`): interface landscape overview (read/write, mmap, O_DIRECT, POSIX AIO, Linux AIO, io_uring, epoll)

## Test plan

- [ ] `mkdocs build` passes with new nav entries
- [ ] Links to `async-io.md` and `io-uring/io-uring-arch.md` resolve correctly
- [ ] Code examples compile (alignment, POSIX AIO, Linux AIO iocb, io_uring liburing snippets)

Closes #378, #379
Part of #377