### PR TITLE
Add real-time Linux tuning and Device Tree docs

### DIFF
--- a/docs/drivers/device-tree.md
+++ b/docs/drivers/device-tree.md
@@ -1,0 +1,443 @@
+# Device Tree: ARM Hardware Description
+
+> DTS syntax, of_ API, platform driver binding, and DT overlays
+
+## What is a Device Tree?
+
+On x86, the kernel discovers hardware at runtime (ACPI, PCI enumeration). On ARM and other embedded platforms, hardware is not self-describing — a **Device Tree** (DT) is a static description passed from the bootloader to the kernel:
+
+```
+Bootloader (U-Boot)
+  → loads kernel Image + DTB (device tree blob) into RAM
+  → sets x0 = 0 (PSCI) + x1 = DTB address
+  → jumps to kernel entry point
+
+Kernel:
+  → setup_machine_fdt(dtb) maps and parses the blob
+  → creates struct device nodes for each hardware block
+  → platform drivers bind to nodes via compatible string
+```
+
+## DTS syntax
+
+Device tree source (`.dts`) is compiled to binary blob (`.dtb`) with `dtc`:
+
+```dts
+/* arch/arm64/boot/dts/example.dts */
+/dts-v1/;
+
+/ {
+    model = "My Board v1.0";
+    compatible = "myvendor,myboard";
+    #address-cells = <1>;    /* 1 u32 for addresses */
+    #size-cells = <1>;       /* 1 u32 for sizes */
+
+    /* CPUs */
+    cpus {
+        #address-cells = <1>;
+        #size-cells = <0>;
+        cpu@0 {
+            compatible = "arm,cortex-a53";
+            device_type = "cpu";
+            reg = <0>;
+            enable-method = "psci";
+        };
+    };
+
+    /* Memory */
+    memory@80000000 {
+        device_type = "memory";
+        reg = <0x80000000 0x40000000>;  /* 1GB at 0x80000000 */
+    };
+
+    /* SoC peripherals */
+    soc {
+        compatible = "simple-bus";
+        #address-cells = <1>;
+        #size-cells = <1>;
+        ranges;                          /* identity mapping */
+
+        uart0: serial@11000000 {
+            compatible = "ns16550a";
+            reg = <0x11000000 0x1000>;   /* MMIO base + size */
+            interrupts = <0 32 4>;       /* type SPI, irq 32, active-low level */
+            clocks = <&uart_clk>;
+            clock-names = "baudclk";
+            current-speed = <115200>;
+            status = "okay";             /* "disabled" to exclude */
+        };
+
+        i2c0: i2c@12000000 {
+            compatible = "myvendor,i2c-v1";
+            reg = <0x12000000 0x100>;
+            interrupts = <0 40 4>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+            clock-frequency = <400000>;  /* 400kHz fast mode */
+            status = "okay";
+
+            /* I2C device at address 0x48 */
+            temp_sensor: temperature@48 {
+                compatible = "ti,tmp102";
+                reg = <0x48>;
+            };
+        };
+
+        gpio: gpio@13000000 {
+            compatible = "myvendor,gpio";
+            reg = <0x13000000 0x1000>;
+            #gpio-cells = <2>;           /* pin + flags */
+            gpio-controller;
+            interrupt-controller;
+            #interrupt-cells = <2>;
+        };
+    };
+};
+```
+
+```bash
+# Compile DTS to DTB:
+dtc -I dts -O dtb -o board.dtb board.dts
+
+# Decompile DTB back to DTS:
+dtc -I dtb -O dts -o board.dts board.dtb
+
+# Dump live DTB from running kernel:
+dtc -I dtb -O dts /proc/device-tree > running.dts
+# or:
+ls /proc/device-tree/
+```
+
+## DTSI includes
+
+```dts
+/* SoC-level DTSI (shared hardware description): */
+/* arch/arm64/boot/dts/myvendor/myvendor-soc.dtsi */
+/ {
+    soc {
+        uart0: serial@11000000 {
+            compatible = "ns16550a";
+            reg = <0x11000000 0x1000>;
+            status = "disabled";         /* off by default */
+        };
+    };
+};
+
+/* Board-level DTS (board-specific configuration): */
+#include "myvendor-soc.dtsi"
+/ {
+    model = "My Board v1.0";
+    &uart0 {
+        status = "okay";             /* enable for this board */
+        current-speed = <115200>;
+    };
+};
+```
+
+## Platform driver binding
+
+### The compatible string
+
+The kernel matches DT nodes to drivers via the `compatible` property:
+
+```c
+/* drivers/tty/serial/ns16550.c */
+
+/* Device table: matches "compatible" strings in DTS */
+static const struct of_device_id ns16550_of_match[] = {
+    { .compatible = "ns16550a",   .data = &ns16550_config },
+    { .compatible = "ns16550",    .data = &ns16550_config },
+    { .compatible = "snps,dw-apb-uart", .data = &dw_apb_config },
+    { /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, ns16550_of_match);
+
+static struct platform_driver ns16550_driver = {
+    .probe   = ns16550_probe,
+    .remove  = ns16550_remove,
+    .driver  = {
+        .name           = "ns16550",
+        .of_match_table = ns16550_of_match,   /* DT binding */
+        .pm             = &ns16550_pm_ops,
+    },
+};
+module_platform_driver(ns16550_driver);
+```
+
+### probe() reading DT properties
+
+```c
+static int ns16550_probe(struct platform_device *pdev)
+{
+    struct device *dev = &pdev->dev;
+    struct device_node *np = dev->of_node;   /* DT node */
+    struct ns16550_port *port;
+    struct resource *res;
+    u32 clk_freq;
+    int irq, ret;
+
+    port = devm_kzalloc(dev, sizeof(*port), GFP_KERNEL);
+    if (!port)
+        return -ENOMEM;
+
+    /* Get MMIO resource from DT "reg" property */
+    res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+    port->base = devm_ioremap_resource(dev, res);
+    if (IS_ERR(port->base))
+        return PTR_ERR(port->base);
+
+    /* Get IRQ from DT "interrupts" property */
+    irq = platform_get_irq(pdev, 0);
+    if (irq < 0)
+        return irq;
+
+    /* Read a u32 property */
+    ret = of_property_read_u32(np, "current-speed", &port->baud);
+    if (ret)
+        port->baud = 115200;     /* default */
+
+    /* Read a string property */
+    const char *str;
+    ret = of_property_read_string(np, "clock-names", &str);
+
+    /* Read an array of u32s */
+    u32 clk_vals[2];
+    ret = of_property_read_u32_array(np, "clock-frequency", clk_vals, 2);
+
+    /* Check a boolean property */
+    if (of_property_read_bool(np, "fifo-enable"))
+        port->has_fifo = true;
+
+    /* Get a GPIO */
+    port->reset_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_LOW);
+
+    /* Get a clock */
+    port->clk = devm_clk_get(dev, "baudclk");
+    if (!IS_ERR(port->clk)) {
+        clk_prepare_enable(port->clk);
+        port->uartclk = clk_get_rate(port->clk);
+    }
+
+    /* Get a regulator */
+    port->vdd = devm_regulator_get_optional(dev, "vdd");
+
+    ret = devm_request_irq(dev, irq, ns16550_isr, 0, dev_name(dev), port);
+    if (ret)
+        return ret;
+
+    return uart_add_one_port(&ns16550_uart_driver, &port->uart);
+}
+```
+
+## of_ API reference
+
+```c
+/* Node lookup */
+struct device_node *of_find_compatible_node(struct device_node *from,
+                                             const char *type,
+                                             const char *compatible);
+struct device_node *of_find_node_by_phandle(phandle handle);
+struct device_node *of_get_parent(const struct device_node *node);
+struct device_node *of_get_next_child(const struct device_node *node,
+                                       struct device_node *prev);
+
+/* Property reading */
+int of_property_read_u32(const struct device_node *np,
+                          const char *propname, u32 *out_value);
+int of_property_read_u64(const struct device_node *np,
+                          const char *propname, u64 *out_value);
+int of_property_read_string(const struct device_node *np,
+                             const char *propname, const char **out_string);
+int of_property_read_u32_array(const struct device_node *np,
+                                const char *propname,
+                                u32 *out_values, size_t sz);
+bool of_property_read_bool(const struct device_node *np,
+                            const char *propname);
+
+/* Address translation */
+int of_address_to_resource(struct device_node *dev, int index,
+                             struct resource *r);
+void __iomem *of_iomap(struct device_node *node, int index);
+
+/* IRQ mapping */
+int of_irq_get(struct device_node *dev, int index);
+int of_irq_count(struct device_node *dev);
+```
+
+## Phandles and cross-references
+
+```dts
+/* Phandles allow nodes to reference other nodes */
+clocks {
+    uart_clk: uart_clk {
+        compatible = "fixed-clock";
+        #clock-cells = <0>;
+        clock-frequency = <24000000>;   /* 24MHz */
+    };
+
+    spi_clk: spi_clk {
+        compatible = "fixed-clock";
+        #clock-cells = <0>;
+        clock-frequency = <48000000>;
+    };
+};
+
+uart0: serial@11000000 {
+    clocks = <&uart_clk>;            /* phandle reference */
+    clock-names = "baudclk";
+};
+
+/* GPIO reference with args */
+leds {
+    led-red {
+        gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;  /* gpio node, pin 5, active high */
+    };
+};
+```
+
+```c
+/* Resolve a phandle reference in driver: */
+struct device_node *clk_node = of_parse_phandle(np, "clocks", 0);
+
+/* Or use the clock framework abstraction: */
+struct clk *clk = of_clk_get_by_name(np, "baudclk");
+```
+
+## Device Tree overlays (DTO)
+
+Overlays allow dynamic modification of the live DT (e.g., Raspberry Pi hats):
+
+```dts
+/* overlay.dts - add a sensor on i2c0 */
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "raspberrypi,3-model-b";
+
+    fragment@0 {
+        target = <&i2c0>;
+        __overlay__ {
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            bmp280@76 {
+                compatible = "bosch,bmp280";
+                reg = <0x76>;
+            };
+        };
+    };
+};
+```
+
+```bash
+# Compile overlay:
+dtc -I dts -O dtb -o my-overlay.dtbo my-overlay.dts
+
+# Apply overlay at runtime (Raspberry Pi / configfs):
+mkdir /sys/kernel/config/device-tree/overlays/my-overlay
+cat my-overlay.dtbo > /sys/kernel/config/device-tree/overlays/my-overlay/dtbo
+
+# Remove overlay:
+rmdir /sys/kernel/config/device-tree/overlays/my-overlay
+
+# Check applied overlays:
+ls /sys/kernel/config/device-tree/overlays/
+```
+
+## Debugging Device Trees
+
+```bash
+# Live DT as filesystem:
+ls /proc/device-tree/
+cat /proc/device-tree/model
+# My Board v1.0
+
+# sysfs: platform devices created from DT:
+ls /sys/bus/platform/devices/
+# 11000000.serial  12000000.i2c  ...
+
+# Check driver binding:
+ls -la /sys/bus/platform/devices/11000000.serial/driver
+# → /sys/bus/platform/drivers/ns16550
+
+# Dump all DT nodes matching a compatible:
+grep -r "compatible" /proc/device-tree/ 2>/dev/null | head -20
+
+# dtc on live kernel:
+apt install device-tree-compiler
+dtc -I fs /proc/device-tree 2>/dev/null | grep -A5 "serial@"
+
+# Check for DT probe failures:
+dmesg | grep -E "of_platform|platform|DT" | head -20
+
+# Device Tree statistics:
+cat /sys/kernel/debug/of_platform_bus/stats 2>/dev/null
+
+# Find what matched a node:
+cat /sys/bus/platform/devices/11000000.serial/of_node/compatible
+# ns16550a
+
+# fdt_probe_driver: check why driver didn't probe
+dmesg | grep "11000000.serial"
+# [    1.234] 11000000.serial: ttyS0 at MMIO 0x11000000 (irq = 32, ...) is a NS16550A
+```
+
+## Platform device lifecycle
+
+```
+DT blob → of_platform_populate() → creates struct platform_device for each node
+                                                      ↓
+                             platform_device.name = "11000000.serial"
+                             platform_device.dev.of_node = &dt_node
+                             platform_device.resource[] = [MMIO, IRQ]
+                                                      ↓
+                        platform_driver registered → of_match_table checked
+                                                      ↓
+                                    probe() called with struct platform_device *
+```
+
+```c
+/* During boot: arch/arm64/kernel/setup.c */
+of_platform_populate(NULL, of_default_bus_match_table, NULL, NULL);
+/* Creates platform_device for every node with compatible that matches
+   of_default_bus_match_table (includes "simple-bus", etc.) */
+
+/* struct platform_device handed to probe(): */
+struct platform_device {
+    const char      *name;          /* "11000000.serial" */
+    int             id;             /* -1 if from DT */
+    struct device   dev;            /* contains of_node pointer */
+    u32             num_resources;
+    struct resource *resource;      /* MMIO base+size, IRQ */
+};
+```
+
+## DT vs ACPI
+
+| Feature | Device Tree | ACPI |
+|---------|-------------|------|
+| Platform | ARM, RISC-V, PowerPC | x86, ARM64 servers |
+| Description | Static DTS file compiled to DTB | AML bytecode in BIOS |
+| Discovery | of_match_table in driver | HID/CID in ACPI tables |
+| Updates | DT overlays, reboot | DSDT patches |
+| Debug | /proc/device-tree, dtc | acpidump, acpiexec |
+| Clocks | DT clock framework | ACPI _CRS |
+| Power | DT regulators, PSCI | ACPI _PSx methods |
+
+```bash
+# Check if system uses ACPI or DT:
+ls /proc/device-tree  2>/dev/null && echo "Device Tree" || echo "ACPI/other"
+ls /sys/firmware/acpi 2>/dev/null && echo "ACPI present"
+```
+
+## Further reading
+
+- [PCI Drivers](pci-driver.md) — PCI device binding (vs DT platform binding)
+- [IRQ Affinity](../interrupts/irq-affinity.md) — DT interrupt-controller binding
+- [Preemption Model](../sched/preemption.md) — RT on embedded/ARM
+- [Real-Time Tuning](../sched/rt-tuning.md) — PREEMPT_RT for ARM
+- `Documentation/devicetree/bindings/` — DT binding specifications
+- `drivers/of/` — of_ API implementation
+- `scripts/dtc/` — Device Tree Compiler
+- `arch/arm64/boot/dts/` — upstream DTS files

--- a/docs/sched/rt-tuning.md
+++ b/docs/sched/rt-tuning.md
@@ -1,0 +1,319 @@
+# Real-Time Linux Tuning Guide
+
+> Achieving deterministic low-latency with PREEMPT_RT: CPU isolation, memory locking, and IRQ management
+
+## What "real-time" means on Linux
+
+A real-time system guarantees a **worst-case response time** — not just average latency. Linux with PREEMPT_RT can achieve:
+- `cyclictest` worst-case latency: **10-100µs** (vs 1-100ms without RT)
+- Suitable for: audio processing, industrial control, motor drives, trading systems
+
+The key components:
+1. `PREEMPT_RT` kernel (sleeping spinlocks, threaded IRQs)
+2. CPU isolation (no kernel threads, no interrupts)
+3. Memory locking (no page faults)
+4. High-priority SCHED_FIFO tasks
+5. Disabled CPU frequency scaling
+
+## Step 1: Install PREEMPT_RT kernel
+
+```bash
+# Check if current kernel has RT:
+uname -v | grep -i preempt
+# #1 SMP PREEMPT_RT ... → RT kernel
+# #1 SMP PREEMPT ...    → non-RT full preemption
+
+# Debian/Ubuntu: install RT kernel
+apt-get install linux-image-rt-amd64
+# or build from source with CONFIG_PREEMPT_RT=y
+
+# Verify RT features:
+zcat /proc/config.gz | grep -E "PREEMPT_RT|PREEMPT_LAZY"
+# CONFIG_PREEMPT_RT=y
+
+# Check for RT patches not in mainline:
+# For older kernels: https://wiki.linuxfoundation.org/realtime/start
+```
+
+## Step 2: CPU isolation with boot parameters
+
+```bash
+# /etc/default/grub:
+GRUB_CMDLINE_LINUX="isolcpus=2,3 nohz_full=2,3 rcu_nocbs=2,3 irqaffinity=0,1"
+# Update grub:
+update-grub && reboot
+
+# After reboot:
+# - CPUs 2,3: isolated from load balancer, tickless
+# - CPUs 0,1: handle all interrupts, kernel threads
+# - irqaffinity=0,1: IRQs only on CPUs 0,1
+
+# Verify isolation:
+cat /sys/devices/system/cpu/isolated    # 2,3
+cat /sys/devices/system/cpu/nohz_full   # 2,3
+```
+
+## Step 3: Move kernel threads off RT CPUs
+
+```bash
+# Move all movable kernel threads to CPUs 0,1:
+for pid in $(ps -eo pid,comm | grep -E "^\s*[0-9]+ \[" | awk '{print $1}'); do
+    taskset -p 3 $pid 2>/dev/null  # mask=0x3 = CPUs 0,1
+done
+
+# Or use tuna (recommended):
+tuna --cpus=2,3 --isolate   # moves all non-isolated tasks away
+
+# Verify: no kernel threads on CPUs 2,3
+ps -eo pid,psr,comm | awk '$2==2 || $2==3' | grep "\["
+# (should be empty or only [irq/...] which will be moved next)
+```
+
+## Step 4: IRQ affinity
+
+```bash
+# Move all interrupts to CPUs 0,1:
+for irq_dir in /proc/irq/*/; do
+    irq=$(basename $irq_dir)
+    [ "$irq" = "0" ] && continue  # keep timer on CPU 0
+    cat $irq_dir/smp_affinity_list 2>/dev/null | grep -q "[23]" && \
+        echo "0,1" > $irq_dir/smp_affinity_list 2>/dev/null
+done
+
+# Stop irqbalance from undoing this:
+systemctl stop irqbalance
+systemctl disable irqbalance
+
+# Verify:
+cat /proc/interrupts | awk 'NR>1{print $1, $NF}' | head -20
+```
+
+## Step 5: Memory locking (prevent page faults)
+
+Page faults are unpredictable. Real-time applications must lock all memory:
+
+```c
+#include <sys/mman.h>
+#include <sched.h>
+
+/* Lock all current and future pages */
+mlockall(MCL_CURRENT | MCL_FUTURE);
+/* MCL_CURRENT: lock existing mappings */
+/* MCL_FUTURE: lock all future mmap/malloc */
+
+/* Pre-fault the stack */
+#define STACK_SIZE (8 * 1024 * 1024)  /* 8MB */
+char stack_prefault[STACK_SIZE];
+memset(stack_prefault, 0, sizeof(stack_prefault));
+
+/* Pre-fault heap (malloc will use pages already touched) */
+void *heap = malloc(HEAP_SIZE);
+memset(heap, 0, HEAP_SIZE);
+
+/* Now: no page faults during RT operation */
+```
+
+```bash
+# System-wide: allow unlimited locked memory for RT tasks
+# /etc/security/limits.conf:
+echo "@realtime - memlock unlimited" >> /etc/security/limits.conf
+# Or just for root (already unlimited usually)
+```
+
+## Step 6: SCHED_FIFO task priority
+
+```c
+#include <sched.h>
+
+/* Set SCHED_FIFO priority 80 (out of 1-99) */
+struct sched_param param = { .sched_priority = 80 };
+sched_setscheduler(0, SCHED_FIFO, &param);
+/* SCHED_FIFO: runs until it blocks or yields; preempts SCHED_OTHER */
+/* SCHED_RR: like FIFO but with a time quantum (round-robin within priority) */
+
+/* Pin to isolated CPU 2 */
+cpu_set_t cpuset;
+CPU_ZERO(&cpuset);
+CPU_SET(2, &cpuset);
+sched_setaffinity(0, sizeof(cpuset), &cpuset);
+
+/* Main RT loop */
+while (1) {
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_activation, NULL);
+
+    /* Do real-time work here */
+    do_work();
+
+    /* Calculate next activation */
+    next_activation.tv_nsec += PERIOD_NS;
+    if (next_activation.tv_nsec >= 1000000000LL) {
+        next_activation.tv_nsec -= 1000000000LL;
+        next_activation.tv_sec++;
+    }
+}
+```
+
+```bash
+# Set process priority from shell:
+chrt -f 80 ./my_rt_program    # SCHED_FIFO prio 80
+chrt -r 80 ./my_rt_program    # SCHED_RR prio 80
+chrt -d --deadline 1000000 --period 10000000 --runtime 500000 ./my_rt_prog
+
+# Check:
+chrt -p <pid>
+# scheduling policy: SCHED_FIFO
+# scheduling priority: 80
+```
+
+## Step 7: Disable CPU frequency scaling
+
+CPU frequency changes add latency:
+
+```bash
+# Set performance governor on all CPUs:
+for cpu in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+    echo performance > $cpu 2>/dev/null
+done
+
+# Disable turbo boost (can cause frequency spikes):
+echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
+# or:
+echo 0 > /sys/devices/system/cpu/cpufreq/boost
+
+# Verify:
+cat /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
+# performance
+cat /proc/cpuinfo | grep MHz | head -4
+# All CPUs at max fixed frequency
+```
+
+## Measuring latency with cyclictest
+
+`cyclictest` is the standard tool for measuring scheduling latency:
+
+```bash
+# Install:
+apt install rt-tests
+
+# Basic test: measure wakeup latency on isolated CPU 2
+cyclictest --cpu=2 --priority=80 --policy=fifo \
+           --interval=1000 --duration=60 \
+           --mlockall --threads=1 \
+           --histogram=200 --histfile=/tmp/hist.dat
+
+# Output:
+# T: 0 ( 1234) P:80 I:1000 C:  60000 Min:      8 Act:     12 Avg:     11 Max:      87
+#                                                      ↑           ↑           ↑
+#                                                   min µs      avg µs      max µs
+
+# With RT kernel + isolation: Max should be < 100µs
+# Without: Max can be > 1ms
+
+# Stress test: run with load to find worst case
+cyclictest --cpu=2 -p80 -i1000 -d60 -m -q &
+# Simultaneously generate load:
+hackbench -l 100000 &
+stress-ng --cpu 6 --io 4 --vm 2 --vm-bytes 256M &
+```
+
+### Generating latency histogram
+
+```bash
+# Run with histogram output
+cyclictest -p80 -m -n -i200 -l1000000 --histogram=200 > /tmp/histogram.dat
+
+# Plot with gnuplot:
+cat << 'EOF' > plot.gp
+set terminal png
+set output "latency_histogram.png"
+set xlabel "Latency (µs)"
+set ylabel "Frequency"
+plot '/tmp/histogram.dat' using 1:2 with histeps
+EOF
+gnuplot plot.gp
+```
+
+## Diagnosing latency spikes
+
+```bash
+# Trace long preemption-disabled periods (> threshold µs):
+echo preemptirqsoff > /sys/kernel/debug/tracing/current_tracer
+echo 50 > /sys/kernel/debug/tracing/tracing_thresh  # 50µs threshold
+cat /sys/kernel/debug/tracing/trace | head -30
+
+# Trace scheduling latency with bpftrace:
+bpftrace -e '
+tracepoint:sched:sched_wakeup
+/args->pid == target_pid/
+{ @wakeup_ts = nsecs; }
+
+tracepoint:sched:sched_switch
+/args->next_pid == target_pid && @wakeup_ts/
+{
+    @lat_us = hist((nsecs - @wakeup_ts) / 1000);
+    delete(@wakeup_ts);
+}'
+
+# hwlatdetect: detect hardware-caused latencies (SMI, BIOS)
+hwlatdetect --duration=60 --threshold=50
+# Detects System Management Interrupts (SMIs) that stall the CPU
+```
+
+## SMI: the worst enemy of real-time
+
+**System Management Interrupts (SMIs)** are generated by the BIOS/UEFI and run in System Management Mode (SMM) — completely invisible to the OS and cannot be disabled by the kernel:
+
+```bash
+# Detect SMI activity:
+hwlatdetect --duration=60 --threshold=100
+# DETECTED: 3 latency spikes above threshold
+# Spike: duration=150µs
+# This is likely an SMI!
+
+# Workaround: disable SMIs in BIOS/UEFI settings
+# (vendor-specific, often under "System Management Mode" or "Intel TXT")
+
+# Intel: can use MSR to monitor SMI count:
+rdmsr -a 0x34  # MSR_SMI_COUNT (per-CPU SMI counter)
+```
+
+## Full RT configuration checklist
+
+```bash
+# Check all RT prerequisites:
+cat << 'EOF' > check_rt.sh
+#!/bin/bash
+echo "=== Kernel PREEMPT_RT ==="
+uname -v | grep -qi preempt_rt && echo "OK: PREEMPT_RT active" || echo "FAIL: Not PREEMPT_RT"
+
+echo "=== CPU Isolation ==="
+[ -s /sys/devices/system/cpu/isolated ] && \
+    echo "OK: isolated=$(cat /sys/devices/system/cpu/isolated)" || \
+    echo "WARN: No CPU isolation"
+
+echo "=== Frequency Scaling ==="
+cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null | \
+    grep -q performance && echo "OK: performance governor" || \
+    echo "WARN: Not performance governor"
+
+echo "=== IRQBalance ==="
+systemctl is-active irqbalance 2>/dev/null | \
+    grep -q inactive && echo "OK: irqbalance stopped" || \
+    echo "WARN: irqbalance running"
+
+echo "=== Turbo/Boost ==="
+[ "$(cat /sys/devices/system/cpu/intel_pstate/no_turbo 2>/dev/null)" = "1" ] && \
+    echo "OK: turbo disabled" || echo "WARN: turbo may be enabled"
+EOF
+bash check_rt.sh
+```
+
+## Further reading
+
+- [Preemption Model](preemption.md) — PREEMPT_RT internals
+- [IRQ Affinity and CPU Isolation](../interrupts/irq-affinity.md) — IRQ management
+- [CPU Affinity](cpu-affinity.md) — SCHED_FIFO and task pinning
+- [SCHED_DEADLINE](deadline.md) — EDF scheduling for hard real-time
+- [RT Scheduler](rt-scheduler.md) — SCHED_FIFO/SCHED_RR internals
+- [The Scheduling Tick](sched-tick.md) — NOHZ_FULL for tickless CPUs
+- `rtl/cyclictest` — latency measurement tool

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,6 +201,7 @@ nav:
       - Energy-Aware Scheduling: sched/eas.md
       - Preemption Model: sched/preemption.md
       - The Scheduling Tick: sched/sched-tick.md
+      - Real-Time Linux Tuning: sched/rt-tuning.md
     - Debugging & Observability:
       - Scheduler Statistics: sched/schedstat.md
       - Scheduler Tracing: sched/sched-tracing.md
@@ -314,6 +315,7 @@ nav:
     - Platform Drivers: drivers/platform-driver.md
     - Character and Misc Devices: drivers/chardev.md
     - PCI Drivers: drivers/pci-driver.md
+    - Device Tree: drivers/device-tree.md
   - IPC:
     - Getting Started: ipc/README.md
     - Signals: ipc/signals.md


### PR DESCRIPTION
## Summary
- `docs/sched/rt-tuning.md`: Complete PREEMPT_RT tuning guide — CPU isolation boot params (isolcpus/nohz_full/rcu_nocbs), moving kernel threads with taskset/tuna, IRQ affinity to non-RT CPUs, mlockall stack/heap prefaulting, SCHED_FIFO clock_nanosleep periodic loop, performance governor, cyclictest with histogram, SMI/hwlatdetect detection, RT checklist script
- `docs/drivers/device-tree.md`: DTS syntax and DTSI includes, platform driver of_match_table binding, full of_ API reference, phandle cross-references, DT overlays via configfs, live DT debugging via /proc/device-tree and sysfs, platform device lifecycle, DT vs ACPI comparison table
- `mkdocs.yml`: adds both pages under Scheduler Advanced and Device Drivers nav sections

## Test plan
- [ ] `mkdocs build` passes without warnings
- [ ] rt-tuning.md appears under Scheduler > Advanced in nav
- [ ] device-tree.md appears under Device Drivers in nav
- [ ] All cross-links resolve (preemption.md, irq-affinity.md, pci-driver.md)

Closes #435, #436