### PR TITLE
Add tracing advanced: ftrace histograms and perf profiling

### DIFF
--- a/docs/tracing/ftrace-advanced.md
+++ b/docs/tracing/ftrace-advanced.md
@@ -1,0 +1,245 @@
+# ftrace Advanced: Histograms, Triggers, and Function Tracing
+
+> Beyond basic tracing: aggregating data in-kernel without overhead
+
+## ftrace recap
+
+The basic ftrace interface lives at `/sys/kernel/debug/tracing/`. The [ftrace basics page](ftrace.md) covers the foundational setup. This page covers advanced features: in-kernel histograms, triggers, synthetic events, and the `function_graph` tracer.
+
+## Event triggers
+
+Triggers execute actions when a tracepoint fires, without copying data to the trace buffer:
+
+```bash
+# Trigger format: echo "action[:count]" > events/.../trigger
+# Actions: traceon, traceoff, snapshot, stacktrace, hist:...
+
+# Enable tracing when a specific process does a write():
+echo 'traceon if comm == "myapp"' > \
+    events/syscalls/sys_enter_write/trigger
+
+# Take a stack trace on every kmalloc > 1MB:
+echo 'stacktrace if bytes_req > 1048576' > \
+    events/kmem/kmalloc/trigger
+
+# Disable trigger:
+echo '!stacktrace if bytes_req > 1048576' > \
+    events/kmem/kmalloc/trigger
+```
+
+## Histogram triggers (hist:)
+
+Histograms aggregate event data **in the kernel**, reducing overhead compared to reading individual events:
+
+### Count by key
+
+```bash
+# Count syscalls by PID
+echo 'hist:keys=pid' > events/raw_syscalls/sys_enter/trigger
+sleep 5
+cat events/raw_syscalls/sys_enter/hist
+# { pid:   1234 } hitcount:   4521
+# { pid:   5678 } hitcount:    891
+# Totals: Hits: 5412, Entries: 2
+
+# Count by syscall number
+echo 'hist:keys=id' > events/raw_syscalls/sys_enter/trigger
+cat events/raw_syscalls/sys_enter/hist
+# { id:        0 } hitcount:  12345  # read
+# { id:        1 } hitcount:   8901  # write
+```
+
+### Aggregate values
+
+```bash
+# Sum bytes written per PID
+echo 'hist:keys=common_pid:vals=count:sort=count.descending' > \
+    events/syscalls/sys_enter_write/trigger
+
+# Latency histogram: how long does write() take?
+echo 'hist:keys=common_pid:vals=lat:sort=lat' > \
+    events/syscalls/sys_exit_write/trigger
+
+# Track kmalloc sizes: sum bytes per call_site
+echo 'hist:keys=call_site.sym:vals=bytes_req:sort=bytes_req.descending' > \
+    events/kmem/kmalloc/trigger
+cat events/kmem/kmalloc/hist
+# { call_site: ext4_write_begin [ext4] } bytes_req:  1048576
+# { call_site: tcp_sendmsg              } bytes_req:   524288
+```
+
+### Two-event latency measurement
+
+Measure time between pairs of events using `onmatch`:
+
+```bash
+# Measure read() latency: time from sys_enter to sys_exit
+echo 'hist:keys=common_pid:ts0=common_timestamp.usecs' > \
+    events/syscalls/sys_enter_read/trigger
+
+echo 'hist:keys=common_pid:
+    vals=lat:
+    lat=common_timestamp.usecs-$ts0:
+    onmatch(syscalls.sys_enter_read).trace(read_lat,$lat)' > \
+    events/syscalls/sys_exit_read/trigger
+
+# Or directly show the latency histogram:
+echo 'hist:keys=lat:
+    lat=common_timestamp.usecs-$ts0.usecs:
+    onmatch(syscalls.sys_enter_read).save(comm)' > \
+    events/syscalls/sys_exit_read/trigger
+```
+
+### Synthetic events: derived events from two sources
+
+```bash
+# Create a synthetic event that fires with latency data
+echo 'wakeup_latency u64 lat; pid_t pid; char comm[16]' > \
+    synthetic_events
+
+# Record start time on wakeup:
+echo 'hist:keys=pid:wakeup_ts=common_timestamp.usecs' > \
+    events/sched/sched_waking/trigger
+
+# On schedule-in: compute latency, fire synthetic event
+echo 'hist:keys=next_pid:
+    wakeup_lat=common_timestamp.usecs-$wakeup_ts:
+    onmatch(sched.sched_waking).wakeup_latency($wakeup_lat,next_pid,next_comm)' > \
+    events/sched/sched_switch/trigger
+
+# Enable the synthetic event
+echo 1 > events/synthetic/wakeup_latency/enable
+cat trace
+# wakeup_latency: lat=45 pid=1234 comm=myapp
+```
+
+## function_graph tracer
+
+`function_graph` traces both function entry and exit, showing the call tree with duration:
+
+```bash
+# Enable function_graph tracer
+echo function_graph > current_tracer
+
+# Run a command
+bash -c 'ls /tmp > /dev/null'
+
+cat trace | head -30
+# # tracer: function_graph
+# #
+# CPU  DURATION                  FUNCTION CALLS
+# |    |   |                     |   |   |   |
+# 0)   1.827 us   |            _raw_spin_lock_irqsave();
+# 0)   5.380 us   |          } /* _raw_spin_unlock_irqrestore */
+# 0) + 12.345 us  |        } /* mutex_lock */
+# 0)              |        vfs_read() {
+# 0)              |          rw_verify_area() {
+# 0)   0.384 us   |            security_file_permission();
+# 0)   2.183 us   |          } /* rw_verify_area */
+# 0)              |          new_sync_read() {
+# 0)   0.234 us   |            __vfs_read();
+# 0) + 45.123 us  |          } /* new_sync_read */
+# 0) + 52.456 us  |        } /* vfs_read */
+```
+
+`+` = >10µs, `!` = >100µs, `#` = >1ms, `@` = >10ms
+
+### Filter to specific functions
+
+```bash
+# Trace only VFS and ext4 functions
+echo 'vfs_* ext4_*' > set_ftrace_filter
+
+# Trace a specific function and its callees
+echo vfs_read > set_graph_function
+
+# Exclude internal functions (too noisy):
+echo '__irq_*' > set_graph_notrace
+```
+
+## function tracer with call graph
+
+The `function` tracer records every function call (very high overhead):
+
+```bash
+echo function > current_tracer
+
+# Limit to specific functions to reduce overhead:
+echo vfs_read > set_ftrace_filter
+echo 1 > function_profile_enabled
+
+# Wait, then show profile:
+cat function_profile/cpu0/ftrace_profile | sort -k2 -n -r | head -20
+# Function                 Hit    Time      Avg
+# vfs_read              12345  123456us   10.0us
+```
+
+### Dynamic function tracing
+
+```bash
+# Trace all calls to a specific module's functions:
+echo ':mod:ext4' > set_ftrace_filter
+
+# Trace functions matching a pattern:
+echo '*alloc*page*' > set_ftrace_filter
+
+# Show available functions:
+cat available_filter_functions | grep 'ext4_'
+```
+
+## Stack tracer: find stack depth offenders
+
+```bash
+# Enable stack tracer (built as module or CONFIG_STACK_TRACER)
+echo 1 > /proc/sys/kernel/stack_tracer_enabled
+
+# See maximum stack depth seen
+cat stack_trace
+# Depth    Size   Location    (42 entries)
+# -----    ----   --------
+#     0    6560   interrupt_entry+0x1a/0x20
+#     1    6536   do_IRQ+0x41/0xd0
+#     ...
+
+# Sort by stack depth
+cat stack_max_size
+# 6560
+```
+
+## trace-cmd: scripted ftrace
+
+`trace-cmd` is a userspace wrapper that simplifies ftrace usage:
+
+```bash
+# Record write() latency for 5 seconds
+trace-cmd record -e syscalls:sys_enter_write \
+                 -e syscalls:sys_exit_write \
+                 -p function_graph \
+                 -g vfs_write \
+                 sleep 5
+
+# View the report
+trace-cmd report | head -50
+
+# Visualize with KernelShark (GUI)
+kernelshark trace.dat
+```
+
+## perf with ftrace
+
+```bash
+# perf ftrace: uses ftrace under the hood
+perf ftrace -G vfs_read,vfs_write ls /tmp
+
+# Function latency profiling
+perf ftrace latency -T vfs_read -- dd if=/dev/zero of=/dev/null bs=4k count=10000
+```
+
+## Further reading
+
+- [ftrace](ftrace.md) — ftrace basics and setup
+- [Kprobes and Tracepoints](kprobes-tracepoints.md) — adding tracepoints to kernel code
+- [perf Events](perf-events.md) — perf-based profiling
+- [perf Profiling Advanced](perf-profiling.md) — flame graphs and off-CPU analysis
+- `Documentation/trace/histogram.rst` — histogram trigger documentation
+- `Documentation/trace/ftrace.rst` — full ftrace documentation

--- a/docs/tracing/perf-profiling.md
+++ b/docs/tracing/perf-profiling.md
@@ -1,0 +1,308 @@
+# perf Profiling Advanced
+
+> Flame graphs, off-CPU analysis, memory profiling, and scheduler tracing
+
+## perf record basics (recap)
+
+```bash
+# CPU profiling: sample at 99Hz for 30 seconds
+perf record -F 99 -a -g -- sleep 30
+
+# Profile a specific command
+perf record -F 999 -g ./my_program
+
+# Read report
+perf report --stdio | head -50
+```
+
+See [perf Events](perf-events.md) for fundamentals. This page covers advanced analysis.
+
+## Flame graphs: visualizing CPU time
+
+Flame graphs show the call stack hierarchy of where CPU time is spent. The x-axis is time (sorted alphabetically, not temporally); width represents time spent.
+
+### Generating flame graphs
+
+```bash
+# 1. Record with call graphs
+perf record -F 99 -a -g -- sleep 30
+# or for a specific process:
+perf record -F 99 -g -p <pid> -- sleep 30
+
+# 2. Convert to flame graph format (Brendan Gregg's tools)
+# Install: git clone https://github.com/brendangregg/FlameGraph
+perf script | \
+    /path/to/FlameGraph/stackcollapse-perf.pl | \
+    /path/to/FlameGraph/flamegraph.pl > cpu-flamegraph.svg
+
+# Open in browser
+open cpu-flamegraph.svg  # or firefox, chromium
+```
+
+### Differential flame graphs
+
+Compare before/after a change:
+
+```bash
+# Before change
+perf record -F 99 -g -o before.data -- ./workload
+perf script -i before.data | stackcollapse-perf.pl > before.folded
+
+# After change
+perf record -F 99 -g -o after.data -- ./workload
+perf script -i after.data | stackcollapse-perf.pl > after.folded
+
+# Generate differential flame graph
+difffolded.pl before.folded after.folded | flamegraph.pl > diff.svg
+# Blue = regressions (more time), Red = improvements (less time)
+```
+
+### Kernel symbols in flame graphs
+
+```bash
+# Ensure kernel symbols are readable:
+echo 0 > /proc/sys/kernel/kptr_restrict
+echo -1 > /proc/sys/kernel/perf_event_paranoid
+
+# For kernel modules: load debug symbols
+modprobe --force-modversion mymodule
+```
+
+## Off-CPU analysis: where threads are blocked
+
+**On-CPU** profiling shows where CPU time is spent. **Off-CPU** analysis shows where threads are *sleeping* — waiting for I/O, locks, page faults, etc.
+
+### Off-CPU with perf sched
+
+```bash
+# Record scheduler events
+perf sched record -- sleep 10
+
+# Show off-CPU time (time waiting to be scheduled)
+perf sched latency | head -30
+# -------------------------------------------------
+# Task                  |   Runtime ms  | Switches | Average delay ms | Maximum delay ms |
+# -------------------------------------------------
+# myapp:1234            |     1234.567  |     8901 |          0.138  |          12.345  |
+
+# Flame graph for scheduler latency
+perf sched script | \
+    stackcollapse-perf-sched.pl | \
+    flamegraph.pl --color=io > offcpu-flamegraph.svg
+```
+
+### Off-CPU with BPF (bpftrace)
+
+```bash
+# Trace time sleeping in do_nanosleep:
+bpftrace -e '
+kprobe:do_nanosleep { @start[tid] = nsecs; }
+kretprobe:do_nanosleep /@start[tid]/
+{
+    @sleep_ms = hist((nsecs - @start[tid]) / 1000000);
+    delete(@start[tid]);
+}'
+
+# Off-CPU profiling: sample stacks at blocking points
+bpftrace -e '
+tracepoint:sched:sched_switch
+/args->prev_state != 0 && args->prev_pid > 0/
+{
+    @stacks[ustack, kstack, args->prev_comm] = sum(1);
+}'
+```
+
+### Off-CPU with BCC offcputime
+
+```bash
+# Install BCC tools
+apt install bpfcc-tools python3-bpfcc
+
+# Profile off-CPU time for 30 seconds
+offcputime-bpfcc -f 30 | flamegraph.pl --color=io --title="Off-CPU Time" > offcpu.svg
+offcputime-bpfcc -f -p <pid> 30 > off-cpu.folded
+```
+
+## Memory profiling
+
+### Finding memory allocations with perf mem
+
+```bash
+# Record memory access events (requires hardware PMU support)
+perf mem record -a -- sleep 5
+perf mem report | head -30
+
+# Loads and stores with latency:
+perf c2c record -g -a -- sleep 5
+perf c2c report   # cache-to-cache transfer analysis
+```
+
+### perf malloc sampling
+
+```bash
+# Profile malloc calls using uprobes
+perf probe -x /lib/x86_64-linux-gnu/libc.so.6 malloc
+perf record -e probe_libc:malloc -a -g -- sleep 5
+perf report
+
+# Or with BCC:
+memleak-bpfcc -p <pid> 10
+# TOP 10 stacks with outstanding allocations:
+#    bytes      count     stack
+#  1048576        100     malloc -> myapp_allocate_buffer -> main
+```
+
+### Tracking page faults
+
+```bash
+# Count page faults per process
+perf stat -e page-faults,major-faults -p <pid> sleep 5
+
+# Find where page faults occur
+perf record -e page-faults -g -p <pid> -- sleep 5
+perf report | head -20
+
+# Minor vs major faults with bpftrace:
+bpftrace -e '
+tracepoint:exceptions:page_fault_user
+{
+    @faults[comm, args->error_code & 1 ? "minor" : "major"] = count();
+}'
+```
+
+## Scheduler analysis
+
+### Visualizing context switches
+
+```bash
+# Record scheduler events for a process
+perf sched record -p <pid> -- sleep 5
+
+# Show timeline: when was the task running vs sleeping?
+perf sched timehist | head -40
+# time   cpu   task name    wait time  sch delay  run time
+# ...    ...   myapp:1234   0.045ms    0.002ms    1.234ms
+
+# Replay in slow motion (simulation mode):
+perf sched replay
+```
+
+### Finding scheduler wakeup latency
+
+```bash
+# Record wakeup events
+perf record -e sched:sched_wakeup,sched:sched_switch -a -g -- sleep 10
+
+# Analyze with script
+perf script | awk '
+/sched_wakeup/ { wake[$3] = $1 }
+/sched_switch/ { if ($6 in wake) { print $6, $1 - wake[$6], "ms wakeup latency"; delete wake[$6] } }
+'
+```
+
+### runqlat: run queue latency histogram
+
+```bash
+# BCC tool: histogram of time tasks wait in run queue
+runqlat-bpfcc 5
+# Tracing run queue latency... Hit Ctrl-C to end.
+# usecs               : count     distribution
+#     0 -> 1          : 12345    |******************************|
+#     2 -> 3          : 4567     |***********                   |
+#     4 -> 7          : 1234     |***                           |
+#     8 -> 15         : 89       |                              |
+#    16 -> 31         : 12       |                              |
+#   64 -> 127         : 2        |                              |
+# 2048 -> 4095        : 1        |                              |  ← problem!
+
+# bpftrace equivalent:
+bpftrace -e '
+tracepoint:sched:sched_wakeup,
+tracepoint:sched:sched_wakeup_new
+{ @qtime[args->pid] = nsecs; }
+
+tracepoint:sched:sched_switch
+{
+    if (@qtime[args->next_pid]) {
+        @usecs = hist((nsecs - @qtime[args->next_pid]) / 1000);
+        delete(@qtime[args->next_pid]);
+    }
+}'
+```
+
+## Profiling with hardware counters
+
+```bash
+# Branch mispredictions (CPU pipeline stalls)
+perf stat -e branch-misses,branches ./my_program
+# branch-misses: 1,234,567  #  12.34% of all branches
+
+# Cache misses
+perf stat -e L1-dcache-load-misses,L1-dcache-loads,
+              LLC-load-misses,LLC-loads ./my_program
+
+# TLB misses (expensive: triggers page table walk)
+perf stat -e dTLB-load-misses,dTLB-loads ./my_program
+
+# Instruction-level profiling:
+perf record -e cycles:pp -g ./my_program   # precise sampling
+perf report --sort=sym,dso --stdio
+```
+
+### perf annotate: hot instruction identification
+
+```bash
+# See which instructions are hottest
+perf record -F 999 -g ./my_program
+perf annotate --stdio | head -60
+
+# Output:
+#  Percent |     Source code & Disassembly of my_program for cycles
+# -------------------------
+#          :    for (i = 0; i < N; i++) {
+#   42.34  :      400b23:  mov    (%rax,%rdx,8),%rcx   ← hot load
+#    0.01  :      400b27:  add    %rcx,%rbx
+#    0.12  :      400b2a:  inc    %rdx
+```
+
+## Linux perf for Java/JVM
+
+```bash
+# Enable JIT symbol mapping (requires perf-map-agent or async-profiler):
+java -XX:+PreserveFramePointer \
+     -agentpath:/path/to/libperfmap.so \
+     MyApp &
+
+# Record and generate flame graph
+perf record -F 99 -g -p $(pgrep java) -- sleep 30
+perf script | stackcollapse-perf.pl | flamegraph.pl > java-flamegraph.svg
+
+# async-profiler (better for JVM):
+./profiler.sh -d 30 -f flamegraph.html $(pgrep java)
+```
+
+## perf top: live profiling
+
+```bash
+# Live CPU usage by function (like 'top' for functions)
+perf top
+
+# Per-thread breakdown
+perf top -t <tid>
+
+# Kernel-only
+perf top -K
+
+# Show assembly
+perf top --disassembler-style=att
+```
+
+## Further reading
+
+- [perf Events](perf-events.md) — perf fundamentals, hardware counters
+- [ftrace Advanced](ftrace-advanced.md) — in-kernel histograms, function_graph
+- [Kprobes and Tracepoints](kprobes-tracepoints.md) — adding custom tracepoints
+- [MM Tracepoints](../mm/mm-tracepoints.md) — memory-specific tracing
+- [Scheduler Tracing](../sched/sched-tracing.md) — scheduler-specific perf
+- FlameGraph: `https://github.com/brendangregg/FlameGraph`
+- BCC tools: `https://github.com/iovisor/bcc`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -331,8 +331,10 @@ nav:
   - Tracing:
     - Getting Started: tracing/README.md
     - ftrace: tracing/ftrace.md
+    - ftrace Advanced: tracing/ftrace-advanced.md
     - Kprobes and Tracepoints: tracing/kprobes-tracepoints.md
     - perf Events: tracing/perf-events.md
+    - perf Profiling Advanced: tracing/perf-profiling.md
   - Kernel Modules:
     - Getting Started: modules/README.md
     - Writing and Loading Modules: modules/module-basics.md


### PR DESCRIPTION
## Summary

- **ftrace Advanced** (`docs/tracing/ftrace-advanced.md`): event trigger actions (traceon/traceoff/stacktrace), `hist:keys=` aggregation with values and sort, two-event latency measurement via `ts0=common_timestamp.usecs` + `onmatch`, synthetic events (`synthetic_events` file), `function_graph` tracer with duration markers (`+` >10µs, `!` >100µs, `#` >1ms), `set_graph_function` filter, function profiler, stack tracer, `trace-cmd record/report/kernelshark`
- **perf Profiling Advanced** (`docs/tracing/perf-profiling.md`): FlameGraph pipeline (`perf script | stackcollapse-perf.pl | flamegraph.pl`), differential flame graphs (`difffolded.pl`), off-CPU with `perf sched latency`, bpftrace blocking analysis, BCC `offcputime-bpfcc`, `perf mem`/`c2c` cache profiling, malloc sampling via uprobes/memleak, `runqlat` BCC + bpftrace equivalent, hardware counters (branch-misses/LLC-load-misses/TLB), `perf annotate` hot instructions, JVM profiling with async-profiler, `perf top`

## Test plan

- [ ] `mkdocs build` passes with new Tracing entries
- [ ] ftrace-advanced.md link to perf-profiling.md resolves (circular ref OK)
- [ ] FlameGraph GitHub URL in "Further reading" doesn't need to be live

Closes #419, #420
Part of #418