### PR TITLE
Add cpuidle C-states and thermal management docs

### DIFF
--- a/docs/power/cpuidle.md
+++ b/docs/power/cpuidle.md
@@ -1,0 +1,278 @@
+# cpuidle: CPU C-states and Idle Power Management
+
+> Hardware sleep states, latency/power tradeoffs, and the cpuidle governor framework
+
+## CPU C-states
+
+When a CPU has no work to do, it enters a **C-state** (idle state). Each state trades deeper power savings for higher wake-up latency:
+
+```
+C-state hierarchy (x86):
+  C0 - Active (running instructions)
+  C1 - HALT (stops pipeline, keeps power on)       ~1µs wake, ~15W saved
+  C1E - C1 + Enhanced (lower voltage)              ~5µs wake, ~20W saved
+  C2 - STOP-GRANT (cache coherent)                 ~10µs wake
+  C3 - SLEEP (LLC may flush, snoop disabled)       ~50µs wake, large savings
+  C6 - DEEP POWER DOWN (core voltage off)          ~100µs wake, max savings
+  C7 - ENHANCED C6 (LLC flushed)                   ~150µs wake
+  C8, C9, C10 - Platform C-states (package + RAM)  ~300µs+ wake
+
+Package C-states (PC-states): the entire socket enters when all cores idle:
+  PC2: ~5µs, PC3: ~50µs, PC6: ~100µs (DRAM power down), PC8: ~300µs
+```
+
+```bash
+# Check available C-states:
+cat /sys/devices/system/cpu/cpu0/cpuidle/state*/name
+# POLL
+# C1
+# C1E
+# C3
+# C6
+# C7s
+# C8
+# C9
+# C10
+
+# Check C-state latency and power:
+for state in /sys/devices/system/cpu/cpu0/cpuidle/state*; do
+    echo -n "$(cat $state/name): "
+    echo -n "latency=$(cat $state/latency)µs "
+    echo "power=$(cat $state/power)mW"
+done
+# C1: latency=1µs power=0mW
+# C3: latency=59µs power=0mW
+# C6: latency=124µs power=0mW
+```
+
+## cpuidle framework
+
+The Linux cpuidle framework selects which C-state to enter when the CPU is idle:
+
+```c
+/* include/linux/cpuidle.h */
+
+/* Describes one C-state: */
+struct cpuidle_state {
+    char        name[CPUIDLE_NAME_LEN];
+    char        desc[CPUIDLE_DESC_LEN];
+    u64         exit_latency_ns;  /* worst-case wake-up latency */
+    u64         target_residency_ns; /* min time to justify entering */
+    unsigned int flags;           /* CPUIDLE_FLAG_TIMER_STOP etc. */
+    int (*enter)(struct cpuidle_device *dev,
+                 struct cpuidle_driver *drv, int index);
+};
+
+/* Per-CPU idle device: */
+struct cpuidle_device {
+    unsigned int    registered:1;
+    unsigned int    enabled:1;
+    unsigned int    poll_time_limit:1;
+    unsigned int    cpu;
+    ktime_t         next_hrtimer;          /* next timer expiry */
+    struct cpuidle_state_usage states_usage[CPUIDLE_STATE_MAX];
+    /* states_usage[i].time_ns: total ns spent in state i */
+    /* states_usage[i].usage:   number of times state i entered */
+};
+
+/* Driver: describes all C-states for a platform: */
+struct cpuidle_driver {
+    const char          *name;
+    struct module       *owner;
+    unsigned int         state_count;
+    struct cpuidle_state states[CPUIDLE_STATE_MAX];
+    int                  safe_state_index; /* fallback if deadline missed */
+};
+```
+
+### intel_idle driver
+
+The `intel_idle` driver provides Intel-specific C-states with known latencies:
+
+```c
+/* drivers/idle/intel_idle.c */
+static struct cpuidle_state skl_cstates[] = {
+    {
+        .name = "C1",
+        .desc = "MWAIT 0x00",
+        .flags = MWAIT2flg(0x00),
+        .exit_latency = 2,
+        .target_residency = 2,
+        .enter = intel_idle,
+    },
+    {
+        .name = "C1E",
+        .desc = "MWAIT 0x01",
+        .exit_latency = 10,
+        .target_residency = 20,
+        .enter = intel_idle,
+    },
+    {
+        .name = "C3",
+        .desc = "MWAIT 0x10",
+        .exit_latency = 70,
+        .target_residency = 100,
+        .enter = intel_idle,
+    },
+    {
+        .name = "C6",
+        .desc = "MWAIT 0x20",
+        .exit_latency = 85,
+        .target_residency = 200,
+        .enter = intel_idle,
+        .flags = CPUIDLE_FLAG_TLB_FLUSHED,
+    },
+    /* ... more states ... */
+};
+
+/* Entering a C-state via MWAIT instruction: */
+static int intel_idle(struct cpuidle_device *dev,
+                       struct cpuidle_driver *drv, int index)
+{
+    unsigned long ecx = 1; /* break on interrupt */
+    unsigned long eax = drv->states[index].flags & MWAIT_SUBSTATE_MASK;
+
+    mwait_idle_with_hints(eax, ecx);  /* issues MONITOR/MWAIT */
+    return index;
+}
+```
+
+## cpuidle governors
+
+The governor decides which C-state to enter based on expected idle duration:
+
+### ladder governor
+
+Simple: tries to stay at or near the current state; moves up/down based on actual vs predicted duration:
+
+```
+idle duration < target_residency[current-1] → demote to lower state
+idle duration > target_residency[current]   → promote to deeper state
+```
+
+### menu governor (default for tickless systems)
+
+Predicts idle duration using the next timer event and historical data:
+
+```c
+/* kernel/sched/idle.c + drivers/cpuidle/governors/menu.c */
+
+/* Inputs to prediction: */
+/* 1. Time to next timer (hrtimer, jiffies timer) */
+/* 2. Historical data: exponentially weighted moving average */
+/* 3. iowait correction: lower C-state if I/O is pending */
+
+/* Output: selected C-state index */
+
+/* Correction factors: */
+/* - If many short idles: don't go deep (I/O about to arrive) */
+/* - If long idles predicted: go deep */
+```
+
+### TEO governor (Timer Events Oriented, Linux 5.1+)
+
+More accurate for modern tickless systems:
+
+```bash
+# Check/set current governor:
+cat /sys/devices/system/cpu/cpuidle/current_governor
+# menu
+
+echo teo > /sys/devices/system/cpu/cpuidle/current_governor
+```
+
+## Disabling C-states
+
+For latency-sensitive workloads, disable deep C-states:
+
+```bash
+# Disable C6 and deeper (state 3+):
+for cpu in /sys/devices/system/cpu/cpu*/cpuidle/state3/; do
+    echo 1 > $cpu/disable 2>/dev/null
+done
+
+# Permanent: add "processor.max_cstate=1" to kernel boot params
+# or: "intel_idle.max_cstate=1"
+
+# For RT systems: disable all C-states except C0/POLL:
+for cpu in /sys/devices/system/cpu/cpu*/cpuidle/state[1-9]*/; do
+    echo 1 > $cpu/disable 2>/dev/null
+done
+
+# Check pm_qos latency constraint (set by applications/drivers):
+cat /sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us
+# 0 = no constraint, other value = max acceptable wakeup latency
+
+# Application: prevent deep C-states (e.g., audio daemon):
+echo 100 > /dev/cpu_dma_latency  # max 100µs wakeup latency
+# (keep fd open; closing reverts the constraint)
+```
+
+## Statistics and observability
+
+```bash
+# Per-CPU per-state time and usage:
+cat /sys/devices/system/cpu/cpu0/cpuidle/state*/usage
+cat /sys/devices/system/cpu/cpu0/cpuidle/state*/time   # µs
+cat /sys/devices/system/cpu/cpu0/cpuidle/state*/name
+
+# cpupower tool:
+cpupower idle-info
+# CPUs which run at the same hardware frequency:  0-7
+# CPUs which need to have their frequency coordinated: 0-7
+# maximum transition latency: 0.00 ms
+# Available idle states:
+# POLL  C1  C1E  C3  C6  C7s  C8  C9  C10
+
+cpupower monitor -i 5  # 5-second sample
+# Mperf | C0   Cx   Freq | POLL C1   C1E  C3   C6   C7s  C8   C9   C10
+#      0| 25%  75% 3.2G  |   0%   0%   0%   0%   0%  10%  20%  45%   0%
+
+# Turbostat: per-CPU C-state residency:
+turbostat --interval 1 --show CPU,Busy%,Bzy_MHz,PkgWatt,C1%,C6%,C8%
+# CPU   Busy%  Bzy_MHz  PkgWatt  C1%    C6%    C8%
+#   0    5.2   3400.0   18.4    2.3    3.1   89.4
+#   1    2.1   3400.0            1.2    1.8   94.9
+
+# BPF trace cpuidle events:
+bpftrace -e '
+tracepoint:power:cpu_idle
+{ @[args->state, cpu] = count(); }'
+# [state, cpu] → entry count
+
+# CPU wake-up latency histogram (time between idle entry and next event):
+bpftrace -e '
+tracepoint:power:cpu_idle /args->state != 4294967295/
+{ @start[cpu] = nsecs; }
+tracepoint:power:cpu_idle /args->state == 4294967295 && @start[cpu]/
+{
+    @lat_us[cpu] = hist((nsecs - @start[cpu]) / 1000);
+    delete(@start[cpu]);
+}'
+```
+
+## Power consumption impact
+
+```bash
+# Measure power with powertop:
+powertop --auto-tune   # apply recommended power settings
+powertop --csv=power.csv --time=60  # 60-second measurement
+
+# RAPL (Running Average Power Limit) energy counters:
+cat /sys/class/powercap/intel-rapl:0/energy_uj       # package energy
+cat /sys/class/powercap/intel-rapl:0:0/energy_uj     # core energy
+cat /sys/class/powercap/intel-rapl:0:1/energy_uj     # uncore energy
+
+# turbostat shows instantaneous watts per package
+turbostat --show PkgWatt,PkgTmp --interval 1
+```
+
+## Further reading
+
+- [cpufreq and P-states](cpufreq.md) — frequency scaling (orthogonal to C-states)
+- [Real-Time Tuning](../sched/rt-tuning.md) — disabling C-states for RT
+- [The Scheduling Tick](../sched/sched-tick.md) — NOHZ interaction with cpuidle
+- [hrtimers](../time/hrtimers.md) — timers that interrupt idle
+- `drivers/cpuidle/` — cpuidle framework and governors
+- `drivers/idle/intel_idle.c` — Intel C-state driver
+- `Documentation/admin-guide/pm/cpuidle.rst`

--- a/docs/power/thermal.md
+++ b/docs/power/thermal.md
@@ -1,0 +1,282 @@
+# Thermal Management: Thermal Zones and Cooling
+
+> Linux thermal framework, trip points, cooling devices, and thermal governors
+
+## Overview
+
+Modern SoCs and CPUs generate heat. Without thermal management, they would throttle or shut down unexpectedly. The Linux thermal framework provides a structured way to:
+1. **Monitor** temperatures via thermal zones
+2. **Define** thermal policies via trip points and governors
+3. **Enforce** cooling via cooling devices (CPU frequency scaling, fan control)
+
+```
+Hardware sensor → thermal zone → governor → cooling device
+     (NTC, PCH, CPU, GPU)          |           (cpufreq, fan, GPU)
+                                   ↓
+                          trip points: warning/critical/throttle
+```
+
+## Thermal zones
+
+A **thermal zone** represents a sensor and its associated policy:
+
+```bash
+# List all thermal zones:
+ls /sys/class/thermal/
+# thermal_zone0  thermal_zone1  thermal_zone2  ...  cooling_device0  ...
+
+# Check a zone:
+cat /sys/class/thermal/thermal_zone0/type          # "x86_pkg_temp"
+cat /sys/class/thermal/thermal_zone0/temp          # current temp in millidegrees
+# 45000 = 45°C
+cat /sys/class/thermal/thermal_zone0/mode          # "enabled" or "disabled"
+cat /sys/class/thermal/thermal_zone0/policy        # "step_wise" etc.
+
+# List trip points:
+for trip in /sys/class/thermal/thermal_zone0/trip_point_*_temp; do
+    type=$(echo $trip | sed 's/_temp/_type/')
+    echo "$(cat $type): $(cat $trip)m°C"
+done
+# passive: 95000m°C   ← throttle at 95°C
+# critical: 105000m°C ← emergency shutdown at 105°C
+```
+
+### Kernel structures
+
+```c
+/* include/linux/thermal.h */
+
+struct thermal_zone_device {
+    int                 id;
+    char                type[THERMAL_NAME_LENGTH];
+    struct device       device;
+    struct thermal_attr temp_attr;
+    struct thermal_attr mode_attr;
+
+    int                 temperature;        /* current temp in millidegrees */
+    int                 last_temperature;
+    int                 emul_temperature;   /* for testing */
+    int                 passive;            /* passive cooling active? */
+    int                 forced_passive;
+
+    struct thermal_zone_device_ops  *ops;   /* .get_temp, .set_trips */
+    struct thermal_zone_params      *tzp;   /* governor params */
+    struct thermal_governor         *governor;
+
+    struct list_head    thermal_instances;  /* connected cooling devices */
+    struct idr          idr;               /* trip point IDs */
+    int                 num_trips;
+    /* ... */
+};
+
+/* Trip point types: */
+enum thermal_trip_type {
+    THERMAL_TRIP_ACTIVE = 0,    /* activate cooling device (fan) */
+    THERMAL_TRIP_PASSIVE,       /* reduce performance (cpufreq) */
+    THERMAL_TRIP_HOT,           /* driver-defined action */
+    THERMAL_TRIP_CRITICAL,      /* emergency shutdown */
+};
+```
+
+## Registering a thermal zone (driver)
+
+```c
+/* Driver: register a temperature sensor as a thermal zone */
+static int my_get_temp(struct thermal_zone_device *tzd, int *temp)
+{
+    struct my_sensor *sensor = tzd->devdata;
+    *temp = read_sensor_millidegrees(sensor);
+    return 0;
+}
+
+static struct thermal_zone_device_ops my_tz_ops = {
+    .get_temp = my_get_temp,
+};
+
+/* At probe time: */
+struct thermal_trip trips[] = {
+    { .temperature = 80000, .type = THERMAL_TRIP_PASSIVE },    /* 80°C */
+    { .temperature = 100000, .type = THERMAL_TRIP_CRITICAL },  /* 100°C */
+};
+
+struct thermal_zone_device *tzd = thermal_zone_device_register(
+    "my_sensor",           /* type string */
+    ARRAY_SIZE(trips),     /* number of trip points */
+    0,                     /* mask of writable trips */
+    sensor_data,           /* driver private data */
+    &my_tz_ops,
+    NULL,                  /* thermal zone params */
+    1000,                  /* passive_delay ms */
+    5000                   /* polling_delay ms */
+);
+thermal_zone_device_enable(tzd);
+```
+
+## Cooling devices
+
+```c
+/* A cooling device can reduce power: e.g., CPU frequency */
+struct thermal_cooling_device {
+    int     id;
+    char    type[THERMAL_NAME_LENGTH];
+    struct  device device;
+    struct  thermal_cooling_device_ops *ops;
+    /* ... */
+};
+
+struct thermal_cooling_device_ops {
+    int (*get_max_state)(struct thermal_cooling_device *, unsigned long *);
+    int (*get_cur_state)(struct thermal_cooling_device *, unsigned long *);
+    int (*set_cur_state)(struct thermal_cooling_device *, unsigned long);
+};
+
+/* CPU frequency scaling cooling device (cpufreq_cooling): */
+/* state 0 = max frequency, state N = minimum frequency */
+struct thermal_cooling_device *cdev =
+    cpufreq_cooling_register(cpu_policy);
+/* This is how cpufreq thermal throttling works */
+```
+
+```bash
+# View cooling devices:
+ls /sys/class/thermal/cooling_device*/
+cat /sys/class/thermal/cooling_device0/type    # "Processor" or "cpufreq"
+cat /sys/class/thermal/cooling_device0/max_state  # e.g., 3 (4 levels)
+cat /sys/class/thermal/cooling_device0/cur_state  # current level (0=off)
+```
+
+## Thermal governors
+
+The governor decides **when** to activate cooling and **how much**:
+
+### step_wise (default on many platforms)
+
+Raises cooling level by 1 when temperature exceeds a trip point, lowers by 1 when below:
+
+```
+temp rising:  trip reached → cooling_state++
+temp falling: temp < (trip - hysteresis) → cooling_state--
+```
+
+### power_allocator (IPA — Intelligent Power Allocation)
+
+A PID controller that distributes a power budget across cooling devices:
+
+```c
+/* drivers/thermal/gov_power_allocator.c */
+/* Parameters (tunable via /sys/class/thermal/thermal_zone*/
+/*                             /sustainable_power etc.):  */
+/* sustainable_power: maximum sustainable power (mW)      */
+/* k_po, k_pu, k_d: PID controller gains                  */
+/* Estimate: (current_temp - control_temp) → power_budget */
+/* → allocate proportionally to each cooling device       */
+```
+
+```bash
+# Tune power_allocator governor:
+echo power_allocator > /sys/class/thermal/thermal_zone0/policy
+echo 3000 > /sys/class/thermal/thermal_zone0/sustainable_power  # 3W budget
+echo 100  > /sys/class/thermal/thermal_zone0/k_po  # proportional gain
+echo 100  > /sys/class/thermal/thermal_zone0/k_pu
+echo 0    > /sys/class/thermal/thermal_zone0/k_d   # derivative gain
+```
+
+### user_space
+
+Delegates decisions to a userspace daemon (e.g., thermald):
+
+```bash
+echo user_space > /sys/class/thermal/thermal_zone0/policy
+# thermald or thermal daemon reads temperature and sets:
+echo 1 > /sys/class/thermal/cooling_device0/cur_state
+```
+
+## ACPI thermal zones
+
+On x86, ACPI defines thermal zones in DSDT/SSDT:
+
+```bash
+# ACPI thermal zones (separate from Linux thermal framework initially):
+cat /sys/class/thermal/thermal_zone*/type | grep -i acpi
+# acpitz
+
+# ACPI trip points come from ACPI _PSV (passive), _CRT (critical), _HOT:
+acpidump -n DSDT | grep -A 20 "ThermalZone"
+```
+
+## Fan control
+
+```bash
+# Fan cooling devices:
+cat /sys/class/thermal/cooling_device*/type | grep -i fan
+# Fan
+
+# Manual fan control (bypass thermal framework):
+# (varies by platform; common methods:)
+
+# Dell laptops (i8k):
+echo 2 > /proc/i8k  # set fan level
+
+# ACPI fans via hwmon:
+cat /sys/class/hwmon/hwmon*/name
+cat /sys/class/hwmon/hwmon0/fan1_input  # RPM
+echo 200 > /sys/class/hwmon/hwmon0/pwm1  # 0-255 speed
+
+# Check fan is thermal-controlled:
+cat /sys/class/hwmon/hwmon0/pwm1_enable
+# 0 = full speed, 1 = manual, 2 = auto (thermal)
+echo 2 > /sys/class/hwmon/hwmon0/pwm1_enable  # auto mode
+```
+
+## Observability and debugging
+
+```bash
+# Watch thermal zones in real time:
+watch -n 1 'for z in /sys/class/thermal/thermal_zone*/; do
+    echo -n "$(cat $z/type): $(cat $z/temp)m°C  "; done; echo'
+
+# Kernel thermal tracepoints:
+echo 1 > /sys/kernel/debug/tracing/events/thermal/enable
+cat /sys/kernel/debug/tracing/trace_pipe
+# thermal_temperature: thermal_zone=x86_pkg_temp id=0 temp=45000 ...
+# thermal_zone_trip: thermal_zone=x86_pkg_temp trip=0 temp=80000 type=passive
+
+# BPF trace thermal throttling:
+bpftrace -e '
+tracepoint:thermal:thermal_zone_trip
+{
+    printf("TRIP: zone=%s, trip=%d, temp=%d°C\n",
+           str(args->thermal_zone), args->trip,
+           args->temp / 1000);
+}'
+
+# Check if CPU is thermally throttled (PROCHOT):
+grep -r "throttle\|prochot" /sys/devices/system/cpu/cpu*/thermal_throttle/
+cat /sys/devices/system/cpu/cpu0/thermal_throttle/core_throttle_count
+
+# MSR-based throttling on Intel:
+rdmsr 0x1b1   # IA32_THERM_STATUS: bit 4 = prochot
+# bit 4 set → CPU is/was thermally throttled
+```
+
+## ARM thermal: SCMI and TF-A
+
+On ARM SoCs, temperature management often involves the firmware:
+
+```bash
+# SCMI thermal (System Control and Management Interface):
+cat /sys/class/thermal/thermal_zone*/type | grep scmi
+# arm-scmi
+
+# TF-A (Trusted Firmware-A) handles critical shutdown;
+# Linux gets temperature via SCMI protocol to secure world
+```
+
+## Further reading
+
+- [cpufreq and P-states](cpufreq.md) — CPU frequency scaling (thermal cooling device)
+- [cpuidle](cpuidle.md) — C-states reduce power to prevent thermal issues
+- [Runtime PM](runtime-pm.md) — device power management
+- [Device Tree](../drivers/device-tree.md) — thermal zones defined in DTS on ARM
+- `drivers/thermal/` — thermal framework
+- `Documentation/driver-api/thermal/` — thermal framework documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -368,6 +368,8 @@ nav:
   - Power Management:
     - Getting Started: power/README.md
     - cpufreq and P-states: power/cpufreq.md
+    - cpuidle and C-states: power/cpuidle.md
+    - Thermal Management: power/thermal.md
     - Runtime PM: power/runtime-pm.md
     - System Suspend: power/suspend.md
   - Time:


### PR DESCRIPTION
## Summary
- **`docs/power/cpuidle.md`** (new): CPU idle power management — C-state hierarchy (C0-C10 with latency/power tradeoffs), cpuidle framework structs (cpuidle_state/device/driver), intel_idle MWAIT-based C-state entry, ladder/menu/TEO governors with selection algorithms, C-state disabling for RT (disable sysfs, processor.max_cstate), pm_qos /dev/cpu_dma_latency latency constraints, turbostat/cpupower/bpftrace observability, RAPL energy measurement
- **`docs/power/thermal.md`** (new): Linux thermal framework — thermal zone sysfs, struct thermal_zone_device/trip_type, driver registration API, cpufreq_cooling device, step_wise/power_allocator (IPA PID controller)/user_space governors, ACPI thermal zones, fan control via hwmon PWM, thermal tracepoints, Intel PROCHOT MSR throttle detection, ARM SCMI thermal
- **`mkdocs.yml`**: add both pages under Power Management nav

## Test plan
- [ ] `mkdocs build` passes
- [ ] cpuidle and Thermal appear in Power Management nav
- [ ] C-state table renders correctly

Closes #453, #454, #455