### PR TITLE
Add scheduler explainers: preemption model and scheduling tick

### DIFF
--- a/docs/sched/preemption.md
+++ b/docs/sched/preemption.md
@@ -1,0 +1,300 @@
+# Linux Preemption Model
+
+> When can the kernel be preempted? Voluntary, full, and PREEMPT_RT
+
+## What is preemption?
+
+**Preemption** means stopping the currently running task to run a higher-priority task. Linux has several preemption models, selected at build time via Kconfig:
+
+```
+CONFIG_PREEMPT_NONE        — Server: only voluntary preemption
+CONFIG_PREEMPT_VOLUNTARY   — Desktop: voluntary + explicit preemption points
+CONFIG_PREEMPT             — Full: preempt anywhere except spinlocks
+CONFIG_PREEMPT_RT          — Real-time: preempt almost everywhere
+```
+
+The model affects **latency** (how quickly high-priority tasks run) vs **throughput** (overall system efficiency).
+
+## preempt_count: the preemption gate
+
+Every task has a `preempt_count` field in its thread_info. Preemption is disabled when this is nonzero:
+
+```c
+/* include/linux/preempt.h */
+/* preempt_count layout (per CPU): */
+/*
+ *         PREEMPT_MASK  (bits 0-7):   preemption nesting depth
+ *         SOFTIRQ_MASK  (bits 8-15):  softirq nesting depth
+ *         HARDIRQ_MASK  (bits 16-19): hardirq (interrupt) nesting depth
+ *         NMI_MASK      (bit 20):     NMI context
+ */
+
+/* Check if preemptible */
+#define preemptible()   (preempt_count() == 0 && !irqs_disabled())
+
+/* Disable/enable preemption */
+preempt_disable();   /* preempt_count++ */
+preempt_enable();    /* preempt_count--; if 0, check for pending reschedule */
+
+/* Low-overhead version (no reschedule check on enable): */
+preempt_disable_notrace();
+preempt_enable_notrace();
+```
+
+### preempt_count contexts
+
+```c
+/* Am I in interrupt context? */
+in_interrupt()    /* HARDIRQ_MASK | SOFTIRQ_MASK | NMI_MASK */
+in_irq()          /* HARDIRQ_MASK only */
+in_softirq()      /* SOFTIRQ_MASK only */
+in_nmi()          /* NMI_MASK only */
+
+/* Am I in atomic context (cannot sleep)? */
+in_atomic()       /* preempt_count != 0 */
+/* Note: this includes hardirq, softirq, spinlock, and preempt_disable */
+```
+
+## CONFIG_PREEMPT_NONE: server model
+
+No preemption except at explicit `schedule()` calls. A kernel code path runs until it voluntarily yields:
+
+```
+High-priority task wakes → must wait for current kernel path to finish
+  ↓
+Current task calls schedule() or returns to userspace
+  ↓
+High-priority task runs
+```
+
+**Latency**: milliseconds to seconds (if kernel path is long)
+**Throughput**: highest (no unnecessary context switches)
+**Use case**: servers, batch workloads (HPC, databases)
+
+## CONFIG_PREEMPT_VOLUNTARY: desktop model
+
+Adds explicit preemption points (`might_sleep()`, `cond_resched()`) at strategic locations in long kernel loops:
+
+```c
+/* mm/filemap.c — long loop with preemption point */
+ssize_t filemap_read(struct kiocb *iocb, struct iov_iter *iter, ...)
+{
+    do {
+        /* ... read pages ... */
+        cond_resched();  /* yield if higher-priority task is waiting */
+    } while (iov_iter_count(iter));
+}
+
+/* kernel/sched/fair.c */
+static void __sched_yield(void)
+{
+    cond_resched();
+}
+```
+
+`cond_resched()` checks `TIF_NEED_RESCHED` and calls `schedule()` if set — but only if preemption is not disabled (`preempt_count == 0`).
+
+**Latency**: tens of milliseconds
+**Use case**: desktop systems
+
+## CONFIG_PREEMPT: full preemption
+
+The kernel can be preempted at any point where `preempt_count == 0`, not just at explicit yield points. When `TIF_NEED_RESCHED` is set, the task is preempted at the next preemption window:
+
+```c
+/* arch/x86/kernel/entry_64.S */
+/*
+ * Interrupt return path:
+ * If returning to kernel mode, check if preemption is needed
+ */
+.Lreturn_from_interrupt:
+    testb $3, CS-ORIG_RAX(%rsp)  /* returning to userspace? */
+    jnz .Lreturn_to_userspace
+
+    /* Returning to kernel: check preempt_count and TIF_NEED_RESCHED */
+    call preempt_schedule_irq    /* preempt if needed */
+```
+
+```c
+/* kernel/sched/core.c */
+asmlinkage __visible void __sched preempt_schedule_irq(void)
+{
+    /* Called from interrupt return when TIF_NEED_RESCHED is set */
+    /* and preempt_count == 0 */
+    do {
+        preempt_disable();       /* prevent recursive preemption */
+        local_irq_enable();
+        __schedule(SM_PREEMPT);  /* context switch */
+        local_irq_disable();
+        sched_preempt_enable_no_resched();
+    } while (need_resched());
+}
+```
+
+**Latency**: hundreds of microseconds
+**Use case**: desktop, embedded, audio systems
+
+## CONFIG_PREEMPT_RT: real-time
+
+PREEMPT_RT (merged in 5.15 for ARM64, 6.12 for all arches) converts almost all spinlocks to sleeping mutexes, allowing preemption even while holding a "spinlock":
+
+```
+Non-RT:                          RT:
+  spin_lock → disable preempt     spin_lock → sleeping mutex
+  [not preemptible]               [can be preempted]
+  spin_unlock                     spin_unlock
+
+  Result: RT task must wait       Result: RT task preempts
+  for lock holder to finish       lock holder immediately
+```
+
+### What changes in PREEMPT_RT
+
+```c
+/* Most spinlocks become rt_mutex under PREEMPT_RT: */
+spinlock_t lock;
+spin_lock(&lock);   /* PREEMPT_RT: sleeping mutex_lock(&rt_mutex) */
+spin_unlock(&lock); /* PREEMPT_RT: mutex_unlock */
+
+/* Exceptions (still raw spinlocks in RT): */
+raw_spinlock_t raw_lock;
+raw_spin_lock(&raw_lock);   /* never sleeps, even in RT */
+/* Used for: scheduler internals, IRQ subsystem, brief critical sections */
+
+/* Softirqs run in dedicated per-CPU threads (RT): */
+/* ksoftirqd/0 is a regular kthread, preemptible */
+
+/* In-kernel timers fire from hrtimer softirq thread (preemptible) */
+```
+
+### Priority inversion prevention
+
+PREEMPT_RT enables the **priority inheritance** mechanism for RT mutexes:
+
+```c
+/* Without priority inheritance: */
+Low-prio task holds lock → High-prio RT task waits → Medium-prio task runs
+  → RT task is effectively blocked by medium-prio task (priority inversion!)
+
+/* With RT mutex priority inheritance: */
+Low-prio task holds lock → High-prio RT task waits
+  → Low-prio task temporarily runs at HIGH priority
+  → Medium-prio task does NOT run
+  → Low-prio finishes, releases lock
+  → High-prio RT task runs immediately
+```
+
+See [Priority Inversion and PI Mutexes](pi-mutexes.md) for details.
+
+### PREEMPT_RT latency
+
+```
+CONFIG_PREEMPT_NONE:       ~1-100ms worst-case
+CONFIG_PREEMPT_VOLUNTARY:  ~1-10ms
+CONFIG_PREEMPT:            ~100-1000µs
+CONFIG_PREEMPT_RT:         ~10-100µs (with proper tuning)
+```
+
+## preempt_disable in practice
+
+### Spinlocks implicitly disable preemption
+
+```c
+spinlock_t lock;
+
+spin_lock(&lock);
+/* preempt_count++ (in non-RT) */
+/* Now: cannot sleep, cannot be preempted */
+
+/* ... critical section ... */
+
+spin_unlock(&lock);
+/* preempt_count-- */
+/* If TIF_NEED_RESCHED: schedule() called here */
+```
+
+### Per-CPU operations require preemption disabled
+
+```c
+/* Per-CPU variables are only safe when preemption is disabled */
+/* (otherwise you could migrate to another CPU mid-operation) */
+
+preempt_disable();
+this_cpu_inc(my_per_cpu_counter);
+preempt_enable();
+
+/* Or use the helper (implicitly disables preemption): */
+this_cpu_inc(my_per_cpu_counter);  /* always safe: implicitly disables preempt */
+```
+
+### Checking context in a driver
+
+```c
+void my_function(void) {
+    if (in_interrupt()) {
+        /* Called from IRQ: cannot sleep, cannot take sleeping locks */
+        /* Use atomic allocation: GFP_ATOMIC */
+        ptr = kmalloc(size, GFP_ATOMIC);
+    } else if (in_atomic()) {
+        /* Called while preemption disabled (spinlock, etc.) */
+        /* Also cannot sleep */
+    } else {
+        /* Normal process context: can sleep */
+        ptr = kmalloc(size, GFP_KERNEL);
+        mutex_lock(&my_mutex);
+    }
+}
+```
+
+## might_sleep: debugging sleeping in atomic context
+
+```c
+/* include/linux/kernel.h */
+#define might_sleep() \
+    do { __might_sleep(__FILE__, __LINE__); } while (0)
+
+void __might_sleep(const char *file, int line)
+{
+    if (in_atomic() || irqs_disabled()) {
+        /* Print a WARN with stack trace */
+        pr_warn("BUG: sleeping function called from invalid context at %s:%d\n",
+                 file, line);
+        dump_stack();
+    }
+}
+
+/* Called automatically by: */
+/* mutex_lock, down_semaphore, copy_to_user, kmalloc(GFP_KERNEL), ... */
+```
+
+This is why you get "BUG: sleeping function called from invalid context" when you accidentally call `mutex_lock()` from an interrupt handler.
+
+## Checking the preemption model
+
+```bash
+# See which preemption model is active
+zcat /proc/config.gz | grep PREEMPT
+# CONFIG_PREEMPT_NONE=y      (or VOLUNTARY, PREEMPT, PREEMPT_RT)
+
+# Check at runtime
+uname -v | grep PREEMPT
+# #1 SMP PREEMPT_RT ...
+
+# Preemption statistics
+cat /proc/sched_debug | grep -A5 "preempt"
+
+# Latency tracing (ftrace)
+echo preemptirqsoff > /sys/kernel/debug/tracing/current_tracer
+# Traces longest preemption-disabled period
+cat /sys/kernel/debug/tracing/trace | head -50
+```
+
+## Further reading
+
+- [Context Switch](context-switch.md) — what schedule() does
+- [What Happens When a Process Wakes Up](wakeup.md) — TIF_NEED_RESCHED setting
+- [Priority Inversion and PI Mutexes](pi-mutexes.md) — RT priority inheritance
+- [Spinlock and raw_spinlock](../locking/spinlock.md) — preemption disabling in spinlocks
+- [Softirqs](../interrupts/softirq.md) — softirq threading in PREEMPT_RT
+- `kernel/sched/core.c` — preempt_schedule_irq, __schedule
+- `include/linux/preempt.h` — preempt_count macros

--- a/docs/sched/sched-tick.md
+++ b/docs/sched/sched-tick.md
@@ -1,0 +1,300 @@
+# The Scheduling Tick
+
+> How the kernel drives time-based scheduling: jiffies, HZ, and NOHZ
+
+## The periodic tick
+
+The kernel runs a periodic timer interrupt (the "tick") at a rate of `HZ` times per second. The tick drives:
+- Updating `jiffies` (coarse-grained time)
+- Updating process CPU time accounting
+- Checking if the current task should be preempted (`scheduler_tick`)
+- Running expired timers (wheel timers)
+
+```c
+/* kernel/time/tick-common.c */
+static void tick_handle_periodic(struct clock_event_device *dev)
+{
+    tick_periodic(cpu);
+}
+
+static void tick_periodic(int cpu)
+{
+    if (tick_do_timer_cpu == cpu) {
+        /* Update jiffies on one designated CPU */
+        do_timer(1);           /* jiffies++ */
+        update_wall_time();    /* update CLOCK_REALTIME */
+    }
+
+    /* Per-CPU: account time, check preemption */
+    update_process_times(user_mode(get_irq_regs()));
+}
+
+void update_process_times(int user_tick)
+{
+    struct task_struct *p = current;
+
+    /* Account CPU time to current task */
+    account_process_tick(p, user_tick);
+
+    /* Run expired timer wheel entries */
+    run_local_timers();
+
+    /* Check if task should be preempted */
+    scheduler_tick();
+}
+```
+
+## HZ: the tick rate
+
+`HZ` is a compile-time constant:
+
+```c
+/* 250 is the default on most x86 kernels */
+/* 100: server (lower overhead)   */
+/* 250: desktop (good compromise) */
+/* 1000: lowest latency (1ms timer resolution) */
+
+CONFIG_HZ_100  → HZ = 100  (10ms tick)
+CONFIG_HZ_250  → HZ = 250  (4ms tick)
+CONFIG_HZ_300  → HZ = 300
+CONFIG_HZ_1000 → HZ = 1000 (1ms tick)
+
+/* Practical timer resolution with HZ=1000: ~1ms */
+/* With NOHZ+hrtimers: sub-millisecond regardless of HZ */
+```
+
+```bash
+# Check configured HZ
+zcat /proc/config.gz | grep "^CONFIG_HZ="
+# CONFIG_HZ=250
+
+# Current jiffies
+cat /proc/uptime   # seconds since boot = jiffies/HZ
+```
+
+## jiffies: coarse-grained time
+
+`jiffies` is a 64-bit counter incremented every tick:
+
+```c
+/* include/linux/jiffies.h */
+extern unsigned long volatile jiffies;
+
+/* Converting between jiffies and time: */
+unsigned long timeout = jiffies + msecs_to_jiffies(100);  /* 100ms */
+unsigned long timeout = jiffies + HZ / 10;                 /* 100ms (HZ=1000) */
+unsigned long timeout = jiffies + HZ * 2;                  /* 2 seconds */
+
+/* Comparison (handles wraparound): */
+if (time_after(jiffies, timeout))
+    /* timeout expired */
+if (time_before(jiffies, deadline))
+    /* deadline not yet reached */
+
+/* jiffies_to_msecs: */
+unsigned long elapsed_ms = jiffies_to_msecs(jiffies - start);
+```
+
+`jiffies` wraps around after `ULONG_MAX / HZ` seconds (~497 days on 32-bit, irrelevant on 64-bit). The `time_after`/`time_before` macros use subtraction to handle wraparound correctly.
+
+## scheduler_tick: preemption check
+
+```c
+/* kernel/sched/core.c */
+void scheduler_tick(void)
+{
+    int cpu = smp_processor_id();
+    struct rq *rq = cpu_rq(cpu);
+    struct task_struct *curr = rq->curr;
+
+    /* Let the scheduling class update its state */
+    curr->sched_class->task_tick(rq, curr, 0);
+    /* For CFS: update vruntime, check if current should yield */
+    /* For RT: check RR timeslice expiry */
+
+    /* Trigger load balancing every tick */
+    trigger_load_balance(rq);
+
+    /* Update scheduler statistics */
+    rq->idle_stamp = 0;
+}
+
+/* CFS tick: */
+static void task_tick_fair(struct rq *rq, struct task_struct *curr, int queued)
+{
+    struct cfs_rq *cfs_rq;
+    struct sched_entity *se = &curr->se;
+
+    for_each_sched_entity(se) {
+        cfs_rq = cfs_rq_of(se);
+        entity_tick(cfs_rq, se, queued);
+    }
+}
+
+static void entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
+{
+    /* Update vruntime (CPU time accounting) */
+    update_curr(cfs_rq);
+
+    /* Update load average (PELT) */
+    update_load_avg(cfs_rq, curr, UPDATE_TG);
+
+    /* Check if the current task should be preempted */
+    if (cfs_rq->nr_running > 1)
+        check_preempt_tick(cfs_rq, curr);
+}
+
+static void check_preempt_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr)
+{
+    unsigned long ideal_runtime;
+    struct sched_entity *se;
+
+    /* How long should this task run? (fair share of CPU) */
+    ideal_runtime = sched_slice(cfs_rq, curr);
+
+    /* How long has it actually run? */
+    delta_exec = curr->sum_exec_runtime - curr->prev_sum_exec_runtime;
+
+    if (delta_exec > ideal_runtime) {
+        /* Task exceeded its timeslice: set TIF_NEED_RESCHED */
+        resched_curr(rq_of(cfs_rq));
+    }
+}
+```
+
+## NOHZ idle: stopping the tick when idle
+
+When a CPU is idle, there's no need to fire the tick interrupt. **NOHZ idle** (CONFIG_NO_HZ_IDLE, enabled by default) suppresses the tick when the CPU is idle:
+
+```
+Normal (HZ=250):             NOHZ idle:
+CPU0 idle: tick every 4ms    CPU0 idle: tick suppressed
+                              Next tick: when timer expires or task wakes
+
+Power savings: significant on idle systems
+```
+
+```c
+/* kernel/time/tick-sched.c */
+void tick_nohz_idle_enter(void)
+{
+    /* Called when CPU enters idle */
+    struct tick_sched *ts = this_cpu_ptr(&tick_cpu_sched);
+
+    ts->inidle = 1;
+    /* Calculate next wake time from timer wheel */
+    /* Program the clock event device for that time */
+    /* No more periodic ticks until wake time */
+}
+
+void tick_nohz_idle_exit(void)
+{
+    /* Called when CPU exits idle */
+    /* Catch up jiffies for the time slept */
+    /* Restore periodic tick */
+}
+```
+
+## NOHZ full: tickless for running tasks
+
+**NOHZ full** (CONFIG_NO_HZ_FULL) goes further — it suppresses the tick even when a single task is running on a CPU:
+
+```bash
+# Boot parameter: make CPUs 1,2,3 fully tickless
+GRUB_CMDLINE_LINUX="nohz_full=1-3 rcu_nocbs=1-3"
+
+# Effects on CPUs 1-3:
+# - No periodic tick when exactly one task running
+# - jiffies updates delegated to CPU 0
+# - RCU callbacks offloaded
+# - Useful for: HPC, real-time, latency-critical workloads
+```
+
+```c
+/* tick-sched.c: NOHZ full logic */
+static bool can_stop_full_tick(int cpu, struct tick_sched *ts)
+{
+    /* Only tickless if exactly one task is running */
+    if (rq->nr_running > 1)
+        return false;
+
+    /* RCU must agree it's OK to go tickless */
+    if (!rcu_is_watching())
+        return false;
+
+    /* No perf events that need the tick */
+    if (perf_event_active(current))
+        return false;
+
+    return true;
+}
+```
+
+NOHZ full CPUs receive a tick "kick" from CPU 0 when:
+- Another task is added to the run queue
+- RCU needs a quiescent state
+- Timers expire
+
+## Tick device and clockevents
+
+The tick is driven by a **clock event device** — a hardware timer that can be programmed to fire at a specific time:
+
+```c
+/* kernel/time/clockevents.c */
+struct clock_event_device {
+    void   (*event_handler)(struct clock_event_device *);
+    int    (*set_next_event)(unsigned long evt, struct clock_event_device *);
+    int    (*set_next_ktime)(ktime_t expires, struct clock_event_device *);
+    ktime_t next_event;
+    u64     max_delta_ns;
+    u64     min_delta_ns;
+    u32     mult;     /* ns conversion */
+    u32     shift;
+    enum clock_event_state state_use_accessors;
+    unsigned int features;
+    /* ... */
+};
+
+/* Per-CPU: each CPU has its own tick device */
+DEFINE_PER_CPU(struct tick_device, tick_cpu_device);
+```
+
+On x86:
+- BSP (boot CPU): uses TSC or HPET for the tick
+- Other CPUs: use the local APIC timer
+- All CPUs: can switch to one-shot mode (for NOHZ)
+
+```bash
+# See clock event devices
+cat /sys/bus/clockevents/devices/*/current_mode
+# periodic (HZ mode)
+# oneshot   (NOHZ mode)
+
+cat /sys/bus/clockevents/devices/*/name
+# lapic (local APIC timer)
+# tsc-deadline (TSC with deadline mode — most efficient)
+```
+
+## Accounting overhead
+
+```bash
+# See scheduler tick statistics
+cat /proc/sched_debug | grep -E "\.nr_switches|\.clock|avg_idle"
+
+# Profiling: how much time is spent in scheduler_tick?
+perf stat -e cycles:k -C 0 sleep 1 | grep cycles
+# Most should be idle (NOHZ_IDLE suppresses ticks)
+
+# Count timer interrupts:
+grep "^LOC:" /proc/interrupts  # "Local timer interrupts"
+```
+
+## Further reading
+
+- [Preemption Model](preemption.md) — TIF_NEED_RESCHED and preemption contexts
+- [CFS](cfs.md) — vruntime, sched_slice, ideal_runtime
+- [hrtimers](../time/hrtimers.md) — high-resolution timers that bypass the tick
+- [Timers and hrtimers](../interrupts/timers.md) — timer wheel and hrtimer integration
+- [Energy-Aware Scheduling](eas.md) — tick and load tracking interaction
+- `kernel/time/tick-sched.c` — NOHZ implementation
+- `kernel/sched/core.c` — scheduler_tick, check_preempt_tick

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,8 @@ nav:
     - Advanced:
       - Load Balancing: sched/load-balancing.md
       - Energy-Aware Scheduling: sched/eas.md
+      - Preemption Model: sched/preemption.md
+      - The Scheduling Tick: sched/sched-tick.md
     - Debugging & Observability:
       - Scheduler Statistics: sched/schedstat.md
       - Scheduler Tracing: sched/sched-tracing.md


### PR DESCRIPTION
## Summary

- **Preemption Model** (`docs/sched/preemption.md`): `preempt_count` bitmask (PREEMPT/SOFTIRQ/HARDIRQ/NMI), all 4 Kconfig models (NONE/VOLUNTARY/PREEMPT/PREEMPT_RT) with latency ranges, `preempt_schedule_irq` interrupt return path for CONFIG_PREEMPT, PREEMPT_RT sleeping spinlocks vs `raw_spinlock_t` exceptions, priority inheritance for RT mutexes, `in_interrupt`/`in_atomic` context checks, `might_sleep` debugging producing "sleeping function called from invalid context"
- **Scheduling Tick** (`docs/sched/sched-tick.md`): `tick_handle_periodic` → `tick_periodic` → `update_process_times` → `scheduler_tick` → `task_tick_fair` → `check_preempt_tick` call chain, HZ values and tick resolution, `jiffies` wraparound-safe `time_after`/`time_before`, NOHZ idle (`tick_nohz_idle_enter`), NOHZ full (`nohz_full=` boot param) for tickless HPC/RT CPUs, `clock_event_device` oneshot mode, tick statistics via `/proc/sched_debug`

## Test plan

- [ ] `mkdocs build` passes with new Scheduler Advanced entries
- [ ] preempt_count layout diagram is accurate (matches kernel headers)
- [ ] Links to pi-mutexes, spinlock, softirq, hrtimers, CFS resolve

Closes #407, #408
Part of #406