### PR TITLE
Expand Btrfs/XDP docs and add dm-crypt deep dive

### DIFF
--- a/docs/filesystems/btrfs.md
+++ b/docs/filesystems/btrfs.md
@@ -1,242 +1,349 @@
-# btrfs
+# Btrfs: B-tree Filesystem
 
-> Copy-on-Write B-tree filesystem with snapshots, checksums, and RAID
+> Copy-on-write B-tree layout, snapshots, subvolumes, and RAID
 
-## Core concepts
+## Why Btrfs?
 
-btrfs is built on a single fundamental mechanism: **Copy-on-Write (CoW) B-trees**. Instead of modifying data in-place, btrfs writes new versions and updates parent pointers atomically. This enables:
+Btrfs (B-tree filesystem) was designed to address limitations of ext4:
 
-- **Snapshots**: zero-copy point-in-time copies (shared CoW pages)
-- **Checksums**: every data and metadata block is checksummed
-- **Self-healing**: with redundant data, corrupted blocks are repaired automatically
-- **Online resize**: grow/shrink while mounted
-- **Built-in RAID**: stripe, mirror, or RAID5/6 without MD/LVM
+| Feature | ext4 | Btrfs |
+|---------|------|-------|
+| Max volume | 1 EiB | 16 EiB |
+| Checksums | No | Yes (CRC32C/xxhash/SHA256) |
+| Snapshots | No | Yes (instant, writable) |
+| Subvolumes | No | Yes (independent namespaces) |
+| RAID | mdraid only | Built-in RAID 0/1/5/6/10 |
+| Compression | No | zlib/lzo/zstd inline |
+| Deduplication | No | Offline (duperemove) |
+| Send/receive | No | Yes (incremental backups) |
+| Copy-on-write | Metadata only | Data + metadata |
 
-## The B-tree structure
+## B-tree structure
 
-All btrfs data is organized in a forest of CoW B-trees. Each tree has a root stored in the superblock or its parent tree:
+Everything in Btrfs is stored in B-trees. There is no separate inode table or block bitmap — all metadata lives in these trees:
 
 ```
-Superblock
-    │
-    ├── Root Tree ─────────────────────────────────────┐
-    │   (tree of trees — maps tree IDs to roots)       │
-    │   ├── FS Tree root (subvol 5 = default)  ←───────┤
-    │   ├── Snapshot Tree root (subvol 256)    ←───────┤
-    │   └── ...                                        │
-    │                                                  │
-    ├── Chunk Tree ──────────────────────────────────── physical location mapping
-    │   (maps logical addresses to physical extents)
-    │
-    └── Device Tree ─────────────────────────────────── device info
+Btrfs superblock
+└── tree of tree roots
+    ├── root tree     ← metadata about all other trees
+    ├── extent tree   ← free space and block reference counts
+    ├── chunk tree    ← logical → physical address mapping
+    ├── device tree   ← physical devices
+    ├── checksum tree ← data block checksums
+    └── [subvolume trees]
+        ├── subvol 256 (default root)  ← files and directories
+        ├── subvol 257 (first snapshot)
+        └── ...
 ```
 
-### B-tree nodes
+### B-tree node format
 
 ```c
-/* fs/btrfs/ctree.h */
+/* include/uapi/linux/btrfs_tree.h */
+
+/* Every node starts with this header: */
 struct btrfs_header {
-    /* checksummed area starts here: */
-    u8      csum[BTRFS_CSUM_SIZE];  /* checksum of node */
-    u8      fsid[BTRFS_FSID_SIZE];  /* filesystem UUID */
-    __le64  bytenr;                  /* logical address of this node */
+    __u8    csum[BTRFS_CSUM_SIZE]; /* checksum of this block */
+    __u8    fsid[BTRFS_FSID_SIZE]; /* filesystem UUID */
+    __le64  bytenr;                /* this block's bytenr (logical addr) */
     __le64  flags;
-    u8      chunk_tree_uuid[BTRFS_UUID_SIZE];
-    __le64  generation;              /* transaction ID that wrote this */
-    __le64  owner;                   /* which tree owns this node */
-    __le32  nritems;                 /* number of items */
-    u8      level;                   /* 0 = leaf, >0 = internal */
+    __u8    chunk_tree_uuid[BTRFS_UUID_SIZE];
+    __le64  generation;            /* transaction ID when written */
+    __le64  owner;                 /* tree ID this node belongs to */
+    __le32  nritems;               /* number of items */
+    __u8    level;                 /* 0 = leaf, >0 = internal node */
 };
 
-/* Leaf node item (internal nodes use btrfs_key_ptr instead): */
-struct btrfs_item {
+/* Internal node: array of (key, blockptr) pairs */
+struct btrfs_key_ptr {
     struct btrfs_disk_key key;
-    __le32 offset;  /* offset within leaf data area */
-    __le32 size;    /* size of item data */
+    __le64 blockptr;           /* child node address */
+    __le64 generation;
 };
 
-/* Key: identifies all btrfs items */
-struct btrfs_disk_key {
-    __le64  objectid;   /* inode number, subvol ID, etc. */
-    u8      type;       /* BTRFS_INODE_ITEM_KEY, BTRFS_EXTENT_DATA_KEY, ... */
-    __le64  offset;     /* file offset, extent start, etc. */
+/* Leaf node: items + data packed from both ends */
+struct btrfs_item {
+    struct btrfs_disk_key key;  /* (objectid, type, offset) triple */
+    __le32 offset;              /* data offset from end of leaf */
+    __le32 size;                /* data size */
 };
+/* Item data sits at end of leaf, items array at start, they grow toward center */
 ```
 
-## Copy-on-Write mechanics
+### Keys
 
-When btrfs modifies a block:
+Every item in every Btrfs tree has a 3-part key:
 
 ```
-1. Allocate a new block at a free location
-2. Write new data to the new block
-3. Update parent node: change pointer to new block
-4. Parent node is also CoW'd (recursively up to the root)
-5. Update superblock to point to new root
-6. Old blocks are freed when no snapshot references them
+(objectid, type, offset)
+   ↑            ↑      ↑
+ inode#    item type  varies
+
+Examples:
+(256, INODE_ITEM,    0)           → inode metadata
+(256, INODE_REF,     parent_id)   → directory reference
+(256, EXTENT_DATA,   file_offset) → file data mapping
+(256, DIR_ITEM,      name_hash)   → directory entry
+(256, XATTR_ITEM,    name_hash)   → extended attribute
 ```
 
-This means:
-- Old data remains valid until all snapshots drop their references
-- No partial writes: either the new root is committed or the old is used
-- Crash safety: the superblock update is atomic (single write)
+## Copy-on-write semantics
+
+Btrfs never overwrites data in place. Every write creates new blocks:
+
+```
+Write to file:
+  1. Allocate new block(s) from extent tree
+  2. Write new data to new block
+  3. Update file's EXTENT_DATA item → new block address
+  4. COW the leaf containing EXTENT_DATA
+  5. COW all parent nodes up to root
+  6. Update root pointer in superblock
+
+Old blocks become unreferenced → freed in next transaction
+
+Benefits:
+  • Crash safety: superblock update is atomic, old tree still valid
+  • Snapshots: share unchanged blocks between snapshots
+  • No journal needed for metadata consistency
+```
+
+```
+Before write:                After write:
+
+Root ──→ [A]                 Root ──→ [A']  (new)
+         │                            │
+        [B]                          [B']  (new)
+         │                            │
+        [leaf: extent→blk1]          [leaf': extent→blk2]  (new)
+
+blk1 still valid (could be shared by snapshot)
+```
 
 ## Subvolumes and snapshots
 
-A **subvolume** is an independent filesystem tree (its own FS tree root). The default mount point is subvolume 5 (or the one set with `btrfs subvolume set-default`).
+A **subvolume** is an independently rootable B-tree (its own root inode):
 
 ```bash
-# Create a subvolume
-btrfs subvolume create /data/mysubvol
-# mounts as: /data/mysubvol/
+# Create a subvolume:
+btrfs subvolume create /data/myapp
 
-# List subvolumes
+# List subvolumes:
 btrfs subvolume list /data
-# ID 256 gen 42 top level 5 path mysubvol
+# ID 256 gen 100 top level 5 path myapp
+# ID 257 gen 102 top level 5 path myapp-snap-2024
 
-# Snapshot: instant copy-on-write copy
-btrfs subvolume snapshot /data/mysubvol /data/snap-20240115
-# Takes nanoseconds: just creates a new root pointing to same leaves
+# Create a snapshot (instant, CoW):
+btrfs subvolume snapshot /data/myapp /data/myapp-snap-2024
+# Read-only snapshot:
+btrfs subvolume snapshot -r /data/myapp /data/myapp-backup
 
-# Read-only snapshot (for backups)
-btrfs subvolume snapshot -r /data/mysubvol /data/snap-readonly
+# Delete snapshot:
+btrfs subvolume delete /data/myapp-snap-2024
 
-# Delete a subvolume/snapshot
-btrfs subvolume delete /data/snap-20240115
+# Set default subvolume (what mounts to /):
+btrfs subvolume set-default 256 /data
 ```
 
-### Snapshot internals
+Snapshot creation is O(1) — it just copies the B-tree root pointer. Shared blocks are reference-counted in the extent tree.
 
-A snapshot is just a new FS tree root that shares all B-tree nodes with its parent. Shared nodes have their reference counts incremented. When a shared node needs modification, it's CoW'd and the reference count decremented:
+## Extent tree: space accounting
 
+```c
+/* Each allocated extent has a back-reference: */
+struct btrfs_extent_item {
+    __le64  refs;          /* reference count */
+    __le64  generation;
+    __le64  flags;         /* BTRFS_EXTENT_FLAG_DATA or _TREE_BLOCK */
+};
+
+/* Inline back-reference (for single owner): */
+struct btrfs_extent_inline_ref {
+    __u8    type;           /* BTRFS_EXTENT_DATA_REF_KEY etc. */
+    __le64  offset;         /* depends on type */
+};
 ```
-Before snapshot:         After snapshot:
-FS Tree                  FS Tree    Snapshot
-  Root                     Root       Root
-  [gen=42]                [gen=42]   [gen=42]←─shared, refcount=2
-     │                       │         │
-   dir a                   dir a     dir a (same node, refcount=2)
-```
 
-When a file in the snapshot changes, only the modified path gets CoW'd; unchanged subtrees remain shared.
+```bash
+# Show extent usage:
+btrfs filesystem df /data
+# Data, single: total=2.00GiB, used=1.23GiB
+# Metadata, DUP: total=256.00MiB, used=12.50MiB
+# System, DUP: total=8.00MiB, used=16.00KiB
+
+# Detailed space info:
+btrfs filesystem usage /data
+
+# Show shared extents between snapshots:
+btrfs inspect-internal dump-tree -t extent /dev/sda1 | head -50
+```
 
 ## Checksums
 
-Every data and metadata block has a checksum stored in its B-tree parent:
+Btrfs checksums every data block and every metadata block:
 
 ```bash
-# Default checksum: crc32c
-btrfs inspect-internal dump-super /dev/sda | grep csum_type
-# csum_type 0 (crc32c)
+# Default checksum: crc32c (fast, hardware-accelerated)
+# Available: xxhash (faster), sha256, blake2b (collision-resistant)
 
-# SHA256 checksum (slower but cryptographic)
-mkfs.btrfs --checksum sha256 /dev/sda
+# Set checksum at mkfs:
+mkfs.btrfs --checksum xxhash /dev/sda1
 
-# BLAKE2b (fast and cryptographic)
-mkfs.btrfs --checksum blake2 /dev/sda
+# Check filesystem:
+btrfs scrub start /data          # verify all checksums
+btrfs scrub status /data         # check progress
+# scrub device /dev/sda1 (id 1) done
+# total bytes scrubbed: 100.23GiB with 0 errors
 
-# Verify checksums
-btrfs scrub start /data    # check all data/metadata on device
-btrfs scrub status /data   # check status
+# Scrub finds silent bit-rot that ext4 would miss!
 ```
 
-When a read encounters a checksum mismatch:
-- Single device: returns EIO
-- RAID1/RAID10: reads from redundant copy and repairs the bad block
+```c
+/* Kernel verifies checksum on every read: */
+/* fs/btrfs/disk-io.c */
+static int csum_one_extent_buffer(struct extent_buffer *eb)
+{
+    struct btrfs_fs_info *fs_info = eb->fs_info;
+    u8 result[BTRFS_CSUM_SIZE];
+    int ret;
 
-## Built-in RAID
-
-```bash
-# Create with RAID1 metadata + RAID1 data (2 devices)
-mkfs.btrfs -m raid1 -d raid1 /dev/sda /dev/sdb
-
-# RAID5 (3+ devices, 1 parity)
-mkfs.btrfs -m raid1 -d raid5 /dev/sda /dev/sdb /dev/sdc
-
-# Check RAID status
-btrfs filesystem df /data
-# Data, RAID1: total=10.00GiB, used=8.50GiB
-# Metadata, RAID1: total=1.00GiB, used=0.50GiB
-
-# Balance: restripe data across devices
-btrfs balance start -dconvert=raid1 /data
+    btrfs_csum_block(fs_info, result, (char *)eb->pages[0]->virtual);
+    ret = memcmp_extent_buffer(eb, result,
+                                btrfs_csum_ptr(fs_info, eb->data),
+                                fs_info->csum_size);
+    if (ret)
+        btrfs_warn_rl(fs_info, "checksum verify failed on %llu",
+                       eb->start);
+    return ret;
+}
 ```
 
-## Deduplication
-
-btrfs supports extents sharing (CoW-based dedup):
+## Inline compression
 
 ```bash
-# Online dedup with duperemove
-duperemove -dr /data/
+# Mount with compression:
+mount -o compress=zstd /dev/sda1 /data      # zstd (best ratio/speed balance)
+mount -o compress=lzo /dev/sda1 /data       # lzo (fastest)
+mount -o compress=zlib /dev/sda1 /data      # zlib (best ratio)
+mount -o compress-force=zstd /dev/sda1 /data # force even for incompressible data
 
-# Or FIDEDUPERANGE ioctl (kernel 4.5+): share identical extents
-# btrfs-dedupe tool
+# Per-file compression:
+btrfs property set /data/bigfile compression zstd
+
+# Check compression ratio:
+compsize /data/bigfile
+# Type       Perc     Disk Usage   Uncompressed Referenced
+# TOTAL       42%      420M         1.00G        1.00G
+# zstd        42%      420M         1.00G        1.00G
 ```
 
-Dedup works by finding files with identical content ranges and pointing their extent references to the same physical block (with refcounting).
-
-## Transparent compression
+## Send/receive (incremental backups)
 
 ```bash
-# Mount with transparent compression
-mount -o compress=zstd /dev/sda /data    # zstd (recommended)
-mount -o compress=lzo /dev/sda /data     # lzo (faster)
-mount -o compress=zlib /dev/sda /data    # zlib (best ratio)
+# Full backup:
+btrfs subvolume snapshot -r /data/myapp /data/myapp-snap-1
+btrfs send /data/myapp-snap-1 | btrfs receive /backup/
 
-# Set per-file compression attribute
-btrfs property set /data/myfile compression zstd
+# Incremental: only changed blocks since snap-1
+btrfs subvolume snapshot -r /data/myapp /data/myapp-snap-2
+btrfs send -p /data/myapp-snap-1 /data/myapp-snap-2 | btrfs receive /backup/
+# Sends only the diff between snap-1 and snap-2
 
-# Check compression ratio
-compsize /data/
-# Uncompressed size:  100G
-# Compressed size:    60G
-# Compression ratio:  1.67
+# Over SSH:
+btrfs send /data/myapp-snap-2 | ssh backuphost "btrfs receive /backup/"
 ```
 
-## Send/receive: efficient incremental backup
+## RAID in Btrfs
 
 ```bash
-# Initial backup: send full snapshot
-btrfs subvolume snapshot -r /data/subvol /data/snap-1
-btrfs send /data/snap-1 | btrfs receive /backup/
+# Create RAID 1 (mirrored metadata + data):
+mkfs.btrfs -d raid1 -m raid1 /dev/sda /dev/sdb
 
-# Incremental: only send the diff
-btrfs subvolume snapshot -r /data/subvol /data/snap-2
-btrfs send -p /data/snap-1 /data/snap-2 | btrfs receive /backup/
-# Much smaller than a full send — only CoW'd blocks
+# Add device to existing filesystem:
+btrfs device add /dev/sdc /data
+btrfs balance start -dconvert=raid1 -mconvert=raid1 /data
 
-# Send to remote
-btrfs send /data/snap-2 | ssh backup-server btrfs receive /backup/
-```
-
-## Monitoring btrfs
-
-```bash
-# Filesystem stats
+# Show RAID status:
 btrfs filesystem show /data
+
+# Replace a failed device:
+btrfs replace start /dev/sdb /dev/sdd /data
+btrfs replace status /data
+```
+
+## Transaction model
+
+Btrfs uses a transaction-based model without a journal:
+
+```c
+/* fs/btrfs/transaction.c */
+struct btrfs_trans_handle {
+    u64             transid;         /* transaction ID */
+    u64             bytes_reserved;  /* space reserved */
+    struct btrfs_transaction *transaction;
+};
+
+/* Begin transaction (reserves space): */
+trans = btrfs_start_transaction(root, 10); /* reserve 10 blocks worth */
+
+/* Modify B-tree items: */
+btrfs_insert_inode(trans, root, inode);
+
+/* Commit (COW all dirty nodes, update superblock): */
+btrfs_commit_transaction(trans, root);
+```
+
+The superblock is written last and contains the root of the tree-of-roots. Until the superblock update, the old tree is intact — crash at any point leaves the previous transaction's state valid.
+
+## Defragmentation
+
+CoW fragmentation builds up over time:
+
+```bash
+# Defragment a file (rewrites extents sequentially):
+btrfs filesystem defragment /data/bigfile
+
+# Defragment with compression:
+btrfs filesystem defragment -czstd /data/bigfile
+
+# Defragment entire subvolume (warning: breaks CoW sharing with snapshots!):
+btrfs filesystem defragment -r /data/myapp
+
+# Auto-defrag on mount:
+mount -o autodefrag /dev/sda1 /data
+```
+
+## Observability
+
+```bash
+# Filesystem stats:
+btrfs filesystem show
 btrfs filesystem df /data
+btrfs filesystem usage /data
 
-# Device stats (I/O errors, checksum errors)
+# Tree inspection (low-level):
+btrfs inspect-internal dump-tree /dev/sda1       # all trees
+btrfs inspect-internal dump-tree -t fs /dev/sda1 # subvolume tree
+btrfs inspect-internal dump-super /dev/sda1       # superblock
+
+# Find which file owns a logical address:
+btrfs inspect-internal logical-resolve 12345678 /data
+
+# Check for errors (offline, non-destructive):
+btrfs check --readonly /dev/sda1
+
+# Stats: read/write errors per device
 btrfs device stats /data
-# [/dev/sda].write_io_errs   0
-# [/dev/sda].read_io_errs    0
-# [/dev/sda].flush_io_errs   0
-# [/dev/sda].corruption_errs 0
-# [/dev/sda].generation_errs 0
 
-# Extent and tree statistics
-btrfs inspect-internal dump-tree /dev/sda   # dump all B-tree data
-btrfs inspect-internal inode-resolve <ino> /data
-
-# Balance status
-btrfs balance status /data
+# Performance tracing:
+bpftrace -e 'kprobe:btrfs_file_write_iter { @[comm] = count(); }'
 ```
 
 ## Further reading
 
-- [ext4](ext4.md) — Traditional journaled alternative
-- [tmpfs](tmpfs.md) — Memory-backed filesystem
-- [VFS: Dentry and Inode Caches](../vfs/dcache-icache.md) — How btrfs integrates with VFS
-- [Copy-on-Write](../mm/cow.md) — CoW mechanism from mm perspective
+- [ext4 Journaling (JBD2)](ext4-journal.md) — journal-based contrast
+- [Page Cache](../mm/page-cache.md) — page cache that Btrfs CoW writes through
+- [Copy-on-Write](../mm/copy-on-write.md) — process CoW vs filesystem CoW
+- [xattr](../vfs/xattr.md) — Btrfs stores xattrs in the subvolume tree
+- `fs/btrfs/` — Btrfs implementation
 - `Documentation/filesystems/btrfs.rst`

--- a/docs/net/xdp.md
+++ b/docs/net/xdp.md
@@ -1,93 +1,115 @@
-# XDP (eXpress Data Path)
+# XDP: eXpress Data Path
 
-> High-performance packet processing before the kernel network stack
+> Kernel bypass at the driver level: BPF programs on the receive fast path
 
-## What XDP is
+## What is XDP?
 
-XDP is a programmable, high-performance packet processing framework that runs eBPF programs **before the kernel allocates `sk_buff`**. It's attached to a network device and invoked by the NIC driver (or the kernel) for every incoming packet.
+XDP (eXpress Data Path) runs a BPF program at the earliest possible point in the kernel network stack — inside the NIC driver, **before** skb allocation. This achieves near-DPDK speeds while staying in the kernel:
 
-XDP eliminates the main overhead sources of traditional kernel packet processing:
-- **No `sk_buff` allocation**: Operates directly on DMA-mapped packet memory
-- **No per-packet memory allocation**: Uses pre-allocated per-CPU buffers
-- **No lock contention**: Each CPU processes its own RX queue independently
+```
+Packet arrival:
 
-This enables packet rates of tens of millions of packets per second on a single core.
+Without XDP:
+  NIC → DMA → driver alloc skb → kernel stack → socket → userspace
+  Latency: ~1-5µs, throughput: limited by skb overhead
 
-## XDP actions (return codes)
+With XDP:
+  NIC → DMA → XDP BPF program → (pass/drop/tx/redirect)
+  Latency: ~100-200ns, throughput: 10-50+ Mpps (million packets/sec)
 
-An XDP program examines the packet and returns one of five actions:
-
-```c
-// include/uapi/linux/bpf.h
-enum xdp_action {
-    XDP_ABORTED = 0,  // BPF error: drop + trace event
-    XDP_DROP,         // Drop the packet immediately
-    XDP_PASS,         // Pass to normal kernel network stack
-    XDP_TX,           // Transmit back out the same NIC (hairpin)
-    XDP_REDIRECT,     // Redirect to another NIC, CPU, or AF_XDP socket
-};
+DPDK (comparison):
+  NIC → userspace poll → DPDK app
+  Latency: ~50-100ns, throughput: 60+ Mpps
+  But: requires dedicated CPUs, no kernel network stack
 ```
 
-## struct xdp_md — the BPF program's context
-
-XDP programs see the packet through `struct xdp_md`:
+## XDP hook points
 
 ```c
-// include/uapi/linux/bpf.h
-struct xdp_md {
-    __u32 data;           // pointer to packet start (cast to void*)
-    __u32 data_end;       // pointer to packet end
-    __u32 data_meta;      // pointer to metadata area (before data)
-    __u32 ingress_ifindex; // receiving interface index
-    __u32 rx_queue_index;  // RX queue number
-    __u32 egress_ifindex;  // for XDP_REDIRECT: target interface
-};
+/* Three attachment modes: */
+
+/* 1. Native XDP (fastest): runs in driver's RX path */
+/*    Supported by: mlx5, i40e, ixgbe, bpfilter, veth, etc. */
+ip link set eth0 xdp obj xdp_prog.o sec xdp
+
+/* 2. Generic XDP (skb-based): works on any driver, slower */
+/*    Runs after skb allocation, in netif_receive_skb() */
+ip link set eth0 xdpgeneric obj xdp_prog.o sec xdp
+
+/* 3. HW offload: runs on the NIC itself (very few NICs) */
+ip link set eth0 xdpoffload obj xdp_prog.o sec xdp
 ```
 
-The underlying kernel structure is `struct xdp_buff`:
+## XDP verdicts
 
 ```c
-// include/net/xdp.h
-struct xdp_buff {
-    void *data;           // packet start
-    void *data_end;       // packet end
-    void *data_meta;      // metadata area
-    void *data_hard_start; // start of DMA buffer (headroom before data)
-    struct xdp_rxq_info *rxq; // RX queue info (device, queue index)
-    u32   frame_sz;       // total frame size
-    u32   flags;
-};
+/* BPF program returns one of these: */
+
+XDP_DROP      /* Drop the packet immediately (no skb alloc, no notification) */
+XDP_PASS      /* Continue normal kernel processing (alloc skb, pass up stack) */
+XDP_TX        /* Retransmit on the same interface (e.g., for reflection) */
+XDP_REDIRECT  /* Forward to another interface, CPU, or AF_XDP socket */
+XDP_ABORTED   /* Drop + trace point for debugging (treated like DROP) */
 ```
 
-## A minimal XDP program
+## XDP program structure
 
 ```c
-// Drop all UDP traffic
+/* xdp_prog.c */
 #include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
 #include <linux/if_ether.h>
 #include <linux/ip.h>
-#include <linux/udp.h>
-#include <bpf/bpf_helpers.h>
+
+/* BPF map: track per-source-IP packet counts */
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);    /* source IP */
+    __type(value, __u64);  /* packet count */
+    __uint(max_entries, 65536);
+} ip_counter SEC(".maps");
+
+/* Blocklist map */
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);    /* blocked IP */
+    __type(value, __u8);
+    __uint(max_entries, 1024);
+} blocklist SEC(".maps");
 
 SEC("xdp")
-int xdp_drop_udp(struct xdp_md *ctx)
+int xdp_firewall(struct xdp_md *ctx)
 {
-    void *data = (void *)(long)ctx->data;
+    void *data     = (void *)(long)ctx->data;
     void *data_end = (void *)(long)ctx->data_end;
 
+    /* Parse Ethernet header */
     struct ethhdr *eth = data;
-    if ((void*)(eth + 1) > data_end)
-        return XDP_PASS;
+    if ((void *)(eth + 1) > data_end)
+        return XDP_DROP;   /* truncated packet */
 
-    if (eth->h_proto != htons(ETH_P_IP))
-        return XDP_PASS;
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+        return XDP_PASS;   /* not IPv4, pass to stack */
 
-    struct iphdr *iph = (void*)(eth + 1);
-    if ((void*)(iph + 1) > data_end)
-        return XDP_PASS;
-
-    if (iph->protocol == IPPROTO_UDP)
+    /* Parse IP header */
+    struct iphdr *ip = (void *)(eth + 1);
+    if ((void *)(ip + 1) > data_end)
         return XDP_DROP;
+
+    __u32 src_ip = ip->saddr;
+
+    /* Check blocklist */
+    if (bpf_map_lookup_elem(&blocklist, &src_ip))
+        return XDP_DROP;   /* blocked: drop silently */
+
+    /* Count packets per source IP */
+    __u64 *count = bpf_map_lookup_elem(&ip_counter, &src_ip);
+    if (count) {
+        __sync_fetch_and_add(count, 1);
+    } else {
+        __u64 one = 1;
+        bpf_map_update_elem(&ip_counter, &src_ip, &one, BPF_ANY);
+    }
 
     return XDP_PASS;
 }
@@ -95,162 +117,236 @@ int xdp_drop_udp(struct xdp_md *ctx)
 char _license[] SEC("license") = "GPL";
 ```
 
-## Attaching XDP programs
-
 ```bash
-# Compile
-clang -O2 -target bpf -c xdp_drop_udp.c -o xdp_drop_udp.o
+# Compile:
+clang -O2 -target bpf -c xdp_prog.c -o xdp_prog.o
 
-# Attach to interface (native mode: highest performance)
-ip link set dev eth0 xdp obj xdp_drop_udp.o sec xdp
+# Attach:
+ip link set eth0 xdp obj xdp_prog.o sec xdp
 
-# Check it's attached
+# Check:
 ip link show eth0
-# → link/ether ... xdp (id 42, flags <XDP_FLAGS_SKB_MODE>)
+# 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 xdp ...
+#     xdp id 42    ← program loaded
 
-# Remove
-ip link set dev eth0 xdp off
-
-# With bpftool
-bpftool net attach xdp id 42 dev eth0
-bpftool net show dev eth0
+# Detach:
+ip link set eth0 xdp off
 ```
 
-## XDP operation modes
-
-```bash
-# Native/driver mode (fastest): program runs in NIC driver's NAPI poll
-ip link set dev eth0 xdp obj prog.o
-
-# Generic/SKB mode (any NIC, slower): runs after sk_buff allocation
-ip link set dev eth0 xdpgeneric obj prog.o
-
-# Hardware offload (smartNICs: Netronome, etc.): runs on NIC hardware
-ip link set dev eth0 xdpoffload obj prog.o
-```
-
-| Mode | Performance | NIC requirement | When to use |
-|------|-------------|-----------------|-------------|
-| Native | Highest | Driver support | Production DDoS mitigation, load balancing |
-| Generic | Moderate | Any NIC | Development, NICs without XDP support |
-| HW Offload | Maximum | Smartcard NIC | Extreme performance (line-rate 100G) |
-
-## XDP_REDIRECT: steering to other destinations
-
-`XDP_REDIRECT` is the most powerful action, allowing redirection to:
+## Packet modification (NAT)
 
 ```c
-// Redirect to another NIC
-bpf_redirect(ifindex, 0);
+SEC("xdp")
+int xdp_dnat(struct xdp_md *ctx)
+{
+    void *data     = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
 
-// Redirect to a CPU (via CPUMAP)
-bpf_redirect_map(&cpu_map, target_cpu, 0);
+    struct ethhdr *eth = data;
+    if ((void *)(eth + 1) > data_end)
+        return XDP_PASS;
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+        return XDP_PASS;
 
-// Redirect to AF_XDP socket (for userspace packet processing)
-bpf_redirect_map(&xsk_map, queue_id, 0);
+    struct iphdr *ip = (void *)(eth + 1);
+    if ((void *)(ip + 1) > data_end)
+        return XDP_PASS;
+
+    /* Rewrite destination IP */
+    __u32 new_dst = bpf_htonl(0xc0a80101);  /* 192.168.1.1 */
+    ip->daddr = new_dst;
+
+    /* Recompute IP checksum */
+    bpf_l3_csum_replace(ctx,
+        (void *)&ip->check - data,   /* offset of checksum field */
+        0, new_dst, sizeof(new_dst));
+
+    return XDP_PASS;  /* or XDP_TX to send back */
+}
 ```
 
-### BPF maps for redirection
+## XDP redirect
+
+### Between interfaces
 
 ```c
-// DEVMAP: redirect to another NIC
+/* Redirect packet to eth1: */
+SEC("xdp")
+int xdp_redirect_iface(struct xdp_md *ctx)
+{
+    int ifindex = 3;  /* eth1's ifindex */
+    return bpf_redirect(ifindex, 0);
+}
+```
+
+### DEVMAP: batch redirect
+
+```c
+/* High-performance redirect via devmap */
 struct {
     __uint(type, BPF_MAP_TYPE_DEVMAP);
+    __uint(key_size, sizeof(int));
+    __uint(value_size, sizeof(int));
     __uint(max_entries, 256);
-    __type(key, __u32);    // ifindex
-    __type(value, __u32);  // destination ifindex
-} tx_port SEC(".maps");
-
-// CPUMAP: send to a specific CPU's RX queue
-struct {
-    __uint(type, BPF_MAP_TYPE_CPUMAP);
-    __uint(max_entries, 16);
-    __type(key, __u32);     // CPU id
-    __type(value, struct bpf_cpumap_val); // queue size + optional XDP prog
-} cpu_map SEC(".maps");
-```
-
-## Common XDP use cases
-
-### DDoS mitigation
-
-```c
-// Drop packets from known attack sources (BPF map lookup)
-struct {
-    __uint(type, BPF_MAP_TYPE_LPM_TRIE);
-    __type(key, struct bpf_lpm_trie_key_u8);
-    __type(value, __u64);  // drop counter
-} blocklist SEC(".maps");
+} tx_ports SEC(".maps");
 
 SEC("xdp")
-int xdp_ddos_filter(struct xdp_md *ctx)
+int xdp_devmap_redirect(struct xdp_md *ctx)
 {
-    struct iphdr *iph = parse_iphdr(ctx);
-    if (!iph) return XDP_PASS;
+    int port = 0;  /* devmap key */
+    return bpf_redirect_map(&tx_ports, port, XDP_DROP);
+}
+```
 
-    struct bpf_lpm_trie_key_u8 key = { .prefixlen = 32 };
-    *((__u32 *)key.data) = iph->saddr;
+```bash
+# Populate devmap (userspace):
+int map_fd = bpf_obj_get("/sys/fs/bpf/tx_ports");
+int ifindex = if_nametoindex("eth1");
+bpf_map_update_elem(map_fd, &key, &ifindex, BPF_ANY);
+```
 
-    if (bpf_map_lookup_elem(&blocklist, &key))
-        return XDP_DROP;
+### CPUMAP: steer to specific CPU
+
+```c
+/* Redirect to CPU for further processing (after XDP) */
+struct {
+    __uint(type, BPF_MAP_TYPE_CPUMAP);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(struct bpf_cpumap_val));
+    __uint(max_entries, 12);
+} cpumap SEC(".maps");
+
+SEC("xdp")
+int xdp_cpumap_redirect(struct xdp_md *ctx)
+{
+    /* RSS-based steering: hash to CPU */
+    __u32 cpu = bpf_get_smp_processor_id() % 4;
+    return bpf_redirect_map(&cpumap, cpu, 0);
+}
+```
+
+## AF_XDP: zero-copy to userspace
+
+AF_XDP (eXpress Data Path socket) moves packets directly to userspace memory without any kernel copying:
+
+```
+NIC DMA → UMEM (userspace memory) → XSK socket → userspace app
+          ↑ zero copy! kernel never touches packet data
+```
+
+### Setup
+
+```c
+/* Userspace: create AF_XDP socket */
+#include <linux/if_xdp.h>
+#include <sys/socket.h>
+
+/* 1. Allocate UMEM (packet buffer pool): */
+void *umem_area = mmap(NULL, UMEM_SIZE, PROT_READ|PROT_WRITE,
+                        MAP_PRIVATE|MAP_ANONYMOUS|MAP_HUGETLB, -1, 0);
+
+struct xdp_umem_reg umem_reg = {
+    .addr = (uint64_t)umem_area,
+    .len  = UMEM_SIZE,
+    .chunk_size = FRAME_SIZE,    /* 4096 bytes per frame */
+    .headroom   = 0,
+};
+setsockopt(xsk_fd, SOL_XDP, XDP_UMEM_REG, &umem_reg, sizeof(umem_reg));
+
+/* 2. Create rings (FILL/COMPLETION/RX/TX): */
+int ring_size = 2048;
+setsockopt(xsk_fd, SOL_XDP, XDP_RX_RING, &ring_size, sizeof(ring_size));
+setsockopt(xsk_fd, SOL_XDP, XDP_UMEM_FILL_RING, &ring_size, sizeof(ring_size));
+
+/* 3. mmap the rings: */
+struct xdp_mmap_offsets off;
+getsockopt(xsk_fd, SOL_XDP, XDP_MMAP_OFFSETS, &off, &optlen);
+
+void *fill_ring = mmap(NULL, off.fr.desc + ring_size * sizeof(uint64_t),
+                        PROT_READ|PROT_WRITE, MAP_SHARED|MAP_POPULATE,
+                        xsk_fd, XDP_UMEM_PGOFF_FILL_RING);
+
+/* 4. Bind to interface queue: */
+struct sockaddr_xdp sxdp = {
+    .sxdp_family   = AF_XDP,
+    .sxdp_ifindex  = if_nametoindex("eth0"),
+    .sxdp_queue_id = 0,           /* NIC queue 0 */
+    .sxdp_flags    = XDP_ZEROCOPY, /* requires native XDP driver support */
+};
+bind(xsk_fd, (struct sockaddr *)&sxdp, sizeof(sxdp));
+```
+
+### XDP program for AF_XDP redirect
+
+```c
+/* BPF map of AF_XDP sockets */
+struct {
+    __uint(type, BPF_MAP_TYPE_XSKMAP);
+    __uint(key_size, sizeof(int));
+    __uint(value_size, sizeof(int));
+    __uint(max_entries, 64);
+} xsks_map SEC(".maps");
+
+SEC("xdp")
+int xdp_sock_prog(struct xdp_md *ctx)
+{
+    int index = ctx->rx_queue_index;
+
+    /* Redirect to AF_XDP socket on same queue */
+    if (bpf_map_lookup_elem(&xsks_map, &index))
+        return bpf_redirect_map(&xsks_map, index, 0);
 
     return XDP_PASS;
 }
 ```
 
-### Load balancing
+## XDP vs alternatives
 
-```c
-// XDP load balancer: forward to backend servers via XDP_TX
-// (used by Facebook's Katran, Cloudflare's layer4 load balancer)
-```
+| | XDP | DPDK | kernel TC | iptables |
+|---|-----|------|-----------|----------|
+| Throughput | 50+ Mpps | 60+ Mpps | 10+ Mpps | 1-5 Mpps |
+| Latency | ~200ns | ~100ns | ~1µs | ~10µs |
+| Kernel stack access | Yes (XDP_PASS) | No | Yes | Yes |
+| CPU dedication | No | Yes | No | No |
+| Programmability | BPF | C | BPF/C | limited |
+| Use case | DDoS mitigation, LB, firewall | High-freq trading, NFV | QoS, TC filter | Generic firewall |
 
-### Packet sampling
-
-```c
-// Sample 1 in 1000 packets to userspace via perf ring buffer
-if (bpf_get_prandom_u32() % 1000 == 0) {
-    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
-                          data, data_end - data);
-}
-return XDP_PASS;
-```
-
-## Statistics and observability
+## Observability
 
 ```bash
-# XDP program statistics
-bpftool prog show
-bpftool prog dump xlated id 42  # show XDP bytecode
+# XDP program info:
+bpftool net show dev eth0
+# xdp:
+#         id 42  name xdp_firewall  flags 0x0
 
-# Count XDP drops (per-CPU)
-bpftool map dump id <map_id>
-
-# ethtool XDP stats
+# XDP stats (via driver):
 ethtool -S eth0 | grep xdp
-# rx_xdp_drop: 12345
-# rx_xdp_redirect: 0
-# rx_xdp_pass: 67890
+# rx_xdp_drop: 1234567
+# rx_xdp_pass: 9876543
+# rx_xdp_tx:          0
+# rx_xdp_redirect:    0
 
-# Trace XDP events
-perf record -e xdp:xdp_exception -ag sleep 10
-trace-cmd record -e xdp:xdp_bulk_tx -e xdp:xdp_redirect_err
+# BPF map inspection:
+bpftool map dump id 5   # dump blocklist map
+
+# XDP program tracing:
+bpftrace -e '
+tracepoint:xdp:xdp_exception
+{ printf("XDP exception: ifindex=%d, prog_id=%d, act=%d\n",
+         args->ifindex, args->prog_id, args->act); }'
+
+# Perf event for XDP drop:
+perf record -e xdp:xdp_drop -ag -- sleep 10
+perf script
 ```
-
-## Performance comparison
-
-At 40 Gbps with small packets:
-
-| Path | Mpps/core | Notes |
-|------|-----------|-------|
-| Kernel TCP stack | ~1-2 | Full stack processing |
-| DPDK (userspace) | ~20-30 | Kernel bypass |
-| XDP native | ~20-25 | In-kernel, no copy |
-| XDP HW offload | ~80+ | NIC handles it |
 
 ## Further reading
 
-- [AF_XDP Sockets](af-xdp.md) — Sending XDP-processed packets to userspace
-- [Network Device and NAPI](napi.md) — Where XDP hooks into the driver
-- [TC and qdisc](tc-qdisc.md) — Alternative packet steering (post-stack)
-- [Netfilter Architecture](netfilter.md) — The older hook-based alternative
+- [BPF Networking](../bpf/bpf-networking.md) — TC BPF, sockmap
+- [sk_buff: The Network Buffer](sk-buff.md) — XDP_PASS creates sk_buff
+- [NVMe Driver](../block/nvme.md) — similar DMA/ring buffer pattern
+- [IRQ Affinity](../interrupts/irq-affinity.md) — NIC queue/CPU affinity for XDP
+- `net/core/filter.c` — BPF network filter infrastructure
+- `drivers/net/ethernet/intel/i40e/i40e_xsk.c` — XDP in i40e driver
+- `samples/bpf/xdpsock_user.c` — AF_XDP userspace example
+- `tools/lib/bpf/xsk.c` — libbpf AF_XDP helper

--- a/docs/security/dm-crypt.md
+++ b/docs/security/dm-crypt.md
@@ -1,0 +1,335 @@
+# dm-crypt: Block-Level Encryption
+
+> Device mapper encryption target, LUKS2 key management, and AES-XTS
+
+## Architecture
+
+dm-crypt sits in the device mapper stack, transparently encrypting/decrypting all I/O between the filesystem and the block device:
+
+```
+Application
+    ↓ read/write
+Filesystem (ext4/Btrfs/XFS)
+    ↓ block I/O
+dm-crypt (device mapper target)
+    ↓ encrypt on write, decrypt on read
+Block device (/dev/sda1, NVMe, etc.)
+    ↓
+Physical storage: only ciphertext on disk
+```
+
+```bash
+# View dm-crypt device:
+dmsetup table /dev/mapper/cryptroot
+# 0 976771072 crypt aes-xts-plain64 :64:logon:cryptsetup:...
+# sectors:    cipher           key          IV mode
+```
+
+## LUKS2 on-disk format
+
+LUKS (**L**inux **U**nified **K**ey **S**etup) is the standard format for dm-crypt headers. LUKS2 (since kernel 4.12 / cryptsetup 2.0):
+
+```
+LUKS2 on-disk layout:
+┌─────────────────────────────────────────────────────────┐
+│ LUKS2 header (4KB) + backup header (4KB)                │
+│   magic: "LUKS\xba\xbe" + version: 2                    │
+│   hdr_size, seqid, label, checksum_alg                  │
+│   salt[64], uuid, subsystem                             │
+├─────────────────────────────────────────────────────────┤
+│ JSON metadata area (variable, default 16KB)             │
+│   keyslots: [{type, priority, kdf_params, af_params}]   │
+│   tokens: [{type, keyslots: [...]}]                     │
+│   segments: [{type: "crypt", offset, size, iv_tweak,    │
+│               encryption: "aes-xts-plain64", ...}]      │
+│   digests: [{type: "pbkdf2", keyslots, segments,        │
+│              salt, digest}]                             │
+├─────────────────────────────────────────────────────────┤
+│ Keyslot area (default 16MB)                             │
+│   Each keyslot: AF-split master key encrypted with      │
+│   user passphrase-derived key                           │
+├─────────────────────────────────────────────────────────┤
+│ Encrypted data (segment 0)                              │
+│   All filesystem data encrypted with master key         │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Key derivation (PBKDF2/Argon2)
+
+```
+User passphrase
+      ↓ PBKDF2 or Argon2id (memory-hard, tuned to take ~1 second)
+Derived key (same size as master key)
+      ↓ XOR with AF-split stripes
+Master key (256-bit for AES-256-XTS)
+      ↓ used directly for AES-XTS encryption
+```
+
+Argon2id (LUKS2 default) is memory-hard — defeating GPU brute-force attacks.
+
+## cryptsetup: LUKS management
+
+```bash
+# Create LUKS2 container:
+cryptsetup luksFormat --type luks2 \
+    --cipher aes-xts-plain64 \
+    --key-size 512 \           # 512-bit key = AES-256-XTS (split 256+256)
+    --hash sha512 \
+    --pbkdf argon2id \
+    --iter-time 3000 \         # KDF tuning: target 3 seconds
+    /dev/sda1
+
+# Open (decrypt and create /dev/mapper/mydev):
+cryptsetup open /dev/sda1 mydev
+# Prompts for passphrase → creates /dev/mapper/mydev
+
+# Create filesystem on decrypted device:
+mkfs.ext4 /dev/mapper/mydev
+mount /dev/mapper/mydev /mnt
+
+# Close (remove decrypted device):
+umount /mnt
+cryptsetup close mydev
+
+# Show LUKS header info:
+cryptsetup luksDump /dev/sda1
+# Version:        2
+# Epoch:          3
+# Metadata area:  16384 [bytes]
+# Keyslots area:  16744448 [bytes]
+# UUID:           ...
+# Label:          (no label)
+# Subsystem:      (no subsystem)
+# Flags:          (no flags)
+# Keyslots:
+#  0: luks2 (active)
+#     Priority:   normal
+#     Cipher:     aes-xts-plain64
+#     Cipher key: 512 bits
+#     PBKDF:      argon2id
+
+# Add a second passphrase (key slot 1):
+cryptsetup luksAddKey /dev/sda1
+
+# Add a keyfile (for automated unlock):
+dd if=/dev/urandom of=/root/keyfile bs=512 count=4
+cryptsetup luksAddKey /dev/sda1 /root/keyfile
+
+# Open with keyfile:
+cryptsetup open /dev/sda1 mydev --key-file /root/keyfile
+
+# Remove a passphrase:
+cryptsetup luksKillSlot /dev/sda1 1   # remove slot 1
+```
+
+## dm-crypt kernel target
+
+The kernel-side implementation is in `drivers/md/dm-crypt.c`:
+
+```c
+/* Device mapper target structure */
+struct dm_target {
+    /* ... */
+    sector_t begin;    /* start of the target in the device */
+    sector_t len;      /* length of the target */
+    struct target_type *type;
+    void *private;     /* points to crypt_config */
+};
+
+/* dm-crypt private state */
+struct crypt_config {
+    struct dm_dev   *dev;          /* underlying device */
+    sector_t         start;        /* start sector */
+
+    /* Crypto */
+    struct crypto_skcipher **tfms; /* per-CPU cipher handles */
+    unsigned int     tfms_count;   /* = num_cpus */
+    char            *cipher_string; /* "aes-xts-plain64" */
+    unsigned int     key_size;
+    u8              *key;          /* master key in kernel memory */
+
+    /* IV */
+    iv_generator_fn  iv_gen_ops;   /* plain64, essiv, tcw, etc. */
+
+    /* I/O */
+    mempool_t        req_pool;     /* pool of crypt_io structs */
+    struct workqueue_struct *io_queue;   /* encrypt/decrypt workers */
+    struct workqueue_struct *crypt_queue;
+};
+```
+
+### Encryption path (write)
+
+```c
+/* dm-crypt intercepts every bio: */
+static int crypt_map(struct dm_target *ti, struct bio *bio)
+{
+    struct crypt_io *io;
+    struct crypt_config *cc = ti->private;
+
+    /* Allocate per-request state */
+    io = mempool_alloc(&cc->io_pool, GFP_NOIO);
+    io->cc = cc;
+    io->base_bio = bio;
+
+    if (bio_data_dir(bio) == WRITE) {
+        /* Encrypt: submit to crypt_queue workqueue */
+        kcryptd_queue_crypt(io);
+    } else {
+        /* Read: submit plain I/O, decrypt in completion */
+        crypt_submit_bio(cc, io, bio);
+    }
+    return DM_MAPIO_SUBMITTED;
+}
+
+/* Encryption worker: */
+static void kcryptd_crypt_write_io_submit(struct crypt_io *io, int async)
+{
+    /* For each page in the bio: */
+    /*   1. Set up IV from sector number */
+    /*   2. skcipher_request_set_crypt() */
+    /*   3. crypto_skcipher_encrypt() */
+    /*   4. Submit encrypted bio to underlying device */
+}
+```
+
+### IV modes
+
+```
+plain64:   IV = sector_number (64-bit)
+           Simple, fast; vulnerable to watermarking attacks
+
+essiv:     IV = encrypt(sector_number, hash(master_key))
+           Sector numbers not visible as IVs
+
+tcw:       Tweak-CBC-Wide; for XTS mode with twist
+           Resists CPA (chosen plaintext attacks)
+
+aes-xts-plain64 (recommended):
+           XTS = XEX (XOR-Encrypt-XOR) Tweakable Block Cipher
+           Two AES keys: one for encryption, one for IV tweak
+           Standard for disk encryption (IEEE P1619)
+```
+
+## Performance
+
+```bash
+# Benchmark cipher options:
+cryptsetup benchmark
+# # Tests are approximate using memory only (no storage IO).
+# PBKDF2-sha1        1234567 iterations per second for 256-bit key
+# PBKDF2-sha512       543210 iterations per second for 256-bit key
+# argon2i           7 iterations per second for 256-bit key (64 MB memory)
+# argon2id          7 iterations per second for 256-bit key (64 MB memory)
+# #     Algorithm |       Key |      Encryption |      Decryption
+#          aes-cbc        128b      1234.5 MiB/s      3456.7 MiB/s
+#          aes-cbc        256b      1012.3 MiB/s      2890.1 MiB/s
+#          aes-xts        256b      2100.4 MiB/s      2098.7 MiB/s
+#          aes-xts        512b      1890.2 MiB/s      1887.3 MiB/s
+
+# AES-NI hardware acceleration:
+grep -m1 aes /proc/cpuinfo
+# flags: ... aes ...  ← hardware AES-NI present
+
+# Measure dm-crypt overhead vs raw device:
+fio --filename=/dev/mapper/mydev --direct=1 --rw=read --bs=128k \
+    --ioengine=libaio --iodepth=32 --name=crypt-read
+fio --filename=/dev/sda1 --direct=1 --rw=read --bs=128k \
+    --ioengine=libaio --iodepth=32 --name=raw-read
+# With AES-NI: typically < 5% overhead
+```
+
+## /etc/crypttab: persistent configuration
+
+```bash
+# /etc/crypttab format: name device keyfile options
+cryptroot   /dev/sda1   none          luks,discard
+cryptdata   /dev/sdb1   /root/keyfile luks,nofail
+cryptswap   /dev/sdc1   /dev/urandom  swap,cipher=aes-xts-plain64
+
+# Fields:
+# name:    → /dev/mapper/<name>
+# device:  UUID=... or /dev/sdX or LABEL=...
+# keyfile: "none" = prompt; path = file; /dev/urandom = random (for swap)
+# options: luks, discard (trim), nofail (skip if not present), etc.
+
+# Use UUID to be device-name-independent:
+blkid /dev/sda1 | grep UUID
+cryptroot   UUID=abc123-...   none   luks
+```
+
+## LUKS vs plain dm-crypt
+
+```bash
+# Plain dm-crypt (no LUKS header, no key management):
+cryptsetup open --type plain \
+    --cipher aes-xts-plain64 \
+    --key-size 512 \
+    --hash sha512 \
+    /dev/sda1 mydev
+# Key derived directly from passphrase via hash (no KDF tuning)
+# No header means no metadata footprint (deniable encryption)
+# But: can't add multiple keys, no integrity checking
+```
+
+## dm-integrity: authentication
+
+dm-crypt provides confidentiality but not integrity. dm-integrity adds authentication tags:
+
+```bash
+# Create dm-integrity + dm-crypt stack:
+# Step 1: format with integrity
+cryptsetup open --type plain --integrity hmac-sha256 /dev/sda1 mydev-int
+# Step 2: LUKS on top
+cryptsetup luksFormat /dev/mapper/mydev-int
+cryptsetup open /dev/mapper/mydev-int mydev
+
+# Or use LUKS2 with integrity directly:
+cryptsetup luksFormat --type luks2 \
+    --integrity hmac-sha256 \
+    /dev/sda1
+# Adds HMAC tag per 512-byte sector → detects tampering
+```
+
+## Observability
+
+```bash
+# dm-crypt stats:
+dmsetup status /dev/mapper/cryptroot
+# 0 976771072 crypt 0 0 0 0 /dev/sda1 2048
+
+# Block I/O stats for dm-crypt device:
+iostat -x /dev/mapper/cryptroot 1
+
+# Crypto subsystem stats:
+cat /proc/crypto | grep -A5 "aes"
+# name         : xts(aes)
+# driver       : xts-aes-aesni
+# module       : kernel
+# priority     : 401
+# type         : skcipher
+
+# Hardware vs software crypto:
+# driver ending in -aesni = hardware accelerated
+# driver ending in -generic = software fallback
+
+# BPF trace encrypt latency:
+bpftrace -e '
+kprobe:kcryptd_crypt_write_convert { @start[tid] = nsecs; }
+kretprobe:kcryptd_crypt_write_convert /@start[tid]/
+{
+    @lat_us = hist((nsecs - @start[tid]) / 1000);
+    delete(@start[tid]);
+}'
+```
+
+## Further reading
+
+- [Btrfs](../filesystems/btrfs.md) — commonly used filesystem on top of dm-crypt
+- [ext4 Journaling](../filesystems/ext4-journal.md) — filesystem below dm-crypt
+- [NVMe Driver](../block/nvme.md) — block device underneath dm-crypt
+- [Kernel Crypto API](../crypto/crypto-api.md) — skcipher/AEAD dm-crypt uses
+- [LSM Framework](lsm.md) — dm-crypt works with SELinux/AppArmor
+- `drivers/md/dm-crypt.c` — dm-crypt target implementation
+- `lib/crypto/` — kernel AES-XTS implementation
+- `Documentation/admin-guide/device-mapper/dm-crypt.rst`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -357,6 +357,7 @@ nav:
     - seccomp BPF: security/seccomp.md
     - Linux Audit: security/audit.md
     - Credentials and User Namespaces: security/credentials.md
+    - dm-crypt (Block Encryption): security/dm-crypt.md
   - Virtualization:
     - Getting Started: virtualization/README.md
     - KVM Architecture: virtualization/kvm-arch.md


### PR DESCRIPTION
## Summary
- **`docs/filesystems/btrfs.md`** (expanded): Full Btrfs internals — B-tree node format with header/item/keyptr structs, 3-part key system (objectid/type/offset), copy-on-write tree diagrams, subvolume snapshot O(1) creation, extent tree back-references, per-block CRC32C checksums, inline zstd/lzo/zlib compression, send/receive incremental backup, built-in RAID, transaction model (no journal needed), defrag
- **`docs/net/xdp.md`** (expanded): Full XDP deep dive — native/generic/offload hook comparison, all 5 XDP verdicts, BPF firewall with bounds checking, packet DNAT via `bpf_l3_csum_replace`, DEVMAP/CPUMAP batch redirect, AF_XDP zero-copy socket setup with UMEM/FILL rings, XDP vs DPDK/TC/iptables table, ethtool stats
- **`docs/security/dm-crypt.md`** (new): dm-crypt architecture, LUKS2 on-disk layout, Argon2id KDF, `cryptsetup` workflow, `struct crypt_config` kernel internals, AES-XTS IV modes, AES-NI performance, `/etc/crypttab`, dm-integrity authentication

## Test plan
- [ ] `mkdocs build` passes
- [ ] Btrfs B-tree diagrams render correctly
- [ ] dm-crypt appears under Security nav
- [ ] XDP AF_XDP section links to af-xdp.md correctly

Closes #438, #439, #440, #441