### PR TITLE
Add fscrypt per-file encryption and SELinux docs

### DIFF
--- a/docs/security/fscrypt.md
+++ b/docs/security/fscrypt.md
@@ -1,0 +1,225 @@
+# fscrypt: Per-File Encryption
+
+> Key hierarchy, HKDF derivation, and transparent encryption in ext4/F2FS/Btrfs
+
+## Overview
+
+fscrypt provides **per-directory** transparent encryption at the VFS layer. Unlike dm-crypt (full disk), fscrypt encrypts individual files and directories, allowing:
+- Multiple users to have separate encrypted directories with different keys
+- Selective encryption (not all files need to be encrypted)
+- Fast key revocation (remove key → files become inaccessible)
+
+Supported filesystems: **ext4, F2FS, UBIFS, Btrfs** (5.14+)
+
+```
+Application read()/write()
+          ↓
+    Page cache (plaintext while key is present)
+          ↓ (encrypt on writeback, decrypt on readahead)
+    fscrypt layer
+          ↓
+    Block device (ciphertext)
+```
+
+## Key hierarchy
+
+fscrypt uses a two-level key hierarchy:
+
+```
+User passphrase / TPM / hardware key
+         ↓ PBKDF2 or Argon2 (userspace)
+Master key (256-bit, type: ext4/logon)
+         ↓ HKDF-SHA512 (kernel)
+         ├── File encryption key (per-file, derived from master + file nonce)
+         ├── Filename encryption key (for directory entries)
+         └── IV (per-block, derived from file nonce + block number)
+```
+
+Each encrypted directory has a **policy** that records:
+- Which master key to use (by key descriptor or key identifier)
+- Which encryption mode (AES-256-XTS for contents, AES-256-CTS for filenames)
+- Key derivation version (v1 trusted keyring, v2 HKDF)
+
+## Setting up encryption (API v2)
+
+```bash
+# Step 1: Enable encryption on the filesystem (ext4):
+tune2fs -O encrypt /dev/sda1
+# or at mkfs time:
+mkfs.ext4 -O encrypt /dev/sda1
+
+# Step 2: Add master key to kernel keyring:
+# Generate a 512-bit key:
+dd if=/dev/urandom bs=64 count=1 of=/tmp/master_key 2>/dev/null
+
+# Add to session keyring:
+keyctl add logon fscrypt:$(xxd -p /tmp/master_key | head -c 16) \
+    /tmp/master_key @s
+
+# Or using the fscrypt tool:
+apt install fscrypt
+fscrypt setup /dev/sda1
+fscrypt encrypt /home/user/private/ --user=user
+```
+
+### Kernel ioctl API
+
+```c
+#include <linux/fscrypt.h>
+
+/* Step 1: Add master key to filesystem keyring */
+struct fscrypt_add_key_arg {
+    struct fscrypt_key_specifier key_spec;  /* identifies the key */
+    __u32 raw_size;     /* 16-64 bytes for AES, 64 bytes for HKDF */
+    __u32 key_id;       /* output: kernel-assigned ID */
+    __u32 __reserved[8];
+    __u8  raw[];        /* key material */
+};
+
+struct fscrypt_key_specifier key_spec = {
+    .type = FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER,  /* v2: HKDF-based */
+};
+int key_fd = open("/", O_RDONLY);
+ioctl(key_fd, FS_IOC_ADD_ENCRYPTION_KEY, &add_key_arg);
+/* Returns key_spec.u.identifier (16-byte hash of key) */
+
+/* Step 2: Set encryption policy on a directory */
+struct fscrypt_policy_v2 policy = {
+    .version           = FSCRYPT_POLICY_V2,
+    .contents_encryption_mode = FSCRYPT_MODE_AES_256_XTS,
+    .filenames_encryption_mode = FSCRYPT_MODE_AES_256_CTS,
+    .flags             = FSCRYPT_POLICY_FLAGS_PAD_32,
+    .master_key_identifier = /* key_spec.u.identifier */,
+};
+int dir_fd = open("/home/user/private", O_RDONLY);
+ioctl(dir_fd, FS_IOC_SET_ENCRYPTION_POLICY, &policy);
+/* From now on, all new files in this directory are encrypted */
+```
+
+## Key derivation internals
+
+```c
+/* fs/crypto/hkdf.c */
+
+/* HKDF-SHA512 is used to derive all per-file keys: */
+
+/* File content key: */
+/* Input keying material (IKM) = master_key */
+/* Info = "fscrypt\0" + mode + filesystem UUID + file nonce */
+fscrypt_hkdf_expand(&ci->ci_master_key->mk_secret.hkdf,
+                     HKDF_CONTEXT_PER_FILE_ENC_KEY,
+                     info, infolen,
+                     derived_key, mode->keysize);
+
+/* File nonce: random 16 bytes stored in inode on disk */
+/* Every file gets a unique nonce → unique key even if same master key */
+
+/* Per-file key stored in: */
+struct fscrypt_inode_info {
+    struct fscrypt_master_key *ci_master_key;
+    union fscrypt_iv    ci_iv;          /* per-block IV base */
+    struct crypto_skcipher *ci_enc_key; /* actual cipher */
+    /* ... */
+};
+```
+
+### IV generation (per-block)
+
+```c
+/* For AES-256-XTS (contents encryption): */
+/* IV = file_nonce XOR (block_number as little-endian u64) */
+/* → each 4K block has a unique IV derived from the file */
+
+/* For filename encryption (AES-256-CTS): */
+/* IV = 0 (filenames are encrypted with ECB-like semantics) */
+/* → same filename in same directory always encrypts the same way */
+/* → directory listing is possible (if you have the key), order leaks */
+
+/* For SipHash-based IV (policy flag FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64): */
+/* IV = SipHash(file_nonce, ino, block_number) */
+/* Enables hardware inline encryption (one key per filesystem) */
+```
+
+## Inline encryption hardware
+
+```bash
+# Check for inline encryption support:
+cat /sys/block/nvme0n1/queue/crypto_capabilities 2>/dev/null
+# AES-256-XTS, key size 64, data unit size 512/1024/2048/4096
+
+# Mount with inline encryption:
+mount -o inlinecrypt /dev/nvme0n1p1 /data
+# Kernel programs NVMe keyslot; block layer does encryption in hardware
+# CPU only sets up keys — no per-block crypto overhead
+
+# Check if inlinecrypt is active:
+cat /proc/mounts | grep inlinecrypt
+```
+
+## Key revocation and locking
+
+```c
+/* Remove master key from filesystem (lock encrypted directories): */
+ioctl(fs_fd, FS_IOC_REMOVE_ENCRYPTION_KEY, &key_spec);
+/* All pages of encrypted files are evicted from page cache */
+/* Inode's ci_enc_key is freed → files become unreadable */
+/* On next access attempt: -ENOKEY (key not available) */
+```
+
+```bash
+# Using fscrypt tool:
+fscrypt lock /home/user/private/   # lock (remove key from kernel)
+fscrypt unlock /home/user/private/ # unlock (re-add key)
+
+# Check encryption status:
+fscrypt status /home/user/private/
+# "/home/user/private": encrypted
+#   Policy version:      2
+#   Encryption mode:     AES-256-XTS (contents)
+#                        AES-256-CTS (filenames)
+#   Key:                 unlocked (key identifier: abc123...)
+```
+
+## fscrypt vs dm-crypt
+
+| | fscrypt | dm-crypt |
+|---|---------|----------|
+| Granularity | Per-directory | Full block device |
+| Multiple keys | Yes | No (one key per device) |
+| Key revocation | Hot-revoke (pages evicted) | Unmount required |
+| Metadata encryption | Filenames only | All metadata |
+| Performance | Slightly higher CPU | AES-NI nearly free |
+| Use case | Multi-user (Android FBE, shared laptops) | Single-user laptop, server |
+| Filesystem | ext4/F2FS/Btrfs | Any FS on top |
+
+## Observability
+
+```bash
+# Check if a file is encrypted:
+fscryptctl get_policy /home/user/private/secret.txt
+# Encryption policy for /home/user/private/secret.txt:
+#   Policy version: 2
+#   Master key identifier: abc1234567890def
+#   Contents encryption mode: AES-256-XTS
+#   Filenames encryption mode: AES-256-CTS
+#   Flags: PAD_32
+
+# List all master keys in a filesystem:
+ioctl(fs_fd, FS_IOC_GET_ENCRYPTION_KEY_STATUS, &status)
+# (or use fscrypt status)
+
+# dmesg for crypto errors:
+dmesg | grep -E "fscrypt|crypto"
+
+# BPF trace key lookups:
+bpftrace -e 'kprobe:fscrypt_get_encryption_info { @[comm] = count(); }'
+```
+
+## Further reading
+
+- [dm-crypt](dm-crypt.md) — full-disk encryption alternative
+- [xattr](../vfs/xattr.md) — fscrypt stores policy in `trusted.fscrypt` xattr
+- [Linux Audit](audit.md) — audit fscrypt key operations
+- [Credentials](credentials.md) — per-user keyrings for master keys
+- `fs/crypto/` — fscrypt implementation
+- `Documentation/filesystems/fscrypt.rst`

--- a/docs/security/selinux.md
+++ b/docs/security/selinux.md
@@ -1,0 +1,284 @@
+# SELinux: Mandatory Access Control
+
+> Security contexts, AVC cache, type enforcement policy, and audit2allow
+
+## What is SELinux?
+
+SELinux (Security-Enhanced Linux) implements **Mandatory Access Control (MAC)**: access decisions are made by a central security policy, not by object owners. Even root cannot override the policy without explicit permission.
+
+```
+Traditional DAC (Discretionary Access Control):
+  owner of file → decides who can access it
+  root → overrides everything
+
+SELinux MAC:
+  Central policy → decides every access
+  root → still restricted by policy
+  Even compromised root process → bounded by its security context
+```
+
+SELinux is built on the **LSM (Linux Security Module)** framework. Every security-sensitive kernel operation calls an LSM hook which SELinux intercepts.
+
+## Security contexts
+
+Every process and file has a **security context** (also called label):
+
+```
+Format: user:role:type:level
+         ↑     ↑    ↑    ↑
+         SELinux user  sensitivity:categories (MLS/MCS)
+
+Examples:
+  Process: system_u:system_r:httpd_t:s0
+  File:    system_u:object_r:httpd_var_run_t:s0
+  Port 80: system_u:object_r:http_port_t:s0
+```
+
+```bash
+# View process context:
+ps -eZ | grep httpd
+# system_u:system_r:httpd_t:s0     1234 httpd
+
+# View file context:
+ls -Z /var/www/html/index.html
+# system_u:object_r:httpd_content_t:s0 /var/www/html/index.html
+
+# Your current context:
+id -Z
+# unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+
+# Change context temporarily:
+runcon -t httpd_t /bin/bash    # run shell as httpd_t
+
+# View all contexts:
+seinfo -t | grep httpd    # all httpd types
+```
+
+## Access Vector Cache (AVC)
+
+Every access check goes through the **AVC** (Access Vector Cache). The AVC is a hash table that caches recent allow/deny decisions:
+
+```c
+/* security/selinux/avc.c */
+
+struct avc_entry {
+    u32             ssid;       /* source security ID */
+    u32             tsid;       /* target security ID */
+    u16             tclass;     /* target class (file, process, socket...) */
+    struct av_decision avd;     /* allow/audit/etc bitmask */
+};
+
+/* Cache lookup: */
+static inline int avc_lookup(struct selinux_avc *avc,
+                              u32 ssid, u32 tsid, u16 tclass,
+                              struct av_decision *avd)
+{
+    struct avc_node *node;
+    unsigned long flags;
+
+    node = avc_cache_lookup(avc, ssid, tsid, tclass);
+    if (node) {
+        *avd = node->ae.avd;
+        /* cache hit: no need to consult policy */
+        return 0;
+    }
+    /* cache miss: slow path → consult policy database */
+    return avc_compute_av(ssid, tsid, tclass, avd);
+}
+```
+
+```bash
+# AVC statistics:
+cat /sys/fs/selinux/avc/cache_stats
+# lookups hits misses allocations reclaims frees
+# 1234567 1200000 34567 34567 0 0
+# ~97% hit rate typical
+
+# AVC cache size:
+cat /sys/fs/selinux/avc/cache_threshold
+# 512 (entries)
+```
+
+## Type Enforcement (TE) policy
+
+The most important policy mechanism. Rules grant access between types:
+
+```
+allow <source_type> <target_type>:<class> { <permissions> };
+
+Examples:
+# httpd can read httpd_content_t files:
+allow httpd_t httpd_content_t:file { read getattr open };
+
+# httpd cannot write to /etc (etc_t):
+# (no allow rule → denied)
+
+# httpd can bind to http_port_t ports:
+allow httpd_t http_port_t:tcp_socket { name_bind };
+
+# Allow httpd to connect to mysql:
+allow httpd_t mysqld_port_t:tcp_socket name_connect;
+```
+
+### Policy source files
+
+```bash
+# Policy is compiled from .te (type enforcement) files:
+ls /usr/share/selinux/targeted/*.pp    # compiled policy modules
+
+# View policy for httpd:
+sesearch --allow -s httpd_t /etc/selinux/targeted/policy/policy.33
+# allow httpd_t httpd_config_t:file { read getattr open };
+# allow httpd_t httpd_log_t:file { append create write ioctl lock };
+# ...
+
+# Check what a type can do:
+sesearch --allow -s httpd_t -c file /etc/selinux/targeted/policy/policy.33
+
+# What types can access a file type:
+sesearch --allow -t httpd_content_t /etc/selinux/targeted/policy/policy.33
+```
+
+## File context labeling
+
+```bash
+# Default contexts come from file_contexts files:
+cat /etc/selinux/targeted/contexts/files/file_contexts | grep www
+# /var/www(/.*)?       system_u:object_r:httpd_content_t:s0
+# /var/www/cgi-bin(/.*)? system_u:object_r:httpd_exec_t:s0
+
+# Restore context to policy default:
+restorecon -Rv /var/www/html/
+
+# Set context manually:
+chcon -t httpd_content_t /tmp/webpage.html
+semanage fcontext -a -t httpd_content_t "/custom/web(/.*)?"
+restorecon -Rv /custom/web/
+
+# Check what the policy says a file's context should be:
+matchpathcon /var/www/html/index.html
+# /var/www/html/index.html system_u:object_r:httpd_content_t:s0
+```
+
+## Audit and audit2allow
+
+When SELinux denies an access, it logs to the audit log:
+
+```bash
+# View recent denials:
+audit2allow -w -a 2>/dev/null | head -30
+# type=AVC msg=audit(1234567890.123:456): avc: denied { name_connect }
+#     for pid=1234 comm="httpd" dest=3306
+#     scontext=system_u:system_r:httpd_t:s0
+#     tcontext=system_u:object_r:mysqld_port_t:s0
+#     tclass=tcp_socket permissive=0
+
+# Raw audit log:
+ausearch -m AVC,USER_AVC -ts recent | audit2allow
+
+# Generate policy to allow a denial:
+audit2allow -a -M myhttpd    # creates myhttpd.pp module
+semodule -i myhttpd.pp       # install the module
+
+# Or interactively suggest what to add:
+audit2allow -a
+# allow httpd_t mysqld_port_t:tcp_socket name_connect;
+```
+
+## Boolean switches
+
+Booleans allow tunable policy without recompiling:
+
+```bash
+# List all booleans:
+getsebool -a | grep httpd | head -10
+# httpd_can_network_connect --> off
+# httpd_can_network_connect_db --> off
+# httpd_can_send_mail --> off
+# httpd_enable_cgi --> on
+
+# Enable httpd → database connections:
+setsebool -P httpd_can_network_connect_db on
+# -P = persistent (survives reboot)
+
+# Common web application booleans:
+setsebool -P httpd_unified on          # allow httpd to read any httpd type
+setsebool -P httpd_enable_homedirs on  # allow ~user/public_html
+```
+
+## SELinux modes
+
+```bash
+# Check current mode:
+getenforce
+# Enforcing
+
+# Modes:
+# Enforcing:  policy enforced, violations denied + audited
+# Permissive: policy not enforced, but violations audited (AVC denials logged)
+# Disabled:   SELinux completely off (requires reboot to re-enable)
+
+# Temporarily switch to permissive (for debugging):
+setenforce 0   # permissive
+setenforce 1   # enforcing
+
+# Per-domain permissive (process type runs permissive, others enforcing):
+semanage permissive -a httpd_t   # httpd_t in permissive mode
+semanage permissive -d httpd_t   # remove permissive
+```
+
+## selinuxfs: kernel interface
+
+```bash
+# SELinux exposes its interface via selinuxfs:
+ls /sys/fs/selinux/
+# access  avc  booleans  class  commit_pending_bools  context
+# create  deny_unknown  disable  enforce  load  mls  null  policy
+# policyvers  relabel  status  user
+
+# Check SELinux is enabled:
+cat /sys/fs/selinux/enforce
+# 1 = enforcing
+
+# Load a new policy:
+cat /etc/selinux/targeted/policy/policy.33 > /sys/fs/selinux/load
+
+# Check policy version:
+cat /sys/fs/selinux/policyvers
+# 33
+```
+
+## Kernel implementation
+
+```c
+/* security/selinux/hooks.c */
+
+/* SELinux hooks into every security-sensitive VFS operation: */
+static int selinux_inode_permission(struct inode *inode, int mask)
+{
+    const struct cred *cred = current_cred();
+    u32 perms;
+    int rc;
+
+    /* Get security IDs for current process and target inode */
+    u32 ssid = cred_sid(cred);
+    u32 tsid = inode_sid(inode);
+    u16 sclass = inode_mode_to_security_class(inode->i_mode);
+
+    perms = file_mask_to_av(inode->i_mode, mask);
+
+    /* AVC check: is ssid allowed perms on tsid:sclass? */
+    rc = avc_has_perm(ssid, tsid, sclass, perms, &ad);
+    return rc;  /* 0 = allowed, -EACCES = denied */
+}
+```
+
+## Further reading
+
+- [LSM Framework](lsm.md) — the security hook infrastructure SELinux uses
+- [Capabilities](capabilities.md) — SELinux and capabilities interact
+- [Linux Audit](audit.md) — SELinux denials go to audit log
+- [Credentials](credentials.md) — process SIDs derived from credentials
+- `security/selinux/` — SELinux implementation
+- `man semanage, restorecon, audit2allow` — policy management tools
+- Red Hat SELinux Guide — comprehensive policy writing documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -359,6 +359,8 @@ nav:
     - Linux Audit: security/audit.md
     - Credentials and User Namespaces: security/credentials.md
     - dm-crypt (Block Encryption): security/dm-crypt.md
+    - fscrypt (Per-File Encryption): security/fscrypt.md
+    - SELinux: security/selinux.md
   - Virtualization:
     - Getting Started: virtualization/README.md
     - KVM Architecture: virtualization/kvm-arch.md


### PR DESCRIPTION
## Summary
- **`docs/security/fscrypt.md`** (new): fscrypt per-file encryption — two-level key hierarchy (master key → HKDF-SHA512 → per-file key), v2 ioctl API (FS_IOC_ADD_ENCRYPTION_KEY, FS_IOC_SET_ENCRYPTION_POLICY), per-block IV derivation (file nonce XOR block number), inline encryption hardware support, hot key revocation via page cache eviction, fscrypt vs dm-crypt comparison table
- **`docs/security/selinux.md`** (new): SELinux MAC deep dive — security context format, AVC cache with struct avc_entry (97% hit rate), type enforcement policy syntax, file context labeling with restorecon/semanage, audit2allow workflow from AVC denials to policy module, booleans for tunable policy, per-domain permissive debugging, selinuxfs kernel interface, selinux_inode_permission hook implementation
- **`mkdocs.yml`**: add fscrypt and SELinux under Security nav

## Test plan
- [ ] `mkdocs build` passes
- [ ] fscrypt and SELinux appear under Security nav
- [ ] AVC cache internals section renders correctly

Closes #457, #458, #459, #460