### PR TITLE
Add networking: TCP congestion control and epoll internals

### DIFF
--- a/docs/net/epoll.md
+++ b/docs/net/epoll.md
@@ -1,0 +1,378 @@
+# epoll Internals
+
+> How epoll monitors thousands of file descriptors efficiently
+
+## The problem with poll/select
+
+`select()` and `poll()` require passing the entire set of monitored file descriptors on every call. For N fds:
+- Userspace → kernel copy: O(N)
+- Kernel scans all fds for readiness: O(N)
+- Kernel → userspace copy of ready fds: O(N)
+- Total per-call: O(N), even if only 1 fd is ready
+
+With 10,000 connections this is unacceptable.
+
+## epoll: O(1) per event
+
+epoll uses a **kernel-resident interest list** — registered once, no re-copying:
+
+```
+epoll workflow:
+
+  epoll_create()  →  create struct eventpoll (rb-tree + ready list)
+  epoll_ctl(ADD)  →  insert fd into rb-tree, add wait queue callback
+  epoll_wait()    →  sleep; wake when ready list is non-empty
+  [fd becomes ready] → ep_poll_callback adds to ready list, wakes waiter
+  epoll_wait returns → copy only ready events (O(ready), not O(N))
+```
+
+## Creating an epoll instance
+
+```c
+#include <sys/epoll.h>
+
+/* Create epoll instance */
+int epfd = epoll_create1(EPOLL_CLOEXEC);
+
+/* Add a file descriptor */
+struct epoll_event ev = {
+    .events  = EPOLLIN | EPOLLERR | EPOLLHUP,
+    .data.fd = sock_fd,   /* or .data.ptr = &mydata */
+};
+epoll_ctl(epfd, EPOLL_CTL_ADD, sock_fd, &ev);
+
+/* Modify */
+ev.events = EPOLLIN | EPOLLOUT;
+epoll_ctl(epfd, EPOLL_CTL_MOD, sock_fd, &ev);
+
+/* Remove */
+epoll_ctl(epfd, EPOLL_CTL_DEL, sock_fd, NULL);
+
+/* Wait: returns up to maxevents ready fds */
+struct epoll_event events[64];
+int n = epoll_wait(epfd, events, 64, -1);   /* -1 = no timeout */
+for (int i = 0; i < n; i++) {
+    int fd = events[i].data.fd;
+    if (events[i].events & EPOLLIN)
+        handle_read(fd);
+    if (events[i].events & EPOLLOUT)
+        handle_write(fd);
+}
+```
+
+## Level-triggered vs edge-triggered
+
+### Level-triggered (LT) — default
+
+`epoll_wait` returns as long as the fd is ready:
+
+```c
+/* LT: no flag needed, it's the default */
+ev.events = EPOLLIN;
+
+/* Behavior: */
+/* recv buffer has 100 bytes */
+/* epoll_wait returns fd=5 (EPOLLIN) */
+/* read only 50 bytes */
+/* epoll_wait returns fd=5 (EPOLLIN) again */
+/* read remaining 50 bytes */
+/* epoll_wait blocks (buffer empty) */
+```
+
+Safe: even if you don't drain the buffer in one call, you'll get notified again.
+
+### Edge-triggered (ET)
+
+`epoll_wait` returns only when the fd **transitions** from not-ready to ready:
+
+```c
+ev.events = EPOLLIN | EPOLLET;
+
+/* Behavior: */
+/* recv buffer has 100 bytes */
+/* epoll_wait returns fd=5 (EPOLLIN) — transition: empty → data */
+/* read only 50 bytes */
+/* epoll_wait does NOT return fd=5 again (still ready, no transition) */
+/* More data arrives: new transition → epoll_wait returns */
+```
+
+With EPOLLET you **must** read until `EAGAIN` in a non-blocking loop:
+
+```c
+void handle_read_et(int fd) {
+    char buf[4096];
+    while (1) {
+        ssize_t n = recv(fd, buf, sizeof(buf), 0);
+        if (n > 0) {
+            process(buf, n);
+        } else if (n == 0) {
+            close_connection(fd);
+            break;
+        } else {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+                break;  /* all data read */
+            if (errno == EINTR)
+                continue;
+            handle_error(fd);
+            break;
+        }
+    }
+}
+```
+
+### EPOLLONESHOT: single notification
+
+Receive one notification, then the fd is automatically disabled:
+
+```c
+ev.events = EPOLLIN | EPOLLONESHOT;
+epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev);
+
+/* After one event, must re-arm to get more: */
+epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &ev);  /* re-enable */
+```
+
+Useful for multi-threaded epoll where only one thread should handle each event.
+
+## Kernel data structures
+
+### struct eventpoll
+
+```c
+/* fs/eventpoll.c */
+struct eventpoll {
+    /* Protects the access to this structure */
+    rwlock_t          lock;
+    struct mutex      mtx;
+
+    /* Wait queue used by sys_epoll_wait() */
+    wait_queue_head_t   wq;
+
+    /* Wait queue used by file->poll() */
+    wait_queue_head_t   poll_wait;
+
+    /* List of ready file descriptors */
+    struct list_head    rdllist;
+
+    /* Lock for rdllist access from IRQ context */
+    rwlock_t            rdl_lock;
+
+    /* RB tree root used to store monitored fds */
+    struct rb_root_cached rbr;
+
+    /* This is a single linked list that chains all the "struct epitem"
+       that happened while transferring ready events to userspace */
+    struct epitem      *ovflist;
+
+    /* wakeup_source used when ep_scan_ready_list is running */
+    struct wakeup_source *ws;
+
+    /* The user that created the eventpoll descriptor */
+    struct user_struct *user;
+
+    /* The epoll file itself */
+    struct file        *file;
+
+    /* Used to optimize the readiness check */
+    int                napi_id;
+    u64                gen;
+    struct hlist_head  refs;
+};
+```
+
+### struct epitem
+
+One `epitem` per monitored fd:
+
+```c
+struct epitem {
+    /* RB tree node used to link this structure to the eventpoll rb-tree */
+    union {
+        struct rb_node  rbn;
+        struct rcu_head rcu;
+    };
+
+    /* List header used to link this item to the eventpoll ready list */
+    struct list_head    rdllink;
+
+    /* Works as temporary storage for the pointer when the
+       ovflist is used */
+    struct epitem      *next;
+
+    /* The file descriptor information this item refers to */
+    struct epoll_filefd  ffd;   /* {file*, fd} pair */
+
+    /* Number of active wait queue attached to poll operations */
+    int                 nwait;
+
+    /* List containing poll wait queues */
+    struct list_head    pwqlist;
+
+    /* The "container" of this item */
+    struct eventpoll   *ep;
+
+    /* List header used to link this item to the ep->items list */
+    struct list_head    fllink;
+
+    /* epoll_event structure from epoll_ctl(EPOLL_CTL_ADD/MOD) */
+    __poll_t            revents;
+    struct epoll_event  event;
+};
+```
+
+### ep_poll_callback: the critical wakeup path
+
+When a monitored fd becomes ready, this callback runs from the fd's wait queue:
+
+```c
+/* fs/eventpoll.c */
+static int ep_poll_callback(wait_queue_entry_t *wait, unsigned mode,
+                              int sync, void *key)
+{
+    struct epitem *epi = ep_item_from_wait(wait);
+    struct eventpoll *ep = epi->ep;
+    __poll_t pollflags = key_to_poll(key);
+    unsigned long flags;
+    int ewake = 0;
+
+    spin_lock_irqsave(&ep->wq.lock, flags);
+
+    /* If the event we wait for is not here, try next one in the chain */
+    if (pollflags && !(pollflags & epi->event.events))
+        goto out_unlock;
+
+    /* If this file is already in the ready list, we exit soon */
+    if (!ep_is_linked(epi)) {
+        list_add_tail(&epi->rdllink, &ep->rdllist);
+        ep_pm_stay_awake_rcu(epi);
+    }
+
+    /* Wake up (if active) both the eventpoll wait list and the ->poll()
+       wait list. */
+    if (waitqueue_active(&ep->wq)) {
+        if ((epi->event.events & EPOLLEXCLUSIVE) &&
+            !(pollflags & POLLFREE)) {
+            switch (pollflags & EPOLLINOUT_BITS) {
+            case EPOLLIN:
+                if (epi->event.events & EPOLLIN)
+                    ewake = 1;
+                break;
+            /* ... */
+            }
+        } else
+            ewake = 1;
+        wake_up_locked(&ep->wq);
+    }
+
+out_unlock:
+    spin_unlock_irqrestore(&ep->wq.lock, flags);
+    return ewake;
+}
+```
+
+### epoll_ctl(ADD) kernel path
+
+```c
+/* fs/eventpoll.c */
+static int ep_insert(struct eventpoll *ep, const struct epoll_event *event,
+                      struct file *tfile, int fd, int full_check)
+{
+    struct epitem *epi;
+
+    /* Allocate the epitem structure */
+    epi = kmem_cache_zalloc(epi_cache, GFP_KERNEL);
+
+    /* Initialize the poll table using the queue callback */
+    epq.epi = epi;
+    init_poll_funcptr(&epq.pt, ep_ptable_queue_proc);
+
+    /* Attach to the file's wait queue via ->poll() */
+    revents = ep_item_poll(epi, &epq.pt, 1);
+    /* This calls file->f_op->poll(file, &epq.pt) */
+    /* poll_wait() inside the driver's poll adds ep_ptable_queue_proc
+       as a wait queue callback */
+
+    /* Insert into eventpoll's rb-tree */
+    ep_rbtree_insert(ep, epi);
+
+    /* If already ready, add to ready list immediately */
+    if (revents & event->events) {
+        list_add_tail(&epi->rdllink, &ep->rdllist);
+        /* Wake any epoll_wait that's sleeping */
+        wake_up(&ep->wq);
+    }
+}
+```
+
+## Thundering herd and EPOLLEXCLUSIVE
+
+When many threads all `epoll_wait` on the same epfd and one event arrives, all threads wake up but only one handles it — **thundering herd**.
+
+`EPOLLEXCLUSIVE` (4.5+) prevents this: only one waiter is woken per event:
+
+```c
+/* Server: one epfd per accept socket, multiple worker threads */
+ev.events = EPOLLIN | EPOLLEXCLUSIVE;
+epoll_ctl(shared_epfd, EPOLL_CTL_ADD, listen_fd, &ev);
+
+/* Only one of the N epoll_wait threads wakes per connection */
+```
+
+Alternative: use separate epfds per thread, each with its own `accept()` thread on a `SO_REUSEPORT` socket:
+
+```c
+/* Per-thread accept: each thread has its own listening socket */
+setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &(int){1}, sizeof(int));
+/* Kernel load-balances new connections across all SO_REUSEPORT sockets */
+```
+
+## epoll with eventfd, signalfd, timerfd
+
+epoll works with any fd that implements `->poll`:
+
+```c
+/* Unified event loop: I/O + signals + timers + events */
+epoll_ctl(epfd, EPOLL_CTL_ADD, sock_fd,   &ev_socket);
+epoll_ctl(epfd, EPOLL_CTL_ADD, signalfd,  &ev_signal);
+epoll_ctl(epfd, EPOLL_CTL_ADD, timerfd,   &ev_timer);
+epoll_ctl(epfd, EPOLL_CTL_ADD, eventfd,   &ev_event);
+epoll_ctl(epfd, EPOLL_CTL_ADD, pipe_rfd,  &ev_pipe);
+```
+
+All block on a single `epoll_wait`. No polling loop, no busy-waiting.
+
+## epoll limitations
+
+- **Regular files**: always "ready" — cannot use epoll for disk file I/O (use io_uring)
+- **Directories**: not pollable
+- **No timeout per fd**: epoll_wait has one timeout for all
+- **Notification only**: epoll tells you a fd is ready but doesn't do the I/O (unlike io_uring)
+
+## Observing epoll
+
+```bash
+# Count epoll instances per process
+ls -l /proc/<pid>/fd | grep eventpoll
+
+# See epoll fds in /proc
+cat /proc/<pid>/fdinfo/<epfd>
+# pos: 0
+# flags: 02
+# mnt_id: 9
+# tfd:   3 events: 19 data: 3000000003  pos:0 ino:7 stype:0x8001
+
+# Trace epoll_wait calls
+strace -e epoll_wait,epoll_ctl nginx &
+
+# Perf: time spent in epoll_wait
+perf stat -e syscalls:sys_enter_epoll_wait nginx
+```
+
+## Further reading
+
+- [Socket Layer Overview](socket-layer.md) — socket poll() implementation
+- [eventfd and signalfd](../ipc/eventfd-signalfd.md) — epoll-compatible event fds
+- [POSIX Timers and timerfd](../time/posix-timers.md) — timerfd with epoll
+- [io_uring Architecture](../io-uring/io-uring-arch.md) — io_uring solves epoll's file I/O limitation
+- [Completions and Wait Queues](../locking/completions.md) — the wait_queue mechanism epoll uses
+- `fs/eventpoll.c` — complete epoll implementation

--- a/docs/net/tcp-congestion.md
+++ b/docs/net/tcp-congestion.md
@@ -1,0 +1,361 @@
+# TCP Congestion Control
+
+> How the kernel decides how fast to send: CUBIC, BBR, and the cc_ops interface
+
+## What congestion control does
+
+TCP congestion control governs the **congestion window (cwnd)** — the maximum number of unacknowledged bytes in flight:
+
+```
+Throughput ≈ min(rwnd, cwnd) / RTT
+
+rwnd: receiver's advertised window (flow control)
+cwnd: sender's estimate of network capacity (congestion control)
+```
+
+The congestion controller runs on the sender and responds to:
+- **ACK received**: increase cwnd (network has capacity)
+- **Loss detected**: decrease cwnd (congestion)
+- **ECN (Explicit Congestion Notification)**: decrease cwnd before loss
+
+## struct tcp_congestion_ops: the cc interface
+
+All congestion control algorithms implement this interface:
+
+```c
+/* include/net/tcp.h */
+struct tcp_congestion_ops {
+    /* Required */
+    u32  (*ssthresh)(struct sock *sk);      /* set ssthresh after loss */
+    void (*cong_avoid)(struct sock *sk,
+                        u32 ack, u32 acked); /* increase cwnd on ACK */
+
+    /* Optional */
+    void (*set_state)(struct sock *sk, u8 new_state);
+    void (*cwnd_event)(struct sock *sk, enum tcp_ca_event ev);
+    void (*in_ack_event)(struct sock *sk, u32 flags);
+    u32  (*undo_cwnd)(struct sock *sk);
+    void (*pkts_acked)(struct sock *sk,
+                        const struct ack_sample *sample);
+    u32  (*min_tso_segs)(struct sock *sk);
+    void (*cong_control)(struct sock *sk, const struct rate_sample *rs);
+    u32  (*get_info)(struct sock *sk, u32 ext,
+                      int *attr, union tcp_cc_info *info);
+
+    char         name[TCP_CA_NAME_MAX];
+    struct module *owner;
+    u32           key;
+    u32           flags;
+};
+```
+
+### Registering an algorithm
+
+```c
+/* net/ipv4/tcp_cubic.c */
+static struct tcp_congestion_ops cubictcp __read_mostly = {
+    .init        = bictcp_init,
+    .ssthresh    = bictcp_recalc_ssthresh,
+    .cong_avoid  = bictcp_cong_avoid,
+    .set_state   = bictcp_state,
+    .undo_cwnd   = tcp_reno_undo_cwnd,
+    .cwnd_event  = bictcp_cwnd_event,
+    .pkts_acked  = bictcp_acked,
+    .owner       = THIS_MODULE,
+    .name        = "cubic",
+};
+
+static int __init cubictcp_register(void)
+{
+    BUILD_BUG_ON(sizeof(struct bictcp) > ICSK_CA_PRIV_SIZE);
+    return tcp_register_congestion_control(&cubictcp);
+}
+```
+
+### Per-socket congestion control data
+
+Each socket has `ICSK_CA_PRIV_SIZE` bytes (16 pointers) for algorithm-specific state:
+
+```c
+struct tcp_sock *tp = tcp_sk(sk);
+struct bictcp *ca = inet_csk_ca(sk);  /* points to icsk_ca_priv */
+```
+
+## TCP Reno: the baseline
+
+Reno is the simplest correct algorithm, required by all TCP implementations:
+
+```
+Slow Start:
+  cwnd starts at IW (≈10 segments)
+  Each ACK: cwnd += 1 MSS  (exponential growth)
+  Until cwnd >= ssthresh
+
+Congestion Avoidance (AIMD):
+  Each RTT: cwnd += 1 MSS  (linear growth, "AI" = Additive Increase)
+
+Loss detected (triple duplicate ACKs):
+  ssthresh = cwnd / 2
+  cwnd = ssthresh  (fast recovery)
+  ("MD" = Multiplicative Decrease)
+
+Timeout (RTO):
+  ssthresh = cwnd / 2
+  cwnd = 1 MSS  (slow start restart)
+```
+
+```c
+/* net/ipv4/tcp_cong.c - Reno implementation */
+void tcp_reno_cong_avoid(struct sock *sk, u32 ack, u32 acked)
+{
+    struct tcp_sock *tp = tcp_sk(sk);
+
+    if (!tcp_is_cwnd_limited(sk))
+        return;
+
+    if (tcp_in_slow_start(tp)) {
+        /* Slow start: grow by acked segments */
+        acked = tcp_slow_start(tp, acked);
+        if (!acked)
+            return;
+    }
+    /* Congestion avoidance: cwnd += 1 MSS per RTT */
+    tcp_cong_avoid_ai(tp, tp->snd_cwnd, acked);
+}
+```
+
+## CUBIC: the Linux default
+
+CUBIC replaces the linear increase of Reno with a **cubic function** of time since the last congestion event. This allows much faster window growth at high bandwidth-delay products.
+
+```
+CUBIC window function:
+  W(t) = C × (t - K)³ + Wmax
+
+  t    = time since last congestion event
+  K    = time to reach Wmax (origin point)
+  Wmax = window at last congestion
+  C    = scaling factor (typically 0.4)
+
+    cwnd
+      │        ╭─── new Wmax
+  Wmax│───╮   ╭
+      │    ╰─╯  concave/convex cubic curve
+      │
+      └────────────── time
+           K
+```
+
+The cubic shape means CUBIC:
+- Grows quickly far below Wmax (catching up after loss)
+- Slows near Wmax (probing carefully)
+- Overshoots if Wmax was limited by receiver
+
+```c
+/* net/ipv4/tcp_cubic.c */
+struct bictcp {
+    u32 cnt;           /* increase cwnd by 1 after ACKs */
+    u32 last_max_cwnd; /* Wmax: last maximum snd_cwnd */
+    u32 last_cwnd;
+    u32 last_time;
+    u32 bic_origin_point; /* origin point of bic function */
+    u32 bic_K;            /* time to origin point */
+    u32 delay_min;        /* min delay (msec << 3) */
+    u32 epoch_start;      /* beginning of an epoch */
+    u32 ack_cnt;          /* number of acks */
+    u32 tcp_cwnd;         /* estimated tcp cwnd */
+    u16 unused;
+    u8  sample_cnt;       /* number of samples to decide curr_rtt */
+    u8  found;            /* the exit point is found? */
+    u32 round_start;      /* beginning of each round */
+    u32 end_seq;          /* end_seq of the round */
+    u32 last_ack;         /* last time when the ACK spacing is close */
+    u32 curr_rtt;         /* the minimum rtt of current round */
+};
+
+static void bictcp_cong_avoid(struct sock *sk, u32 ack, u32 acked)
+{
+    struct tcp_sock *tp = tcp_sk(sk);
+    struct bictcp *ca = inet_csk_ca(sk);
+
+    if (!tcp_is_cwnd_limited(sk))
+        return;
+
+    if (tcp_in_slow_start(tp)) {
+        if (hystart && after(ack, ca->end_seq))
+            bictcp_hystart_reset(sk);  /* HyStart: slow start exit
+                                          when delay increases */
+        acked = tcp_slow_start(tp, acked);
+        if (!acked)
+            return;
+    }
+    bictcp_update(ca, tp->snd_cwnd, acked);
+    tcp_cong_avoid_ai(tp, ca->cnt, acked);
+}
+```
+
+### HyStart++: safe slow start exit
+
+CUBIC uses HyStart to exit slow start before actual loss:
+- **Delay increase**: exit when RTT increases by more than a threshold (ACK train delay)
+- **ACK train end**: exit when ACK spacing shows the pipe is full
+
+```bash
+# Check/set HyStart
+sysctl net.ipv4.tcp_cubic_hystart
+```
+
+## BBR: bandwidth-based congestion control
+
+BBR (Bottleneck Bandwidth and Round-trip propagation time) takes a fundamentally different approach: instead of reacting to **loss**, it estimates **bandwidth** and **RTT** to set the sending rate directly.
+
+```
+BBR's model:
+  BtlBw  = bottleneck bandwidth (bytes/sec)
+  RTprop = round-trip propagation delay (min RTT)
+
+  Optimal operating point:
+    Inflight = BtlBw × RTprop
+    Rate = BtlBw
+
+BBR phases:
+  STARTUP:       probe bandwidth (double rate each RTT, like slow start)
+  DRAIN:         drain the queue STARTUP filled
+  PROBE_BW:      cycle pacing_gain (1.25/0.75/1.0...) to probe bandwidth
+  PROBE_RTT:     reduce cwnd to 4 MSS to measure min RTT (every 10s)
+```
+
+```c
+/* net/ipv4/tcp_bbr.c */
+struct bbr {
+    u32  min_rtt_us;           /* min RTT in usec */
+    u32  min_rtt_stamp;        /* timestamp of min_rtt_us */
+    u32  probe_rtt_done_stamp; /* end time for BBR_PROBE_RTT mode */
+    struct minmax bw;          /* max recent delivery rate */
+    u32  rtt_cnt;              /* count of packet-timed rounds elapsed */
+    u32  next_rtt_delivered;   /* scb->tx.delivered at end of round */
+    u64  cycle_mstamp;         /* time of this cycle phase start */
+    u32  mode:3,               /* current BBR mode */
+         prev_ca_state:3,      /* CA state on previous ACK */
+         packet_conservation:1,/* use packet conservation? */
+         round_start:1,        /* start of packet-timed tx.delivered round? */
+         idle_restart:1,       /* restarting after idle? */
+         probe_rtt_round_done:1, /* a BBR_PROBE_RTT round at 4 pkts? */
+         unused:13,
+         lt_is_sampling:1,     /* taking long-term ("LT") samples now? */
+         lt_rtt_cnt:7,         /* round trips in long-term interval */
+         lt_use_bw:1;          /* use lt_bw as our bw estimate? */
+    u32  lt_bw;                /* LT est delivery rate in pkts/uS << 24 */
+    u32  lt_last_delivered;    /* LT intvl start: tp->delivered */
+    u32  lt_last_stamp;        /* LT intvl start: tp->delivered_mstamp */
+    u32  lt_last_lost;         /* LT intvl start: tp->lost */
+    u32  pacing_gain:10,       /* current gain for sending rate */
+         cwnd_gain:10,         /* current gain for cwnd */
+         full_bw_reached:1,    /* hit BBR_FULL_BW_THRESH? */
+         full_bw_cnt:2,        /* number of rounds with thresh */
+         cycle_idx:3,          /* current index in pacing_gain cycle array */
+         has_seen_rtt:1,       /* have we seen an RTT sample yet? */
+         unused_b:5;
+    u32  prior_cwnd;           /* prior cwnd upon entering loss recovery */
+    u32  full_bw;              /* recent bw, to estimate if pipe is full */
+};
+```
+
+### BBR pacing
+
+BBR uses **pacing** (spreading packets evenly over time) rather than bursting:
+
+```c
+/* Set pacing rate: BtlBw × pacing_gain */
+static void bbr_set_pacing_rate(struct sock *sk, u32 bw, int gain)
+{
+    struct tcp_sock *tp = tcp_sk(sk);
+    struct bbr *bbr = inet_csk_ca(sk);
+    u64 rate = bw;
+
+    rate = bbr_rate_bytes_per_sec(sk, rate, gain);
+    rate = min_t(u64, rate, sk->sk_max_pacing_rate);
+    if (bbr->mode != BBR_STARTUP || rate > sk->sk_pacing_rate)
+        WRITE_ONCE(sk->sk_pacing_rate, rate);
+}
+```
+
+TCP pacing is implemented by the packet scheduler (FQ/fq_codel qdisc) or via hrtimers if no pacing qdisc is present.
+
+```bash
+# Enable FQ pacing for BBR (recommended):
+tc qdisc add dev eth0 root fq
+sysctl -w net.ipv4.tcp_congestion_control=bbr
+```
+
+## BBR vs CUBIC
+
+| Aspect | CUBIC | BBR |
+|--------|-------|-----|
+| Reacts to | Loss | Bandwidth + RTT |
+| Pacing | No (bursts) | Yes (BtlBw rate) |
+| Queue filling | Fills bottleneck queue | Targets BtlBw×RTprop |
+| Fairness | Fair to other CUBIC | Can be unfair to loss-based |
+| Performance on loss | Good | Better on high loss |
+| Latency | Higher (queue) | Lower (targets min RTT) |
+| Kernel version | 2.6.19 default | 4.9 |
+
+## Selecting and observing congestion control
+
+```bash
+# System default
+sysctl net.ipv4.tcp_congestion_control
+
+# Change system default
+sysctl -w net.ipv4.tcp_congestion_control=bbr
+
+# Per-socket (requires CAP_NET_ADMIN for non-standard algorithms):
+setsockopt(fd, IPPROTO_TCP, TCP_CONGESTION, "bbr", 4);
+
+# List available algorithms
+sysctl net.ipv4.tcp_available_congestion_control
+# or:
+cat /proc/sys/net/ipv4/tcp_available_congestion_control
+
+# Observe per-connection state (ss -i shows cwnd, rtt, etc.)
+ss -tni
+# Outputs:
+#  cubic wscale:7,7 rto:204 rtt:0.748/0.374 ato:40
+#  mss:1448 pmtu:1500 rcvmss:1448 advmss:1448 cwnd:10 ssthresh:7
+#  bytes_sent:1234 bytes_acked:1234 segs_out:10 segs_in:10
+
+# BBR-specific info
+ss -tni | grep -A2 bbr
+#  bbr wscale:7,7 rto:204 rtt:1.234/0.617
+#  bw:1.23Gbps pacing_rate:1.50Gbps
+```
+
+## ECN: explicit congestion notification
+
+ECN allows routers to signal congestion via IP header bits before dropping:
+
+```
+IP header: ECT(0), ECT(1) — ECN capable transport
+TCP: CWR (congestion window reduced), ECE (ECN echo)
+
+Flow:
+  1. Sender marks packets as ECN-capable (ECT)
+  2. Router sets CE (Congestion Experienced) when queue fills
+  3. Receiver echoes CE back to sender via ECE flag
+  4. Sender reduces cwnd (like a loss signal) and sets CWR
+```
+
+```bash
+# Enable ECN
+sysctl -w net.ipv4.tcp_ecn=1  # enable if both ends support it
+# 0: disabled, 1: request ECN, 2: always use ECN
+```
+
+## Further reading
+
+- [TCP Implementation](tcp.md) — TCP socket state machine, fast retransmit
+- [Network Buffer Tuning](net-buffer-tuning.md) — tuning cwnd initial values
+- [TC and qdisc](tc-qdisc.md) — FQ qdisc for BBR pacing
+- `net/ipv4/tcp_cubic.c` — CUBIC implementation
+- `net/ipv4/tcp_bbr.c` — BBR implementation
+- `net/ipv4/tcp_cong.c` — cc_ops registration and dispatch

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,6 +204,7 @@ nav:
       - "Why Is the Network Stack So Complex?": net/network-stack-overview.md
       - "sk_buff: The Network Buffer": net/sk-buff.md
       - Socket Layer Overview: net/socket-layer.md
+      - epoll Internals: net/epoll.md
       - Network Device and NAPI: net/napi.md
     - Lifecycle:
       - Life of a Packet (receive): net/life-of-packet-rx.md
@@ -211,6 +212,7 @@ nav:
       - What Happens When You connect(): net/connect.md
     - TCP/IP:
       - TCP Implementation: net/tcp.md
+      - TCP Congestion Control: net/tcp-congestion.md
       - IP Routing: net/ip-routing.md
     - Filtering:
       - Netfilter Architecture: net/netfilter.md


### PR DESCRIPTION
## Summary

- **TCP Congestion Control** (`docs/net/tcp-congestion.md`): `struct tcp_congestion_ops` interface, Reno AIMD, CUBIC cubic window function with `bictcp` state and HyStart++ safe exit, BBR bandwidth/RTT model with `struct bbr`, BBR phases (STARTUP/DRAIN/PROBE_BW/PROBE_RTT), FQ pacing for BBR, ECN CE/CWR flow, `ss -i` output guide, `sysctl tcp_congestion_control`
- **epoll Internals** (`docs/net/epoll.md`): O(1) per-event vs O(N) poll/select, `struct eventpoll` rb-tree + ready list architecture, `struct epitem` per-fd registration, `ep_poll_callback` wait queue wakeup path, `ep_insert` attaching to file's wait queue via `->poll()`, level-triggered vs EPOLLET drain loop, EPOLLONESHOT, EPOLLEXCLUSIVE thundering herd, unified event loop with eventfd/signalfd/timerfd, epoll limitations for regular files

## Test plan

- [ ] `mkdocs build` passes
- [ ] `ss -i` output notes match what Linux actually prints
- [ ] Links to socket-layer.md, io_uring, eventfd/signalfd resolve

Closes #395, #396
Part of #394