### PR TITLE
Add procfs/sysfs internals and Netlink protocol

### DIFF
--- a/docs/net/netlink.md
+++ b/docs/net/netlink.md
@@ -1,0 +1,329 @@
+# Netlink
+
+> Kernel-userspace communication for network configuration tools
+
+## What is Netlink?
+
+Netlink is a socket-based IPC mechanism for communication between userspace and the kernel. It's how most network configuration tools work:
+
+| Tool | Netlink family | Purpose |
+|------|---------------|---------|
+| `ip link`, `ip addr` | `NETLINK_ROUTE` (rtnetlink) | Interface/address/route management |
+| `ss`, `netstat` | `NETLINK_SOCK_DIAG` | Socket statistics |
+| `ethtool` | `NETLINK_GENERIC` (ethtool_nl) | NIC configuration |
+| `iw`, `nmcli` | `NETLINK_GENERIC` (nl80211) | WiFi configuration |
+| `tc` | `NETLINK_ROUTE` | Traffic control |
+| `nftables` | `NETLINK_NETFILTER` | Firewall rules |
+| `audit` | `NETLINK_AUDIT` | Audit subsystem |
+| `uevent` | `NETLINK_KOBJECT_UEVENT` | Device hotplug events |
+
+## Netlink socket basics
+
+```c
+#include <linux/netlink.h>
+#include <sys/socket.h>
+
+/* Open a Netlink socket */
+int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+
+/* Bind: register our PID */
+struct sockaddr_nl addr = {
+    .nl_family = AF_NETLINK,
+    .nl_pid    = getpid(),   /* 0 = kernel assigns */
+    .nl_groups = 0,          /* multicast groups (see below) */
+};
+bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+```
+
+## Netlink message format
+
+Every Netlink message has a fixed header:
+
+```c
+/* include/uapi/linux/netlink.h */
+struct nlmsghdr {
+    __u32 nlmsg_len;    /* Total length including header */
+    __u16 nlmsg_type;   /* Message type (family-specific) */
+    __u16 nlmsg_flags;  /* Flags: NLM_F_REQUEST, NLM_F_ACK, NLM_F_DUMP, ... */
+    __u32 nlmsg_seq;    /* Sequence number (for matching replies) */
+    __u32 nlmsg_pid;    /* Sender PID (0 = kernel) */
+    /* Payload follows: family-specific struct + attributes */
+};
+```
+
+Common flags:
+- `NLM_F_REQUEST`: this is a request to the kernel
+- `NLM_F_ACK`: request an acknowledgement
+- `NLM_F_DUMP`: dump all objects of this type
+- `NLM_F_CREATE`: create if not exists (add operations)
+- `NLM_F_EXCL`: fail if exists (add operations)
+
+## rtnetlink: network interface management
+
+`NETLINK_ROUTE` (rtnetlink) is used by `ip` to manage interfaces, addresses, and routes.
+
+### List all interfaces (GETLINK dump)
+
+```c
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+
+/* Build a RTM_GETLINK dump request */
+struct {
+    struct nlmsghdr nlh;
+    struct ifinfomsg ifi;
+} req = {
+    .nlh = {
+        .nlmsg_len   = NLMSG_LENGTH(sizeof(struct ifinfomsg)),
+        .nlmsg_type  = RTM_GETLINK,
+        .nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP,
+        .nlmsg_seq   = 1,
+    },
+    .ifi = {
+        .ifi_family = AF_UNSPEC,
+    },
+};
+
+send(fd, &req, req.nlh.nlmsg_len, 0);
+
+/* Read replies (multiple messages, one per interface) */
+char buf[8192];
+while (1) {
+    ssize_t n = recv(fd, buf, sizeof(buf), 0);
+    struct nlmsghdr *nlh = (struct nlmsghdr *)buf;
+
+    for (; NLMSG_OK(nlh, n); nlh = NLMSG_NEXT(nlh, n)) {
+        if (nlh->nlmsg_type == NLMSG_DONE)
+            goto done;
+        if (nlh->nlmsg_type == RTM_NEWLINK) {
+            struct ifinfomsg *ifi = NLMSG_DATA(nlh);
+            /* Parse attributes */
+            struct rtattr *rta = IFLA_RTA(ifi);
+            int len = IFLA_PAYLOAD(nlh);
+            for (; RTA_OK(rta, len); rta = RTA_NEXT(rta, len)) {
+                if (rta->rta_type == IFLA_IFNAME)
+                    printf("interface: %s\n", (char *)RTA_DATA(rta));
+                if (rta->rta_type == IFLA_MTU)
+                    printf("mtu: %u\n", *(uint32_t *)RTA_DATA(rta));
+            }
+        }
+    }
+}
+done:;
+```
+
+### Netlink attributes (rtattr / nlattr)
+
+Netlink uses a TLV (Type-Length-Value) attribute format:
+
+```c
+/* rtattr format: */
+struct rtattr {
+    unsigned short rta_len;   /* Total length including header */
+    unsigned short rta_type;  /* Attribute type */
+    /* Data follows */
+};
+
+/* Parse: RTA_DATA(rta) points to the attribute data */
+/* Nested: RTA_DATA(rta) is itself a list of rtatrr */
+
+/* Modern generic netlink uses nlattr with same layout: */
+struct nlattr {
+    __u16 nla_len;
+    __u16 nla_type;  /* Top 2 bits: NLA_F_NESTED, NLA_F_NET_BYTEORDER */
+};
+```
+
+### RTM_NEWROUTE: add a route
+
+```c
+/* Add route: 10.0.0.0/8 via 192.168.1.1 dev eth0 */
+struct {
+    struct nlmsghdr  nlh;
+    struct rtmsg     rtm;
+    char             attrs[256];
+} req = {};
+
+req.nlh.nlmsg_len   = NLMSG_LENGTH(sizeof(req.rtm));
+req.nlh.nlmsg_type  = RTM_NEWROUTE;
+req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_ACK;
+req.nlh.nlmsg_seq   = 2;
+
+req.rtm.rtm_family   = AF_INET;
+req.rtm.rtm_dst_len  = 8;   /* prefix length */
+req.rtm.rtm_table    = RT_TABLE_MAIN;
+req.rtm.rtm_protocol = RTPROT_STATIC;
+req.rtm.rtm_scope    = RT_SCOPE_UNIVERSE;
+req.rtm.rtm_type     = RTN_UNICAST;
+
+/* Add destination: RTA_DST */
+uint32_t dst = inet_addr("10.0.0.0");
+addattr_l(&req.nlh, sizeof(req), RTA_DST, &dst, 4);
+
+/* Add gateway: RTA_GATEWAY */
+uint32_t gw = inet_addr("192.168.1.1");
+addattr_l(&req.nlh, sizeof(req), RTA_GATEWAY, &gw, 4);
+
+/* Add interface index: RTA_OIF */
+int ifidx = if_nametoindex("eth0");
+addattr32(&req.nlh, sizeof(req), RTA_OIF, ifidx);
+
+send(fd, &req, req.nlh.nlmsg_len, 0);
+/* Read ACK to confirm success */
+```
+
+## Generic Netlink (genetlink)
+
+Generic Netlink is a multiplexer that allows kernel subsystems to define their own message families without using a reserved `NETLINK_*` protocol number.
+
+```
+AF_NETLINK + NETLINK_GENERIC
+    ↓
+genetlink dispatcher
+    ├── family "ethtool"   → ethtool_nl handlers
+    ├── family "nl80211"   → cfg80211 handlers
+    ├── family "nlctrl"    → list families
+    └── family "devlink"   → devlink handlers
+```
+
+### Using libnl3
+
+Most tools use `libnl3` rather than raw sockets:
+
+```c
+#include <netlink/netlink.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+
+struct nl_sock *sock = nl_socket_alloc();
+genl_connect(sock);
+
+/* Resolve family name to ID */
+int family = genl_ctrl_resolve(sock, "nl80211");
+
+/* Build and send a message */
+struct nl_msg *msg = nlmsg_alloc();
+genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, family, 0, 0,
+            NL80211_CMD_GET_INTERFACE, 0);
+nla_put_u32(msg, NL80211_ATTR_IFINDEX, if_nametoindex("wlan0"));
+
+nl_send_auto(sock, msg);
+nlmsg_free(msg);
+
+/* Receive and parse reply */
+nl_recvmsgs_default(sock);
+```
+
+## Kernel side: registering a genetlink family
+
+```c
+/* net/wireless/nl80211.c (simplified) */
+#include <net/genetlink.h>
+
+static const struct genl_ops nl80211_ops[] = {
+    {
+        .cmd    = NL80211_CMD_GET_INTERFACE,
+        .doit   = nl80211_get_interface,
+        .dumpit = nl80211_dump_interface,
+        .policy = nl80211_policy,
+    },
+    {
+        .cmd    = NL80211_CMD_SET_INTERFACE,
+        .doit   = nl80211_set_interface,
+        .flags  = GENL_ADMIN_PERM,  /* requires CAP_NET_ADMIN */
+    },
+    /* ... many more ... */
+};
+
+static struct genl_family nl80211_fam __ro_after_init = {
+    .name     = NL80211_GENL_NAME,   /* "nl80211" */
+    .version  = 1,
+    .maxattr  = NL80211_ATTR_MAX,
+    .policy   = nl80211_policy,
+    .module   = THIS_MODULE,
+    .ops      = nl80211_ops,
+    .n_ops    = ARRAY_SIZE(nl80211_ops),
+    .mcgrps   = nl80211_mcgrps,      /* multicast groups */
+    .n_mcgrps = ARRAY_SIZE(nl80211_mcgrps),
+};
+
+static int __init nl80211_init(void)
+{
+    return genl_register_family(&nl80211_fam);
+}
+```
+
+## Netlink multicast: event notifications
+
+Netlink multicast allows the kernel to push events to interested userspace processes:
+
+```c
+/* Subscribe to route change events */
+struct sockaddr_nl addr = {
+    .nl_family = AF_NETLINK,
+    .nl_groups = RTMGRP_LINK        /* interface changes */
+              | RTMGRP_IPV4_IFADDR  /* address changes */
+              | RTMGRP_IPV4_ROUTE,  /* route changes */
+};
+bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+
+/* Now recv() will receive RTM_NEWLINK, RTM_NEWADDR, RTM_NEWROUTE events
+   without sending any request */
+
+/* systemd-networkd, NetworkManager, and dhclient use this to detect
+   cable plug/unplug, DHCP lease changes, etc. */
+```
+
+### Kernel side: sending a multicast notification
+
+```c
+/* net/core/rtnetlink.c */
+/* Called when an interface comes up: */
+void rtmsg_ifinfo(int type, struct net_device *dev, unsigned int change,
+                   gfp_t flags)
+{
+    struct sk_buff *skb = rtmsg_ifinfo_build_skb(type, dev, change,
+                                                    0, flags, NULL, 0, 0);
+    if (skb) {
+        /* Send to RTNLGRP_LINK multicast group */
+        rtnl_notify(skb, dev_net(dev), 0, RTNLGRP_LINK, NULL, flags);
+    }
+}
+```
+
+## NETLINK_SOCK_DIAG: socket statistics
+
+Used by `ss` to list sockets faster than `/proc/net/tcp`:
+
+```c
+/* Request TCP socket dump */
+struct {
+    struct nlmsghdr nlh;
+    struct inet_diag_req_v2 req;
+} request = {
+    .nlh = {
+        .nlmsg_len   = sizeof(request),
+        .nlmsg_type  = SOCK_DIAG_BY_FAMILY,
+        .nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP,
+    },
+    .req = {
+        .sdiag_family   = AF_INET,
+        .sdiag_protocol = IPPROTO_TCP,
+        .idiag_states   = (1 << TCP_ESTABLISHED) | (1 << TCP_LISTEN),
+        .idiag_ext      = (1 << (INET_DIAG_INFO - 1)),  /* get tcp_info */
+    },
+};
+send(fd, &request, sizeof(request), 0);
+/* Receive: one INET_DIAG_INFO per socket */
+```
+
+## Further reading
+
+- [Socket Layer Overview](socket-layer.md) — AF_NETLINK socket implementation
+- [procfs and sysfs](../vfs/procfs-sysfs.md) — alternative kernel-userspace interfaces
+- [XDP and AF_XDP](af-xdp.md) — socket-based packet processing
+- [Network Debugging](net-debugging.md) — `ss` and `ip` command internals
+- `net/netlink/` — core netlink implementation
+- `net/core/rtnetlink.c` — rtnetlink
+- `net/wireless/nl80211.c` — nl80211 genetlink family
+- `libnl3` documentation — userspace netlink library

--- a/docs/vfs/procfs-sysfs.md
+++ b/docs/vfs/procfs-sysfs.md
@@ -1,0 +1,376 @@
+# procfs and sysfs
+
+> How /proc and /sys expose kernel state to userspace
+
+## /proc: the process filesystem
+
+`/proc` is a virtual filesystem that exposes kernel and process information. Files in `/proc` have no on-disk representation — content is generated on-the-fly when read.
+
+```bash
+# Common /proc files:
+/proc/cpuinfo         # CPU description
+/proc/meminfo         # memory statistics
+/proc/interrupts      # IRQ counts per CPU
+/proc/net/dev         # network interface statistics
+/proc/sys/            # sysctl tunables
+
+# Per-process (one directory per PID):
+/proc/<pid>/maps      # virtual memory areas
+/proc/<pid>/status    # task status
+/proc/<pid>/fd/       # open file descriptors (symlinks)
+/proc/<pid>/cmdline   # command line arguments
+/proc/<pid>/mem       # process memory (requires ptrace)
+```
+
+## Creating a /proc entry
+
+### Simple single-value file
+
+```c
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+
+/* Show function: called on read */
+static int mymod_show(struct seq_file *m, void *v)
+{
+    seq_printf(m, "value: %d\n", my_value);
+    seq_printf(m, "name: %s\n", my_name);
+    return 0;
+}
+
+/* Write function: called on write */
+static ssize_t mymod_write(struct file *file, const char __user *buf,
+                             size_t count, loff_t *ppos)
+{
+    char kbuf[32];
+    if (copy_from_user(kbuf, buf, min(count, sizeof(kbuf) - 1)))
+        return -EFAULT;
+    kbuf[count] = '\0';
+    kstrtoint(kbuf, 10, &my_value);
+    return count;
+}
+
+/* File operations: use single_open for simple one-page files */
+static int mymod_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, mymod_show, NULL);
+}
+
+static const struct proc_ops mymod_fops = {
+    .proc_open    = mymod_open,
+    .proc_read    = seq_read,
+    .proc_write   = mymod_write,
+    .proc_lseek   = seq_lseek,
+    .proc_release = single_release,
+};
+
+/* Create /proc/mymod on init */
+static int __init mymod_init(void)
+{
+    proc_create("mymod", 0644, NULL, &mymod_fops);
+    /* NULL parent = /proc/ root */
+    return 0;
+}
+
+static void __exit mymod_exit(void)
+{
+    remove_proc_entry("mymod", NULL);
+}
+```
+
+### seq_file: multi-page iterators
+
+For files with many entries (like `/proc/net/tcp`), use the seq_file iterator API:
+
+```c
+/* Iterate over a list of entries */
+static void *mylist_seq_start(struct seq_file *m, loff_t *pos)
+{
+    return seq_list_start(&my_list, *pos);
+}
+
+static void *mylist_seq_next(struct seq_file *m, void *v, loff_t *pos)
+{
+    return seq_list_next(v, &my_list, pos);
+}
+
+static void mylist_seq_stop(struct seq_file *m, void *v)
+{
+    /* Cleanup if needed (unlock, etc.) */
+}
+
+static int mylist_seq_show(struct seq_file *m, void *v)
+{
+    struct my_entry *e = list_entry(v, struct my_entry, list);
+    seq_printf(m, "%s %d %llu\n", e->name, e->count, e->bytes);
+    return 0;
+}
+
+static const struct seq_operations mylist_seq_ops = {
+    .start = mylist_seq_start,
+    .next  = mylist_seq_next,
+    .stop  = mylist_seq_stop,
+    .show  = mylist_seq_show,
+};
+
+/* Open: set up the seq_file */
+static int mylist_open(struct inode *inode, struct file *file)
+{
+    return seq_open(file, &mylist_seq_ops);
+}
+```
+
+`seq_file` handles pagination automatically: if the output doesn't fit in one page, the kernel calls `start`/`next`/`show` again with the right offset for the next read.
+
+### /proc directory
+
+```c
+struct proc_dir_entry *mydir;
+
+/* Create /proc/mymod/ directory */
+mydir = proc_mkdir("mymod", NULL);
+
+/* Create /proc/mymod/status */
+proc_create("status", 0444, mydir, &status_fops);
+
+/* Create /proc/mymod/stats (read-only) */
+proc_create_single("stats", 0444, mydir, stats_show);
+
+/* Remove on exit */
+remove_proc_subtree("mymod", NULL);
+```
+
+## /proc internals: struct proc_dir_entry
+
+```c
+/* fs/proc/internal.h */
+struct proc_dir_entry {
+    /* Inode number: assigned sequentially */
+    unsigned int    low_ino;
+    nlink_t         nlink;
+    kuid_t          uid;
+    kgid_t          gid;
+    loff_t          size;
+
+    const struct inode_operations *proc_iops;
+    union {
+        const struct proc_ops *proc_ops;
+        const struct file_operations *proc_dir_ops;
+    };
+    const struct dentry_operations *proc_dops;
+    union {
+        const struct seq_operations *seq_ops;
+        int (*single_show)(struct seq_file *, void *);
+    };
+    proc_write_t write;
+    void         *data;
+    unsigned int  state_size;
+    unsigned int  len;
+    char          name[];
+};
+```
+
+The `/proc` filesystem is implemented as a regular VFS filesystem (`proc_fs_type`) that creates inodes on demand when a path is looked up.
+
+## sysfs: the device and driver hierarchy
+
+`sysfs` is mounted at `/sys` and exposes the kernel's device model as a directory tree:
+
+```
+/sys/
+├── bus/           (bus types: pci, usb, i2c, ...)
+├── class/         (device classes: net, block, input, ...)
+├── devices/       (device hierarchy mirroring hardware topology)
+│   ├── pci0000:00/
+│   │   └── 0000:00:1c.0/   (PCI bridge)
+│   │       └── 0000:01:00.0/  (network card)
+└── kernel/        (kernel parameters and statistics)
+    ├── mm/transparent_hugepage/
+    └── security/
+```
+
+## kobject: the sysfs object
+
+`kobject` is the fundamental object in the sysfs/device model hierarchy:
+
+```c
+/* include/linux/kobject.h */
+struct kobject {
+    const char          *name;
+    struct list_head    entry;
+    struct kobject      *parent;         /* parent kobject */
+    struct kset         *kset;
+    const struct kobj_type *ktype;
+    struct kernfs_node  *sd;             /* sysfs directory node */
+    struct kref         kref;            /* reference count */
+    /* ... */
+};
+
+/* Create a kobject (creates a sysfs directory): */
+struct kobject *kobj;
+kobj = kobject_create_and_add("myobject", kernel_kobj);
+/* Creates: /sys/kernel/myobject/ */
+
+/* Cleanup: */
+kobject_put(kobj);  /* decrement ref; frees when 0 */
+```
+
+## Sysfs attributes: files in sysfs
+
+```c
+/* A sysfs attribute = one file in /sys/... */
+struct attribute {
+    const char *name;
+    umode_t     mode;   /* permissions */
+};
+
+/* For device attributes (struct device): */
+struct device_attribute {
+    struct attribute  attr;
+    ssize_t (*show)(struct device *dev, struct device_attribute *attr, char *buf);
+    ssize_t (*store)(struct device *dev, struct device_attribute *attr,
+                      const char *buf, size_t count);
+};
+
+/* Define a device attribute: */
+static ssize_t speed_show(struct device *dev,
+                           struct device_attribute *attr, char *buf)
+{
+    struct mydev *d = dev_get_drvdata(dev);
+    return sysfs_emit(buf, "%u\n", d->speed);
+}
+
+static ssize_t speed_store(struct device *dev,
+                             struct device_attribute *attr,
+                             const char *buf, size_t count)
+{
+    struct mydev *d = dev_get_drvdata(dev);
+    unsigned int val;
+    if (kstrtouint(buf, 10, &val))
+        return -EINVAL;
+    d->speed = val;
+    return count;
+}
+
+static DEVICE_ATTR_RW(speed);   /* creates dev_attr_speed */
+/* DEVICE_ATTR_RO(speed): read-only */
+/* DEVICE_ATTR_WO(speed): write-only */
+```
+
+### Attribute groups
+
+Drivers typically register attribute groups (multiple attributes at once):
+
+```c
+/* Declare attributes */
+static DEVICE_ATTR_RO(stats);
+static DEVICE_ATTR_RW(enable);
+static DEVICE_ATTR_RW(threshold);
+
+/* Group them */
+static struct attribute *mydev_attrs[] = {
+    &dev_attr_stats.attr,
+    &dev_attr_enable.attr,
+    &dev_attr_threshold.attr,
+    NULL,
+};
+
+static const struct attribute_group mydev_attr_group = {
+    .attrs = mydev_attrs,
+    /* Optional: .name = "config" → creates /sys/.../config/ subdir */
+};
+
+static const struct attribute_group *mydev_attr_groups[] = {
+    &mydev_attr_group,
+    NULL,
+};
+
+/* Register with device (in probe): */
+/* Option 1: manual */
+device_add_group(&pdev->dev, &mydev_attr_group);
+
+/* Option 2: via device's driver_data at registration */
+struct device_driver mydev_driver = {
+    .dev_groups = mydev_attr_groups,
+    /* ... */
+};
+/* Attributes are created/removed automatically with the device */
+```
+
+## kernfs: the sysfs backend
+
+sysfs is built on top of `kernfs`, a generic virtual filesystem infrastructure:
+
+```c
+/* fs/kernfs/kernfs-internal.h */
+struct kernfs_node {
+    atomic_t         count;
+    atomic_t         active;
+    struct kernfs_node *parent;
+    const char       *name;
+    struct rb_node   rb;
+
+    const void       *ns;       /* namespace for per-ns files */
+    unsigned int     hash;
+
+    union {
+        struct kernfs_elem_dir    dir;      /* directory */
+        struct kernfs_elem_symlink symlink; /* symlink */
+        struct kernfs_elem_attr   attr;     /* attribute (file) */
+    };
+
+    void     *priv;       /* kobject/attribute pointer */
+    kuid_t    uid;
+    kgid_t    gid;
+    struct kernfs_iattrs *iattr;
+};
+```
+
+`/sys` attributes go through: `sysfs_read_file → kernfs_fop_read_iter → kernfs_seq_show → attribute->show()`
+
+## sysctl: /proc/sys via sysfs-like API
+
+```c
+#include <linux/sysctl.h>
+
+static int my_value = 42;
+static int my_min = 0;
+static int my_max = 1000;
+
+static struct ctl_table mymod_table[] = {
+    {
+        .procname   = "my_value",
+        .data       = &my_value,
+        .maxlen     = sizeof(int),
+        .mode       = 0644,
+        .proc_handler = proc_dointvec_minmax,
+        .extra1     = &my_min,
+        .extra2     = &my_max,
+    },
+    { }  /* sentinel */
+};
+
+static struct ctl_table_header *mymod_sysctl;
+
+static int __init mymod_init(void)
+{
+    mymod_sysctl = register_sysctl("mymod", mymod_table);
+    /* Creates: /proc/sys/mymod/my_value */
+    return 0;
+}
+
+static void __exit mymod_exit(void)
+{
+    unregister_sysctl_table(mymod_sysctl);
+}
+```
+
+## Further reading
+
+- [VFS Objects](vfs-objects.md) — inode/dentry fundamentals
+- [Linux Device Model](../drivers/device-model.md) — kobject hierarchy in detail
+- [Sysctl Reference](../mm/sysctl-reference.md) — kernel tunables via /proc/sys
+- [Netlink](../net/netlink.md) — kernel-userspace messaging beyond /proc
+- `fs/proc/` — procfs implementation
+- `fs/sysfs/` and `fs/kernfs/` — sysfs/kernfs implementation
+- `include/linux/kobject.h`, `include/linux/device.h`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -231,6 +231,7 @@ nav:
     - Advanced:
       - Container Networking: net/container-networking.md
       - Kernel TLS (kTLS): net/ktls.md
+      - Netlink: net/netlink.md
     - Debugging & Observability:
       - Network Debugging with ss and ip: net/net-debugging.md
       - Network Tracing: net/net-tracing.md
@@ -279,6 +280,7 @@ nav:
       - splice, sendfile, copy_file_range: vfs/splice-sendfile.md
       - inotify and fanotify: vfs/inotify.md
       - Extended Attributes (xattr): vfs/xattr.md
+      - procfs and sysfs: vfs/procfs-sysfs.md
   - Block Layer:
     - Getting Started: block/README.md
     - Block Layer Overview: block/block-overview.md


### PR DESCRIPTION
## Summary

- **procfs and sysfs** (`docs/vfs/procfs-sysfs.md`): `proc_create` with `single_open`/`seq_read` for simple files, `seq_operations` (start/next/stop/show) for paginated multi-entry files (like `/proc/net/tcp`), `proc_dir_entry` fields, sysfs `kobject` create-and-add, `device_attribute`/`DEVICE_ATTR_RW`/`DEVICE_ATTR_RO`, attribute groups for bulk create/remove, `kernfs_node` backing store, `sysctl` `register_sysctl` for `/proc/sys` tunables
- **Netlink** (`docs/net/netlink.md`): `nlmsghdr` format with `NLM_F_*` flags, rtnetlink `RTM_GETLINK` dump with `rtattr` TLV parsing loop, `RTM_NEWROUTE` route insertion, genetlink multiplexer with `genl_register_family`/`genl_ops` (nl80211 example), multicast group subscription for hotplug/route events (`RTMGRP_LINK`), `SOCK_DIAG` for `ss` socket stats, libnl3 API

## Test plan

- [ ] `mkdocs build` passes with new VFS Advanced and Net Advanced entries
- [ ] `proc_ops` vs `file_operations` distinction noted (5.6+ uses proc_ops)
- [ ] Links to device-model.md, socket-layer.md, sysctl-reference.md resolve

Closes #415, #416
Part of #414