### PR TITLE
Add security advanced: Linux audit and credentials/user namespaces

### DIFF
--- a/docs/security/audit.md
+++ b/docs/security/audit.md
@@ -1,0 +1,259 @@
+# Linux Audit Subsystem
+
+> Mandatory security auditing: logging syscalls, file accesses, and user actions
+
+## What the audit subsystem does
+
+The Linux audit subsystem provides mandatory, tamper-resistant logging of security-relevant events:
+- Syscall execution (who called `open()`, `execve()`, `setuid()`?)
+- File access (who read `/etc/shadow`?)
+- Authentication events (PAM, sudo)
+- User/group changes
+- Network connections
+
+Unlike optional logging (`syslog`), audit records cannot be suppressed by the audited process — they're written by the kernel before the syscall returns.
+
+```bash
+# Start auditd (usually runs at boot)
+systemctl start auditd
+systemctl enable auditd
+
+# Log files
+/var/log/audit/audit.log         # audit records
+/etc/audit/audit.rules           # persistent rules
+/etc/audit/auditd.conf           # daemon configuration
+```
+
+## audit rules with auditctl
+
+```bash
+# Watch a file for reads and writes:
+auditctl -w /etc/shadow -p rwa -k shadow_access
+# -w: watch path, -p: permissions (r/w/x/a = read/write/exec/attr)
+# -k: key (search tag)
+
+# Watch a directory:
+auditctl -w /etc/audit/ -p wa -k audit_config_change
+
+# Audit a syscall:
+auditctl -a always,exit -F arch=b64 -S execve -k exec_tracking
+
+# Audit execve for specific users:
+auditctl -a always,exit -F arch=b64 -S execve \
+         -F uid=1000 -k user_execve
+
+# Audit privilege escalation:
+auditctl -a always,exit -F arch=b64 \
+         -S setuid -S setgid -S setresuid -S setresgid \
+         -k privilege_change
+
+# List current rules:
+auditctl -l
+
+# Delete all rules:
+auditctl -D
+
+# Make rules immutable (lock until reboot):
+auditctl -e 2
+```
+
+### Persistent rules
+
+```bash
+# /etc/audit/rules.d/50-my-rules.rules
+-w /etc/passwd -p wa -k identity
+-w /etc/group -p wa -k identity
+-w /etc/shadow -p wa -k identity
+
+-a always,exit -F arch=b64 -S execve -k execve
+
+# Apply rules at boot:
+augenrules --load  # merges /etc/audit/rules.d/*.rules
+```
+
+## Reading audit logs
+
+```bash
+# Raw format:
+grep "key=shadow_access" /var/log/audit/audit.log
+# type=SYSCALL msg=audit(1234567890.123:456):
+#   arch=c000003e syscall=2 success=yes exit=3
+#   a0=7fff123 a1=0 a2=0 a3=0
+#   items=1 ppid=1234 pid=5678 auid=1000 uid=0 gid=0 euid=0 suid=0
+#   fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0
+#   ses=1 comm="cat" exe="/usr/bin/cat" key="shadow_access"
+# type=CWD msg=audit(1234567890.123:456): cwd="/root"
+# type=PATH msg=audit(1234567890.123:456):
+#   item=0 name="/etc/shadow" inode=12345 dev=08:01
+#   mode=0100640 ouid=0 ogid=42 rdev=00:00
+
+# Pretty format with ausearch:
+ausearch -k shadow_access --interpret
+ausearch -x /usr/bin/sudo -i  # all sudo activity, interpreted
+
+# Summary with aureport:
+aureport --summary                # overview
+aureport -x --summary             # execve summary
+aureport -l                       # failed logins
+aureport -au                      # authentication events
+aureport --failed                 # all failed events
+
+# Recent events
+ausearch --start today --interpret | head -100
+ausearch --start recent -m EXECVE -i | tail -20
+```
+
+## Kernel implementation
+
+### struct audit_context
+
+Each syscall entry allocates (or reuses) an audit context:
+
+```c
+/* include/linux/audit.h */
+struct audit_context {
+    int           in_syscall; /* 1 if currently in syscall */
+    enum audit_state state;   /* AUDIT_DISABLED, AUDIT_BUILD_CONTEXT, AUDIT_RECORD_CONTEXT */
+    unsigned int  serial;     /* sequence number */
+    struct timespec64 ctime;  /* time of syscall entry */
+
+    int           major;      /* syscall number */
+    unsigned long argv[4];    /* syscall arguments */
+    long          return_code; /* syscall return value */
+    int           return_valid; /* 0: not yet returned */
+
+    int           name_count;
+    struct audit_names names[AUDIT_NAMES]; /* file paths accessed */
+    struct audit_names *names_list;
+
+    struct {
+        uid_t         loginuid; /* /proc/self/loginuid: original uid */
+        unsigned int  sessionid;
+    };
+
+    /* LSM-specific data */
+    void         *lsm_entry;
+};
+```
+
+### Audit record generation
+
+```c
+/* kernel/audit.c */
+void __audit_syscall_entry(int major, unsigned long a1,
+                            unsigned long a2, unsigned long a3,
+                            unsigned long a4)
+{
+    struct task_struct *t = current;
+    struct audit_context *context = audit_context();
+
+    if (!audit_enabled)
+        return;
+
+    /* Check if this syscall should be audited */
+    state = audit_filter_syscall(t, context);
+    if (state == AUDIT_DISABLED)
+        return;
+
+    context->major       = major;
+    context->argv[0]     = a1;
+    context->argv[1]     = a2;
+    context->argv[2]     = a3;
+    context->argv[3]     = a4;
+    context->in_syscall  = 1;
+    context->state       = state;
+    ktime_get_coarse_real_ts64(&context->ctime);
+}
+
+void __audit_syscall_exit(int success, long return_code)
+{
+    /* Called on syscall exit */
+    audit_log_exit();  /* write the SYSCALL record to audit buffer */
+    /* Sends via Netlink (NETLINK_AUDIT) to auditd */
+}
+```
+
+### Audit path records
+
+```c
+/* fs/namei.c: called when a file path is resolved */
+void audit_inode(struct filename *name, const struct dentry *dentry,
+                  unsigned int aflags)
+{
+    struct audit_context *context = audit_context();
+    struct audit_names *n;
+
+    if (!auditing_this_syscall(context))
+        return;
+
+    /* Record the path for the current syscall's audit record */
+    n = audit_alloc_name(context, AUDIT_TYPE_NORMAL);
+    n->name = name;
+    n->dentry = dget(dentry);
+    /* Written as TYPE=PATH record when syscall exits */
+}
+```
+
+## Audit from userspace: audit_log_user_message
+
+```c
+#include <libaudit.h>
+
+int audit_fd = audit_open();
+
+/* Log a custom security-relevant event */
+audit_log_user_message(audit_fd, AUDIT_USER_AUTH,
+                        "op=login acct=alice res=failed",
+                        NULL, NULL, NULL, 0);
+
+/* PAM uses this for authentication logging: */
+/* type=USER_AUTH msg=audit(1234567890.123:789): pid=5678 uid=1000
+   auid=1000 ses=1 op=login acct=alice res=failed */
+
+audit_close(audit_fd);
+```
+
+## Querying audit logs programmatically
+
+```bash
+# ausearch: powerful query tool
+# Find all execve of /bin/sh in the last hour:
+ausearch -x /bin/sh --start recent -i
+
+# Find who accessed /etc/sudoers:
+ausearch -f /etc/sudoers -i
+
+# Find setuid calls by a specific user:
+ausearch -ua 1000 -sc setuid -i
+
+# JSON output (auditd ≥ 3.0):
+ausearch --format enriched -i | head -50
+```
+
+## Integrity Measurement Architecture (IMA)
+
+IMA builds on audit to provide file integrity:
+
+```bash
+# IMA measures files before execution and logs to audit:
+# type=INTEGRITY_PCR msg=audit(...):
+#   pid=1234 uid=0 auid=0 ses=0
+#   op=hash_check
+#   cause=open_id
+#   comm="myapp" filename=/usr/bin/myapp
+#   dev="sda1" ino=12345
+#   integrity_status=pass
+
+# Enable IMA logging:
+echo "measure func=FILE_MMAP mask=MAY_EXEC" >> /etc/ima/ima-policy
+```
+
+## Further reading
+
+- [LSM Framework](lsm.md) — LSM hooks that feed audit
+- [Capabilities](capabilities.md) — capability changes trigger audit events
+- [seccomp BPF](seccomp.md) — syscall filtering; audit logs seccomp denials
+- [Credentials and User Namespaces](credentials.md) — audit's auid (login uid)
+- `kernel/audit.c` — audit core implementation
+- `kernel/auditsc.c` — syscall audit records
+- `man 8 auditctl`, `man 8 ausearch`, `man 8 aureport`

--- a/docs/security/credentials.md
+++ b/docs/security/credentials.md
@@ -1,0 +1,301 @@
+# Credentials and User Namespaces
+
+> struct cred, uid mapping, and capability inheritance across namespace boundaries
+
+## struct cred: task credentials
+
+Every task has a `struct cred` that holds its security identity:
+
+```c
+/* include/linux/cred.h */
+struct cred {
+    atomic_long_t usage;        /* reference count */
+
+    kuid_t        uid;          /* real UID */
+    kgid_t        gid;          /* real GID */
+    kuid_t        suid;         /* saved UID */
+    kgid_t        sgid;         /* saved GID */
+    kuid_t        euid;         /* effective UID (used for permission checks) */
+    kgid_t        egid;         /* effective GID */
+    kuid_t        fsuid;        /* UID for filesystem access */
+    kgid_t        fsgid;        /* GID for filesystem access */
+
+    kernel_cap_t  cap_inheritable; /* capabilities child can gain via execve */
+    kernel_cap_t  cap_permitted;   /* maximum allowed capabilities */
+    kernel_cap_t  cap_effective;   /* currently active capabilities */
+    kernel_cap_t  cap_bset;        /* capability bounding set */
+    kernel_cap_t  cap_ambient;     /* ambient capabilities (cross-exec) */
+
+    struct user_struct *user;
+    struct user_namespace *user_ns;  /* namespace this UID belongs to */
+
+    /* LSM blobs */
+    void *security;   /* selinux_cred, etc. */
+};
+```
+
+### Credential immutability
+
+Credentials are **copy-on-write**: to modify credentials, you prepare a new copy, modify it, then commit:
+
+```c
+/* kernel/cred.c */
+/* Example: setuid() implementation */
+int do_setuid(uid_t uid)
+{
+    struct cred *new;
+
+    /* Prepare a modifiable copy */
+    new = prepare_creds();
+    if (!new)
+        return -ENOMEM;
+
+    /* Modify the copy */
+    new->uid  = make_kuid(current_user_ns(), uid);
+    new->suid = new->uid;
+    new->euid = new->uid;
+
+    /* Commit atomically: replaces current->cred */
+    return commit_creds(new);
+    /* Old cred is freed when no references remain */
+}
+
+/* Reading credentials (always safe): */
+uid_t uid = current_uid().val;
+uid_t euid = current_euid().val;
+
+/* Or from any task: */
+uid_t uid = task_uid(task).val;
+```
+
+### The credential transition on execve
+
+```c
+/* security/commoncap.c */
+int cap_bprm_set_creds(struct linux_binprm *bprm)
+{
+    const struct cred *old = current_cred();
+    struct cred *new = bprm->cred;
+
+    /* For set-uid binary: */
+    if (uid_eq(new->euid, root_uid) ||
+        capable_wrt_inode_uidgid(&init_user_ns, file_inode(bprm->file),
+                                   CAP_SETUID)) {
+        new->euid = inode->i_uid;  /* set-uid: gain file owner's uid */
+    }
+
+    /* Capabilities:
+     * pP' = (pI & fI) | (fP & bounding_set)
+     * pE' = pP' & fE
+     * pI' = pI
+     *
+     * where:
+     *   p = process (old)
+     *   f = file capability bits
+     *   P = permitted, E = effective, I = inheritable
+     */
+    new->cap_permitted = cap_intersect(
+        cap_union(cap_intersect(old->cap_inheritable, fcaps->inheritable),
+                   cap_intersect(fcaps->permitted, old->cap_bset)),
+        old->cap_permitted);
+}
+```
+
+## User namespaces
+
+A **user namespace** creates a private mapping between UIDs/GIDs in the namespace and the host system. This allows:
+- Unprivileged container creation
+- "root" inside a container without host root
+- Capability isolation: root inside namespace ≠ root outside
+
+```bash
+# Create a user namespace (unprivileged):
+unshare --user --map-root-user bash
+# Inside: whoami → root
+# But: /proc/self/uid_map shows we're mapped to our real UID
+
+cat /proc/self/uid_map
+# 0     1000    1   (UID 0 in ns = UID 1000 on host; 1 UID mapped)
+```
+
+### uid_map and gid_map
+
+```bash
+# /proc/<pid>/uid_map format:
+# <ns-uid-start> <host-uid-start> <count>
+
+# Typical single-user mapping (for a container):
+# 0     100000    65536
+# UIDs 0-65535 in the namespace map to 100000-165535 on the host
+
+# Write the mapping (from parent namespace or privileged):
+echo "0 1000 1" > /proc/<pid>/uid_map
+echo "0 1000 1" > /proc/<pid>/gid_map
+# Note: requires either: be the process itself (unshare), or CAP_SETUID on host
+```
+
+### newuidmap / newgidmap
+
+```bash
+# For containers with range mappings:
+# /etc/subuid and /etc/subgid define allowed ranges:
+cat /etc/subuid
+# alice:100000:65536
+# (alice can use UIDs 100000-165535 for container mappings)
+
+# Map container UIDs:
+newuidmap <pid> 0 1000 1 1 100000 65536
+# UID 0 in container = 1000 on host (1 UID)
+# UIDs 1-65536 in container = 100000-165535 on host
+
+newgidmap <pid> 0 1000 1 1 100000 65536
+```
+
+## Kernel: UID translation
+
+When the kernel resolves UIDs for permission checks, it always works with **k**uids (kernel UIDs) that map to the initial user namespace:
+
+```c
+/* include/linux/uidgid.h */
+typedef struct {
+    uid_t val;
+} kuid_t;  /* always in the initial user namespace */
+
+/* Translate from namespace to kernel uid: */
+kuid_t kuid = make_kuid(current_user_ns(), ns_uid);
+/* Translate back: */
+uid_t  ns_uid = from_kuid(current_user_ns(), kuid);
+
+/* Check if a kuid is valid in a namespace: */
+if (!uid_valid(kuid))
+    return -EINVAL;
+
+/* Check ownership: */
+if (!uid_eq(kuid, file_inode->i_uid))
+    return -EACCES;
+```
+
+### struct user_namespace
+
+```c
+/* include/linux/user_namespace.h */
+struct user_namespace {
+    struct uid_gid_map uid_map;    /* uid translations */
+    struct uid_gid_map gid_map;
+    struct uid_gid_map projid_map;
+
+    struct user_namespace *parent; /* enclosing namespace */
+    int level;                     /* nesting depth (max 32) */
+    kuid_t owner;                  /* creator's kuid in parent ns */
+    kgid_t group;                  /* creator's kgid in parent ns */
+
+    struct ns_common ns;
+    unsigned long flags;
+
+    /* /proc/<pid>/uid_map + gid_map */
+    struct list_head  keyring_name_list;
+    struct key        *user_keyring_register;
+
+    /* Per-namespace process limits */
+    ucount_t         ucounts;
+};
+```
+
+## Capabilities across namespaces
+
+Capabilities are **namespace-scoped**: having `CAP_NET_ADMIN` in a network namespace only grants control over that namespace's network stack.
+
+```bash
+# Check capabilities in a namespace:
+capsh --print
+# Current: =
+# cap_net_admin+eip  (only net_admin effective/inheritable/permitted)
+
+# Run a process with specific capabilities:
+capsh --caps='cap_net_admin+eip cap_sys_admin+eip' -- -c 'ip link add ...'
+
+# Container with only net_admin (via Docker):
+docker run --cap-drop=ALL --cap-add=NET_ADMIN myimage
+```
+
+```c
+/* capability check: is the process allowed? */
+bool capable(int cap)
+{
+    return ns_capable(&init_user_ns, cap);
+}
+
+bool ns_capable(struct user_namespace *ns, int cap)
+{
+    /* Check effective capability in the given namespace */
+    return security_capable(current_cred(), ns, cap, CAP_OPT_NONE) == 0;
+}
+
+/* For filesystem operations: check against file's namespace */
+bool capable_wrt_inode_uidgid(struct user_namespace *ns,
+                                const struct inode *inode, int cap)
+{
+    /* Capable if we have cap in the ns where the inode's uid is mapped */
+    struct user_namespace *inode_ns = inode->i_sb->s_user_ns;
+    return ns_capable(inode_ns, cap);
+}
+```
+
+## The loginuid: audit identity
+
+`/proc/self/loginuid` records the original user who logged in, even after `su`/`sudo`:
+
+```bash
+# After ssh login as alice:
+cat /proc/self/loginuid    # 1000 (alice's UID)
+
+# After sudo su:
+id                         # uid=0(root) ...
+cat /proc/self/loginuid    # 1000 (still alice!)
+
+# This is what audit uses for auid (audit uid):
+ausearch -ua 1000          # find all alice's actions, even as root
+```
+
+```c
+/* set on login via PAM: */
+/* /proc/<pid>/loginuid is backed by task->loginuid */
+kuid_t task_loginuid(const struct task_struct *t)
+{
+    return t->loginuid;
+}
+
+/* Cannot be changed after first set (without CAP_AUDIT_CONTROL) */
+```
+
+## Observing credential changes
+
+```bash
+# Trace setuid/setgid calls
+bpftrace -e '
+tracepoint:syscalls:sys_enter_setuid {
+    printf("%s(%d) setuid(%d)\n", comm, pid, args->uid);
+}'
+
+# Watch capability use
+bpftrace -e '
+kprobe:cap_capable {
+    printf("%s: checking cap %d in ns %p\n", comm, arg2, arg1);
+}'
+
+# Track credential changes (execve, setuid, etc.)
+auditctl -a always,exit -F arch=b64 \
+    -S execve -S setuid -S setresuid -S setresgid \
+    -k cred_change
+ausearch -k cred_change -i | tail -20
+```
+
+## Further reading
+
+- [Capabilities](capabilities.md) — capability bit reference
+- [LSM Framework](lsm.md) — LSM hooks on credential transitions
+- [Namespaces](../cgroups/namespaces.md) — user namespace with other namespaces
+- [Container Isolation](../cgroups/container-isolation.md) — practical container security
+- [Linux Audit](audit.md) — audit uses loginuid for auid
+- `kernel/cred.c` — credential lifecycle
+- `kernel/user_namespace.c` — user namespace implementation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -350,6 +350,8 @@ nav:
     - LSM Framework: security/lsm.md
     - Capabilities: security/capabilities.md
     - seccomp BPF: security/seccomp.md
+    - Linux Audit: security/audit.md
+    - Credentials and User Namespaces: security/credentials.md
   - Virtualization:
     - Getting Started: virtualization/README.md
     - KVM Architecture: virtualization/kvm-arch.md


### PR DESCRIPTION
## Summary

- **Linux Audit** (`docs/security/audit.md`): `auditctl -w` file watches with `-p rwa` permissions and `-k` keys, `-a always,exit -S execve` syscall rules, `augenrules --load`, `ausearch`/`aureport` queries, `struct audit_context` (serial/major/argv/names), `__audit_syscall_entry`/`__audit_syscall_exit` kernel path, `audit_inode` path recording, `libaudit` `audit_log_user_message` API, IMA integrity measurement
- **Credentials and User Namespaces** (`docs/security/credentials.md`): `struct cred` fields (uid/euid/fsuid/cap_permitted/cap_effective/cap_ambient), copy-on-write `prepare_creds`/`commit_creds`, capability transition formula on execve (pP'=(pI∩fI)∪(fP∩bset)), user namespace `uid_map`/`gid_map` translation, `newuidmap`/`newgidmap`, `kuid_t` always-initial-ns design, `struct user_namespace` parent chain, `ns_capable` namespace-scoped checks, `loginuid` audit identity survives `su`/`sudo`

## Test plan

- [ ] `mkdocs build` passes with new Security entries
- [ ] `audit.md` references `credentials.md` (loginuid → auid) and vice versa
- [ ] Links to lsm.md, capabilities.md, namespaces.md resolve

Closes #423, #424
Part of #422