### PR TITLE
Add VFS advanced section: splice/sendfile, inotify/fanotify, xattr

### DIFF
--- a/docs/vfs/inotify.md
+++ b/docs/vfs/inotify.md
@@ -1,0 +1,346 @@
+# inotify and fanotify
+
+> Filesystem event notification: watching files and directories for changes
+
+## inotify: file/directory watch API
+
+`inotify` provides notifications when files or directories change. It's used by file managers, build systems, editors, and container runtimes.
+
+```c
+#include <sys/inotify.h>
+
+/* 1. Create an inotify instance */
+int ifd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+
+/* 2. Add a watch */
+int wd = inotify_add_watch(ifd, "/etc/nginx/nginx.conf",
+                            IN_MODIFY | IN_CREATE | IN_DELETE);
+
+/* 3. Read events */
+char buf[4096] __attribute__((aligned(__alignof__(struct inotify_event))));
+ssize_t n = read(ifd, buf, sizeof(buf));
+
+char *ptr = buf;
+while (ptr < buf + n) {
+    struct inotify_event *ev = (struct inotify_event *)ptr;
+
+    printf("wd=%d mask=%x cookie=%u name=%s\n",
+           ev->wd, ev->mask, ev->cookie,
+           ev->len ? ev->name : "");
+
+    ptr += sizeof(*ev) + ev->len;
+}
+
+/* 4. Remove a watch */
+inotify_rm_watch(ifd, wd);
+close(ifd);
+```
+
+### Event masks
+
+```c
+/* Watch events (what to watch for) */
+IN_ACCESS        /* File was read */
+IN_MODIFY        /* File was modified */
+IN_ATTRIB        /* Metadata changed (chmod, chown, timestamps) */
+IN_CLOSE_WRITE   /* File opened for writing was closed */
+IN_CLOSE_NOWRITE /* File opened read-only was closed */
+IN_OPEN          /* File was opened */
+IN_MOVED_FROM    /* File moved out of watched directory */
+IN_MOVED_TO      /* File moved into watched directory */
+IN_CREATE        /* File/directory created in watched directory */
+IN_DELETE        /* File/directory deleted from watched directory */
+IN_DELETE_SELF   /* Watched file/directory itself deleted */
+IN_MOVE_SELF     /* Watched file/directory itself moved */
+
+/* Convenience combinations */
+IN_CLOSE    /* IN_CLOSE_WRITE | IN_CLOSE_NOWRITE */
+IN_MOVE     /* IN_MOVED_FROM | IN_MOVED_TO */
+IN_ALL_EVENTS /* All of the above */
+
+/* Event flags returned in mask (not used in add_watch) */
+IN_UNMOUNT   /* Filesystem containing watched object was unmounted */
+IN_Q_OVERFLOW /* Event queue overflowed (wd = -1) */
+IN_IGNORED   /* Watch was removed (inotify_rm_watch or file deleted) */
+IN_ISDIR     /* Subject of this event is a directory */
+
+/* Watch flags (inotify_add_watch flags parameter) */
+IN_DONT_FOLLOW  /* Don't dereference symlinks */
+IN_EXCL_UNLINK  /* Don't generate events for unlinked files */
+IN_ONESHOT      /* Remove watch after first event */
+IN_ONLYDIR      /* Only watch if path is a directory */
+```
+
+### Rename detection with cookie
+
+`IN_MOVED_FROM` and `IN_MOVED_TO` events for the same rename share a `cookie` value:
+
+```c
+/* Detect rename: /src/old → /dst/new */
+int wd_src = inotify_add_watch(ifd, "/src", IN_MOVE);
+int wd_dst = inotify_add_watch(ifd, "/dst", IN_MOVE);
+
+/* Read events */
+/* Event 1: wd=wd_src, mask=IN_MOVED_FROM, cookie=42, name="old" */
+/* Event 2: wd=wd_dst, mask=IN_MOVED_TO,   cookie=42, name="new" */
+
+/* Match by cookie to reconstruct the rename */
+```
+
+If only one side is watched, you get an `IN_MOVED_FROM` or `IN_MOVED_TO` without the matching pair — detect cross-directory renames that way.
+
+### inotify limits
+
+```bash
+# Maximum number of inotify instances per user
+cat /proc/sys/fs/inotify/max_user_instances  # default: 128
+
+# Maximum number of watches per instance
+cat /proc/sys/fs/inotify/max_user_watches    # default: 8192
+
+# Maximum queue length (events before IN_Q_OVERFLOW)
+cat /proc/sys/fs/inotify/max_queued_events   # default: 16384
+
+# Increase for large codebases (e.g., webpack, VS Code):
+echo 524288 | sudo tee /proc/sys/fs/inotify/max_user_watches
+```
+
+### inotify limitations
+
+- **Recursive watching**: inotify does not watch subdirectories automatically — you must add a watch for each directory
+- **No event for the watcher itself**: if the watched directory is deleted, you get `IN_DELETE_SELF` but cannot watch the replacement
+- **Network filesystems**: inotify may not work on NFS, CIFS (depends on server support)
+- **Overflow loses events**: `IN_Q_OVERFLOW` tells you events were dropped but not which ones
+
+## fanotify: filesystem-wide event notification
+
+`fanotify` is a superset of inotify with additional capabilities:
+- Watch entire mount points, not just individual files/dirs
+- Receive the file descriptor of the changed file (open for reading)
+- **Permission events**: intercept access and deny it (used by AV scanners)
+- Watch for filesystem-wide changes (all files on a mount)
+
+```c
+#include <sys/fanotify.h>
+#include <fcntl.h>
+
+/* Create fanotify instance: requires CAP_SYS_ADMIN for some flags */
+int fan = fanotify_init(FAN_CLOEXEC | FAN_CLASS_NOTIF,
+                         O_RDONLY | O_LARGEFILE);
+
+/* Watch an entire mount point */
+fanotify_mark(fan, FAN_MARK_ADD | FAN_MARK_MOUNT,
+              FAN_OPEN | FAN_CLOSE_WRITE | FAN_MODIFY,
+              AT_FDCWD, "/home");
+
+/* Read events */
+struct fanotify_event_metadata buf[10];
+ssize_t n = read(fan, buf, sizeof(buf));
+
+for (struct fanotify_event_metadata *m = buf;
+     FAN_EVENT_OK(m, n);
+     m = FAN_EVENT_NEXT(m, n)) {
+
+    if (m->fd == FAN_NOFD)
+        continue;  /* overflow or error event */
+
+    /* m->fd is a readable fd to the changed file */
+    /* Read /proc/self/fd/N to get the path: */
+    char path[PATH_MAX];
+    char fdpath[64];
+    snprintf(fdpath, sizeof(fdpath), "/proc/self/fd/%d", m->fd);
+    readlink(fdpath, path, sizeof(path));
+
+    printf("pid=%d fd=%d mask=%llx path=%s\n",
+           m->pid, m->fd, m->mask, path);
+
+    close(m->fd);  /* MUST close each event fd */
+}
+```
+
+### fanotify permission events
+
+```c
+/* Permission events: intercept and allow/deny access */
+int fan = fanotify_init(FAN_CLOEXEC | FAN_CLASS_CONTENT,
+                         O_RDONLY | O_LARGEFILE);
+
+fanotify_mark(fan, FAN_MARK_ADD | FAN_MARK_MOUNT,
+              FAN_OPEN_PERM | FAN_ACCESS_PERM,
+              AT_FDCWD, "/restricted");
+
+/* Read a permission event */
+struct fanotify_event_metadata ev;
+read(fan, &ev, sizeof(ev));
+
+/* Inspect the file (ev.fd is open for reading) */
+/* ... check if access should be allowed ... */
+
+/* Respond: allow or deny */
+struct fanotify_response resp = {
+    .fd       = ev.fd,
+    .response = FAN_ALLOW,  /* or FAN_DENY */
+};
+write(fan, &resp, sizeof(resp));
+close(ev.fd);
+```
+
+`FAN_CLASS_CONTENT` (for `FAN_OPEN_PERM` etc.) requires `CAP_SYS_ADMIN`. This is how antivirus software (like ClamAV's `clamonacc`) implements on-access scanning on Linux.
+
+### fanotify mark types (5.1+)
+
+```c
+/* Mark an individual filesystem object (5.1+) */
+fanotify_mark(fan, FAN_MARK_ADD | FAN_MARK_FILESYSTEM,
+              FAN_CREATE | FAN_DELETE | FAN_RENAME,
+              AT_FDCWD, "/");
+/* Watches all creates/deletes/renames on entire filesystem */
+
+/* FAN_RENAME event includes both source and dest info (5.17+) */
+/* FAN_REPORT_FID: report file ID instead of fd (avoids fd leak) */
+int fan = fanotify_init(FAN_CLASS_NOTIF | FAN_REPORT_FID, 0);
+```
+
+## Kernel implementation: fsnotify
+
+Both `inotify` and `fanotify` are built on top of `fsnotify`, a generic filesystem notification framework:
+
+```c
+/* include/linux/fsnotify_backend.h */
+struct fsnotify_backend_group {
+    /* One per inotify/fanotify instance */
+    struct list_head        marks_list;
+    struct fsnotify_ops    *ops;
+    struct notification_queue q;  /* event queue */
+    atomic_t                num_marks;
+    u32                     mask;  /* aggregated event mask */
+};
+
+struct fsnotify_mark {
+    /* Attached to: inode, mount point, or filesystem */
+    __u32 mask;
+    union {
+        struct inode    *inode;
+        struct mount    *mnt;
+        struct super_block *sb;
+    };
+    struct fsnotify_group *group;
+};
+```
+
+When a VFS operation occurs (e.g., `vfs_write`):
+
+```c
+/* fs/notify/fsnotify.c */
+int fsnotify(struct inode *inode, __u32 mask, const void *data, int data_type,
+             const struct qstr *file_name, u32 cookie)
+{
+    /* Called from VFS hooks after each operation */
+
+    /* Walk marks on this inode */
+    hlist_for_each_entry(mark, &inode->i_fsnotify_marks, obj_list) {
+        if (mark->mask & mask) {
+            /* Deliver event to this group (inotify or fanotify) */
+            mark->group->ops->handle_event(mark->group, mark, inode,
+                                            mask, data, ...);
+        }
+    }
+}
+
+/* Called from: */
+/* vfs_write → file_update_time → fsnotify(IN_MODIFY) */
+/* vfs_unlink → fsnotify_unlink → fsnotify(IN_DELETE) */
+/* security_inode_rename → fsnotify_rename */
+```
+
+### VFS hook points
+
+```c
+/* fs/attr.c */
+int notify_change(struct dentry *dentry, ...)
+{
+    /* ... */
+    fsnotify_change(dentry, ia_valid);  /* → IN_ATTRIB */
+}
+
+/* fs/namei.c */
+int vfs_unlink(...)
+{
+    /* ... */
+    fsnotify_unlink(dir, dentry);  /* → IN_DELETE */
+}
+
+int vfs_rename(...)
+{
+    /* ... */
+    fsnotify_move(old_dir, new_dir, old_name, new_name, ...);
+    /* → IN_MOVED_FROM + IN_MOVED_TO with shared cookie */
+}
+```
+
+## Practical patterns
+
+### Watch a directory recursively (userspace workaround)
+
+```c
+/* inotify has no recursive mode — must add watches manually */
+void watch_recursive(int ifd, const char *path) {
+    int wd = inotify_add_watch(ifd, path, IN_ALL_EVENTS);
+
+    DIR *dir = opendir(path);
+    struct dirent *de;
+    while ((de = readdir(dir))) {
+        if (de->d_type == DT_DIR && strcmp(de->d_name, ".") != 0
+                                 && strcmp(de->d_name, "..") != 0) {
+            char subpath[PATH_MAX];
+            snprintf(subpath, sizeof(subpath), "%s/%s", path, de->d_name);
+            watch_recursive(ifd, subpath);
+        }
+    }
+    closedir(dir);
+}
+
+/* When IN_CREATE | IN_ISDIR arrives: add a new watch for the new subdir */
+```
+
+### Using epoll with inotify
+
+```c
+/* inotify fd integrates with epoll */
+int epfd = epoll_create1(0);
+struct epoll_event ev = {
+    .events  = EPOLLIN,
+    .data.fd = ifd,
+};
+epoll_ctl(epfd, EPOLL_CTL_ADD, ifd, &ev);
+
+/* Event loop */
+struct epoll_event evs[16];
+int n = epoll_wait(epfd, evs, 16, -1);
+for (int i = 0; i < n; i++) {
+    if (evs[i].data.fd == ifd) {
+        /* Read inotify events */
+    }
+}
+```
+
+## inotify vs fanotify
+
+| Feature | inotify | fanotify |
+|---------|---------|---------|
+| Watch granularity | File or directory | File, mount, filesystem |
+| Recursive | No (userspace workaround) | Yes (FAN_MARK_MOUNT) |
+| Event fd for changed file | No | Yes |
+| Permission events | No | Yes (FAN_CLASS_CONTENT) |
+| Network filesystems | Limited | Better support |
+| Privileges required | None | CAP_SYS_ADMIN for some |
+| Rename tracking | Cookie-based | FAN_RENAME (5.17+) |
+| Typical use | Build systems, editors | AV scanning, audit |
+
+## Further reading
+
+- [VFS Objects](vfs-objects.md) — inodes and dentries that receive events
+- [File Operations](file-ops.md) — VFS hooks that trigger fsnotify
+- [IPC: Signals](../ipc/signals.md) — `SIGEV_SIGNAL` delivery for fanotify
+- `fs/notify/` — fsnotify, inotify, and fanotify implementation
+- `include/linux/fsnotify.h` — fsnotify hook declarations

--- a/docs/vfs/splice-sendfile.md
+++ b/docs/vfs/splice-sendfile.md
@@ -1,0 +1,278 @@
+# splice, sendfile, and copy_file_range
+
+> Zero-copy data transfer between file descriptors
+
+## The problem: data movement overhead
+
+Normal `read()` + `write()` copies data through userspace:
+
+```
+Disk → kernel page cache → [copy] → userspace buffer → [copy] → kernel socket buffer → NIC
+                                         ↑
+                               Two copies through CPU
+```
+
+For large data transfers (serving files over HTTP, piping data between processes), these copies are wasteful. Linux provides several zero-copy alternatives.
+
+## sendfile: file-to-socket zero-copy
+
+`sendfile()` sends a file directly to a socket without copying through userspace:
+
+```c
+#include <sys/sendfile.h>
+
+ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count);
+
+/* Example: serve a file over HTTP */
+int file_fd = open("file.dat", O_RDONLY);
+int sock_fd = accept(listen_fd, NULL, NULL);
+
+off_t offset = 0;
+ssize_t sent = sendfile(sock_fd, file_fd, &offset, file_size);
+```
+
+Data path with sendfile:
+```
+Disk → page cache → [DMA] → NIC (with scatter-gather DMA)
+              ↑
+    No copy through userspace
+    No copy through socket buffer (with NIC scatter-gather)
+```
+
+### sendfile limitations
+
+- `out_fd` must be a socket (or pipe on some kernels)
+- `in_fd` must support `mmap`-like operations (regular files, not sockets)
+- Does not work for file-to-file copies
+- Requires NIC scatter-gather for true zero-copy; otherwise one kernel→kernel copy
+
+## splice: pipe-based zero-copy
+
+`splice()` moves data between a pipe and a file descriptor using page references — no data copying:
+
+```c
+#define _GNU_SOURCE
+#include <fcntl.h>
+
+ssize_t splice(int fd_in, loff_t *off_in,
+               int fd_out, loff_t *off_out,
+               size_t len, unsigned int flags);
+/* flags: SPLICE_F_MOVE, SPLICE_F_NONBLOCK, SPLICE_F_MORE */
+```
+
+At least one of `fd_in` or `fd_out` must be a pipe. The pipe acts as a staging buffer:
+
+```c
+/* File to socket via pipe (zero-copy) */
+int pipefd[2];
+pipe(pipefd);
+
+/* Stage 1: file → pipe (moves page references, no copy) */
+splice(file_fd, &file_offset, pipefd[1], NULL, len, SPLICE_F_MOVE);
+
+/* Stage 2: pipe → socket (zero-copy with scatter-gather NIC) */
+splice(pipefd[0], NULL, sock_fd, NULL, len, SPLICE_F_MOVE | SPLICE_F_MORE);
+```
+
+### tee: duplicate pipe data
+
+`tee()` duplicates data between two pipes without consuming from the source:
+
+```c
+ssize_t tee(int fd_in, int fd_out, size_t len, unsigned int flags);
+
+/* Duplicate a stream: log and forward simultaneously */
+int log_pipe[2], fwd_pipe[2];
+pipe(log_pipe); pipe(fwd_pipe);
+
+/* Source → log_pipe */
+splice(source_fd, NULL, log_pipe[1], NULL, len, 0);
+
+/* Duplicate log_pipe → fwd_pipe (no copy, pages shared) */
+tee(log_pipe[0], fwd_pipe[1], len, 0);
+
+/* Consume from both independently */
+splice(log_pipe[0], NULL, logfile_fd, NULL, len, 0);
+splice(fwd_pipe[0], NULL, socket_fd, NULL, len, 0);
+```
+
+## copy_file_range: kernel-side file copy
+
+`copy_file_range()` copies between two files without touching userspace. On modern filesystems it can use **server-side copy** (e.g., NFS, SMB, Btrfs reflinking):
+
+```c
+#define _GNU_SOURCE
+#include <unistd.h>
+
+ssize_t copy_file_range(int fd_in, loff_t *off_in,
+                         int fd_out, loff_t *off_out,
+                         size_t len, unsigned int flags);
+
+/* Fast file copy (may be instantaneous with reflink) */
+int src = open("src.dat", O_RDONLY);
+int dst = open("dst.dat", O_WRONLY | O_CREAT, 0644);
+
+off_t off_in = 0, off_out = 0;
+copy_file_range(src, &off_in, dst, &off_out, file_size, 0);
+```
+
+### Btrfs reflink
+
+On Btrfs (and XFS with reflink), `copy_file_range` does a **reflink** — the destination shares the same extents as the source with copy-on-write semantics:
+
+```
+Before copy_file_range:
+  src inode → [extent A] [extent B] [extent C]
+
+After copy_file_range (reflink):
+  src inode → [extent A] [extent B] [extent C]
+  dst inode →     ↑           ↑          ↑
+              (shared, COW on write)
+
+No data copied — instantaneous regardless of file size!
+```
+
+```bash
+# Check if filesystem supports reflink
+cp --reflink=always src.dat dst.dat   # fails if not supported
+cp --reflink=auto   src.dat dst.dat   # falls back to copy if needed
+```
+
+## Kernel implementation
+
+### sendfile kernel path
+
+```c
+/* net/socket.c */
+SYSCALL_DEFINE4(sendfile64, int, out_fd, int, in_fd,
+                loff_t __user *, offset, loff_t, count)
+{
+    struct fd in = fdget(in_fd);
+    struct fd out = fdget(out_fd);
+
+    /* Delegate to do_sendfile */
+    return do_sendfile(out.file, in.file, ppos, count, 0);
+}
+
+/* mm/filemap.c - the actual transfer */
+static ssize_t do_sendfile(struct file *out_file, struct file *in_file, ...)
+{
+    /* Uses file->f_op->splice_read to get pages from in_file */
+    /* Uses sock_sendpage (or generic_file_splice_write) for out_file */
+
+    /* For sockets: calls tcp_sendpage → skb_fill_page_desc */
+    /* Page reference is added to skb — no copy if NIC has scatter-gather */
+}
+```
+
+### splice kernel path
+
+```c
+/* fs/splice.c */
+SYSCALL_DEFINE6(splice, int, fd_in, loff_t __user *, off_in,
+                int, fd_out, loff_t __user *, off_out,
+                size_t, len, unsigned int, flags)
+{
+    if (ipipe && opipe) {
+        /* pipe-to-pipe: just move the pipe_buffer references */
+        return splice_pipe_to_pipe(ipipe, opipe, len, flags);
+    }
+    if (ipipe) {
+        /* pipe-to-file: write pipe buffers to file */
+        return do_splice_from(ipipe, out, &offset, len, flags);
+    }
+    if (opipe) {
+        /* file-to-pipe: add page references to pipe */
+        return do_splice_to(in, &offset, opipe, len, flags);
+    }
+}
+
+/* pipe_buffer: a reference to a page, no data copy */
+struct pipe_buffer {
+    struct page      *page;
+    unsigned int     offset, len;
+    const struct pipe_buf_operations *ops;
+    unsigned int     flags;
+};
+```
+
+### copy_file_range kernel path
+
+```c
+/* fs/read_write.c */
+SYSCALL_DEFINE6(copy_file_range, ...)
+{
+    /* Try filesystem-specific implementation first */
+    if (out_file->f_op->copy_file_range) {
+        ret = out_file->f_op->copy_file_range(file_in, pos_in,
+                                               file_out, pos_out,
+                                               len, flags);
+        if (ret != -EOPNOTSUPP && ret != -EXDEV)
+            return ret;
+    }
+
+    /* Fallback: generic_copy_file_range (splice-based) */
+    return generic_copy_file_range(file_in, pos_in,
+                                    file_out, pos_out, len, flags);
+}
+
+/* Btrfs implementation: */
+static ssize_t btrfs_copy_file_range(...)
+{
+    /* btrfs_clone_file_range → create shared extents */
+    ret = btrfs_clone(src, dst, off, len, len, destoff, 0);
+}
+```
+
+## Comparison
+
+| API | Zero-copy? | Use case | Kernel → userspace copy |
+|-----|-----------|----------|------------------------|
+| `read()` + `write()` | No | Universal | 2 copies |
+| `sendfile()` | Yes (with NIC SG) | File → socket | 0 copies |
+| `splice()` | Yes | Any fd ↔ pipe | 0 copies |
+| `tee()` | Yes | Pipe duplication | 0 copies |
+| `copy_file_range()` | Yes (reflink) | File → file | 0 copies (reflink) |
+| `mmap()` + `write()` | Partial | File → socket | 1 copy (page → SKB) |
+
+## Performance tips
+
+```bash
+# Verify sendfile is used (strace a file server):
+strace -e sendfile64,splice nginx -g 'daemon off;' 2>&1 | head -20
+
+# Check NIC scatter-gather support (required for true zero-copy):
+ethtool -k eth0 | grep scatter-gather
+# scatter-gather: on
+
+# For large files: sendfile outperforms read+write significantly
+# Typical: 2-4x throughput improvement for 100MB+ files
+```
+
+```c
+/* io_uring splice: zero-copy without blocking */
+struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+io_uring_prep_splice(sqe,
+    file_fd, file_offset,
+    pipe_fd[1], -1,
+    len, SPLICE_F_MOVE);
+io_uring_sqe_set_flags(sqe, IOSQE_IO_LINK);
+
+/* Chain: pipe → socket */
+sqe = io_uring_get_sqe(&ring);
+io_uring_prep_splice(sqe,
+    pipe_fd[0], -1,
+    sock_fd, -1,
+    len, SPLICE_F_MOVE);
+
+io_uring_submit(&ring);
+```
+
+## Further reading
+
+- [File Operations](file-ops.md) — read/write VFS path
+- [Page Cache](../mm/page-cache.md) — page references in splice
+- [Direct I/O](../io/direct-io.md) — bypassing page cache entirely
+- [io_uring Operations](../io-uring/io-uring-ops.md) — `IORING_OP_SPLICE`
+- `fs/splice.c` — splice/sendfile/tee implementation
+- `include/linux/splice.h`

--- a/docs/vfs/xattr.md
+++ b/docs/vfs/xattr.md
@@ -1,0 +1,295 @@
+# Extended Attributes (xattr)
+
+> Attaching arbitrary metadata to files and directories
+
+## What are extended attributes?
+
+Extended attributes (xattr) allow attaching name-value pairs to files and directories. They extend the traditional POSIX metadata (owner, permissions, timestamps) with arbitrary key-value data.
+
+```c
+#include <sys/xattr.h>
+
+/* Set an extended attribute */
+setxattr("/path/to/file", "user.comment", "reviewed", 8, 0);
+
+/* Get an extended attribute */
+char value[256];
+ssize_t len = getxattr("/path/to/file", "user.comment", value, sizeof(value));
+
+/* List all attributes */
+char list[4096];
+ssize_t list_len = listxattr("/path/to/file", list, sizeof(list));
+/* list is NUL-separated: "user.comment\0user.author\0" */
+
+/* Remove an attribute */
+removexattr("/path/to/file", "user.comment");
+```
+
+There are also `l` variants (`lgetxattr`, `lsetxattr`) that don't follow symlinks, and `f` variants (`fgetxattr`, `fsetxattr`) that operate on open file descriptors.
+
+## Namespace prefixes
+
+Every xattr name must begin with a recognized namespace prefix:
+
+| Namespace | Prefix | Who can set/get | Purpose |
+|-----------|--------|----------------|---------|
+| `user` | `user.` | Any process (with write permission on file) | General application use |
+| `system` | `system.` | Kernel and privileged processes | NFSv4 ACLs, POSIX ACLs |
+| `security` | `security.` | Kernel security modules (LSMs) | SELinux labels, AppArmor |
+| `trusted` | `trusted.` | CAP_SYS_ADMIN only | Container runtimes, OverlayFS |
+
+### `user` namespace
+
+Any process with write permission on the file can set `user.*` attributes:
+
+```bash
+# Tag a file for application use
+setfattr -n user.reviewed -v "2024-01-15" report.pdf
+getfattr -n user.reviewed report.pdf
+# file: report.pdf
+# user.reviewed="2024-01-15"
+
+# List all user attributes
+getfattr -d report.pdf
+```
+
+Restrictions:
+- Not supported on symlinks or device files (to prevent privilege escalation via root-owned devices)
+- Subject to filesystem quota if enabled
+
+### `security` namespace
+
+Used by Linux Security Modules. You rarely set these directly:
+
+```bash
+# SELinux file context label
+getfattr -n security.selinux /etc/passwd
+# security.selinux="system_u:object_r:passwd_file_t:s0"
+
+# AppArmor (uses security.apparmor)
+getfattr -n security.apparmor /usr/bin/python3
+```
+
+Setting `security.*` requires `CAP_SYS_ADMIN` or LSM-specific permissions.
+
+### `trusted` namespace
+
+Requires `CAP_SYS_ADMIN`. Used by:
+- **OverlayFS**: `trusted.overlay.opaque`, `trusted.overlay.whiteout` for directory/file hiding
+- **Container runtimes**: Store container metadata on image layers
+- **Quota systems**: Some implementations store quota data in `trusted.*`
+
+```bash
+# OverlayFS opaque directory marker
+getfattr -n trusted.overlay.opaque /some/overlayfs/dir
+# trusted.overlay.opaque="y"
+```
+
+### `system` namespace
+
+Used for POSIX ACLs (NFSv4 and traditional):
+
+```bash
+# POSIX ACL stored as system.posix_acl_access
+setfacl -m u:alice:rw /shared/file
+getfattr -n system.posix_acl_access /shared/file
+# Returns binary ACL encoding
+```
+
+## Filesystem support
+
+```bash
+# Check if filesystem supports xattr
+mount | grep " / " | grep -o 'user_xattr\|xattr'
+# or
+tune2fs -l /dev/sda1 | grep "Default mount options"
+
+# ext4: supports all namespaces by default
+# tmpfs: supports user.* and trusted.* (no security by default)
+# btrfs: full xattr support
+# XFS: full xattr support (uses B-tree per inode for many attrs)
+# NFS: depends on server; NFSv4.2 has native xattr support
+# OverlayFS: delegates to upper/lower filesystem
+```
+
+## Kernel implementation
+
+### xattr dispatch: struct xattr_handler
+
+Each filesystem registers handlers for each namespace:
+
+```c
+/* include/linux/xattr.h */
+struct xattr_handler {
+    const char *name;    /* exact name match (e.g., "system.posix_acl_access") */
+    const char *prefix;  /* prefix match (e.g., "user.")  */
+    int flags;
+
+    bool (*list)(struct dentry *dentry);
+    int  (*get)(const struct xattr_handler *,
+                struct dentry *, struct inode *,
+                const char *name, void *buffer, size_t size);
+    int  (*set)(const struct xattr_handler *,
+                struct mnt_idmap *, struct dentry *, struct inode *,
+                const char *name, const void *value, size_t size, int flags);
+};
+```
+
+ext4's xattr handler table:
+
+```c
+/* fs/ext4/xattr.c */
+static const struct xattr_handler * const ext4_xattr_handler_map[] = {
+    [EXT4_XATTR_INDEX_USER]              = &ext4_xattr_user_handler,
+    [EXT4_XATTR_INDEX_POSIX_ACL_ACCESS]  = &posix_acl_access_xattr_handler,
+    [EXT4_XATTR_INDEX_POSIX_ACL_DEFAULT] = &posix_acl_default_xattr_handler,
+    [EXT4_XATTR_INDEX_TRUSTED]           = &ext4_xattr_trusted_handler,
+    [EXT4_XATTR_INDEX_SECURITY]          = &ext4_xattr_security_handler,
+    NULL
+};
+
+const struct xattr_handler * const *ext4_xattr_handlers = ext4_xattr_handler_map;
+```
+
+### VFS xattr syscall path
+
+```c
+/* fs/xattr.c */
+SYSCALL_DEFINE5(setxattr, const char __user *, pathname,
+                const char __user *, name,
+                const void __user *, value, size_t, size, int, flags)
+{
+    struct path path;
+    user_path_at(AT_FDCWD, pathname, LOOKUP_FOLLOW, &path);
+    error = setxattr(mnt_idmap(path.mnt), path.dentry, name, kvalue, size, flags);
+}
+
+int setxattr(struct mnt_idmap *idmap, struct dentry *dentry,
+             const char __user *name, const void __user *value,
+             size_t size, int flags)
+{
+    /* Parse namespace prefix: "user.", "security.", etc. */
+    handler = xattr_resolve_name(dentry->d_inode, &kname);
+
+    /* Check namespace-specific permissions */
+    error = handler->set(handler, idmap, dentry, inode, kname,
+                          kvalue, size, flags);
+}
+```
+
+### Storage in ext4
+
+ext4 stores xattrs in two places:
+
+1. **Inode body** (EA inode inline): small attributes stored directly in inode's unused space
+2. **Dedicated xattr block**: a 4KB block holding multiple attributes in a key-value format
+
+```
+ext4 inode
+├── i_extra_isize (points to end of fixed inode)
+└── [xattr inline area]
+    ├── entry: name_index=1("user.") name_len=3 value_len=5 → "foo" = "hello"
+    └── ...
+
+[if overflow] → separate xattr block (4096 bytes)
+    ├── header: magic, refcount, hash
+    ├── entries: name/value pairs sorted by name
+    └── values: stored at end of block (grow backwards)
+```
+
+```bash
+# Inspect xattr storage in ext4
+debugfs -R "stat <inode_number>" /dev/sda1
+# i_extra_isize: 28
+# Extended attributes stored in inode body / block
+```
+
+## Security module integration
+
+SELinux and other LSMs use `security.*` xattrs to label files:
+
+```c
+/* security/selinux/hooks.c */
+static int selinux_inode_init_security(struct inode *inode,
+                                        struct inode *dir,
+                                        const struct qstr *qstr,
+                                        struct xattr *xattrs,
+                                        int *num_xattrs)
+{
+    /* Set security.selinux on new file based on parent context */
+    xattrs[0].name  = XATTR_SELINUX_SUFFIX;  /* "selinux" */
+    xattrs[0].value = context;
+    xattrs[0].value_len = clen;
+    return 0;
+}
+
+/* Called from vfs_create → security_inode_init_security */
+```
+
+```bash
+# Relabel a file (restore SELinux context from policy):
+restorecon /path/to/file
+
+# Check context:
+ls -Z /etc/passwd
+# system_u:object_r:passwd_file_t:s0 /etc/passwd
+
+# Recursively relabel after restore:
+restorecon -R /var/www/html/
+```
+
+## fscrypt and xattr
+
+fscrypt stores its per-file encryption policy as an xattr:
+
+```c
+/* fs/crypto/policy.c */
+static int fscrypt_set_inode_policy(struct inode *inode,
+                                     const struct fscrypt_policy_v2 *policy)
+{
+    /* Stored as: "encryption.c" on ext4 (system.encryption or similar) */
+    /* Actually stored in a special EA: */
+    return inode->i_sb->s_cop->set_context(inode, policy, sizeof(*policy), NULL);
+}
+
+/* ext4 uses: EXT4_XATTR_INDEX_ENCRYPTION → "encryption" */
+```
+
+```bash
+# Check if a file is encrypted:
+getfattr -n encryption.c /encrypted/file
+# or:
+lsattr /encrypted/file | grep -o 'E'
+```
+
+## OverlayFS whiteout and opaque markers
+
+OverlayFS uses `trusted.*` xattrs to implement its layering:
+
+```bash
+# Opaque directory: tells overlayfs to stop looking at lower layers
+getfattr -n trusted.overlay.opaque /overlay/upper/somedir
+# trusted.overlay.opaque="y"
+
+# Origin: tracks which lower inode this was copied from
+getfattr -n trusted.overlay.origin /overlay/upper/file
+```
+
+```c
+/* fs/overlayfs/xattr.c */
+int ovl_check_setxattr(struct ovl_fs *ofs, struct dentry *upperdentry,
+                        enum ovl_xattr ox, const void *value, size_t size, int xerr)
+{
+    /* ox == OVL_XATTR_OPAQUE: trusted.overlay.opaque */
+    return ovl_do_setxattr(ofs, upperdentry, ox, value, size);
+}
+```
+
+## Further reading
+
+- [VFS Objects](vfs-objects.md) — inodes that store xattrs
+- [OverlayFS](../filesystems/overlayfs.md) — uses trusted.overlay.* xattrs
+- [dm-crypt and fscrypt](../crypto/encryption.md) — fscrypt encryption policy xattr
+- [LSM Framework](../security/lsm.md) — SELinux/AppArmor use security.* xattrs
+- `fs/xattr.c` — VFS xattr dispatch
+- `fs/ext4/xattr.c` — ext4 xattr storage implementation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -266,6 +266,10 @@ nav:
     - Lifecycle:
       - Life of a write() Syscall: vfs/life-of-write.md
       - Dentry and Inode Caches: vfs/dcache-icache.md
+    - Advanced:
+      - splice, sendfile, copy_file_range: vfs/splice-sendfile.md
+      - inotify and fanotify: vfs/inotify.md
+      - Extended Attributes (xattr): vfs/xattr.md
   - Block Layer:
     - Getting Started: block/README.md
     - Block Layer Overview: block/block-overview.md


### PR DESCRIPTION
## Summary

- **splice, sendfile, copy_file_range** (`docs/vfs/splice-sendfile.md`): zero-copy data movement, `pipe_buffer` page-reference mechanism, `sendfile` NIC scatter-gather path, `tee` for stream duplication, `copy_file_range` with Btrfs reflink (instantaneous copy), io_uring splice chaining, comparison table
- **inotify and fanotify** (`docs/vfs/inotify.md`): `inotify_add_watch` event masks, `IN_MOVED_FROM`/`IN_MOVED_TO` cookie-based rename tracking, `/proc/sys/fs/inotify/` limits, fanotify permission events for AV scanning (`FAN_OPEN_PERM`/`FAN_DENY`), `fsnotify` framework VFS hooks, inotify vs fanotify comparison
- **Extended Attributes** (`docs/vfs/xattr.md`): namespace prefixes (user/system/security/trusted), ext4 inline-inode vs xattr-block storage, SELinux `security.selinux` labeling, fscrypt encryption policy, OverlayFS `trusted.overlay.opaque`/`origin`, `xattr_handler` dispatch table

## Test plan

- [ ] `mkdocs build` passes with new VFS Advanced nav section
- [ ] Cross-links to OverlayFS, fscrypt, LSM pages resolve
- [ ] `getfattr`/`setfattr` command examples are correct

Closes #382, #383, #384
Part of #381