### PR TITLE
Add MM address translation: vDSO internals and page fault handler

### DIFF
--- a/docs/mm/page-fault.md
+++ b/docs/mm/page-fault.md
@@ -1,0 +1,356 @@
+# Page Fault Handler
+
+> From hardware exception to page mapped: the complete fault path
+
+## Hardware page fault
+
+When the CPU encounters a virtual address that isn't mapped in the page tables, it raises a **page fault exception** (#PF on x86):
+
+```
+CPU accesses virtual address 0x7fff1234
+  → page table walk: PTE not present
+  → hardware raises exception #14 (Page Fault)
+  → saves RIP, RFLAGS, error code on stack
+  → jumps to IDT entry 14 → kernel's fault handler
+```
+
+## x86 page fault error codes
+
+The error code pushed by the CPU describes the fault:
+
+```
+Bit 0 (P):   0 = not present (PTE absent)
+             1 = protection violation (present but wrong permissions)
+Bit 1 (W):   0 = read access
+             1 = write access
+Bit 2 (U):   0 = kernel mode access
+             1 = user mode access
+Bit 3 (R):   0 = non-reserved bit fault
+             1 = reserved bit set in PTE
+Bit 4 (I):   0 = data access
+             1 = instruction fetch (NX violation)
+Bit 5 (PK):  1 = protection key violation
+Bit 15 (SS): 1 = shadow stack access
+```
+
+```c
+/* arch/x86/mm/fault.c */
+#define X86_PF_PROT   (1 << 0)   /* PTE present: protection violation */
+#define X86_PF_WRITE  (1 << 1)   /* write access */
+#define X86_PF_USER   (1 << 2)   /* from userspace */
+#define X86_PF_RSVD   (1 << 3)   /* reserved bit in PTE */
+#define X86_PF_INSTR  (1 << 4)   /* instruction fetch */
+#define X86_PF_PK     (1 << 5)   /* protection key */
+```
+
+`CR2` register holds the **faulting virtual address** at the time of the fault.
+
+## Kernel entry point
+
+```c
+/* arch/x86/mm/fault.c */
+DEFINE_IDTENTRY_RAW_ERRORCODE(exc_page_fault)
+{
+    unsigned long address = read_cr2();  /* faulting virtual address */
+
+    irqentry_state_t state = irqentry_enter(regs);
+    handle_page_fault(regs, error_code, address);
+    irqentry_exit(regs, state);
+}
+
+static __always_inline void
+handle_page_fault(struct pt_regs *regs, unsigned long error_code,
+                   unsigned long address)
+{
+    if (unlikely(kmmio_fault(regs, address)))
+        return;  /* MMIO trace: handled */
+
+    /* Was fault in kernel space? */
+    if (unlikely(fault_in_kernel_space(address)))
+        do_kern_addr_fault(regs, error_code, address);
+    else
+        do_user_addr_fault(regs, error_code, address);
+}
+```
+
+## User-space fault path
+
+```c
+/* arch/x86/mm/fault.c */
+static void
+do_user_addr_fault(struct pt_regs *regs, unsigned long error_code,
+                    unsigned long address)
+{
+    struct vm_area_struct *vma;
+    struct task_struct *tsk = current;
+    struct mm_struct *mm = tsk->mm;
+    vm_fault_t fault;
+
+    /* 1. Check for obvious non-canonical addresses */
+    if (unlikely(error_code & X86_PF_RSVD))
+        goto bad_area;
+
+    /* 2. Don't handle faults while holding mmap_lock for write */
+    if (unlikely(faulthandler_disabled() || !mm))
+        goto bad_area_nosemaphore;
+
+    /* 3. Find the VMA that should contain 'address' */
+    vma = lock_vma_under_rcu(mm, address);
+    if (!vma) {
+        /* No VMA: try mmap_lock path */
+        mmap_read_lock(mm);
+        vma = find_vma(mm, address);
+    }
+
+    /* 4. Check the VMA covers the faulting address */
+    if (unlikely(!vma || address < vma->vm_start))
+        goto bad_area;
+
+    /* 5. Check access permissions against VMA flags */
+    if (unlikely(access_error(error_code, vma)))
+        goto bad_area;
+
+    /* 6. Handle the fault */
+    fault = handle_mm_fault(vma, address, flags, regs);
+
+    /* 7. Check for fault completion */
+    if (fault_signal_pending(fault, regs))
+        return;  /* signal arrived during fault */
+
+    if (unlikely(fault & VM_FAULT_ERROR)) {
+        if (fault & VM_FAULT_OOM)
+            goto out_of_memory;
+        if (fault & VM_FAULT_SIGBUS)
+            goto do_sigbus;
+        if (fault & VM_FAULT_SIGSEGV)
+            goto bad_area;
+    }
+    return;
+
+bad_area:
+    /* VMA not found or permission denied */
+    force_sig_fault(SIGSEGV, SEGV_MAPERR, (void __user *)address);
+    return;
+
+do_sigbus:
+    /* Hardware error or VM_FAULT_HWPOISON */
+    force_sig_fault(SIGBUS, BUS_ADRERR, (void __user *)address);
+}
+```
+
+## Fault types and their handling
+
+```c
+/* mm/memory.c */
+vm_fault_t handle_mm_fault(struct vm_area_struct *vma,
+                             unsigned long address,
+                             unsigned int flags,
+                             struct pt_regs *regs)
+{
+    /* Handle huge page faults first */
+    if (unlikely(is_vm_hugetlb_page(vma)))
+        return hugetlb_fault(vma->vm_mm, vma, address, flags);
+
+    /* THP: transparent huge page fault */
+    if (pmd_none(*vmf.pmd) && hugepage_vma_check(vma, vm_flags))
+        return create_huge_pmd(vmf);
+
+    return handle_pte_fault(vmf);
+}
+
+static vm_fault_t handle_pte_fault(struct vm_fault *vmf)
+{
+    pte_t entry;
+
+    if (unlikely(pmd_none(*vmf->pmd))) {
+        vmf->pte = NULL;
+        vmf->flags |= FAULT_FLAG_ORIG_PTE_VALID;
+    } else {
+        vmf->pte = pte_offset_map_lock(vmf->vma->vm_mm, vmf->pmd,
+                                         vmf->address, &vmf->ptl);
+        entry = *vmf->pte;
+    }
+
+    if (!vmf->pte || pte_none(entry)) {
+        /* No PTE: anonymous or file-backed fault */
+        if (vma_is_anonymous(vmf->vma))
+            return do_anonymous_page(vmf);  /* demand-zero page */
+        else
+            return do_fault(vmf);           /* file-backed: filemap_fault */
+    }
+
+    if (!pte_present(entry)) {
+        /* PTE exists but page not present: swapped out */
+        if (pte_swp_soft_dirty(entry))
+            return do_swap_page(vmf);       /* swap in the page */
+    }
+
+    /* Present PTE: must be a write fault on read-only PTE */
+    if (vmf->flags & FAULT_FLAG_WRITE) {
+        if (!pte_write(entry))
+            return do_wp_page(vmf);         /* copy-on-write */
+    }
+
+    /* Spurious fault or soft dirty tracking */
+    return 0;
+}
+```
+
+## Fault types summary
+
+| PTE state | Access type | Handler | Description |
+|-----------|------------|---------|-------------|
+| No PTE, anonymous VMA | Read/Write | `do_anonymous_page` | Demand-zero page |
+| No PTE, file VMA | Read | `do_read_fault` → `filemap_fault` | Demand page from file |
+| No PTE, file VMA | Write | `do_cow_fault` | Copy-on-write from file |
+| Swap PTE | Any | `do_swap_page` | Swap in from disk |
+| Present, read-only | Write | `do_wp_page` | COW or shared dirty |
+| No VMA | Any | SIGSEGV | Segmentation fault |
+| VMA: no write perm | Write | SIGSEGV | Permission denied |
+| VMA: no exec perm | Fetch | SIGSEGV | NX violation |
+
+## do_anonymous_page: demand-zero page
+
+```c
+/* mm/memory.c */
+static vm_fault_t do_anonymous_page(struct vm_fault *vmf)
+{
+    struct vm_area_struct *vma = vmf->vma;
+    struct page *page;
+    pte_t entry;
+
+    if (read_fault) {
+        /* Read of unwritten anonymous page: map the zero page */
+        /* (shared physical zero page — copy-on-write if written later) */
+        entry = pte_mkspecial(pfn_pte(my_zero_pfn(vmf->address),
+                                       vmf->vma->vm_page_prot));
+        set_pte_at(vmf->vma->vm_mm, vmf->address, vmf->pte, entry);
+        return 0;
+    }
+
+    /* Write: allocate a real zeroed page */
+    page = alloc_zeroed_user_highpage_movable(vma, vmf->address);
+    if (!page)
+        return VM_FAULT_OOM;
+
+    /* Install the PTE */
+    entry = mk_pte(page, vma->vm_page_prot);
+    entry = pte_sw_mkyoung(entry);
+    if (vma->vm_flags & VM_WRITE)
+        entry = pte_mkwrite(pte_mkdirty(entry));
+
+    set_pte_at(vmf->vma->vm_mm, vmf->address, vmf->pte, entry);
+    return 0;
+}
+```
+
+## do_wp_page: copy-on-write
+
+```c
+/* mm/memory.c */
+static vm_fault_t do_wp_page(struct vm_fault *vmf)
+{
+    struct vm_area_struct *vma = vmf->vma;
+    struct page *old_page = vm_normal_page(vma, vmf->address, vmf->orig_pte);
+
+    if (PageAnon(old_page)) {
+        /* Anonymous page: can we reuse it? */
+        if (page_count(old_page) == 1) {
+            /* We're the only owner: make it writable in-place */
+            wp_page_reuse(vmf);
+            return VM_FAULT_WRITE;
+        }
+        /* Shared: allocate a new copy */
+        return wp_page_copy(vmf);
+    }
+
+    if (vma->vm_flags & VM_SHARED) {
+        /* Shared mapping: dirty the page in-place */
+        return wp_page_shared(vmf);
+    }
+
+    /* Private file mapping: COW */
+    return wp_page_copy(vmf);
+}
+
+static vm_fault_t wp_page_copy(struct vm_fault *vmf)
+{
+    /* Allocate new page */
+    new_page = alloc_page_vma(GFP_HIGHUSER_MOVABLE, vmf->vma, vmf->address);
+
+    /* Copy old page content */
+    cow_user_page(new_page, old_page, vmf);
+
+    /* Install new writable PTE */
+    new_entry = mk_pte(new_page, vma->vm_page_prot);
+    new_entry = pte_mkwrite(pte_mkdirty(new_entry));
+    set_pte_at_notify(vmf->vma->vm_mm, vmf->address, vmf->pte, new_entry);
+
+    /* Decrement reference to old page */
+    put_page(old_page);
+    return VM_FAULT_WRITE;
+}
+```
+
+## Kernel page faults
+
+```c
+/* Kernel-space fault: usually a bug */
+static noinline void
+do_kern_addr_fault(struct pt_regs *regs, unsigned long error_code,
+                    unsigned long address)
+{
+    /* vmalloc fault: mapping not synced from init_mm */
+    if (!(error_code & X86_PF_USER) &&
+        !(error_code & X86_PF_PROT) &&
+        vmalloc_fault(address) >= 0)
+        return;
+
+    /* fixup_exception: expected fault from copy_to_user etc. */
+    if (!user_mode(regs) && fixup_exception(regs, X86_TRAP_PF,
+                                              error_code, address))
+        return;
+
+    /* Unrecoverable: kernel bug */
+    oops_begin();
+    show_fault_oops(regs, error_code, address);
+    oops_end(flags, regs, SIGKILL);
+}
+```
+
+Common kernel fault: `copy_to_user` / `copy_from_user` with an invalid user pointer. The `fixup_exception` mechanism uses a table of `{fault_address → recovery_address}` pairs — if the fault address is in the table, execution jumps to the recovery code (returns `-EFAULT`).
+
+## Observing page faults
+
+```bash
+# Per-process fault statistics
+cat /proc/<pid>/stat | awk '{print "minor:", $10, "major:", $12}'
+# minor: 12345  (page was in cache; just needed mapping)
+# major: 42     (page was not in memory; required I/O)
+
+# System-wide fault rates (perf)
+perf stat -e page-faults,major-faults -- my_program
+
+# Trace specific faults with ftrace
+echo 1 > /sys/kernel/debug/tracing/events/exceptions/page_fault_user/enable
+cat /sys/kernel/debug/tracing/trace
+
+# perf-record to find where faults happen
+perf record -e page-faults -- my_program
+perf report
+
+# USDT/bpftrace:
+bpftrace -e 'tracepoint:exceptions:page_fault_user {
+    @addrs[uaddr] = count();
+}'
+```
+
+## Further reading
+
+- [File-backed mmap and page faults](file-mmap.md) — do_fault/filemap_fault path
+- [Copy-on-Write](cow.md) — do_wp_page mechanics
+- [Process Address Space](mmap.md) — VMA structure
+- [Swap](swap.md) — do_swap_page path
+- [KASAN](kasan.md) — detecting invalid kernel memory accesses
+- `arch/x86/mm/fault.c` — x86 page fault entry
+- `mm/memory.c` — handle_mm_fault, do_anonymous_page, do_wp_page

--- a/docs/mm/vdso.md
+++ b/docs/mm/vdso.md
@@ -1,0 +1,266 @@
+# vDSO: Virtual Dynamic Shared Object
+
+> Syscalls without entering the kernel: gettimeofday at userspace speed
+
+## The problem
+
+Every system call requires a mode switch: user → kernel → user. For `gettimeofday()`, this means:
+- Save registers, change privilege level (CPL 0)
+- Look up time in the kernel
+- Restore registers, return to userspace
+
+For high-frequency time queries (trading systems, profilers, game loops), this round-trip costs ~100-300ns. The vDSO eliminates it.
+
+## What is the vDSO?
+
+The vDSO (virtual dynamic shared object) is a small shared library that the kernel **maps into every process address space** automatically. It contains a few time-related functions implemented as pure userspace code that read from a kernel-maintained shared memory region — no syscall needed.
+
+```bash
+# See vDSO mapping in every process
+cat /proc/self/maps | grep vdso
+# 7fff12345000-7fff12346000 r-xp  [vdso]
+
+# Extract and disassemble the vDSO
+objcopy --dump-section .text=/tmp/vdso.so [vdso] /dev/null 2>/dev/null
+# Or:
+dd if=/proc/self/mem bs=4096 count=1 skip=$((0x7fff12345000/4096)) > /tmp/vdso.so
+```
+
+## Functions in the vDSO
+
+```c
+/* The vDSO exports these symbols (x86-64): */
+__vdso_clock_gettime()    /* clock_gettime(CLOCK_REALTIME, ...)  — fast */
+__vdso_clock_getres()     /* clock_getres()                      — fast */
+__vdso_gettimeofday()     /* gettimeofday()                      — fast */
+__vdso_time()             /* time()                              — fast */
+__vdso_getcpu()           /* getcpu() — current CPU/NUMA node   — fast */
+
+/* These call the vDSO instead of the kernel: */
+/* glibc wraps all of these to use vDSO automatically */
+```
+
+## The vdso_data shared page
+
+The kernel maintains a **vvar** (vDSO variable) page that is:
+- Mapped read-only into every process
+- Written by the kernel (holding current time)
+- Read by the vDSO functions (no syscall)
+
+```c
+/* arch/x86/include/asm/vvar.h */
+/* arch/x86/entry/vdso/vma.c */
+struct vdso_data {
+    u32 seq;              /* seqlock sequence counter */
+
+    s32 clock_mode;       /* VDSO_CLOCKMODE_* */
+    u64 cycle_last;       /* TSC value at last update */
+    u64 mask;             /* TSC bitmask */
+    u32 mult;             /* TSC → ns multiplier */
+    u32 shift;            /* TSC → ns shift */
+
+    /* Per-clockid data: */
+    struct {
+        u64 nsec;         /* sub-second nanoseconds */
+        u64 sec;          /* seconds since epoch */
+        u64 snsec;        /* CLOCK_MONOTONIC offsets */
+    } basetime[VDSO_BASES];
+
+    s32 tz_minuteswest;   /* timezone */
+    s32 tz_dsttime;
+    u32 hrtimer_res;
+    u32 __unused;
+};
+
+/* Two copies for NMI safety: */
+extern struct vdso_data _vdso_data[CS_BASES];  /* in vmlinux */
+/* Mapped to [vvar] page in each process */
+```
+
+## The seqlock pattern
+
+The kernel updates `vdso_data` while user code reads it concurrently. A **seqlock** ensures consistent reads:
+
+```c
+/* Kernel (timekeeping.c): write side */
+void update_vsyscall(struct timekeeper *tk)
+{
+    struct vdso_data *vdata = __arch_get_k_vdso_data();
+
+    /* Increment seq to odd: mark as "being updated" */
+    vdso_write_begin(vdata);
+
+    /* Update all fields */
+    vdata->cycle_last = tk->tkr_mono.cycle_last;
+    vdata->mult       = tk->tkr_mono.mult;
+    vdata->shift      = tk->tkr_mono.shift;
+    /* ... */
+
+    /* Increment seq to even: "update complete" */
+    vdso_write_end(vdata);
+}
+```
+
+```c
+/* vDSO userspace: read side (in [vdso] mapping) */
+notrace static __always_inline int
+do_hres(const struct vdso_data *vd, clockid_t clk, struct __kernel_timespec *ts)
+{
+    const struct vdso_timestamp *vdso_ts = &vd->basetime[clk];
+    u64 cycles, ns;
+    u32 seq;
+
+    do {
+        /* Read seq: must be even (not being updated) */
+        seq = vdso_read_begin(vd);
+        if (unlikely(vd->clock_mode == VDSO_CLOCKMODE_NONE))
+            return -1;  /* fallback to syscall */
+
+        /* Read TSC */
+        cycles = __arch_get_hw_counter(vd->clock_mode, vd);
+
+        /* Compute nanoseconds: (cycles - cycle_last) * mult >> shift */
+        ns = vdso_ts->nsec;
+        ns += (cycles - vd->cycle_last) * vd->mult;
+        ns >>= vd->shift;
+
+        ts->tv_sec  = vdso_ts->sec;
+        ts->tv_nsec = ns;
+
+    } while (unlikely(vdso_read_retry(vd, seq)));
+    /* Retry if seq changed mid-read (kernel was updating) */
+
+    return 0;
+}
+```
+
+The retry loop is the key: if the kernel updated `vdso_data` during our read (seq changed), we retry. Typically 0 retries.
+
+## AT_SYSINFO_EHDR: finding the vDSO
+
+The kernel passes the vDSO address via the ELF auxiliary vector:
+
+```c
+/* Auxiliary vector entry at program startup */
+AT_SYSINFO_EHDR = 33   /* address of the vDSO ELF header */
+
+/* glibc reads this during startup: */
+void __dl_discover_osversion(void)
+{
+    ElfW(Phdr) *phdr = (void *)getauxval(AT_SYSINFO_EHDR);
+    /* dlopen-like loading of the vDSO */
+}
+```
+
+```c
+/* Read auxiliary vector from /proc/self/auxv: */
+#include <sys/auxv.h>
+unsigned long vdso_addr = getauxval(AT_SYSINFO_EHDR);
+printf("vDSO at %#lx\n", vdso_addr);
+
+/* Or parse /proc/self/auxv manually: */
+#include <elf.h>
+Elf64_auxv_t auxv;
+int fd = open("/proc/self/auxv", O_RDONLY);
+while (read(fd, &auxv, sizeof(auxv)) == sizeof(auxv)) {
+    if (auxv.a_type == AT_SYSINFO_EHDR) {
+        printf("vDSO ELF header at %#lx\n", auxv.a_un.a_val);
+        break;
+    }
+}
+```
+
+## vDSO fallback to syscall
+
+If the vDSO can't provide the answer (e.g., clock is not TSC-based, or it's a non-monotonic clock), it falls back to a real syscall:
+
+```c
+/* arch/x86/entry/vdso/vclock_gettime.c */
+notrace int __vdso_clock_gettime(clockid_t clock, struct __kernel_timespec *ts)
+{
+    const struct vdso_data *vd = __arch_get_vdso_data();
+
+    switch (clock) {
+    case CLOCK_REALTIME:
+    case CLOCK_MONOTONIC:
+    case CLOCK_BOOTTIME:
+    case CLOCK_TAI:
+        /* Fast path via TSC */
+        if (likely(do_hres(vd + clock, clock, ts) == 0))
+            return 0;
+        break;
+
+    case CLOCK_REALTIME_COARSE:
+    case CLOCK_MONOTONIC_COARSE:
+        /* Coarse: just read from vdso_data without TSC */
+        do_coarse(vd + clock, clock, ts);
+        return 0;
+
+    default:
+        break;
+    }
+
+    /* Fallback: real syscall */
+    return clock_gettime_fallback(clock, ts);
+}
+```
+
+## Performance comparison
+
+```c
+/* Benchmark: syscall vs vDSO vs rdtsc */
+
+/* syscall gettimeofday: ~150-300ns */
+struct timeval tv;
+gettimeofday(&tv, NULL);  /* uses vDSO automatically with glibc */
+
+/* Direct vDSO call (same as gettimeofday with glibc): ~5-15ns */
+
+/* Raw RDTSC (fastest, but no unit): ~2-5ns */
+uint64_t t = __rdtsc();
+```
+
+```bash
+# Measure gettimeofday latency
+perf stat -e syscalls:sys_enter_gettimeofday -- \
+    python3 -c "import time; [time.time() for _ in range(1000000)]"
+# syscalls:sys_enter_gettimeofday: 0  (zero syscalls — all vDSO!)
+
+# Force syscall path (bypass vDSO):
+LD_PRELOAD=/lib/x86_64-linux-gnu/libpthread.so.0  # doesn't work anymore
+# Use seccomp to intercept, or strace:
+strace -c -e gettimeofday myprogram  # will show 0 if vDSO is working
+```
+
+## vDSO on other architectures
+
+The vDSO is architecture-specific:
+
+| Architecture | vDSO functions |
+|-------------|---------------|
+| x86-64 | clock_gettime, gettimeofday, time, getcpu |
+| ARM64 | clock_gettime, gettimeofday, clock_getres |
+| RISC-V | clock_gettime, gettimeofday |
+| Power | clock_gettime, gettimeofday, getcpu |
+| s390 | clock_gettime, gettimeofday |
+
+```bash
+# ARM64 vDSO functions
+nm /proc/self/mem 2>/dev/null | grep vdso || \
+    objdump -d /proc/self/mem 2>/dev/null | head
+# Or:
+cat /proc/self/maps | grep vdso
+# Extract and inspect:
+dd if=/proc/self/mem of=/tmp/vdso.so bs=4096 count=1 \
+   skip=$(($(cat /proc/self/maps | grep vdso | cut -d- -f1 | head -1 | xargs printf '%d')/4096)) 2>/dev/null
+nm /tmp/vdso.so
+```
+
+## Further reading
+
+- [Timekeeping and Clocksources](../time/timekeeping.md) — how the kernel maintains time
+- [Process Address Space](mmap.md) — vDSO VMA in process maps
+- [What happens during exec()](exec.md) — AT_SYSINFO_EHDR in the auxiliary vector
+- [Syscall Entry Path](../syscalls/syscall-entry.md) — when vDSO falls back to syscall
+- `arch/x86/entry/vdso/` — x86-64 vDSO implementation
+- `include/vdso/datapage.h` — struct vdso_data

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,8 @@ nav:
     - Address Translation:
       - Page Tables: mm/page-tables.md
       - Process Address Space: mm/mmap.md
+      - Page Fault Handler: mm/page-fault.md
+      - vDSO: Fast Syscalls Without the Kernel: mm/vdso.md
     - Caching & Reclaim:
       - Page Cache: mm/page-cache.md
       - Page Reclaim: mm/reclaim.md


### PR DESCRIPTION
## Summary

- **vDSO** (`docs/mm/vdso.md`): `[vdso]` + `[vvar]` VMA mapping, `struct vdso_data` fields (cycle_last/mult/shift/basetime), seqlock `do_hres` retry pattern, `AT_SYSINFO_EHDR` auxiliary vector, x86-64 exported functions (clock_gettime/gettimeofday/time/getcpu), VDSO_CLOCKMODE_NONE fallback path, `getauxval(AT_SYSINFO_EHDR)`, performance comparison (syscall ~200ns vs vDSO ~10ns vs RDTSC ~3ns), cross-architecture table
- **Page Fault Handler** (`docs/mm/page-fault.md`): x86 error code bit table (P/W/U/R/I/PK), `do_user_addr_fault` VMA lookup and `access_error` permission check, `handle_pte_fault` dispatch (anonymous/file/swap/COW), `do_anonymous_page` zero-page optimization, `do_wp_page` single-owner in-place reuse vs `wp_page_copy`, kernel fault `fixup_exception` for `copy_to_user`/`copy_from_user`, fault observation (`/proc/stat` minor/major, `perf -e page-faults`, ftrace tracepoint)

## Test plan

- [ ] `mkdocs build` passes with new Address Translation entries
- [ ] vdso_data field names match `include/vdso/datapage.h`
- [ ] Links to exec.md (AT_SYSINFO_EHDR), file-mmap.md, cow.md, swap.md resolve

Closes #411, #412
Part of #410