### PR TITLE
Add IPC advanced: eventfd/signalfd and POSIX message queues

### DIFF
--- a/docs/ipc/eventfd-signalfd.md
+++ b/docs/ipc/eventfd-signalfd.md
@@ -1,0 +1,362 @@
+# eventfd and signalfd
+
+> Event notification and signal delivery through file descriptors
+
+## eventfd: a counter you can poll
+
+`eventfd` creates a file descriptor backed by a kernel counter. It's used for:
+- Event notification between threads or processes
+- Waking up `epoll`/`select`/`poll` from another context
+- Counting occurrences (semaphore-like, but pollable)
+
+```c
+#include <sys/eventfd.h>
+
+int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+/* initval=0: initial counter value */
+/* EFD_SEMAPHORE: semaphore mode (see below) */
+```
+
+### Writing (signaling)
+
+Writing an 8-byte `uint64_t` adds to the counter:
+
+```c
+uint64_t value = 1;
+write(efd, &value, sizeof(value));  /* counter += 1 */
+
+/* Multiple signals: */
+value = 5;
+write(efd, &value, sizeof(value));  /* counter += 5 */
+
+/* Counter saturates at UINT64_MAX - 1 */
+/* write blocks (or returns EAGAIN with EFD_NONBLOCK) when at max */
+```
+
+### Reading (consuming)
+
+Reading an 8-byte `uint64_t` returns the current counter and resets it to 0:
+
+```c
+uint64_t count;
+ssize_t n = read(efd, &count, sizeof(count));
+/* n == 8, count == accumulated value, counter reset to 0 */
+
+/* EFD_NONBLOCK: returns EAGAIN if counter == 0 */
+```
+
+### EFD_SEMAPHORE mode
+
+With `EFD_SEMAPHORE`, each `read()` decrements by 1 and returns 1 (not the full count):
+
+```c
+int efd = eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK);
+
+write(efd, &(uint64_t){3}, 8);  /* counter = 3 */
+
+uint64_t val;
+read(efd, &val, 8);  /* val=1, counter=2 */
+read(efd, &val, 8);  /* val=1, counter=1 */
+read(efd, &val, 8);  /* val=1, counter=0 */
+read(efd, &val, 8);  /* EAGAIN: counter==0 */
+```
+
+### epoll integration
+
+The key feature: `eventfd` integrates with `epoll` so you can wake a sleeping event loop:
+
+```c
+int epfd = epoll_create1(0);
+int efd  = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+
+struct epoll_event ev = { .events = EPOLLIN, .data.fd = efd };
+epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev);
+
+/* In another thread or signal handler: */
+write(efd, &(uint64_t){1}, 8);  /* wakes epoll_wait */
+
+/* Main loop: */
+struct epoll_event events[16];
+int n = epoll_wait(epfd, events, 16, -1);
+for (int i = 0; i < n; i++) {
+    if (events[i].data.fd == efd) {
+        uint64_t count;
+        read(efd, &count, 8);   /* consume + reset */
+        /* Handle the event */
+    }
+}
+```
+
+### Typical uses
+
+**Thread pool wakeup**: Instead of a mutex+condvar, use eventfd with a work queue:
+
+```c
+struct thread_pool {
+    int        wakeup_efd;  /* eventfd */
+    /* ... work queue ... */
+};
+
+/* Enqueue work and wake a thread */
+void enqueue(struct thread_pool *pool, struct work *w) {
+    work_queue_push(pool, w);
+    write(pool->wakeup_efd, &(uint64_t){1}, 8);
+}
+
+/* Worker thread */
+void worker(struct thread_pool *pool) {
+    while (1) {
+        uint64_t count;
+        read(pool->wakeup_efd, &count, 8);  /* blocks until work */
+        /* process 'count' items */
+    }
+}
+```
+
+**io_uring completion notification**: io_uring can post to an eventfd when completions arrive:
+
+```c
+io_uring_register_eventfd(ring, efd);
+/* Now epoll_wait on efd wakes when CQEs are available */
+```
+
+### Kernel implementation
+
+```c
+/* fs/eventfd.c */
+struct eventfd_ctx {
+    struct kref     kref;
+    wait_queue_head_t wqh;
+    __u64           count;
+    unsigned int    flags;
+    int             id;   /* for debugging */
+};
+
+static ssize_t eventfd_write(struct file *file, const char __user *buf,
+                              size_t count, loff_t *ppos)
+{
+    struct eventfd_ctx *ctx = file->private_data;
+    __u64 ucnt = 0;
+
+    copy_from_user(&ucnt, buf, sizeof(ucnt));
+
+    spin_lock_irq(&ctx->wqh.lock);
+    /* Saturate at ULLONG_MAX - 1 */
+    if (ULLONG_MAX - ctx->count > ucnt)
+        ctx->count += ucnt;
+    else
+        ctx->count = ULLONG_MAX - 1;
+
+    /* Wake up anyone polling/reading */
+    if (waitqueue_active(&ctx->wqh))
+        wake_up_locked_poll(&ctx->wqh, EPOLLIN);
+    spin_unlock_irq(&ctx->wqh.lock);
+}
+
+static ssize_t eventfd_read(struct file *file, char __user *buf,
+                              size_t count, loff_t *ppos)
+{
+    struct eventfd_ctx *ctx = file->private_data;
+    __u64 ucnt = 0;
+
+    spin_lock_irq(&ctx->wqh.lock);
+    if (!ctx->count) {
+        if (file->f_flags & O_NONBLOCK) {
+            spin_unlock_irq(&ctx->wqh.lock);
+            return -EAGAIN;
+        }
+        /* Sleep until count > 0 */
+        wait_event_interruptible_locked_irq(ctx->wqh, ctx->count);
+    }
+
+    if (ctx->flags & EFD_SEMAPHORE) {
+        ucnt = 1;
+        ctx->count--;
+    } else {
+        ucnt = ctx->count;
+        ctx->count = 0;
+    }
+    /* Wake up blocked writers if count was at max */
+    if (waitqueue_active(&ctx->wqh))
+        wake_up_locked_poll(&ctx->wqh, EPOLLOUT);
+    spin_unlock_irq(&ctx->wqh.lock);
+
+    copy_to_user(buf, &ucnt, sizeof(ucnt));
+    return sizeof(ucnt);
+}
+```
+
+## signalfd: receive signals via file descriptor
+
+Normally, signals interrupt the current execution at unpredictable points. `signalfd` delivers signals as readable data on a file descriptor, making signal handling compatible with `epoll`-driven event loops.
+
+```c
+#include <sys/signalfd.h>
+#include <signal.h>
+
+/* Block signals from normal delivery first */
+sigset_t mask;
+sigemptyset(&mask);
+sigaddset(&mask, SIGINT);
+sigaddset(&mask, SIGTERM);
+sigaddset(&mask, SIGUSR1);
+sigprocmask(SIG_BLOCK, &mask, NULL);
+
+/* Create signalfd for these signals */
+int sfd = signalfd(-1, &mask, SFD_NONBLOCK | SFD_CLOEXEC);
+
+/* Read signal info (blocks or EAGAIN with SFD_NONBLOCK) */
+struct signalfd_siginfo ssi;
+ssize_t n = read(sfd, &ssi, sizeof(ssi));
+if (n == sizeof(ssi)) {
+    printf("signal %u from pid %u\n", ssi.ssi_signo, ssi.ssi_pid);
+    printf("uid=%u code=%d status=%d\n",
+           ssi.ssi_uid, ssi.ssi_code, ssi.ssi_status);
+}
+```
+
+### signalfd_siginfo fields
+
+```c
+struct signalfd_siginfo {
+    uint32_t ssi_signo;    /* Signal number */
+    int32_t  ssi_errno;    /* Error number (usually 0) */
+    int32_t  ssi_code;     /* Signal code (SI_USER, SI_KERNEL, etc.) */
+    uint32_t ssi_pid;      /* PID of sender */
+    uint32_t ssi_uid;      /* UID of sender */
+    int32_t  ssi_fd;       /* File descriptor (SIGIO) */
+    uint32_t ssi_tid;      /* Timer ID (SIGALRM/SIGVTALRM) */
+    uint32_t ssi_band;     /* Band event (SIGIO) */
+    uint32_t ssi_overrun;  /* Timer overrun count */
+    uint32_t ssi_trapno;   /* Trap number (hardware fault) */
+    int32_t  ssi_status;   /* Exit status/signal (SIGCHLD) */
+    int32_t  ssi_int;      /* Integer payload (sigqueue) */
+    uint64_t ssi_ptr;      /* Pointer payload (sigqueue) */
+    uint64_t ssi_utime;    /* User CPU time consumed (SIGCHLD) */
+    uint64_t ssi_stime;    /* System CPU time consumed (SIGCHLD) */
+    uint64_t ssi_addr;     /* Faulting address (SIGSEGV/SIGBUS) */
+    /* ... padding ... */
+};
+```
+
+### epoll with signalfd
+
+The canonical pattern for a single-threaded server handling both I/O and signals:
+
+```c
+/* Block signals at thread/process level */
+sigset_t mask;
+sigemptyset(&mask);
+sigaddset(&mask, SIGINT);
+sigaddset(&mask, SIGTERM);
+sigaddset(&mask, SIGCHLD);
+pthread_sigmask(SIG_BLOCK, &mask, NULL);
+
+int sfd = signalfd(-1, &mask, SFD_NONBLOCK | SFD_CLOEXEC);
+int epfd = epoll_create1(EFD_CLOEXEC);
+
+/* Add signalfd and other fds to epoll */
+struct epoll_event ev = { .events = EPOLLIN, .data.fd = sfd };
+epoll_ctl(epfd, EPOLL_CTL_ADD, sfd, &ev);
+
+/* ... add socket fds, timer fds, etc. ... */
+
+/* Single event loop for everything */
+while (running) {
+    struct epoll_event events[32];
+    int n = epoll_wait(epfd, events, 32, -1);
+
+    for (int i = 0; i < n; i++) {
+        int fd = events[i].data.fd;
+
+        if (fd == sfd) {
+            struct signalfd_siginfo ssi;
+            read(sfd, &ssi, sizeof(ssi));
+            if (ssi.ssi_signo == SIGTERM || ssi.ssi_signo == SIGINT)
+                running = 0;
+            else if (ssi.ssi_signo == SIGCHLD)
+                reap_children();
+        } else {
+            handle_io(fd);
+        }
+    }
+}
+```
+
+### signalfd vs traditional signal handling
+
+| Approach | Thread-safe | epoll-compatible | Signal info |
+|----------|------------|-----------------|-------------|
+| `signal()`/`sigaction()` | Careful with SA_RESTART | No | Limited |
+| `sigwaitinfo()` | Yes (blocking) | No | Full siginfo |
+| `signalfd` | Yes | **Yes** | Full siginfo_t |
+| `self-pipe trick` | Yes | Yes | Signal number only |
+
+The **self-pipe trick** (write a byte to a pipe in the signal handler, read from the other end in the event loop) was the traditional solution. `signalfd` replaces it cleanly.
+
+### signalfd update
+
+Pass an existing sfd to update its mask:
+
+```c
+/* Add SIGUSR2 to existing signalfd */
+sigaddset(&mask, SIGUSR2);
+signalfd(sfd, &mask, 0);  /* first arg is existing fd */
+```
+
+### Kernel implementation
+
+```c
+/* fs/signalfd.c */
+static ssize_t signalfd_read(struct file *file, char __user *buf,
+                              size_t count, loff_t *ppos)
+{
+    struct signalfd_ctx *ctx = file->private_data;
+    struct signalfd_siginfo __user *siginfo = (void __user *)buf;
+    int ret = 0;
+    siginfo_t info;
+
+    count /= sizeof(*siginfo);
+    if (!count)
+        return -EINVAL;
+
+    do {
+        /* Dequeue a pending signal matching our mask */
+        ret = dequeue_signal(current, &ctx->sigmask, &info, &type);
+        if (!ret) {
+            /* No signal: block or EAGAIN */
+            if (file->f_flags & O_NONBLOCK)
+                return -EAGAIN;
+            /* Wait for a signal in our mask */
+            wait_event_interruptible(ctx->wqh,
+                next_signal(&current->pending, &ctx->sigmask) ||
+                next_signal(&current->signal->shared_pending, &ctx->sigmask));
+        }
+    } while (!ret);
+
+    /* Copy siginfo to userspace signalfd_siginfo format */
+    copy_siginfo_to_user_sighand(siginfo, &info);
+    return sizeof(*siginfo);
+}
+```
+
+## timerfd: pollable timers
+
+`timerfd` (covered in [POSIX Timers](../time/posix-timers.md)) follows the same pattern — a file descriptor that becomes readable when a timer fires. Combined with eventfd and signalfd, it enables a complete event loop without threads:
+
+```c
+/* All three work with epoll: */
+epoll_ctl(epfd, EPOLL_CTL_ADD, timerfd, &ev_timer);
+epoll_ctl(epfd, EPOLL_CTL_ADD, signalfd, &ev_signal);
+epoll_ctl(epfd, EPOLL_CTL_ADD, eventfd,  &ev_event);
+epoll_ctl(epfd, EPOLL_CTL_ADD, sock_fd,  &ev_socket);
+/* One epoll_wait handles timers + signals + events + I/O */
+```
+
+## Further reading
+
+- [Completions and Wait Queues](../locking/completions.md) — kernel-side wait primitives
+- [IPC: Signals](signals.md) — traditional signal delivery
+- [POSIX Timers and timerfd](../time/posix-timers.md) — timerfd
+- [io_uring Architecture](../io-uring/io-uring-arch.md) — io_uring + eventfd
+- `fs/eventfd.c`, `fs/signalfd.c` — implementations

--- a/docs/ipc/mqueue.md
+++ b/docs/ipc/mqueue.md
@@ -1,0 +1,347 @@
+# POSIX Message Queues
+
+> Priority-ordered, kernel-managed message passing between processes
+
+## Overview
+
+POSIX message queues (`mq_open`, `mq_send`, `mq_receive`) provide a message-passing IPC mechanism with:
+- **Priority ordering**: messages are dequeued highest-priority first
+- **Blocking and non-blocking**: readers block until a message arrives
+- **Async notification**: `mq_notify` delivers a signal or starts a thread when a message arrives
+- **Kernel persistence**: queues survive until explicitly deleted or system reboot
+- **VFS integration**: queues appear as files under `/dev/mqueue`
+
+```bash
+# Mount the mqueue filesystem (usually automatic on modern systems)
+mount -t mqueue none /dev/mqueue
+ls /dev/mqueue/   # lists all open queues
+```
+
+## Basic usage
+
+```c
+#include <mqueue.h>
+/* Link with -lrt */
+
+/* Create or open a queue */
+struct mq_attr attr = {
+    .mq_maxmsg  = 10,     /* maximum messages in queue */
+    .mq_msgsize = 256,    /* maximum message size (bytes) */
+};
+
+/* Producer: open for writing */
+mqd_t mq = mq_open("/myqueue", O_WRONLY | O_CREAT, 0644, &attr);
+
+/* Consumer: open for reading */
+mqd_t mq = mq_open("/myqueue", O_RDONLY);
+
+/* Send a message (priority 5) */
+const char *msg = "hello";
+mq_send(mq, msg, strlen(msg), 5);  /* prio=5 (higher = dequeued first) */
+
+/* Receive the highest-priority message */
+char buf[256];
+unsigned int prio;
+ssize_t n = mq_receive(mq, buf, sizeof(buf), &prio);
+printf("received %zd bytes, priority=%u: %.*s\n", n, prio, (int)n, buf);
+
+/* Delete the queue */
+mq_close(mq);
+mq_unlink("/myqueue");
+```
+
+### Queue attributes
+
+```c
+/* Query queue attributes */
+struct mq_attr attr;
+mq_getattr(mq, &attr);
+printf("maxmsg=%ld msgsize=%ld curmsgs=%ld\n",
+       attr.mq_maxmsg, attr.mq_msgsize, attr.mq_curmsgs);
+
+/* Set non-blocking mode */
+attr.mq_flags = O_NONBLOCK;
+mq_setattr(mq, &attr, NULL);
+
+/* Non-blocking receive: returns EAGAIN if empty */
+ssize_t n = mq_receive(mq, buf, sizeof(buf), &prio);
+if (n == -1 && errno == EAGAIN)
+    printf("queue empty\n");
+```
+
+## Priority queue behavior
+
+Messages are ordered by priority (highest first). Same priority messages are FIFO:
+
+```c
+mq_send(mq, "low",    3, 1);  /* priority 1 */
+mq_send(mq, "high",   4, 9);  /* priority 9 */
+mq_send(mq, "medium", 6, 5);  /* priority 5 */
+mq_send(mq, "high2",  5, 9);  /* priority 9 */
+
+/* Dequeue order: high (p9), high2 (p9), medium (p5), low (p1) */
+```
+
+Priority range: 0 to `sysconf(_SC_MQ_PRIO_MAX) - 1` (at least 32, typically 32768).
+
+## Timed operations
+
+```c
+#include <time.h>
+
+/* Send with timeout (absolute time) */
+struct timespec deadline;
+clock_gettime(CLOCK_REALTIME, &deadline);
+deadline.tv_sec += 5;  /* 5 seconds from now */
+
+int ret = mq_timedsend(mq, msg, len, prio, &deadline);
+if (ret == -1 && errno == ETIMEDOUT)
+    printf("queue full, timed out\n");
+
+/* Receive with timeout */
+ssize_t n = mq_timedreceive(mq, buf, size, &prio, &deadline);
+if (n == -1 && errno == ETIMEDOUT)
+    printf("queue empty, timed out\n");
+```
+
+## Async notification: mq_notify
+
+`mq_notify` delivers a notification when a message arrives in an empty queue:
+
+```c
+/* Signal notification */
+struct sigevent sev = {
+    .sigev_notify = SIGEV_SIGNAL,
+    .sigev_signo  = SIGUSR1,
+};
+mq_notify(mq, &sev);
+
+/* Only one process can be registered for notifications at a time */
+/* Registration is one-shot: must re-register after each notification */
+
+/* Thread notification: starts a thread on message arrival */
+struct sigevent sev = {
+    .sigev_notify            = SIGEV_THREAD,
+    .sigev_notify_function   = my_handler,
+    .sigev_notify_attributes = NULL,  /* default thread attrs */
+};
+mq_notify(mq, &sev);
+
+void my_handler(union sigval sv) {
+    /* Called in a new thread when message arrives */
+    mqd_t mq = sv.sival_int;  /* pass mq via sigval if needed */
+    /* Read messages, then re-register: */
+    mq_notify(mq, &sev);
+}
+```
+
+### epoll with mq_notify + eventfd
+
+For integration with an event loop:
+
+```c
+int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+
+/* Notify via eventfd write */
+struct sigevent sev = {
+    .sigev_notify            = SIGEV_THREAD,
+    .sigev_notify_function   = notify_handler,
+    .sigev_value.sival_int   = efd,
+};
+mq_notify(mq, &sev);
+
+void notify_handler(union sigval sv) {
+    int efd = sv.sival_int;
+    write(efd, &(uint64_t){1}, 8);
+    mq_notify(mq, &sev);  /* re-register */
+}
+
+/* epoll_wait on efd triggers when message arrives */
+```
+
+## System limits
+
+```bash
+# Maximum number of message queues per user
+cat /proc/sys/fs/mqueue/queues_max    # default: 256
+
+# Default maximum messages per queue
+cat /proc/sys/fs/mqueue/msg_max       # default: 10
+
+# Default maximum message size
+cat /proc/sys/fs/mqueue/msgsize_max   # default: 8192
+
+# Maximum priority
+cat /proc/sys/fs/mqueue/msg_default   # default message max
+
+# View all open queues with their attributes:
+ls -la /dev/mqueue/
+cat /dev/mqueue/myqueue  # shows: QSIZE:0 NOTIFY:0 SIGNO:0 NOTIFY_PID:0
+```
+
+## Kernel implementation
+
+### struct mqueue_inode
+
+```c
+/* ipc/mqueue.c */
+struct mqueue_inode {
+    struct inode      vfs_inode;
+
+    /* Priority queue: array of linked lists, one per priority */
+    struct list_head  msg_tree[MQUEUE_PRIO_MAX];
+    struct rb_root    msg_tree_rb;   /* newer kernels use rb-tree */
+
+    struct msg_msg   *messages;
+    struct mq_attr    attr;
+
+    /* Notification */
+    struct sigevent   notify;
+    struct pid       *notify_owner;
+    struct user_struct *notify_user;
+
+    /* Wait queues */
+    wait_queue_head_t  wait_q;        /* blocked receivers */
+    struct list_head   e_wait_q[2];   /* poll/select waiters */
+
+    spinlock_t        lock;
+};
+```
+
+### Message structure
+
+```c
+/* include/linux/msg.h */
+struct msg_msg {
+    struct list_head  m_list;   /* on priority list */
+    long              m_type;   /* priority (stored as type) */
+    size_t            m_ts;     /* message text size */
+    struct msg_msgseg *next;    /* for messages > PAGE_SIZE */
+    void             *security; /* LSM security label */
+    /* Message data follows immediately in memory */
+};
+```
+
+### mq_send kernel path
+
+```c
+/* ipc/mqueue.c */
+static int do_mq_send(mqd_t mqdes, const char __user *u_msg_ptr,
+                       size_t msg_len, unsigned int msg_prio,
+                       struct timespec64 *ts)
+{
+    struct mqueue_inode *info;
+    struct msg_msg *msg_ptr;
+
+    /* Allocate and copy message data from userspace */
+    msg_ptr = load_msg(u_msg_ptr, msg_len);
+    msg_ptr->m_type = (long)msg_prio;
+
+    spin_lock(&info->lock);
+
+    if (info->attr.mq_curmsgs == info->attr.mq_maxmsg) {
+        /* Queue full: block or EAGAIN */
+        if (filp->f_flags & O_NONBLOCK) {
+            spin_unlock(&info->lock);
+            return -EAGAIN;
+        }
+        /* Block on wait_q until space available */
+        wait_event_interruptible(info->wait_q,
+            info->attr.mq_curmsgs < info->attr.mq_maxmsg);
+    }
+
+    /* Insert into priority tree */
+    msg_insert(msg_ptr, info);
+    info->attr.mq_curmsgs++;
+
+    /* Wake up a blocked receiver */
+    if (waitqueue_active(&info->wait_q))
+        wake_up(&info->wait_q);
+
+    /* Fire mq_notify if queue was empty and notifier registered */
+    if (info->attr.mq_curmsgs == 1 && info->notify_owner)
+        do_notify_owner(info);
+
+    spin_unlock(&info->lock);
+    return 0;
+}
+```
+
+### Priority tree insertion
+
+```c
+static void msg_insert(struct msg_msg *ptr, struct mqueue_inode *info)
+{
+    /* Insert into rb-tree ordered by priority (highest first) */
+    /* Equal-priority messages are FIFO via a per-priority list */
+    struct rb_node **p = &info->msg_tree_rb.rb_node;
+    while (*p) {
+        struct msg_msg *n = rb_entry(*p, struct msg_msg, rb_node);
+        if (ptr->m_type > n->m_type)
+            p = &(*p)->rb_left;   /* higher priority → left (min-heap) */
+        else
+            p = &(*p)->rb_right;
+    }
+    rb_link_node(&ptr->rb_node, parent, p);
+    rb_insert_color(&ptr->rb_node, &info->msg_tree_rb);
+}
+```
+
+## POSIX mqueue vs SysV message queues
+
+| Feature | POSIX mqueue | SysV msgsnd/msgrcv |
+|---------|-------------|-------------------|
+| API | `mq_open`/`mq_send` | `msgget`/`msgsnd` |
+| Name | `/name` in mqueue FS | Integer key (IPC_PRIVATE) |
+| Priority | Yes (per-message priority) | Type-based filtering |
+| Notification | `mq_notify` (signal/thread) | None (polling only) |
+| epoll | No (not a real fd) | No |
+| VFS | `/dev/mqueue/` | `/proc/sysvipc/msg` |
+| Persistence | Until `mq_unlink` | Until explicit removal |
+| Portability | POSIX standard | Historical (XSI) |
+
+Note: POSIX mqueue file descriptors do NOT work with `epoll` directly. Use `mq_notify` + eventfd for event-loop integration.
+
+## SysV message queues (brief)
+
+```c
+#include <sys/msg.h>
+
+/* Create/get a SysV message queue */
+int msqid = msgget(IPC_PRIVATE, IPC_CREAT | 0666);
+/* or by key: key_t key = ftok("/some/file", 'A'); */
+
+/* Send */
+struct msgbuf {
+    long mtype;   /* must be > 0; used for filtering */
+    char mtext[256];
+} msg = { .mtype = 1, .mtext = "hello" };
+msgsnd(msqid, &msg, strlen(msg.mtext), 0);
+
+/* Receive: mtype=0 → first message; mtype>0 → first msg of that type */
+struct msgbuf recv;
+msgrcv(msqid, &recv, sizeof(recv.mtext), 0, 0);
+
+/* Remove */
+msgctl(msqid, IPC_RMID, NULL);
+```
+
+```bash
+# List SysV queues
+ipcs -q
+
+# Show queue details
+ipcs -q -i <msqid>
+
+# Remove all SysV queues
+ipcrm --all=msg
+```
+
+## Further reading
+
+- [IPC: Pipes and FIFOs](pipes.md) — byte-stream IPC
+- [IPC: Shared Memory](shared-memory.md) — zero-copy bulk IPC
+- [eventfd and signalfd](eventfd-signalfd.md) — mq_notify integration
+- [POSIX Timers](../time/posix-timers.md) — similar kernel notification model
+- `ipc/mqueue.c` — POSIX mqueue kernel implementation
+- `ipc/msg.c` — SysV message queue implementation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -304,6 +304,8 @@ nav:
     - Signals: ipc/signals.md
     - Pipes and FIFOs: ipc/pipes.md
     - Shared Memory and Semaphores: ipc/shared-memory.md
+    - eventfd and signalfd: ipc/eventfd-signalfd.md
+    - POSIX Message Queues: ipc/mqueue.md
   - I/O Patterns:
     - Getting Started: io/README.md
     - Direct I/O: io/direct-io.md


### PR DESCRIPTION
## Summary

- **eventfd and signalfd** (`docs/ipc/eventfd-signalfd.md`): `eventfd` counter semantics, `EFD_SEMAPHORE` mode (decrement-by-1), epoll integration for wake-on-event, io_uring `io_uring_register_eventfd`, kernel `eventfd_ctx` with spinlock+wait queue; `signalfd` replacing the self-pipe trick, `signalfd_siginfo` field reference, single-threaded epoll loop handling signals + I/O + timers, kernel `dequeue_signal` path
- **POSIX Message Queues** (`docs/ipc/mqueue.md`): `mq_open`/`mq_send`/`mq_receive`, priority rb-tree ordering (highest dequeued first), `mq_timedsend`/`mq_timedreceive`, `mq_notify` with `SIGEV_SIGNAL`/`SIGEV_THREAD`, mq_notify + eventfd epoll integration, kernel `mqueue_inode` and `msg_insert` rb-tree, SysV `msgsnd`/`msgrcv` comparison table

## Test plan

- [ ] `mkdocs build` passes
- [ ] eventfd/signalfd examples compile with `-lrt` (mqueue) noted
- [ ] Links to signals.md, timerfd, io_uring resolve correctly

Closes #387, #388
Part of #386