### PR TITLE
Add MM lifecycle: exec() and file-backed mmap page faults

### DIFF
--- a/docs/mm/exec.md
+++ b/docs/mm/exec.md
@@ -1,0 +1,293 @@
+# What Happens During exec()
+
+> From execve() syscall to a running new process
+
+## Overview
+
+`execve()` replaces the current process image with a new one. The PID stays the same, but the address space, file descriptors (non-`O_CLOEXEC`), and registers are replaced:
+
+```
+execve("./myprogram", argv, envp)
+   │
+   ├─ syscall entry → do_execveat_common()
+   ├─ bprm allocation (struct linux_binprm)
+   ├─ bprm_init: open + read file header
+   ├─ search_binary_handler: find ELF/script handler
+   ├─ load_elf_binary:
+   │     ├─ parse ELF headers, validate
+   │     ├─ flush old address space (exec_mmap)
+   │     ├─ map PT_LOAD segments → VMAs
+   │     ├─ map interpreter (ld.so) → VMAs
+   │     ├─ setup stack (argv, envp, auxv)
+   │     └─ set entry point: interpreter start or ELF e_entry
+   └─ start_thread: set IP = entry, SP = stack top
+```
+
+## The linux_binprm structure
+
+```c
+/* include/linux/binfmts.h */
+struct linux_binprm {
+    struct vm_area_struct *vma;
+    unsigned long         vma_pages;
+    struct mm_struct *mm;
+
+    /* argv[0] path, used for /proc/PID/exe */
+    const char *filename;
+    const char *interp;
+
+    /* The first BINPRM_BUF_SIZE bytes of the file */
+    char buf[BINPRM_BUF_SIZE];  /* 256 bytes */
+
+    struct file *file;
+    struct cred *cred;          /* proposed new credentials */
+
+    int argc, envc;
+
+    /* Address of the top of the stack in the new mm */
+    unsigned long p;
+
+    /* argv[] and envp[] are stored on the stack above p */
+    unsigned long argmin;
+
+    /* ELF-specific: executable type flags */
+    unsigned int per_flags;
+    unsigned int unsafe;
+};
+```
+
+## Step 1: syscall entry
+
+```c
+/* fs/exec.c */
+SYSCALL_DEFINE3(execve,
+    const char __user *, filename,
+    const char __user *const __user *, argv,
+    const char __user *const __user *, envp)
+{
+    return do_execve(getname(filename), argv, envp);
+}
+
+static int do_execveat_common(int fd, struct filename *filename,
+                               struct user_arg_ptr argv,
+                               struct user_arg_ptr envp,
+                               int flags)
+{
+    struct linux_binprm *bprm;
+
+    bprm = alloc_bprm(fd, filename, flags);
+
+    /* Copy argv/envp strings to bprm (checked for length limits) */
+    retval = copy_strings_kernel(1, &bprm->filename, bprm);
+    retval = copy_strings(bprm->envc, envp, bprm);
+    retval = copy_strings(bprm->argc, argv, bprm);
+
+    /* Read the first 256 bytes of the file (magic number check) */
+    retval = bprm_execve(bprm, fd, filename, flags);
+}
+```
+
+## Step 2: binary format detection
+
+```c
+/* fs/exec.c */
+static int search_binary_handler(struct linux_binprm *bprm)
+{
+    /* Walk list of registered binary handlers */
+    list_for_each_entry(fmt, &formats, lh) {
+        retval = fmt->load_binary(bprm);
+        if (retval != -ENOEXEC)
+            break;
+    }
+}
+
+/* Registered handlers (in order): */
+/* 1. ELF:     fs/binfmt_elf.c    — matches "\x7fELF" */
+/* 2. Scripts: fs/binfmt_script.c — matches "#!"       */
+/* 3. Misc:    fs/binfmt_misc.c   — user-defined rules */
+/* 4. Flat:    fs/binfmt_flat.c   — uClinux flat binaries */
+```
+
+For `#!/bin/sh` scripts, `binfmt_script` re-invokes `search_binary_handler` with `/bin/sh` as the new executable.
+
+## Step 3: ELF loading
+
+```c
+/* fs/binfmt_elf.c */
+static int load_elf_binary(struct linux_binprm *bprm)
+{
+    struct elf_phdr *elf_phdata;
+    struct elf_ehdr *elf_ex = (struct elf_ehdr *)bprm->buf;
+
+    /* 1. Validate ELF magic and architecture */
+    if (memcmp(elf_ex->e_ident, ELFMAG, SELFMAG) != 0)
+        return -ENOEXEC;
+
+    /* 2. Read all program headers */
+    elf_phdata = load_elf_phdrs(elf_ex, bprm->file);
+
+    /* 3. Find the interpreter (PT_INTERP = dynamic linker path) */
+    for (i = 0; i < elf_ex->e_phnum; i++) {
+        if (elf_phdata[i].p_type == PT_INTERP) {
+            /* Read "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2" */
+            elf_interpreter = kmalloc(elf_phdata[i].p_filesz, GFP_KERNEL);
+            kernel_read(bprm->file, elf_interpreter, ...);
+        }
+    }
+
+    /* 4. Flush old address space, create new mm */
+    retval = begin_new_exec(bprm);
+    /* → exec_mmap: replace current mm with fresh mm_struct */
+    /* → close O_CLOEXEC fds */
+    /* → reset signal handlers */
+
+    /* 5. Map PT_LOAD segments */
+    for each PT_LOAD segment {
+        elf_map(bprm->file, load_addr + vaddr,
+                eppnt, elf_prot, elf_flags, total_size);
+        /* Creates a VMA for each segment:
+             .text: PROT_READ|EXEC, MAP_PRIVATE|FIXED
+             .data: PROT_READ|WRITE, MAP_PRIVATE|FIXED  */
+    }
+
+    /* 6. Load the interpreter (ld.so) at a random address */
+    if (elf_interpreter) {
+        interp_load_addr = load_elf_interp(&interp_elf_ex, interpreter);
+        elf_entry = interp_load_addr + interp_elf_ex.e_entry;
+        /* Process starts at ld.so, not at e_entry of the binary */
+    } else {
+        elf_entry = elf_ex->e_entry;  /* statically linked */
+    }
+
+    /* 7. Set up the stack */
+    retval = setup_arg_pages(bprm, randomize_stack_top(STACK_TOP),
+                              executable_stack);
+    /* Creates the stack VMA: PROT_READ|WRITE, grows down */
+
+    /* 8. Create [vvar] and [vdso] mappings */
+    arch_setup_additional_pages(bprm, !!elf_interpreter);
+
+    /* 9. Push auxiliary vector onto stack */
+    /* auxv entries: AT_PHDR, AT_PHNUM, AT_ENTRY, AT_BASE,
+                     AT_PAGESZ, AT_RANDOM, AT_PLATFORM, ... */
+
+    /* 10. Start the new binary */
+    start_thread(regs, elf_entry, bprm->p);
+    /* Sets IP=elf_entry, SP=bprm->p (stack top with argv/envp/auxv) */
+}
+```
+
+## The resulting address space
+
+After exec completes, `/proc/<pid>/maps` shows:
+
+```
+Address           Perms  Name
+00400000-00401000 r--p   /usr/bin/myprogram    [ELF .text]
+00401000-00402000 r-xp   /usr/bin/myprogram    [ELF .text]
+00402000-00403000 r--p   /usr/bin/myprogram    [ELF .rodata]
+00403000-00404000 r--p   /usr/bin/myprogram    [.data start]
+00404000-00405000 rw-p   /usr/bin/myprogram    [ELF .data/.bss]
+7f1234560000-...  r--p   /lib/.../ld-linux.so  [ld.so segments]
+7f1234590000-...  r-xp   /lib/.../ld-linux.so
+7ffcc1234000-...  rw-p   [stack]
+7ffcc1400000-...  r--p   [vvar]
+7ffcc1401000-...  r-xp   [vdso]
+```
+
+## Dynamic linker startup
+
+The kernel jumps to `ld.so`'s entry point, not the main binary's. `ld.so`:
+1. Maps itself (it's position-independent)
+2. Reads the binary's `PT_DYNAMIC` segment to find shared library dependencies
+3. Loads each `.so` via `mmap()` (creating new VMAs)
+4. Resolves PLT/GOT relocations (symbol addresses)
+5. Calls `DT_INIT` constructors (e.g., `__attribute__((constructor))` functions)
+6. Jumps to the main binary's `e_entry` (the `_start` symbol)
+
+```c
+/* ld.so loads libraries into the process address space */
+/* After ld.so finishes: */
+00400000-...  r-xp   /usr/bin/myprogram
+7f0000000000-...  r-xp   /lib/x86_64-linux-gnu/libc.so.6
+7f0001000000-...  r-xp   /lib/x86_64-linux-gnu/libm.so.6
+/* Each shared library gets its own set of VMAs */
+```
+
+## begin_new_exec: the point of no return
+
+```c
+/* fs/exec.c */
+int begin_new_exec(struct linux_binprm *bprm)
+{
+    struct task_struct *me = current;
+
+    /* Create a new mm_struct (blank address space) */
+    retval = exec_mmap(bprm->mm);
+    /* This replaces current->mm — old mappings gone! */
+
+    /* Close O_CLOEXEC file descriptors */
+    do_close_on_exec(current->files);
+
+    /* Reset signal handlers to SIG_DFL */
+    flush_signal_handlers(me, 0);
+
+    /* Drop capabilities acquired via set-uid */
+    /* Update credentials if set-uid/set-gid binary */
+    retval = install_exec_creds(bprm);
+
+    /* Change process name (/proc/PID/comm) */
+    __set_task_comm(me, kbasename(bprm->filename), true);
+
+    return 0;
+}
+```
+
+## exec and threads
+
+If the calling process has multiple threads, `execve` kills all other threads before replacing the address space:
+
+```c
+/* fs/exec.c */
+static int de_thread(struct task_struct *tsk)
+{
+    struct signal_struct *sig = tsk->signal;
+    struct sighand_struct *oldsighand = tsk->sighand;
+
+    /* Unshare the thread group */
+    /* Signal all other threads to exit */
+    zap_other_threads(tsk);
+
+    /* Wait for all other threads to die */
+    while (atomic_read(&sig->count) > 1)
+        schedule_timeout(1);
+}
+```
+
+## Observing exec
+
+```bash
+# Trace exec syscalls
+strace -e execve /bin/ls
+
+# Trace all execs system-wide
+bpftrace -e 'tracepoint:syscalls:sys_enter_execve { printf("%s exec %s\n", comm, str(args->filename)); }'
+
+# See ELF segments
+readelf -l /usr/bin/ls | grep -A1 LOAD
+
+# See dynamic linker loading
+LD_DEBUG=all /usr/bin/ls 2>&1 | head -50
+
+# See full address space after exec
+cat /proc/$(pgrep myprogram)/maps
+```
+
+## Further reading
+
+- [What Happens When You fork()](fork.md) — fork creates the starting mm
+- [Process Address Space](mmap.md) — VMA layout
+- [Life of a malloc](life-of-malloc.md) — heap after exec
+- [Copy-on-Write](cow.md) — ELF data segments use COW
+- `fs/exec.c` — execve implementation
+- `fs/binfmt_elf.c` — ELF loader

--- a/docs/mm/file-mmap.md
+++ b/docs/mm/file-mmap.md
@@ -1,0 +1,333 @@
+# File-Backed mmap and Page Faults
+
+> How mmap() of a file works: from mapping to first read
+
+## mmap of a regular file
+
+```c
+int fd = open("data.bin", O_RDONLY);
+void *addr = mmap(NULL, file_size, PROT_READ, MAP_PRIVATE | MAP_POPULATE, fd, 0);
+```
+
+`mmap()` creates a **VMA** (virtual memory area) but does NOT immediately read the file. Pages are faulted in lazily — the first access to each page triggers a **page fault**.
+
+```
+mmap() call:
+  1. Allocate struct vm_area_struct
+  2. Link to mm_struct's VMA tree (maple tree)
+  3. Set vma->vm_file = file
+     vma->vm_ops = &generic_file_vm_ops (or ext4_file_vm_ops)
+  4. Return virtual address — no pages allocated yet
+
+First read from addr:
+  1. CPU: address not in page table → hardware page fault
+  2. Kernel: do_page_fault() → handle_mm_fault()
+  3. VMA found → filemap_fault() or ext4_filemap_fault()
+  4. Page cache lookup: is the page already in cache?
+     Hit: map the existing page into the process's page table
+     Miss: allocate a page, read from disk, map into page table
+```
+
+## The page fault path
+
+```c
+/* mm/memory.c */
+vm_fault_t handle_mm_fault(struct vm_area_struct *vma,
+                             unsigned long address, unsigned int flags,
+                             struct pt_regs *regs)
+{
+    pgd_t *pgd = pgd_offset(mm, address);
+    p4d_t *p4d = p4d_alloc(mm, pgd, address);
+    pud_t *pud = pud_alloc(mm, p4d, address);
+    pmd_t *pmd = pmd_alloc(mm, pud, address);
+
+    return handle_pte_fault(vmf);
+}
+
+static vm_fault_t handle_pte_fault(struct vm_fault *vmf)
+{
+    pte_t entry = *vmf->pte;
+
+    if (!pte_present(entry)) {
+        if (pte_none(entry)) {
+            if (vma->vm_ops) {
+                /* File-backed: call the VMA's fault handler */
+                return do_fault(vmf);
+            }
+            /* Anonymous: allocate a zero page */
+            return do_anonymous_page(vmf);
+        }
+        /* Swap entry: page is in swap */
+        return do_swap_page(vmf);
+    }
+
+    /* Present but write-protected: copy-on-write */
+    if (vmf->flags & FAULT_FLAG_WRITE && !pte_write(entry))
+        return do_wp_page(vmf);
+
+    return VM_FAULT_PFNMAP;
+}
+```
+
+### do_fault: file-backed fault
+
+```c
+/* mm/memory.c */
+static vm_fault_t do_fault(struct vm_fault *vmf)
+{
+    struct vm_area_struct *vma = vmf->vma;
+
+    if (!vma->vm_ops->fault)
+        return VM_FAULT_SIGBUS;
+
+    if (!(vmf->flags & FAULT_FLAG_WRITE)) {
+        /* Read fault: share the page (MAP_PRIVATE or MAP_SHARED) */
+        return do_read_fault(vmf);
+    }
+
+    if (!(vma->vm_flags & VM_SHARED)) {
+        /* Write fault on MAP_PRIVATE: copy-on-write */
+        return do_cow_fault(vmf);
+    }
+
+    /* Write fault on MAP_SHARED: dirty the page */
+    return do_shared_fault(vmf);
+}
+
+static vm_fault_t do_read_fault(struct vm_fault *vmf)
+{
+    /* Call the VMA's fault() operation */
+    ret = __do_fault(vmf);
+    /* For ext4: → ext4_filemap_fault → filemap_fault */
+
+    map_pages(vmf, vmf->pgoff, vmf->pgoff);
+    /* Install PTE: virtual address → physical page */
+}
+```
+
+### filemap_fault: page cache lookup
+
+```c
+/* mm/filemap.c */
+vm_fault_t filemap_fault(struct vm_fault *vmf)
+{
+    struct file *file = vmf->vma->vm_file;
+    struct address_space *mapping = file->f_mapping;
+    pgoff_t offset = vmf->pgoff;
+
+    /* 1. Lookup page in page cache */
+    folio = filemap_get_folio(mapping, offset);
+
+    if (!folio) {
+        /* Page cache miss: need to read from disk */
+
+        /* 2. Trigger readahead for surrounding pages */
+        page_cache_sync_readahead(mapping, ra, file, offset,
+                                   ra->ra_pages);
+
+        /* 3. Allocate a new folio */
+        folio = filemap_alloc_folio(vmf->gfp_mask, 0);
+
+        /* 4. Add to page cache */
+        filemap_add_folio(mapping, folio, offset, vmf->gfp_mask);
+
+        /* 5. Read from disk via address_space_operations */
+        mapping->a_ops->readahead(rac);
+        /* → ext4_readahead → ext4_mpage_readpages → bio submission */
+
+        wait_on_page_locked(folio);
+    } else {
+        /* Cache hit: trigger async readahead for future pages */
+        page_cache_async_readahead(mapping, ra, file, folio,
+                                    offset, ra->ra_pages);
+    }
+
+    vmf->page = folio_file_page(folio, offset);
+    return VM_FAULT_LOCKED;
+    /* Caller installs the PTE */
+}
+```
+
+## Readahead
+
+The kernel prefetches pages ahead of sequential access:
+
+```c
+/* mm/readahead.c */
+void page_cache_sync_readahead(struct address_space *mapping,
+                                struct file_ra_state *ra,
+                                struct file *filp,
+                                pgoff_t index, unsigned long req_count)
+{
+    /* Adaptive: start small, double until hitting the ra_max limit */
+    /* Typical: 128KB initial, up to 512KB or more */
+    ondemand_readahead(mapping, ra, filp, false, index, req_count);
+}
+```
+
+Readahead state per file (`struct file_ra_state`):
+
+```c
+struct file_ra_state {
+    pgoff_t start;          /* where readahead starts */
+    unsigned int size;      /* # of readahead pages */
+    unsigned int async_size;/* # to trigger async readahead */
+    unsigned int ra_pages;  /* max readahead window */
+    unsigned int mmap_miss; /* for mmap readahead */
+    loff_t prev_pos;        /* previous file position */
+};
+```
+
+## MAP_PRIVATE vs MAP_SHARED
+
+### MAP_PRIVATE (copy-on-write)
+
+```
+Initial state:
+  Process PTE → page cache page (read-only)
+
+On first write:
+  COW fault:
+  1. Allocate a new page
+  2. Copy page cache page → new page
+  3. Install new PTE → new page (writable)
+  4. Page cache page unchanged
+```
+
+```c
+/* MAP_PRIVATE write fault */
+static vm_fault_t do_cow_fault(struct vm_fault *vmf)
+{
+    /* Allocate a new page */
+    vmf->cow_page = alloc_page_vma(GFP_HIGHUSER_MOVABLE, vma, vmf->address);
+
+    /* Read the original file page */
+    ret = __do_fault(vmf);
+
+    /* Copy original page to new COW page */
+    copy_user_highpage(vmf->cow_page, vmf->page, vmf->address, vma);
+
+    /* Install PTE to the new writable copy */
+    finish_fault(vmf);
+}
+```
+
+### MAP_SHARED (shared dirty)
+
+```
+Write to MAP_SHARED:
+  1. PTE was read-only (even though VMA is writable)
+  2. do_shared_fault: dirty the page in-place
+  3. Mark page dirty in page cache
+  4. Install writable PTE
+
+Later:
+  Writeback daemon flushes dirty pages to disk
+```
+
+```c
+static vm_fault_t do_shared_fault(struct vm_fault *vmf)
+{
+    /* Get page from file (may read from disk) */
+    ret = __do_fault(vmf);
+
+    /* If filesystem needs it: notify about the dirty page */
+    if (vma->vm_ops->page_mkwrite) {
+        vma->vm_ops->page_mkwrite(vmf);
+        /* ext4: starts a journal transaction, marks page dirty */
+    }
+
+    /* Install writable PTE */
+    finish_fault(vmf);
+    set_page_dirty(vmf->page);
+}
+```
+
+## madvise hints
+
+`madvise()` tells the kernel how the application will access pages:
+
+```c
+madvise(addr, length, advice);
+```
+
+| Advice | Effect |
+|--------|--------|
+| `MADV_SEQUENTIAL` | Increase readahead aggressively; free pages after use |
+| `MADV_RANDOM` | Disable readahead; random access pattern |
+| `MADV_WILLNEED` | Prefetch pages now (async readahead) |
+| `MADV_DONTNEED` | Discard pages, free physical memory |
+| `MADV_FREE` | Mark pages as candidates for reclaim (lazy free) |
+| `MADV_HUGEPAGE` | Request THP for this range |
+| `MADV_POPULATE_READ` | Populate pages by simulating reads (no COW) |
+| `MADV_POPULATE_WRITE` | Populate pages by simulating writes (triggers COW) |
+
+```c
+/* Prefetch a file section before processing */
+madvise(file_addr, CHUNK_SIZE, MADV_WILLNEED);
+/* ... do other work ... */
+/* Now access file_addr — pages likely already in cache */
+
+/* Free a large mapping after done with it */
+madvise(mmap_addr, file_size, MADV_DONTNEED);
+/* Physical pages freed immediately; next access re-reads from file */
+```
+
+### MADV_SEQUENTIAL in the kernel
+
+```c
+/* mm/madvise.c */
+static long madvise_behavior(struct vm_area_struct *vma, ...)
+{
+    switch (behavior) {
+    case MADV_SEQUENTIAL:
+        new_flags |= VM_SEQ_READ;
+        new_flags &= ~VM_RAND_READ;
+        break;
+    case MADV_RANDOM:
+        new_flags |= VM_RAND_READ;
+        new_flags &= ~VM_SEQ_READ;
+        break;
+    }
+}
+
+/* In filemap_fault: check vm_flags */
+if (vma->vm_flags & VM_SEQ_READ)
+    ra->ra_pages = max(ra->ra_pages, bdi->ra_pages);
+if (vma->vm_flags & VM_RAND_READ)
+    ra->ra_pages = 0;  /* disable readahead */
+```
+
+## Huge pages for file mappings (THP)
+
+File-backed mappings can use Transparent Huge Pages if the filesystem supports it (ext4, tmpfs, xfs with 5.18+):
+
+```c
+/* Huge page fault: maps 2MB instead of 4KB */
+vm_fault_t do_huge_pmd_anonymous_page(struct vm_fault *vmf)
+{
+    /* For file-backed: filemap_fault_huge → read 512 contiguous pages */
+}
+```
+
+```bash
+# Enable THP for file mappings
+echo always > /sys/kernel/mm/transparent_hugepage/enabled
+
+# Per-mapping
+madvise(addr, length, MADV_HUGEPAGE);
+
+# Check THP usage
+cat /proc/<pid>/smaps | grep -A5 "file_name"
+# AnonHugePages:    2048 kB
+```
+
+## Further reading
+
+- [Page Cache](page-cache.md) — the cache filemap_fault reads from
+- [Copy-on-Write](cow.md) — MAP_PRIVATE COW mechanics
+- [Process Address Space](mmap.md) — VMA layout
+- [What Happens During exec()](exec.md) — file mmaps created by ELF loader
+- [Page Reclaim](reclaim.md) — reclaiming file-backed pages
+- `mm/filemap.c` — filemap_fault, readahead
+- `mm/madvise.c` — madvise implementation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,8 +122,10 @@ nav:
       - Life of a malloc: mm/life-of-malloc.md
       - Life of a page: mm/life-of-page.md
       - What happens when you fork: mm/fork.md
+      - What happens during exec(): mm/exec.md
       - Running out of memory: mm/oom.md
       - Life of a file read: mm/life-of-read.md
+      - File-backed mmap and page faults: mm/file-mmap.md
       - What happens during swapping: mm/swapping.md
     - Explainers:
       - Virtual vs Physical vs Resident: mm/virtual-physical-resident.md


### PR DESCRIPTION
## Summary

- **exec()** (`docs/mm/exec.md`): `linux_binprm` structure, `do_execveat_common` → `search_binary_handler` → `load_elf_binary` ELF loading, PT_LOAD segment mapping, PT_INTERP dynamic linker loading, `begin_new_exec` address space replacement (`exec_mmap`, O_CLOEXEC fd close, signal handler reset), stack/auxv setup, `start_thread` IP/SP setup, `de_thread` for multi-threaded callers, ld.so PLT/GOT relocation, observability (`strace`, `LD_DEBUG`, `readelf -l`)
- **File-backed mmap** (`docs/mm/file-mmap.md`): `handle_mm_fault` → `do_fault` → `filemap_fault` page cache path, readahead `file_ra_state` adaptive sizing, `MAP_PRIVATE` COW (`do_cow_fault` copy + new PTE) vs `MAP_SHARED` dirty (`do_shared_fault` + `page_mkwrite`), `madvise` hints table (SEQUENTIAL/RANDOM/WILLNEED/DONTNEED/FREE/POPULATE_*), THP for file mappings

## Test plan

- [ ] `mkdocs build` passes with new Lifecycle entries
- [ ] ELF segment map in exec.md matches `readelf -l /usr/bin/ls` output
- [ ] Links to cow.md, mmap.md, page-cache.md, fork.md resolve

Closes #399, #400
Part of #398