### PR TITLE
Add device drivers and IRQ management: PCI drivers and IRQ affinity

### DIFF
--- a/docs/drivers/pci-driver.md
+++ b/docs/drivers/pci-driver.md
@@ -1,0 +1,346 @@
+# PCI Drivers
+
+> Writing a PCI device driver: probing, BAR mapping, and MSI-X interrupts
+
+## PCI bus overview
+
+PCI (Peripheral Component Interconnect) is the standard bus for connecting devices to a CPU. PCIe (PCI Express) is the modern serial version, but the driver API is largely the same.
+
+```
+CPU ← PCIe root complex → PCIe switch → endpoint devices
+                                         (NIC, NVMe, GPU, etc.)
+
+Each PCI device has:
+  - Vendor ID + Device ID (16-bit each): identifies the device type
+  - BARs (Base Address Registers): memory/IO regions exposed by the device
+  - Configuration space (256B standard, 4KB extended): PCI registers
+  - Interrupt: legacy INTx, MSI, or MSI-X
+```
+
+## Registering a PCI driver
+
+```c
+#include <linux/pci.h>
+#include <linux/module.h>
+
+/* Device ID table: which devices does this driver handle? */
+static const struct pci_device_id mydev_ids[] = {
+    { PCI_DEVICE(0x1234, 0x5678) },    /* vendor=0x1234, device=0x5678 */
+    { PCI_DEVICE(0x1234, 0x5679) },    /* another model */
+    { PCI_DEVICE_CLASS(PCI_CLASS_NETWORK_ETHERNET, ~0) }, /* all ethernet */
+    { 0 }  /* sentinel */
+};
+MODULE_DEVICE_TABLE(pci, mydev_ids);
+
+/* Driver registration */
+static struct pci_driver mydev_driver = {
+    .name     = "mydev",
+    .id_table = mydev_ids,
+    .probe    = mydev_probe,    /* called when device found */
+    .remove   = mydev_remove,   /* called on device removal */
+    .suspend  = mydev_suspend,  /* optional: PM */
+    .resume   = mydev_resume,
+    .shutdown = mydev_shutdown,
+};
+
+static int __init mydev_init(void)
+{
+    return pci_register_driver(&mydev_driver);
+}
+
+static void __exit mydev_exit(void)
+{
+    pci_unregister_driver(&mydev_driver);
+}
+
+module_init(mydev_init);
+module_exit(mydev_exit);
+```
+
+The kernel calls `probe()` when a matching device is found (at boot, hot-plug, or module load).
+
+## Probe function
+
+```c
+struct mydev {
+    struct pci_dev *pdev;
+    void __iomem   *bar0;    /* MMIO base for BAR 0 */
+    void __iomem   *bar2;
+    int             irq;
+    /* device state */
+};
+
+static int mydev_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+{
+    struct mydev *dev;
+    int ret;
+
+    /* 1. Allocate driver-private data */
+    dev = devm_kzalloc(&pdev->dev, sizeof(*dev), GFP_KERNEL);
+    if (!dev)
+        return -ENOMEM;
+    dev->pdev = pdev;
+    pci_set_drvdata(pdev, dev);
+
+    /* 2. Enable the PCI device */
+    ret = pci_enable_device(pdev);
+    if (ret) {
+        dev_err(&pdev->dev, "cannot enable PCI device\n");
+        return ret;
+    }
+
+    /* 3. Request ownership of BARs */
+    ret = pci_request_regions(pdev, "mydev");
+    if (ret) {
+        dev_err(&pdev->dev, "cannot request regions\n");
+        goto err_disable;
+    }
+
+    /* 4. Map BAR 0 (MMIO registers) */
+    dev->bar0 = pci_iomap(pdev, 0, 0);  /* BAR 0, map all of it */
+    if (!dev->bar0) {
+        ret = -ENOMEM;
+        goto err_release;
+    }
+
+    /* 5. Set DMA mask */
+    ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+    if (ret) {
+        ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+        if (ret) {
+            dev_err(&pdev->dev, "no usable DMA configuration\n");
+            goto err_unmap;
+        }
+    }
+
+    /* 6. Enable bus mastering (required for DMA) */
+    pci_set_master(pdev);
+
+    /* 7. Setup MSI-X interrupts */
+    ret = mydev_setup_interrupts(dev);
+    if (ret)
+        goto err_unmap;
+
+    /* 8. Initialize hardware */
+    mydev_hw_init(dev);
+
+    dev_info(&pdev->dev, "mydev initialized, BAR0=%pK\n", dev->bar0);
+    return 0;
+
+err_unmap:
+    pci_iounmap(pdev, dev->bar0);
+err_release:
+    pci_release_regions(pdev);
+err_disable:
+    pci_disable_device(pdev);
+    return ret;
+}
+
+static void mydev_remove(struct pci_dev *pdev)
+{
+    struct mydev *dev = pci_get_drvdata(pdev);
+
+    mydev_hw_stop(dev);
+    mydev_teardown_interrupts(dev);
+    pci_iounmap(pdev, dev->bar0);
+    pci_release_regions(pdev);
+    pci_disable_device(pdev);
+    /* devm_* allocations freed automatically */
+}
+```
+
+## BAR mapping and MMIO access
+
+BARs (Base Address Registers) are the windows through which the CPU accesses device memory/registers:
+
+```c
+/* Read a 32-bit register at offset 0x10 */
+u32 val = ioread32(dev->bar0 + 0x10);
+
+/* Write a 64-bit register */
+iowrite64(value, dev->bar0 + 0x20);
+
+/* Read-modify-write */
+u32 ctrl = ioread32(dev->bar0 + REG_CTRL);
+ctrl |= CTRL_ENABLE;
+iowrite32(ctrl, dev->bar0 + REG_CTRL);
+
+/* Memory barrier: ensure MMIO writes are visible to the device */
+mmiowb();  /* or wmb() on most architectures */
+```
+
+Always use `ioread*`/`iowrite*` (not plain pointer dereference) for MMIO regions — they handle architecture-specific memory ordering and MMIO semantics.
+
+```bash
+# Inspect BARs from userspace
+lspci -vv -s <bus:dev.fn> | grep -A2 "Memory at\|I/O ports"
+
+# See all PCI devices with their driver
+lspci -k
+
+# PCI configuration space
+setpci -s <bus:dev.fn> VENDOR_ID.w   # read vendor ID
+setpci -s <bus:dev.fn> STATUS.w      # read status register
+```
+
+## MSI and MSI-X interrupts
+
+Modern devices use MSI (Message Signaled Interrupts) instead of legacy edge/level INTx signals:
+
+- **Legacy INTx**: shared pin, slow, requires IOAPIC programming
+- **MSI**: single interrupt vector, device writes to a magic memory address
+- **MSI-X**: up to 2048 independent interrupt vectors, per-vector affinity
+
+### MSI setup (single interrupt)
+
+```c
+/* Request a single MSI interrupt */
+ret = pci_alloc_irq_vectors(pdev, 1, 1, PCI_IRQ_MSI);
+if (ret < 0) {
+    /* Fall back to legacy INTx */
+    ret = pci_alloc_irq_vectors(pdev, 1, 1, PCI_IRQ_LEGACY);
+}
+
+int irq = pci_irq_vector(pdev, 0);  /* get the assigned IRQ number */
+
+ret = request_irq(irq, mydev_isr, 0, "mydev", dev);
+
+/* In remove: */
+free_irq(pci_irq_vector(pdev, 0), dev);
+pci_free_irq_vectors(pdev);
+```
+
+### MSI-X setup (multiple vectors)
+
+```c
+#define MYDEV_NUM_QUEUES 4
+
+static int mydev_setup_interrupts(struct mydev *dev)
+{
+    struct pci_dev *pdev = dev->pdev;
+    int nvecs, i, ret;
+
+    /* Request up to MYDEV_NUM_QUEUES MSI-X vectors */
+    nvecs = pci_alloc_irq_vectors(pdev,
+                                   1,                  /* min vectors */
+                                   MYDEV_NUM_QUEUES,   /* max vectors */
+                                   PCI_IRQ_MSIX);
+    if (nvecs < 0)
+        return nvecs;
+
+    dev->num_queues = nvecs;
+
+    /* Request an IRQ handler per vector */
+    for (i = 0; i < nvecs; i++) {
+        int irq = pci_irq_vector(pdev, i);
+        snprintf(dev->queue[i].irq_name, sizeof(dev->queue[i].irq_name),
+                 "mydev-q%d", i);
+
+        ret = request_irq(irq, mydev_queue_isr, 0,
+                           dev->queue[i].irq_name, &dev->queue[i]);
+        if (ret) {
+            while (--i >= 0)
+                free_irq(pci_irq_vector(pdev, i), &dev->queue[i]);
+            pci_free_irq_vectors(pdev);
+            return ret;
+        }
+
+        /* Pin each queue's IRQ to a specific CPU */
+        irq_set_affinity_hint(irq, cpumask_of(i % num_online_cpus()));
+    }
+    return 0;
+}
+```
+
+### MSI-X interrupt handler
+
+```c
+static irqreturn_t mydev_queue_isr(int irq, void *data)
+{
+    struct mydev_queue *q = data;
+    u32 status;
+
+    /* Read interrupt status register */
+    status = ioread32(q->dev->bar0 + QUEUE_STATUS(q->idx));
+    if (!(status & QUEUE_IRQ_PENDING))
+        return IRQ_NONE;
+
+    /* Clear the interrupt */
+    iowrite32(QUEUE_IRQ_CLEAR, q->dev->bar0 + QUEUE_STATUS(q->idx));
+
+    /* Process completions */
+    mydev_process_completions(q);
+
+    return IRQ_HANDLED;
+}
+```
+
+## DMA with PCI
+
+```c
+/* Allocate coherent DMA memory (CPU and device see the same data) */
+dma_addr_t dma_handle;
+void *cpu_addr = dma_alloc_coherent(&pdev->dev, 4096, &dma_handle, GFP_KERNEL);
+/* dma_handle: the address to program into the device's DMA register */
+/* cpu_addr: the CPU virtual address */
+
+/* Program device with DMA address */
+iowrite64(dma_handle, dev->bar0 + REG_DMA_BASE);
+
+/* Later: free */
+dma_free_coherent(&pdev->dev, 4096, cpu_addr, dma_handle);
+
+/* Streaming DMA (for existing buffers): */
+dma_addr_t dma = dma_map_single(&pdev->dev, skb->data, skb->len,
+                                  DMA_TO_DEVICE);
+/* ... program device ... */
+/* After device finishes: */
+dma_unmap_single(&pdev->dev, dma, skb->len, DMA_TO_DEVICE);
+/* Now safe to access skb->data */
+```
+
+## Reading PCI configuration space from a driver
+
+```c
+u16 vendor, device;
+u8  revision;
+u32 class_code;
+
+pci_read_config_word(pdev, PCI_VENDOR_ID, &vendor);
+pci_read_config_word(pdev, PCI_DEVICE_ID, &device);
+pci_read_config_byte(pdev, PCI_REVISION_ID, &revision);
+pci_read_config_dword(pdev, PCI_CLASS_REVISION, &class_code);
+
+/* Check link speed (PCIe) */
+u16 lnksta;
+pcie_capability_read_word(pdev, PCI_EXP_LNKSTA, &lnksta);
+int speed = lnksta & PCI_EXP_LNKSTA_CLS;  /* link speed */
+int width = (lnksta & PCI_EXP_LNKSTA_NLW) >> 4;  /* link width */
+```
+
+## Using devm_ helpers
+
+`devm_*` (device-managed) resources are automatically freed when the device is removed:
+
+```c
+/* Memory */
+dev = devm_kzalloc(&pdev->dev, sizeof(*dev), GFP_KERNEL);
+
+/* IOMAP */
+dev->bar0 = devm_pci_iomap(&pdev->dev, pdev, 0, 0);
+
+/* IRQ */
+ret = devm_request_irq(&pdev->dev, irq, handler, 0, "mydev", dev);
+
+/* No manual cleanup needed in .remove for devm_ resources */
+```
+
+## Further reading
+
+- [Linux Device Model](device-model.md) — struct device, driver binding
+- [Platform Drivers](platform-driver.md) — non-discoverable devices
+- [DMA API](../mm/dma.md) — dma_alloc_coherent and scatter-gather
+- [PCI BAR Mapping](../mm/pci-bar-mapping.md) — BAR physical layout
+- [Interrupt Handling](../interrupts/interrupts.md) — IRQ descriptor path
+- `include/linux/pci.h` — PCI driver API
+- `drivers/net/ethernet/intel/e1000e/` — real NIC driver example

--- a/docs/interrupts/irq-affinity.md
+++ b/docs/interrupts/irq-affinity.md
@@ -1,0 +1,243 @@
+# IRQ Affinity and CPU Isolation
+
+> Controlling which CPUs handle interrupts for performance and latency
+
+## Why IRQ affinity matters
+
+By default, the kernel distributes interrupts across CPUs automatically (`irqbalance` daemon). For latency-sensitive or high-throughput workloads, manual affinity control lets you:
+- Dedicate CPUs to specific network queues (one queue per CPU)
+- Isolate real-time tasks from interrupt storms
+- Colocate IRQ handling with the NUMA node that owns the memory
+
+## Viewing IRQ assignments
+
+```bash
+# List all IRQs with CPU affinity and counts
+cat /proc/interrupts
+# CPU0     CPU1     CPU2     CPU3
+#   0:   ...   IO-APIC   2-edge      timer
+#  16:   ...   PCI-MSI   xhci_hcd
+# eth0-q0: (MSI-X queue 0)
+# eth0-q1: (MSI-X queue 1)
+
+# Show affinity for a specific IRQ
+cat /proc/irq/42/smp_affinity      # bitmask (hex)
+cat /proc/irq/42/smp_affinity_list # human-readable (CPU list)
+
+# Example: IRQ 42 runs on CPU 0 and CPU 1
+# /proc/irq/42/smp_affinity:      00000003  (CPUs 0,1)
+# /proc/irq/42/smp_affinity_list: 0-1
+```
+
+## Setting IRQ affinity
+
+```bash
+# Pin IRQ 42 to CPU 3 only
+echo 8 > /proc/irq/42/smp_affinity       # 0x8 = bit 3 = CPU 3
+# or:
+echo 3 > /proc/irq/42/smp_affinity_list  # CPU 3
+
+# Pin to multiple CPUs (0 and 3):
+echo 9 > /proc/irq/42/smp_affinity       # 0x9 = bits 0,3
+echo 0,3 > /proc/irq/42/smp_affinity_list
+
+# All CPUs:
+echo ff > /proc/irq/42/smp_affinity      # 0xff = CPUs 0-7
+```
+
+### High-throughput NIC: one queue per CPU
+
+```bash
+# Find IRQ numbers for each NIC queue
+grep 'eth0' /proc/interrupts
+# 100:  0  0  0  0  PCI-MSI  eth0-q0
+# 101:  0  0  0  0  PCI-MSI  eth0-q1
+# 102:  0  0  0  0  PCI-MSI  eth0-q2
+# 103:  0  0  0  0  PCI-MSI  eth0-q3
+
+# Bind each queue to one CPU
+echo 1  > /proc/irq/100/smp_affinity  # q0 → CPU 0
+echo 2  > /proc/irq/101/smp_affinity  # q1 → CPU 1
+echo 4  > /proc/irq/102/smp_affinity  # q2 → CPU 2
+echo 8  > /proc/irq/103/smp_affinity  # q3 → CPU 3
+
+# Also set XPS (Transmit Packet Steering) for TX:
+echo 1 > /sys/class/net/eth0/queues/tx-0/xps_cpus  # tx-0 → CPU 0
+echo 2 > /sys/class/net/eth0/queues/tx-1/xps_cpus  # tx-1 → CPU 1
+```
+
+## irqbalance: automatic balancing
+
+`irqbalance` is a daemon that periodically rebalances IRQs across CPUs:
+
+```bash
+# Start/stop irqbalance
+systemctl start irqbalance
+systemctl stop irqbalance  # stop for manual control
+
+# irqbalance policy hints
+# Mark an IRQ as "performance" (don't move it):
+IRQBALANCE_BANNED_IRQS="42 43"  # in /etc/sysconfig/irqbalance
+
+# One-shot: balance and exit
+irqbalance --oneshot
+
+# Watch irqbalance decisions
+irqbalance --debug --foreground 2>&1 | head -50
+```
+
+For latency-sensitive workloads, stop irqbalance and set affinity manually.
+
+## Kernel API: irq_set_affinity_hint
+
+Drivers can suggest preferred CPUs for their IRQs:
+
+```c
+#include <linux/interrupt.h>
+#include <linux/cpumask.h>
+
+/* Suggest CPU 3 for this IRQ (irqbalance will respect this hint) */
+irq_set_affinity_hint(irq, cpumask_of(3));
+
+/* Suggest a range of CPUs */
+cpumask_t mask;
+cpumask_clear(&mask);
+cpumask_set_cpu(0, &mask);
+cpumask_set_cpu(1, &mask);
+irq_set_affinity_hint(irq, &mask);
+
+/* Clear the hint */
+irq_set_affinity_hint(irq, NULL);
+
+/* Force affinity (bypasses irqbalance) */
+irq_set_affinity(irq_desc, &mask);
+```
+
+NIC drivers like mlx5 use `irq_set_affinity_hint` in their queue setup to suggest NUMA-local CPUs:
+
+```c
+/* net/ethernet/mellanox/mlx5/core/eq.c */
+static int mlx5_irq_set_affinity_hint(struct mlx5_irq *irq, int i)
+{
+    struct cpumask *mask = mlx5_irq_get_affinity_mask(irq->pool, i);
+    return irq_set_affinity_hint(irq->map.irq, mask);
+}
+```
+
+## CPU isolation for real-time workloads
+
+For real-time tasks that must not be interrupted, isolate CPUs from the kernel's scheduler and interrupt balancer:
+
+### isolcpus: remove CPUs from the scheduler
+
+```bash
+# Boot parameter: remove CPUs 2,3 from scheduler load balancing
+GRUB_CMDLINE_LINUX="isolcpus=2,3"
+
+# After boot: CPUs 2,3 won't run kernel threads or normal processes
+# Only explicitly placed tasks run there (taskset/cgroup cpuset)
+
+# Place a task on an isolated CPU:
+taskset -c 2 ./realtime_task
+
+# Or via cgroup cpuset:
+echo 2 > /sys/fs/cgroup/realtime/cpuset.cpus
+echo 0 > /sys/fs/cgroup/realtime/cpuset.mems
+```
+
+### nohz_full: tickless operation
+
+```bash
+# Remove CPUs from the scheduling tick (reduces timer interrupts to ~0)
+GRUB_CMDLINE_LINUX="isolcpus=2,3 nohz_full=2,3 rcu_nocbs=2,3"
+
+# nohz_full: disable the periodic scheduling tick when only 1 task runs
+# rcu_nocbs: offload RCU callbacks from these CPUs to "RCU kthreads"
+
+# Verify: after boot, isolated CPUs should have near-zero interrupts
+watch -n1 'cat /proc/interrupts | head -5'
+```
+
+### irq_default_affinity: exclude isolated CPUs
+
+```bash
+# Set system-wide default affinity to exclude CPUs 2,3
+echo 3 > /proc/irq/default_smp_affinity  # 0x3 = CPUs 0,1 only
+# New IRQs will be placed on CPUs 0,1 by default
+```
+
+### Full isolation example (latency-critical CPU)
+
+```bash
+#!/bin/bash
+# Isolate CPU 3 for a real-time task
+
+CPU=3
+MASK=$((1 << CPU))
+HEX_MASK=$(printf '%x' $MASK)  # = "8" for CPU 3
+
+# 1. Move all movable IRQs off CPU 3
+for irq in /proc/irq/*/; do
+    irq_num=$(basename $irq)
+    [ "$irq_num" = "0" ] && continue  # skip timer
+    current=$(cat /proc/irq/$irq_num/smp_affinity 2>/dev/null)
+    # If current mask includes CPU 3, remove it
+    new_mask=$(( 0x$current & ~MASK ))
+    [ $new_mask -eq 0 ] && new_mask=1  # can't have empty mask
+    echo $new_mask > /proc/irq/$irq_num/smp_affinity 2>/dev/null
+done
+
+# 2. Stop irqbalance from moving IRQs back
+systemctl stop irqbalance
+
+# 3. Move kernel threads off CPU 3 (optional, requires tuna)
+tuna --cpus=3 --isolate
+
+# 4. Pin the real-time task
+taskset -c $CPU ./realtime_task &
+```
+
+## Monitoring interrupt distribution
+
+```bash
+# Live interrupt counts per CPU
+watch -n0.5 'cat /proc/interrupts'
+
+# Show interrupt rate per IRQ (sar)
+sar -I ALL 1 5
+
+# Total interrupts per CPU:
+cat /proc/stat | grep intr
+
+# IRQ affinity summary script:
+for irq in /proc/irq/*/; do
+    name=$(cat $irq/irq_name 2>/dev/null || basename $irq)
+    aff=$(cat $irq/smp_affinity_list 2>/dev/null)
+    printf "IRQ %-4s affinity=%-10s name=%s\n" $(basename $irq) "$aff" "$name"
+done
+```
+
+## Receive Packet Steering (RPS/RFS)
+
+For NICs with fewer hardware queues than CPUs, RPS steers packets to specific CPUs in software:
+
+```bash
+# Enable RPS: steer received packets across all CPUs
+echo ff > /sys/class/net/eth0/queues/rx-0/rps_cpus  # all 8 CPUs
+
+# RFS: steer to the CPU that last ran the application (cache-hot)
+echo 4096 > /sys/class/net/eth0/queues/rx-0/rps_flow_cnt
+echo 4096 > /proc/sys/net/core/rps_sock_flow_entries
+```
+
+RPS is implemented as a softirq that moves packet processing to the target CPU via IPI (inter-processor interrupt).
+
+## Further reading
+
+- [IRQ Descriptor and irq_chip](irq-desc.md) — struct irq_desc internals
+- [request_irq and free_irq](request-irq.md) — IRQ handler registration
+- [Threaded IRQs](threaded-irq.md) — threaded IRQ handlers for latency
+- [PCI Drivers](../drivers/pci-driver.md) — MSI-X affinity in NIC drivers
+- [CPU Affinity](../sched/cpu-affinity.md) — process CPU pinning
+- [Scheduling Domains](../sched/sched-domains.md) — scheduler topology
+- `kernel/irq/manage.c` — irq_set_affinity implementation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,6 +255,7 @@ nav:
       - IRQ Descriptor and irq_chip: interrupts/irq-desc.md
       - request_irq and free_irq: interrupts/request-irq.md
       - Threaded IRQs: interrupts/threaded-irq.md
+      - IRQ Affinity and CPU Isolation: interrupts/irq-affinity.md
     - Deferred Work:
       - Softirqs: interrupts/softirq.md
       - Tasklets: interrupts/tasklets.md
@@ -305,6 +306,7 @@ nav:
     - Linux Device Model: drivers/device-model.md
     - Platform Drivers: drivers/platform-driver.md
     - Character and Misc Devices: drivers/chardev.md
+    - PCI Drivers: drivers/pci-driver.md
   - IPC:
     - Getting Started: ipc/README.md
     - Signals: ipc/signals.md


### PR DESCRIPTION
## Summary

- **PCI Drivers** (`docs/drivers/pci-driver.md`): `pci_device_id` table with `MODULE_DEVICE_TABLE`, `pci_register_driver` lifecycle, `probe` callback: `pci_enable_device`/`pci_request_regions`/`pci_iomap`/`dma_set_mask_and_coherent`/`pci_set_master`, MMIO access with `ioread32`/`iowrite32`, MSI single vector and MSI-X multi-queue with `pci_alloc_irq_vectors`/`irq_set_affinity_hint`, coherent vs streaming DMA, `devm_*` resource management, PCI config space reading
- **IRQ Affinity** (`docs/interrupts/irq-affinity.md`): `/proc/irq/N/smp_affinity` bitmask/list format, NIC queue-per-CPU setup with XPS, `irqbalance` daemon management, `irq_set_affinity_hint` kernel API, CPU isolation (`isolcpus`, `nohz_full`, `rcu_nocbs` boot params), full isolation bash script for RT workloads, RPS/RFS software packet steering, interrupt monitoring (`sar -I ALL`, `/proc/interrupts`)

## Test plan

- [ ] `mkdocs build` passes with new driver and interrupt entries
- [ ] `lspci` commands and `/proc/irq/` paths are accurate
- [ ] Links to DMA API, PCI BAR Mapping, cpu-affinity, irq-desc resolve

Closes #403, #404
Part of #402