### PR TITLE
Add arch/x86, HMM, userfaultfd, user namespaces, and workqueue docs

### DIFF
--- a/docs/arch/x86/exceptions.md
+++ b/docs/arch/x86/exceptions.md
@@ -1,0 +1,527 @@
+# x86 Exception and Interrupt Handling
+
+> IDT, exception entry, hardware exceptions, and the page fault handler path
+
+## x86 exception fundamentals
+
+On x86, all exceptions and interrupts are delivered via the **Interrupt Descriptor Table (IDT)**. The IDT has 256 entries:
+
+```
+IDT entry layout (gate descriptor, 16 bytes on x86-64):
+ ┌──────────────────────────────────────────────────┐
+ │ Offset[63:32]                                    │
+ ├──────────────────────────────────────────────────┤
+ │ Reserved                  │ Offset[31:16]        │
+ ├───────────┬───────────────┼──────────────────────┤
+ │  P DPL S  │   Type        │ Segment Selector     │
+ ├───────────┴───────────────┴──────────────────────┤
+ │ Offset[15:0]                                     │
+ └──────────────────────────────────────────────────┘
+
+P   = present
+DPL = descriptor privilege level (0=kernel, 3=user)
+Type= 0xE = interrupt gate (clears IF), 0xF = trap gate (keeps IF)
+```
+
+Entries 0-31 are reserved for CPU exceptions. Entries 32-255 are for external interrupts and software traps (syscalls use int 0x80 historically, or SYSCALL instruction on x86-64).
+
+## CPU exception vectors
+
+| Vector | Mnemonic | Name | Error code | Fault/Trap/Abort |
+|--------|----------|------|------------|-----------------|
+| 0 | #DE | Divide Error | No | Fault |
+| 1 | #DB | Debug | No | Fault/Trap |
+| 2 | NMI | Non-Maskable Interrupt | No | Interrupt |
+| 3 | #BP | Breakpoint | No | Trap |
+| 4 | #OF | Overflow | No | Trap |
+| 5 | #BR | BOUND Range Exceeded | No | Fault |
+| 6 | #UD | Invalid Opcode | No | Fault |
+| 7 | #NM | Device Not Available | No | Fault |
+| 8 | #DF | Double Fault | Zero | Abort |
+| 10 | #TS | Invalid TSS | Yes | Fault |
+| 11 | #NP | Segment Not Present | Yes | Fault |
+| 12 | #SS | Stack-Segment Fault | Yes | Fault |
+| 13 | #GP | General Protection | Yes | Fault |
+| 14 | #PF | Page Fault | Yes | Fault |
+| 16 | #MF | x87 FPU Error | No | Fault |
+| 17 | #AC | Alignment Check | Zero | Fault |
+| 18 | #MC | Machine Check | No | Abort |
+| 19 | #XM | SIMD FP Exception | No | Fault |
+| 20 | #VE | Virtualization Exception | No | Fault |
+
+**Fault**: saved CS:RIP points to the faulting instruction (re-executed after handler).
+**Trap**: saved CS:RIP points to the instruction after the trap.
+**Abort**: unrecoverable; saved state may be corrupted.
+
+## IDT initialization
+
+```c
+/* arch/x86/kernel/idt.c */
+
+/* IDT gate descriptor in kernel code */
+struct idt_data {
+    unsigned int    vector;
+    unsigned int    segment;
+    struct idt_bits bits;
+    const void      *addr;
+};
+
+/* Early IDT setup (before C code) */
+static const __initconst struct idt_data def_idts[] = {
+    INTG(X86_TRAP_DE,       asm_exc_divide_error),
+    INTG(X86_TRAP_NMI,      asm_exc_nmi),
+    INTG(X86_TRAP_BP,       asm_exc_int3),     /* DPL=3: user can trigger */
+    INTG(X86_TRAP_OF,       asm_exc_overflow),
+    INTG(X86_TRAP_UD,       asm_exc_invalid_op),
+    INTG(X86_TRAP_NM,       asm_exc_device_not_available),
+    INTG(X86_TRAP_GP,       asm_exc_general_protection),
+    INTG(X86_TRAP_PF,       asm_exc_page_fault),
+    /* ... */
+};
+
+void __init idt_setup_early_traps(void)
+{
+    idt_setup_from_table(idt_table, early_idts, ARRAY_SIZE(early_idts), true);
+    load_idt(&idt_descr);  /* LIDT instruction */
+}
+```
+
+The `LIDT` instruction loads the IDT register (IDTR) with the base address and limit of the IDT table.
+
+## Exception entry: hardware behavior
+
+When the CPU delivers an exception to ring 0 (from ring 3 userspace):
+
+```
+Hardware actions (automatic, before any software):
+  1. Look up IDT[vector] → get handler address and DPL
+  2. Check DPL ≥ CPL (prevents user invoking kernel-only gates)
+  3. Switch to kernel stack (via TSS.RSP0 for ring 0 target)
+  4. Push on new stack:
+       [SS]        ← old user SS
+       [RSP]       ← old user RSP
+       [RFLAGS]    ← old RFLAGS
+       [CS]        ← old user CS
+       [RIP]       ← address of faulting instruction (fault) or next (trap)
+       [Error Code] ← for exceptions with error codes (GP, PF, etc.)
+  5. Clear IF (interrupt gate): disables maskable interrupts
+  6. Jump to handler address from IDT entry
+```
+
+For ring-0 → ring-0 exceptions (kernel taking a fault):
+- No stack switch (stays on current kernel stack)
+- Still pushes RIP/CS/RFLAGS/error code
+
+## Exception entry assembly (x86-64)
+
+Linux uses `DEFINE_IDTENTRY_*` macros to generate exception entry stubs:
+
+```c
+/* arch/x86/include/asm/idtentry.h */
+
+/* Generates the asm entry stub + C handler declaration */
+#define DEFINE_IDTENTRY_ERRORCODE(func)                         \
+    __visible noinstr void func(struct pt_regs *regs, long error_code)
+
+/* arch/x86/kernel/traps.c */
+DEFINE_IDTENTRY_ERRORCODE(exc_general_protection)
+{
+    struct task_struct *tsk = current;
+    unsigned long condition = error_code;
+    char *desc;
+
+    cond_local_irq_enable(regs);
+
+    if (static_cpu_has(X86_FEATURE_UMIP)) {
+        if (user_mode(regs) && fixup_umip_exception(regs))
+            return;
+    }
+
+    if (v8086_mode(regs)) {
+        handle_vm86_fault((struct kernel_vm86_regs *) regs, error_code);
+        return;
+    }
+
+    tsk->thread.error_code = error_code;
+    tsk->thread.trap_nr = X86_TRAP_GP;
+
+    if (show_unhandled_signals && unhandled_signal(tsk, SIGSEGV) &&
+        printk_ratelimit()) {
+        pr_info("%s[%d] general protection ip:%lx sp:%lx error:%lx",
+                tsk->comm, task_pid_nr(tsk),
+                regs->ip, regs->sp, error_code);
+    }
+
+    force_sig_fault(SIGSEGV, SEGV_MAPERR, (void __user *)0);
+}
+```
+
+## struct pt_regs
+
+All exception handlers receive a `struct pt_regs` that captures the full register state:
+
+```c
+/* arch/x86/include/asm/ptrace.h */
+struct pt_regs {
+    /* Callee-saved registers (pushed by entry asm) */
+    unsigned long r15, r14, r13, r12;
+    unsigned long rbp;
+    unsigned long rbx;
+
+    /* Argument registers */
+    unsigned long r11, r10, r9, r8;
+    unsigned long rax, rcx, rdx, rsi, rdi;
+
+    /* CPU-pushed on exception entry */
+    unsigned long orig_rax;  /* syscall number or error code */
+    unsigned long rip;
+    unsigned long cs;
+    unsigned long eflags;
+    unsigned long rsp;
+    unsigned long ss;
+};
+```
+
+The entry assembly (`arch/x86/entry/entry_64.S`) saves all registers to build this structure before calling the C handler.
+
+## Task State Segment (TSS)
+
+The TSS is critical for stack switching on exception delivery:
+
+```c
+/* arch/x86/include/asm/processor.h */
+struct x86_hw_tss {
+    u32         reserved1;
+    u64         sp0;    /* RSP0: kernel stack pointer (used for ring-0 target) */
+    u64         sp1;
+    u64         sp2;
+    u64         reserved2;
+    u64         ist[7]; /* IST1-IST7: Interrupt Stack Table entries */
+    u32         reserved3;
+    u32         reserved4;
+    u16         reserved5;
+    u16         io_bitmap_base;
+} __attribute__((packed));
+```
+
+**IST (Interrupt Stack Table)**: Some critical exceptions use dedicated stacks from IST to handle faults even when the regular kernel stack is corrupted:
+
+| Exception | IST | Reason |
+|-----------|-----|--------|
+| NMI | IST1 | Can interrupt any code including exception handlers |
+| #DF (double fault) | IST2 | Stack pointer might be corrupted |
+| #MC (machine check) | IST3 | Hardware may be completely broken |
+| #DB (debug) | IST4 | Can fire in weird contexts |
+
+## Page fault handler (#PF)
+
+The page fault is the most important exception in a running system:
+
+### Error code bits
+
+```
+#PF error code:
+  bit 0: P   — 0=non-present, 1=protection violation
+  bit 1: W/R — 0=read, 1=write
+  bit 2: U/S — 0=supervisor (kernel), 1=user
+  bit 3: RSVD — reserved bit violation
+  bit 4: I/D — 0=data, 1=instruction fetch
+  bit 5: PK  — protection key violation
+  bit 6: SGX — SGX-related fault
+```
+
+### Handler entry
+
+```c
+/* arch/x86/mm/fault.c */
+
+/*
+ * CR2 contains the faulting linear address.
+ * Called from asm_exc_page_fault after saving pt_regs.
+ */
+DEFINE_IDTENTRY_RAW_ERRORCODE(exc_page_fault)
+{
+    unsigned long address = read_cr2();  /* faulting virtual address */
+    irqentry_state_t state;
+
+    prefetchw(&current->mm->mmap_lock);
+
+    /*
+     * KVM: notify before running page fault handler.
+     * Allows hypervisor to handle EPT-related faults first.
+     */
+    if (kvm_handle_async_pf(regs, (u32)error_code))
+        return;
+
+    state = irqentry_enter(regs);
+    instrumentation_begin();
+    handle_page_fault_out_of_line(regs, error_code, address);
+    instrumentation_end();
+    irqentry_exit(regs, state);
+}
+```
+
+### Fault classification
+
+```c
+static noinline void
+handle_page_fault_out_of_line(struct pt_regs *regs, unsigned long error_code,
+                               unsigned long address)
+{
+    /* Fault from kernel mode? */
+    if (unlikely(fault_in_kernel_space(address))) {
+        do_kern_addr_fault(regs, error_code, address);
+        return;
+    }
+
+    /* Fault from user mode or kernel accessing user memory */
+    do_user_addr_fault(regs, error_code, address);
+}
+```
+
+### User address fault path
+
+```c
+static inline void
+do_user_addr_fault(struct pt_regs *regs, unsigned long error_code,
+                   unsigned long address)
+{
+    struct vm_area_struct *vma;
+    struct task_struct *tsk = current;
+    struct mm_struct *mm = tsk->mm;
+    vm_fault_t fault;
+    unsigned int flags = FAULT_FLAG_DEFAULT;
+
+    /* Spurious fault? Check if address is in a valid VMA */
+    if (unlikely(!mm)) {
+        bad_area_nosemaphore(regs, error_code, address);
+        return;
+    }
+
+    /* Indicate this is a write or instruction fetch */
+    if (error_code & X86_PF_WRITE)
+        flags |= FAULT_FLAG_WRITE;
+    if (error_code & X86_PF_INSTR)
+        flags |= FAULT_FLAG_INSTRUCTION;
+    if (error_code & X86_PF_USER)
+        flags |= FAULT_FLAG_USER;
+
+    /* Acquire mmap_lock (shared for reads, exclusive if needed) */
+    if (unlikely(!mmap_read_trylock(mm))) {
+        /* If in interrupt context or killed, can't wait */
+        if (unlikely(faulthandler_disabled() || !user_mode(regs))) {
+            bad_area_nosemaphore(regs, error_code, address);
+            return;
+        }
+        mmap_read_lock(mm);
+    }
+
+    /* Find the VMA containing the faulting address */
+    vma = find_vma(mm, address);
+    if (unlikely(!vma)) {
+        bad_area(regs, error_code, address, NULL);
+        goto done;
+    }
+    if (likely(vma->vm_start <= address))
+        goto good_area;
+
+    /* Address is in a hole between VMAs — check if it's a stack growth */
+    if (unlikely(!(vma->vm_flags & VM_GROWSDOWN))) {
+        bad_area(regs, error_code, address, vma);
+        goto done;
+    }
+    if (unlikely(expand_stack(vma, address))) {
+        bad_area(regs, error_code, address, vma);
+        goto done;
+    }
+
+good_area:
+    fault = handle_mm_fault(mm, vma, address, flags);
+    /* ... */
+
+done:
+    mmap_read_unlock(mm);
+}
+```
+
+### Kernel address fault path
+
+```c
+static noinline void
+do_kern_addr_fault(struct pt_regs *regs, unsigned long hw_error_code,
+                   unsigned long address)
+{
+    /* Check the fixup table: expected faults in kernel code */
+    if (fixup_exception(regs, X86_TRAP_PF, hw_error_code, address))
+        return;
+
+    /* KASAN/KFENCE shadow memory? */
+    if (kfence_handle_page_fault(address, hw_error_code & X86_PF_WRITE, regs))
+        return;
+
+    /* vmalloc fault? (lazy mapping, VMALLOC_START to VMALLOC_END) */
+    if (!(hw_error_code & (X86_PF_RSVD | X86_PF_USER | X86_PF_PK))) {
+        if (vmalloc_fault(address) >= 0)
+            return;
+    }
+
+    /* Oops: unexpected kernel fault */
+    bad_area_nosemaphore(regs, hw_error_code, address);
+}
+```
+
+## Exception fixup table
+
+The kernel's exception fixup table maps faulting instruction addresses to recovery code. Used for `copy_from_user`/`copy_to_user`:
+
+```c
+/* arch/x86/lib/usercopy_64.S */
+/* If this copy instruction faults: */
+1:  rep movsb
+    /* ... */
+2:  ret
+    /* Fixup entry: if [1] faults, jump to [3] */
+    _ASM_EXTABLE_UA(1b, 3f)
+3:  mov %ecx, %eax   /* Return number of bytes not copied */
+    ret
+
+/* In C: */
+unsigned long copy_from_user(void *to, const void __user *from, unsigned long n)
+{
+    /*
+     * If the copy faults (bad user pointer), the CPU exception
+     * handler checks the fixup table and jumps to the error path
+     * instead of oopsing.
+     */
+    return raw_copy_from_user(to, from, n);
+}
+```
+
+## NMI handling
+
+Non-Maskable Interrupts cannot be masked with `cli`. They require careful handling because they can interrupt *any* code including interrupt handlers:
+
+```c
+/* arch/x86/kernel/nmi.c */
+DEFINE_IDTENTRY_RAW(exc_nmi)
+{
+    irqentry_state_t irq_state;
+
+    /*
+     * NMI uses its own IST stack. Since NMI can nest (NMI within NMI
+     * handling), the kernel uses a careful "NMI nesting" protocol:
+     */
+
+    /* Check if we interrupted an NMI handler itself */
+    if (this_cpu_read(nmi_state) != NMI_NOT_RUNNING) {
+        this_cpu_write(nmi_cr2, read_cr2());
+        this_cpu_write(nmi_state, NMI_LATCHED);
+        return;
+    }
+
+    this_cpu_write(nmi_state, NMI_EXECUTING);
+    this_cpu_write(nmi_cr2, read_cr2());
+
+    nmi_restart:
+    irq_state = irqentry_nmi_enter(regs);
+    do_nmi(regs, 0);
+    irqentry_nmi_exit(regs, irq_state);
+
+    /* Check if NMI was latched while handling */
+    if (this_cpu_dec_return(nmi_state) == NMI_LATCHED)
+        goto nmi_restart;
+}
+```
+
+NMIs are used for:
+- Hardware errors (MCE, watchdog)
+- Perf PMU overflow interrupts (PEBS/LBR)
+- kdump NMI shootdown (crash on one CPU, NMI all others)
+- Kernel watchdog (`CONFIG_HARDLOCKUP_DETECTOR`)
+
+## SYSCALL/SYSRET (fast system call)
+
+Modern x86-64 uses the `SYSCALL` instruction instead of `int 0x80`:
+
+```
+SYSCALL (user → kernel):
+  1. Load RIP from MSR_LSTAR (syscall entry point)
+  2. Save user RIP in RCX, RFLAGS in R11
+  3. Load CS/SS from MSR_STAR segments
+  4. Clear RFLAGS bits in MSR_SFMASK
+  * Does NOT switch stack — kernel must do this in entry asm
+
+SYSRET (kernel → user):
+  1. Restore RIP from RCX, RFLAGS from R11
+  2. Restore CS/SS
+  * Does NOT save/restore any other registers
+```
+
+```c
+/* arch/x86/entry/entry_64.S */
+SYM_CODE_START(entry_SYSCALL_64)
+    /* Switch from user stack to kernel stack: */
+    swapgs                          /* swap GS with MSR_KERNEL_GS_BASE */
+    movq    %rsp, PER_CPU_VAR(cpu_tss_rw + TSS_sp2)
+    SWITCH_TO_KERNEL_CR3 scratch_reg=%rsp
+    movq    PER_CPU_VAR(cpu_current_top_of_stack), %rsp
+
+    /* Save user state: */
+    pushq   $__USER_DS              /* ss */
+    pushq   PER_CPU_VAR(cpu_tss_rw + TSS_sp2)  /* rsp */
+    pushq   %r11                   /* rflags */
+    pushq   $__USER_CS             /* cs */
+    pushq   %rcx                   /* rip (saved by SYSCALL) */
+
+    /* ... save remaining regs, call do_syscall_64() ... */
+```
+
+## Observability
+
+```bash
+# Count exceptions per type (perf)
+perf stat -e exceptions:page_fault_user,exceptions:page_fault_kernel \
+          -p <pid> sleep 5
+
+# Watch page fault rate (vmstat)
+vmstat 1
+# pgfault: minor faults (page in from cache or anon)
+# pgmajfault: major faults (disk read)
+
+# Trace all page faults (heavy!)
+bpftrace -e '
+tracepoint:exceptions:page_fault_user {
+    @[ustack] = count();
+}'
+
+# Decode IDT
+crash> idt
+
+# Show exception handler address for vector 14 (#PF)
+python3 -c "
+import struct, sys
+# /sys/kernel/debug/x86/idt_table is a binary dump of the IDT
+with open('/sys/kernel/debug/x86/idt_table','rb') as f:
+    data = f.read()
+v = 14  # page fault
+entry = data[v*16:(v+1)*16]
+lo16, seg, bits16, hi16, hi32, _ = struct.unpack('<HHHHII', entry)
+addr = lo16 | (hi16 << 16) | (hi32 << 32)
+print(f'#PF handler: {addr:#x}')
+"
+
+# /proc/interrupts shows interrupt counts per CPU
+cat /proc/interrupts | head -5
+```
+
+## Further reading
+
+- [ARM64 Exception Model](../arm64/exception-model.md) — equivalent AArch64 mechanisms
+- [Page Fault Handler](../../mm/page-fault.md) — handle_mm_fault and VMA resolution
+- [IRQ Handling](../../interrupts/interrupts.md) — external interrupt delivery
+- [Syscall Entry](../../syscalls/syscall-entry.md) — SYSCALL/SYSRET path in detail
+- [Kernel Hardening](../../security/kernel-hardening.md) — SMEP/SMAP, KPTI
+- `arch/x86/kernel/traps.c` — exception handler implementations
+- `arch/x86/mm/fault.c` — page fault handler
+- `arch/x86/entry/entry_64.S` — exception/syscall entry assembly
+- Intel SDM Vol 3A, Chapter 6 — Interrupt and Exception Handling

--- a/docs/interrupts/workqueue-internals.md
+++ b/docs/interrupts/workqueue-internals.md
@@ -1,0 +1,315 @@
+# Workqueue Internals
+
+> cmwq architecture, worker pools, work item lifecycle, and NUMA affinity
+
+## Why workqueues exist
+
+Interrupt handlers (hardirq and softirq) run atomically — they cannot sleep or block. Work that needs to sleep, acquire mutexes, or do I/O must be deferred. Workqueues provide a kernel thread pool that can run this deferred work in process context.
+
+```
+Interrupt fires:
+  hardirq handler → schedule_work(&my_work)   ← non-sleeping, fast
+                         │
+                         ▼
+                    [kworker thread]            ← sleeps OK
+                    my_work_func()
+                    → can mutex_lock(), kmalloc(GFP_KERNEL), etc.
+```
+
+## Concurrency-Managed Workqueues (cmwq)
+
+Since Linux 2.6.36, workqueues use **cmwq** — a unified worker pool that automatically manages concurrency:
+
+```
+Before cmwq (per-CPU dedicated threads):
+  cpu0: kblockd/0, kworker/0:0, kworker/0:1, ...
+  cpu1: kblockd/1, kworker/1:0, kworker/1:1, ...
+  Problem: each workqueue had its own per-CPU thread → thread explosion
+
+After cmwq (shared worker pool):
+  cpu0: [shared pool] kworker/0:0, kworker/0:1, kworker/0:2H (high-prio)
+  cpu1: [shared pool] kworker/1:0, kworker/1:1, kworker/1:2H
+  All workqueues share the pool → far fewer threads
+```
+
+### Worker pool types
+
+```c
+/* kernel/workqueue.c */
+
+/* Per-CPU worker pools (2 per CPU: normal and highpri): */
+static DEFINE_PER_CPU_SHARED_ALIGNED(struct worker_pool [NR_STD_WORKER_POOLS],
+                                     cpu_worker_pools);
+/*
+ * cpu_worker_pools[0]: normal priority (SCHED_NORMAL, nice=0)
+ * cpu_worker_pools[1]: high priority  (SCHED_NORMAL, nice=-20)
+ */
+
+/* Unbound worker pools: not tied to any CPU, for WQ_UNBOUND workqueues */
+static DEFINE_HASHTABLE(unbound_pool_hash, UNBOUND_POOL_HASH_ORDER);
+```
+
+## Creating workqueues
+
+```c
+#include <linux/workqueue.h>
+
+/* System workqueues (prefer these): */
+system_wq             /* general-purpose, can sleep */
+system_highpri_wq     /* high-priority, time-critical work */
+system_long_wq        /* for work that may run for a long time */
+system_unbound_wq     /* not bound to a specific CPU */
+system_freezable_wq   /* suspended during system freeze */
+system_power_efficient_wq  /* prefers low-power CPUs */
+
+/* Use system_wq for most cases: */
+schedule_work(&my_work);  /* submits to system_wq */
+
+/* Custom workqueue: */
+struct workqueue_struct *wq;
+
+/* Bound to a CPU (work runs on the CPU it was submitted from): */
+wq = alloc_workqueue("my-wq", WQ_MEM_RECLAIM, 1);
+
+/* Unbound (can run on any CPU, better for NUMA): */
+wq = alloc_workqueue("my-unbound-wq", WQ_UNBOUND, 0);
+
+/* High priority + unbound: */
+wq = alloc_workqueue("my-hipri-wq", WQ_UNBOUND | WQ_HIGHPRI, 0);
+
+/* Flags: */
+WQ_UNBOUND          /* not bound to a specific CPU */
+WQ_FREEZABLE        /* freeze during system suspend */
+WQ_MEM_RECLAIM      /* may be needed during memory reclaim (reserves a rescue thread) */
+WQ_HIGHPRI          /* high-priority worker pool */
+WQ_CPU_INTENSIVE    /* hint: work is CPU-intensive, don't limit concurrency */
+WQ_SYSFS            /* expose workqueue attributes in /sys/bus/workqueue */
+
+/* Last arg: max_active = max concurrent work items per CPU (0 = default=256) */
+```
+
+## Work items
+
+```c
+/* Declare and initialize work: */
+DECLARE_WORK(my_work, my_work_func);
+/* or: */
+struct work_struct my_work;
+INIT_WORK(&my_work, my_work_func);
+
+/* Work function: */
+static void my_work_func(struct work_struct *work)
+{
+    struct my_device *dev = container_of(work, struct my_device, work);
+    /* Process dev->data — can sleep here */
+    mutex_lock(&dev->lock);
+    process_data(dev);
+    mutex_unlock(&dev->lock);
+}
+
+/* Submit work: */
+schedule_work(&my_work);          /* to system_wq, current CPU */
+queue_work(wq, &my_work);         /* to custom wq */
+queue_work_on(cpu, wq, &my_work); /* to specific CPU's pool */
+
+/* Wait for work to complete: */
+flush_work(&my_work);             /* blocks until this work item finishes */
+flush_workqueue(wq);              /* blocks until all items in wq finish */
+```
+
+## Delayed work
+
+```c
+struct delayed_work my_dwork;
+INIT_DELAYED_WORK(&my_dwork, my_dwork_func);
+
+/* Schedule to run after 100ms: */
+schedule_delayed_work(&my_dwork, msecs_to_jiffies(100));
+queue_delayed_work(wq, &my_dwork, msecs_to_jiffies(100));
+
+/* Cancel (may or may not cancel if already running): */
+cancel_delayed_work(&my_dwork);
+
+/* Cancel and wait for completion: */
+cancel_delayed_work_sync(&my_dwork);
+```
+
+## struct work_struct internals
+
+```c
+struct work_struct {
+    atomic_long_t   data;       /* encodes: pool pointer + flags */
+    struct list_head entry;     /* in pool->worklist */
+    work_func_t     func;
+#ifdef CONFIG_LOCKDEP
+    struct lockdep_map lockdep_map;
+#endif
+};
+
+/* data field encodes: */
+/* bits [0]: WORK_STRUCT_PENDING — work is queued */
+/* bits [1]: WORK_STRUCT_INACTIVE — work is in an inactive list */
+/* bits [2]: WORK_STRUCT_PWQ — lower bits point to pool_workqueue */
+/* bits [WORK_STRUCT_FLAG_BITS..]: pointer to pool_workqueue or last pool */
+```
+
+## Worker pool and concurrency management
+
+```c
+struct worker_pool {
+    spinlock_t          lock;
+    int                 cpu;        /* CPU or -1 for unbound */
+    int                 node;       /* NUMA node */
+    int                 id;
+    unsigned int        flags;
+
+    unsigned long       watchdog_ts;
+    bool                cpu_stall;
+
+    struct list_head    worklist;   /* pending work items */
+    int                 nr_workers;
+    int                 nr_idle;
+
+    struct list_head    idle_list;  /* idle workers */
+    struct timer_list   idle_timer;
+    struct work_struct  idle_cull_work;
+
+    struct timer_list   mayday_timer; /* safety valve */
+    DECLARE_HASHTABLE(busy_hash, BUSY_WORKER_HASH_ORDER);
+
+    struct worker       *manager;   /* thread managing the pool */
+    struct list_head    workers;    /* all workers in pool */
+    struct completion   *detach_completion;
+
+    struct ida          worker_ida;
+    struct workqueue_attrs *attrs;
+    struct hlist_node   hash_node;
+    int                 refcnt;
+    struct rcu_head     rcu;
+};
+```
+
+### Concurrency management algorithm
+
+cmwq maintains exactly enough workers to keep the CPU busy:
+
+```
+Rule: pool tries to keep at least one runnable worker
+  (one that is executing work AND not sleeping)
+
+When a worker goes to sleep (blocks on mutex, I/O, etc.):
+  → pool checks: is there another runnable worker?
+  → if not: wake an idle worker (or create a new one)
+  → prevents CPU stall while work is blocked
+
+When a worker wakes up:
+  → pool checks: too many runnable workers?
+  → if yes: go back to sleep (idle)
+
+Result: CPU always busy, minimal thread creation
+```
+
+```c
+/* kernel/workqueue.c */
+static void worker_enter_idle(struct worker *worker)
+{
+    struct worker_pool *pool = worker->pool;
+
+    /* ... */
+    pool->nr_idle++;
+    worker->last_active = jiffies;
+    worker->flags |= WORKER_IDLE;
+    list_add(&worker->entry, &pool->idle_list);
+
+    /* Destroy idle workers after 5 minutes of idleness */
+    if (too_many_workers(pool))
+        mod_timer(&pool->idle_timer, jiffies + IDLE_WORKER_TIMEOUT);
+}
+
+static bool keep_working(struct worker_pool *pool)
+{
+    return !list_empty(&pool->worklist) &&
+           atomic_read(&pool->nr_running) <= 1;
+}
+```
+
+## Workqueue attributes and NUMA affinity
+
+```c
+/* Get/set workqueue attributes (WQ_UNBOUND only): */
+struct workqueue_attrs *attrs = alloc_workqueue_attrs();
+attrs->nice = -5;           /* worker thread niceness */
+attrs->cpumask = cpu_mask;  /* which CPUs workers can run on */
+attrs->no_numa = false;     /* respect NUMA locality */
+
+apply_workqueue_attrs(wq, attrs);
+free_workqueue_attrs(attrs);
+
+/* NUMA-aware unbound pools:
+   By default, unbound workqueues have per-NUMA-node pools.
+   Work submitted from node 0 runs on node 0 workers.
+   This ensures cache-hot data stays on the same node. */
+```
+
+## Workqueue debugging
+
+```bash
+# Show all workqueues and their stats:
+cat /sys/kernel/debug/workqueue/stats
+
+# Show worker threads:
+ps aux | grep kworker
+# kworker/0:1   — bound to CPU 0, pool 1 (normal)
+# kworker/0:1H  — bound to CPU 0, pool H (high priority)
+# kworker/u8:2  — unbound, u = unbound, 8 = num CPUs, pool 2
+
+# Show per-workqueue stats (if WQ_SYSFS):
+ls /sys/bus/workqueue/devices/
+cat /sys/bus/workqueue/devices/system_wq/per_cpu
+
+# Dump all pending work items (requires CONFIG_WQ_WATCHDOG or crash):
+echo workqueue > /proc/sysrq-trigger
+# Kernel prints work items to dmesg
+
+# Trace work submission and execution:
+bpftrace -e '
+kprobe:queue_work_on {
+    printf("queue_work: cpu=%d func=%s\n", (int)arg0,
+           ksym(((struct work_struct *)arg1)->func));
+}
+kprobe:process_one_work {
+    printf("exec_work: cpu=%d pid=%d func=%s\n",
+           cpu, pid, ksym(((struct work_struct *)arg1)->func));
+}'
+
+# Watchdog: detect hung workers (CONFIG_WQ_WATCHDOG=y)
+# Kernel will warn if a worker pool stalls for > 30 seconds:
+# "BUG: workqueue lockup"
+# Tune:
+echo 60 > /sys/module/workqueue/parameters/watchdog_thresh
+```
+
+## WQ_MEM_RECLAIM and rescue workers
+
+```c
+/*
+ * Work used during memory reclaim (e.g., writeback) MUST use WQ_MEM_RECLAIM.
+ * This ensures a dedicated rescue worker exists that won't be blocked
+ * waiting for memory (avoiding deadlock):
+ *
+ * Memory reclaim path:
+ *   1. kswapd needs to write dirty pages → queues work
+ *   2. Normal workers might be sleeping waiting for memory
+ *   3. Rescue worker picks up the work — always has one thread reserved
+ */
+wq = alloc_workqueue("writeback", WQ_MEM_RECLAIM | WQ_UNBOUND, 1);
+```
+
+## Further reading
+
+- [Workqueues](workqueues.md) — API reference and basic usage
+- [Softirq and Tasklets](softirq.md) — lighter-weight deferral (no sleep)
+- [Threaded IRQs](threaded-irq.md) — IRQ handlers in thread context
+- [RCU](../locking/rcu.md) — lock-free deferred work
+- `kernel/workqueue.c` — complete implementation (~6000 lines)
+- `Documentation/core-api/workqueue.rst` — kernel documentation

--- a/docs/mm/hmm.md
+++ b/docs/mm/hmm.md
@@ -1,0 +1,284 @@
+# HMM: Heterogeneous Memory Management
+
+> Sharing virtual address spaces between CPU and GPU — struct page for device memory
+
+## The problem
+
+Modern systems have GPUs and other accelerators with their own memory (VRAM). Applications want to use a single virtual address space across CPU and GPU:
+
+```
+Traditional (two address spaces):
+  CPU:  malloc → virtual addr 0x7f000000
+  GPU:  cudaMalloc → device addr 0xc000000000
+  Programmer: explicit copies between the two
+
+With HMM (unified virtual address space):
+  CPU:  mmap → virtual addr 0x7f000000
+  GPU:  same virtual addr 0x7f000000 (GPU MMU maps same pages)
+  Programmer: writes to address, GPU reads from same address
+  Kernel: tracks ownership and handles faults on both sides
+```
+
+## HMM components
+
+```
+Application virtual address space
+         │
+    ┌────┴────────────────────────────────┐
+    │         CPU page tables (MMU)        │
+    │         GPU page tables (IOMMU)      │
+    └────┬────────────────────────────────┘
+         │
+    ┌────┴───────────────────────┐
+    │        HMM layer           │
+    │  - mirror (CPU↔GPU sync)   │
+    │  - range (snapshot VA)     │
+    │  - device memory (VRAM)    │
+    └────┬──────────────────────┘
+         │
+    ┌────┴───────────────────────────────────────────┐
+    │  Physical memory:                              │
+    │  DRAM (system RAM)    VRAM (GPU memory)        │
+    │  struct page          struct page (ZONE_DEVICE) │
+    └────────────────────────────────────────────────┘
+```
+
+## struct page for device memory
+
+HMM extends `struct page` to represent GPU/device memory through `ZONE_DEVICE`:
+
+```c
+/* mm/memremap.c */
+
+/* Device memory types: */
+enum memory_type {
+    MEMORY_DEVICE_PRIVATE,     /* GPU private memory, not CPU-accessible */
+    MEMORY_DEVICE_COHERENT,    /* CPU-accessible device memory (CXL, etc.) */
+    MEMORY_DEVICE_FS_DAX,      /* DAX filesystems */
+    MEMORY_DEVICE_GENERIC,     /* generic device memory */
+    MEMORY_DEVICE_PCI_P2PDMA,  /* P2P DMA between PCIe devices */
+};
+
+/* Register device memory as ZONE_DEVICE pages: */
+struct dev_pagemap pgmap = {
+    .type  = MEMORY_DEVICE_PRIVATE,
+    .range = {
+        .start = phys_base,
+        .end   = phys_base + size - 1,
+    },
+    .ops = &my_device_pagemap_ops,
+};
+devm_memremap_pages(dev, &pgmap);
+/* Now: pfn_to_page(pfn) works for device memory pages */
+```
+
+## HMM mirror: synchronizing CPU and GPU page tables
+
+The **HMM mirror** allows a device driver to receive notifications when the CPU page table changes, so it can update the GPU page table accordingly:
+
+```c
+/* include/linux/hmm.h */
+
+/* A driver creates one mirror per process/GPU context: */
+struct hmm_mirror {
+    struct mm_struct        *mm;
+    const struct hmm_mirror_ops *ops;
+    struct list_head         list;       /* in mm->hmm->mirrors */
+};
+
+/* Callbacks the driver implements: */
+const struct hmm_mirror_ops my_gpu_mirror_ops = {
+    /* CPU page table changed for a range — update GPU page table */
+    .sync_cpu_device_pagetables = my_gpu_update_pagetable,
+};
+
+/* Register the mirror: */
+hmm_mirror_register(&mirror, mm);
+```
+
+### mmu_interval_notifier: lighter alternative (Linux 5.10+)
+
+```c
+/* Preferred modern API: no full mirror, just range notifications */
+struct mmu_interval_notifier notifier;
+
+static const struct mmu_interval_notifier_ops gpu_mni_ops = {
+    .invalidate = gpu_invalidate_range,
+};
+
+/* Register: notified when [start, end) VA range changes */
+mmu_interval_notifier_insert(&notifier, mm, start, length, &gpu_mni_ops);
+
+static bool gpu_invalidate_range(struct mmu_interval_notifier *mni,
+                                  const struct mmu_notifier_invalidate_range_start_t *range,
+                                  unsigned long cur_seq)
+{
+    /* GPU must stop accessing this range */
+    gpu_unmap_range(mni->start, mni->length);
+    mmu_interval_set_seq(mni, cur_seq);
+    return true;
+}
+```
+
+## HMM range snapshot
+
+A driver uses `hmm_range_fault()` to snapshot the current CPU page table state for a range, getting the physical addresses (PFNs) the GPU should map:
+
+```c
+/* arch/x86/kernel/gpu_driver.c (simplified) */
+
+#define HMM_PFN_VALID   (1UL << 0)
+#define HMM_PFN_WRITE   (1UL << 1)
+#define HMM_PFN_DEVICE  (1UL << 2)
+
+static int gpu_fault_and_map(struct mm_struct *mm, unsigned long addr,
+                              unsigned long len)
+{
+    unsigned long pfns[len / PAGE_SIZE];
+    struct hmm_range range = {
+        .notifier     = &notifier,
+        .notifier_seq = mmu_interval_read_begin(&notifier),
+        .start        = addr,
+        .end          = addr + len,
+        .pfns         = pfns,
+        .flags        = HMM_PFN_VALID | HMM_PFN_WRITE,
+        .values       = hmm_range_values,  /* driver fills this */
+        .default_flags = HMM_PFN_VALID,
+        .pfn_flags_mask = HMM_PFN_WRITE,
+    };
+
+    int ret;
+retry:
+    ret = hmm_range_fault(&range);
+    if (ret == -EBUSY) {
+        /* Page table changed while we were snapshotting — retry */
+        range.notifier_seq = mmu_interval_read_begin(&notifier);
+        goto retry;
+    }
+    if (ret)
+        return ret;
+
+    /* Now pfns[] contains the host PFNs for each page in [addr, addr+len) */
+    /* pfns[i] has HMM_PFN_VALID set if page is present */
+    /* pfns[i] has HMM_PFN_WRITE set if writeable */
+
+    /* Program GPU page table to use these physical addresses */
+    for (int i = 0; i < len / PAGE_SIZE; i++) {
+        if (!(pfns[i] & HMM_PFN_VALID))
+            continue;
+        phys_addr_t phys = PFN_PHYS(pfns[i] >> HMM_PFN_SHIFT);
+        gpu_map_page(addr + i * PAGE_SIZE, phys, pfns[i] & HMM_PFN_WRITE);
+    }
+    return 0;
+}
+```
+
+## Device-private memory migration
+
+For GPUs with private VRAM (not CPU-addressable), pages are migrated between system RAM and VRAM on demand:
+
+```
+GPU accesses CPU page:
+  GPU page fault → driver's fault handler
+  → migrate_vma_setup() + migrate_vma_pages()
+  → pages move from DRAM to VRAM
+  → GPU page table updated with VRAM physical address
+
+CPU accesses GPU page:
+  CPU page fault (page has ZONE_DEVICE private struct page)
+  → driver's migrate_to_ram callback
+  → pages move from VRAM to DRAM
+  → CPU page table updated with DRAM physical address
+```
+
+```c
+/* Driver implements: */
+static const struct dev_pagemap_ops my_pgmap_ops = {
+    /* Called when CPU tries to access device-private page */
+    .migrate_to_ram = my_gpu_migrate_to_ram,
+
+    /* Called when device-private page reference count drops to 0 */
+    .page_free = my_gpu_page_free,
+};
+
+static vm_fault_t my_gpu_migrate_to_ram(struct vm_fault *vmf)
+{
+    /* Migrate the GPU page back to system RAM */
+    struct migrate_vma args = {
+        .vma        = vmf->vma,
+        .start      = vmf->address & PAGE_MASK,
+        .end        = (vmf->address & PAGE_MASK) + PAGE_SIZE,
+        .src        = src_pfns,
+        .dst        = dst_pfns,
+        .pgmap_owner = my_gpu_device,
+        .flags      = MIGRATE_VMA_SELECT_DEVICE_PRIVATE,
+    };
+
+    migrate_vma_setup(&args);
+    /* args.src now has PFNs of GPU pages to migrate */
+
+    /* Allocate system RAM pages, copy GPU memory to them */
+    for_each_migrate_pfn(args.src, args.dst, i) {
+        struct page *dpage = alloc_page(GFP_HIGHUSER_MOVABLE);
+        gpu_copy_to_ram(args.src[i], dpage);
+        args.dst[i] = migrate_pfn(page_to_pfn(dpage));
+    }
+
+    migrate_vma_pages(&args);    /* install RAM pages in CPU PTE */
+    migrate_vma_finalize(&args); /* release GPU pages */
+    return 0;
+}
+```
+
+## SVM (Shared Virtual Memory) in practice
+
+CUDA and ROCm implement SVM using HMM:
+
+```c
+/* CUDA managed memory: */
+cudaMallocManaged(&ptr, size, cudaMemAttachGlobal);
+/* ptr is a CPU VA backed by HMM */
+/* Access from CPU → normal page fault, kernel allocates DRAM */
+/* Access from GPU → GPU fault, driver calls hmm_range_fault() */
+/*                   or migrates to VRAM */
+
+/* cudaMemPrefetchAsync: hint to migrate pages before needed */
+cudaMemPrefetchAsync(ptr, size, cudaCpuDeviceId);  /* prefetch to CPU */
+cudaMemPrefetchAsync(ptr, size, 0);                /* prefetch to GPU 0 */
+```
+
+## Observing HMM
+
+```bash
+# Check if kernel has HMM support:
+zcat /proc/config.gz | grep -E "HMM|ZONE_DEVICE|DEVICE_PRIVATE"
+# CONFIG_HMM_MIRROR=y
+# CONFIG_ZONE_DEVICE=y
+# CONFIG_DEVICE_PRIVATE=y
+
+# ZONE_DEVICE memory stats:
+cat /proc/zoneinfo | grep -A20 "Device"
+
+# nvidia-smi shows unified memory stats:
+nvidia-smi --query-gpu=memory.used,memory.free --format=csv
+
+# Trace HMM range faults:
+bpftrace -e '
+kprobe:hmm_range_fault {
+    printf("hmm_range_fault: pid=%d addr=%lx\n", pid, ((struct hmm_range *)arg0)->start);
+}'
+
+# NUMA-aware: HMM migrates pages to GPU memory (different NUMA node)
+numastat -p <cuda_process>
+```
+
+## Further reading
+
+- [Memory Tiering](memory-tiering.md) — CXL and NUMA memory tiers
+- [IOMMU](../iommu/iommu-arch.md) — IOMMU for GPU DMA
+- [VFIO](../virtualization/vfio.md) — device passthrough using IOMMU
+- [DMA API](../iommu/dma-api.md) — DMA mapping fundamentals
+- [Page Allocator](page-allocator.md) — ZONE_DEVICE integration
+- `mm/hmm.c` — HMM core implementation
+- `mm/migrate_device.c` — device memory migration
+- `Documentation/mm/hmm.rst` — kernel HMM documentation

--- a/docs/mm/userfaultfd.md
+++ b/docs/mm/userfaultfd.md
@@ -1,0 +1,374 @@
+# userfaultfd: Userspace Page Fault Handling
+
+> Let userspace handle page faults — the mechanism behind QEMU live migration and CRIU
+
+## What problem does userfaultfd solve?
+
+Normally, page faults are handled by the kernel: a missing page triggers an anonymous allocation, swap-in, or file read. But some applications need to **intercept** page faults — to provide pages from their own storage or to implement copy-on-write in userspace.
+
+Use cases:
+- **QEMU live migration**: receive guest RAM pages on-the-fly as the guest accesses them
+- **CRIU** (Checkpoint/Restore In Userspace): restore process memory lazily
+- **Hypervisors**: implement demand-paging for guest memory from userspace
+- **Garbage collectors**: implement generational GC barriers without mprotect overhead
+- **Sandboxes**: provide deterministic memory contents for testing
+
+## API overview
+
+```c
+#include <sys/ioctl.h>
+#include <linux/userfaultfd.h>
+#include <poll.h>
+
+/* 1. Create userfaultfd */
+int uf_fd = syscall(SYS_userfaultfd, O_CLOEXEC | O_NONBLOCK);
+
+/* 2. Check API version */
+struct uffdio_api api = {
+    .api   = UFFD_API,
+    .features = UFFD_FEATURE_PAGEFAULT_FLAG_WP |
+                UFFD_FEATURE_MINOR_FAULTS,
+};
+ioctl(uf_fd, UFFDIO_API, &api);
+/* api.features now has supported features */
+/* api.ioctls has available ioctls */
+
+/* 3. Register a memory range to intercept */
+struct uffdio_register reg = {
+    .range.start = (unsigned long)addr,
+    .range.len   = size,
+    .mode        = UFFDIO_REGISTER_MODE_MISSING,  /* intercept missing pages */
+};
+ioctl(uf_fd, UFFDIO_REGISTER, &reg);
+
+/* 4. Poll for faults in a thread */
+struct pollfd pfd = { .fd = uf_fd, .events = POLLIN };
+while (1) {
+    poll(&pfd, 1, -1);
+
+    struct uffd_msg msg;
+    read(uf_fd, &msg, sizeof(msg));
+
+    if (msg.event == UFFD_EVENT_PAGEFAULT) {
+        unsigned long fault_addr = msg.arg.pagefault.address;
+        unsigned long flags      = msg.arg.pagefault.flags;
+        /* UFFD_PAGEFAULT_FLAG_WRITE: write fault */
+        /* UFFD_PAGEFAULT_FLAG_WP:    write-protect fault */
+
+        /* Resolve: provide a zero page */
+        struct uffdio_zeropage zp = {
+            .range.start = fault_addr & ~(PAGE_SIZE - 1),
+            .range.len   = PAGE_SIZE,
+        };
+        ioctl(uf_fd, UFFDIO_ZEROPAGE, &zp);
+    }
+}
+```
+
+## Fault resolution methods
+
+### UFFDIO_COPY — install a page with data
+
+```c
+static char page_data[PAGE_SIZE];
+/* Fill page_data with the content you want */
+
+struct uffdio_copy copy = {
+    .dst  = fault_addr & ~(PAGE_SIZE - 1),
+    .src  = (unsigned long)page_data,
+    .len  = PAGE_SIZE,
+    .mode = 0,  /* or UFFDIO_COPY_MODE_DONTWAKE if you'll wake later */
+};
+ioctl(uf_fd, UFFDIO_COPY, &copy);
+/* Wakes the faulting thread */
+```
+
+### UFFDIO_ZEROPAGE — install a zero page
+
+```c
+struct uffdio_zeropage zp = {
+    .range.start = fault_addr & ~(PAGE_SIZE - 1),
+    .range.len   = PAGE_SIZE,
+    .mode = 0,
+};
+ioctl(uf_fd, UFFDIO_ZEROPAGE, &zp);
+```
+
+### UFFDIO_CONTINUE — resolve minor fault (for shared mappings)
+
+```c
+/* Minor fault: page exists in page cache but not in PTE */
+struct uffdio_continue cont = {
+    .range.start = fault_addr & ~(PAGE_SIZE - 1),
+    .range.len   = PAGE_SIZE,
+    .mode = 0,
+};
+ioctl(uf_fd, UFFDIO_CONTINUE, &cont);
+```
+
+### UFFDIO_WRITEPROTECT — write-protect pages to catch writes
+
+```c
+/* Write-protect a region (triggers WP fault on write) */
+struct uffdio_writeprotect wp = {
+    .range.start = (unsigned long)addr,
+    .range.len   = size,
+    .mode = UFFDIO_WRITEPROTECT_MODE_WP,     /* enable WP */
+};
+ioctl(uf_fd, UFFDIO_WRITEPROTECT, &wp);
+
+/* Later, when WP fault arrives (UFFD_PAGEFAULT_FLAG_WP set): */
+wp.mode = 0;  /* remove WP — allow future writes */
+ioctl(uf_fd, UFFDIO_WRITEPROTECT, &wp);
+```
+
+## Registration modes
+
+```c
+/* UFFDIO_REGISTER_MODE_MISSING: intercept missing page faults */
+reg.mode = UFFDIO_REGISTER_MODE_MISSING;
+
+/* UFFDIO_REGISTER_MODE_WP: intercept write-protect faults */
+reg.mode = UFFDIO_REGISTER_MODE_WP;
+
+/* Both (Linux 5.7+): */
+reg.mode = UFFDIO_REGISTER_MODE_MISSING | UFFDIO_REGISTER_MODE_WP;
+
+/* UFFDIO_REGISTER_MODE_MINOR (Linux 5.13+): for shmem/hugetlb minor faults */
+reg.mode = UFFDIO_REGISTER_MODE_MINOR;
+```
+
+## Complete example: lazy page provider
+
+```c
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <linux/userfaultfd.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define SIZE    (64 * 1024 * 1024)  /* 64MB */
+
+static int uf_fd;
+static void *region;
+
+static void *fault_handler_thread(void *arg)
+{
+    struct pollfd pfd = { .fd = uf_fd, .events = POLLIN };
+    static char page[4096];
+
+    while (1) {
+        poll(&pfd, 1, -1);
+
+        struct uffd_msg msg;
+        if (read(uf_fd, &msg, sizeof(msg)) != sizeof(msg))
+            break;
+
+        if (msg.event != UFFD_EVENT_PAGEFAULT)
+            continue;
+
+        unsigned long page_addr = msg.arg.pagefault.address & ~0xFFFUL;
+        unsigned long page_index = (page_addr - (unsigned long)region) / 4096;
+
+        /* Generate the page content on-demand */
+        memset(page, 0, sizeof(page));
+        snprintf(page, 64, "Page %lu: generated on demand", page_index);
+
+        struct uffdio_copy copy = {
+            .dst = page_addr,
+            .src = (unsigned long)page,
+            .len = PAGE_SIZE,
+        };
+        ioctl(uf_fd, UFFDIO_COPY, &copy);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    /* Create a large anonymous mapping (no physical pages yet) */
+    region = mmap(NULL, SIZE, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    /* Create userfaultfd */
+    uf_fd = syscall(SYS_userfaultfd, O_CLOEXEC | O_NONBLOCK);
+
+    struct uffdio_api api = { .api = UFFD_API };
+    ioctl(uf_fd, UFFDIO_API, &api);
+
+    /* Register the entire region */
+    struct uffdio_register reg = {
+        .range = { .start = (unsigned long)region, .len = SIZE },
+        .mode  = UFFDIO_REGISTER_MODE_MISSING,
+    };
+    ioctl(uf_fd, UFFDIO_REGISTER, &reg);
+
+    /* Start fault handler thread */
+    pthread_t thr;
+    pthread_create(&thr, NULL, fault_handler_thread, NULL);
+
+    /* Access memory — each access triggers a fault, handled by our thread */
+    for (int i = 0; i < SIZE / 4096; i += 1024) {
+        char *p = (char *)region + i * 4096;
+        printf("Reading page %d: '%s'\n", i, p);
+    }
+
+    return 0;
+}
+```
+
+## QEMU live migration with userfaultfd
+
+QEMU uses userfaultfd for **post-copy live migration**: start the destination VM before all memory has arrived.
+
+```
+Source VM                              Destination VM
+─────────────────────────────────────────────────────
+                                       QEMU registers guest RAM with uffd
+Transfer CPU state + a few pages ────►
+                                       Start guest execution
+                                       ↓
+                                       Guest accesses page not yet received
+                                       → userfaultfd fault event
+                                       ↓
+                                       Fault handler requests page from source
+                               ◄────── request page N
+Transfer page N ──────────────────────►
+                                       uffd_copy resolves fault
+                                       Guest continues
+                                       (background: transfer remaining pages)
+```
+
+The key benefit: the destination VM starts running quickly, with only hot pages needing to be fetched on-demand.
+
+## Kernel implementation
+
+### Fault interception
+
+```c
+/* mm/userfaultfd.c */
+
+/*
+ * Called from handle_mm_fault() when a page is missing.
+ * Returns VM_FAULT_RETRY if userfaultfd will handle it.
+ */
+vm_fault_t handle_userfault(struct vm_fault *vmf, unsigned long reason)
+{
+    struct mm_struct *mm = vmf->vma->vm_mm;
+    struct userfaultfd_ctx *ctx;
+    struct uffd_msg msg = {};
+
+    ctx = vmf->vma->vm_userfaultfd_ctx.ctx;
+    if (!ctx)
+        return 0;  /* no uffd registered for this VMA */
+
+    /* Build the fault message */
+    msg.event = UFFD_EVENT_PAGEFAULT;
+    msg.arg.pagefault.flags = 0;
+    if (reason & VM_UFFD_WP)
+        msg.arg.pagefault.flags |= UFFD_PAGEFAULT_FLAG_WP;
+    if (vmf->flags & FAULT_FLAG_WRITE)
+        msg.arg.pagefault.flags |= UFFD_PAGEFAULT_FLAG_WRITE;
+    msg.arg.pagefault.address = vmf->real_address;
+
+    /* Enqueue the fault message — the uffd file becomes readable */
+    userfaultfd_event_wait_completion(ctx, &ewq);
+
+    /*
+     * The fault-handler thread has resolved the fault via UFFDIO_COPY
+     * or UFFDIO_ZEROPAGE. Now retry the fault — the page is present.
+     */
+    return VM_FAULT_RETRY;
+}
+```
+
+### struct userfaultfd_ctx
+
+```c
+struct userfaultfd_ctx {
+    wait_queue_head_t   fault_pending_wqh; /* faults waiting to be read */
+    wait_queue_head_t   fault_wqh;         /* faults waiting for resolution */
+    wait_queue_head_t   event_wqh;         /* non-fault events (fork, remap) */
+    wait_queue_head_t   fd_wqh;            /* fd poll wait queue */
+
+    atomic_t            pending_nacks;
+    seqcount_spinlock_t refile_seq;
+    unsigned long       features;
+    bool                released;
+    atomic_t            mmap_changing;
+
+    struct mm_struct    *mm;
+};
+```
+
+## Events beyond page faults
+
+userfaultfd can also deliver non-fault events when the monitored region changes:
+
+```c
+/* Features to enable non-fault events: */
+api.features = UFFD_FEATURE_EVENT_FORK        |  /* fork() duplicates VMA */
+               UFFD_FEATURE_EVENT_REMAP       |  /* mremap() */
+               UFFD_FEATURE_EVENT_REMOVE      |  /* madvise(MADV_REMOVE) */
+               UFFD_FEATURE_EVENT_UNMAP;         /* munmap() */
+
+/* In the handler: */
+switch (msg.event) {
+case UFFD_EVENT_FORK:
+    /* msg.arg.fork.ufd = new uffd for child process */
+    break;
+case UFFD_EVENT_REMAP:
+    /* msg.arg.remap.from/to/len */
+    break;
+case UFFD_EVENT_REMOVE:
+case UFFD_EVENT_UNMAP:
+    /* msg.arg.remove.start/end */
+    break;
+}
+```
+
+## Performance considerations
+
+```
+userfaultfd overhead:
+  - Per fault: ~1-10µs (syscall + thread wakeup + copy + wakeup)
+  - UFFDIO_COPY for 1 page: ~5µs
+  - vs. normal page fault: ~1µs (anon) to 1ms+ (from disk)
+
+Optimization techniques:
+  1. Batch: use UFFDIO_COPY with larger ranges when possible
+  2. Async wake: UFFDIO_COPY_MODE_DONTWAKE, then UFFDIO_WAKE
+  3. Multiple handler threads: each reads from the same uf_fd
+  4. Huge pages: register with huge page alignment, copy 2MB at a time
+```
+
+```bash
+# Monitor userfaultfd activity
+bpftrace -e '
+kprobe:handle_userfault {
+    @[kstack] = count();
+}'
+
+# Check if a process uses userfaultfd
+ls -la /proc/<pid>/fd/ | grep userfaultfd
+
+# Trace uffd ioctls
+bpftrace -e '
+tracepoint:syscalls:sys_enter_ioctl
+/args->fd > 0 && (args->cmd == 0xc018aa03 || args->cmd == 0xc028aa04)/
+{ printf("UFFDIO from pid %d\n", pid); }'
+```
+
+## Further reading
+
+- [Page Fault Handler](page-fault.md) — handle_mm_fault, the entry point for userfaultfd
+- [File-backed mmap](file-mmap.md) — mmap fundamentals
+- [QEMU](../virtualization/kvm-memory.md) — live migration using userfaultfd
+- [CRIU documentation](https://criu.org/Userfaultfd) — restore using lazy page transfer
+- `mm/userfaultfd.c` — kernel implementation
+- `tools/testing/selftests/mm/userfaultfd.c` — kernel self-test and usage example

--- a/docs/security/user-namespaces.md
+++ b/docs/security/user-namespaces.md
@@ -1,0 +1,304 @@
+# User Namespaces and Credential Mapping
+
+> uid/gid mapping, capability sets, and the privilege model for containers
+
+## What user namespaces provide
+
+A user namespace maps user and group IDs between a process's view and the host system. Inside the namespace, a process can have uid 0 (root) while being mapped to an unprivileged uid on the host.
+
+This is the foundation for **rootless containers**: running containers without any host privileges.
+
+```
+Host system:           Container (user namespace):
+  uid=1000 (alice)  ←→  uid=0 (root inside container)
+  gid=1000           ←→  gid=0
+  uid=1001-65535     ←→  uid=1-64535
+```
+
+## Creating a user namespace
+
+```c
+#include <sched.h>
+#include <unistd.h>
+
+/* Clone with new user namespace */
+pid_t pid = clone(child_func, stack_top,
+                  CLONE_NEWUSER | SIGCHLD, NULL);
+
+/* Or in the shell: */
+/* unshare -U /bin/bash */
+/* id → uid=65534(nobody) until mapped */
+```
+
+After `clone(CLONE_NEWUSER)`, the child process has a new user namespace but **no uid/gid mapping yet**. All operations requiring privileges fail until the parent writes the mapping.
+
+## uid_map and gid_map
+
+```bash
+# From the parent (after fork):
+# Map child uid 0 → host uid 1000, range 1
+echo "0 1000 1" > /proc/<child_pid>/uid_map
+echo "0 1000 1" > /proc/<child_pid>/gid_map
+
+# Format: <ns-uid> <host-uid> <count>
+# Maps ns-uid range [0, count) to host-uid range [host-uid, host-uid+count)
+
+# Multi-range mapping (for container with many users):
+echo "0 1000 1" > /proc/<pid>/uid_map    # root maps to host 1000
+echo "1 100000 65534" >> ...             # uid 1-65534 maps to host 100000-165533
+```
+
+### newuidmap / newgidmap
+
+For unprivileged users to write mappings beyond the single-entry restriction, the `newuidmap` setuid helper is used:
+
+```bash
+# /etc/subuid format: user:start:count
+# alice:100000:65536
+# means alice can use host uids 100000-165535 in user namespaces
+
+# newuidmap writes the uid_map for an unprivileged process:
+newuidmap <pid> <ns-uid> <host-uid> <count> [...]
+newuidmap 1234 0 1000 1 1 100000 65535
+
+# Podman/rootless Docker use this automatically:
+podman run --rm alpine id
+# uid=0(root) gid=0(root) groups=0(root)
+# (on host, process runs as alice with uid 1000)
+```
+
+### /etc/subuid and /etc/subgid
+
+```bash
+# View subordinate ID ranges allocated for a user:
+cat /etc/subuid
+# alice:100000:65536
+# bob:165536:65536
+
+# Allocate a range for a new user:
+usermod --add-subuids 200000-265535 charlie
+usermod --add-subgids 200000-265535 charlie
+```
+
+## Capabilities in user namespaces
+
+Within a new user namespace, a process starts with a **full set of capabilities** — but only within that namespace:
+
+```c
+/* Capabilities in a user namespace are scoped: */
+
+/* Permitted inside namespace: */
+CAP_NET_ADMIN    /* modify network config of ns-owned network namespaces */
+CAP_SYS_ADMIN    /* various admin ops within the namespace */
+CAP_SETUID       /* change uid to any uid in the mapping */
+CAP_CHOWN        /* chown to any uid in the mapping */
+/* ... */
+
+/* NOT permitted even inside namespace: */
+/* CAP_SYS_RAWIO: direct hardware access */
+/* CAP_SYS_MODULE: load kernel modules */
+/* Anything requiring global system access */
+```
+
+### struct cred
+
+```c
+/* include/linux/cred.h */
+struct cred {
+    atomic_long_t   usage;
+
+    kuid_t          uid;    /* real UID */
+    kgid_t          gid;    /* real GID */
+    kuid_t          suid;   /* saved UID */
+    kgid_t          sgid;   /* saved GID */
+    kuid_t          euid;   /* effective UID */
+    kgid_t          egid;   /* effective GID */
+    kuid_t          fsuid;  /* filesystem UID */
+    kgid_t          fsgid;  /* filesystem GID */
+    unsigned        securebits;  /* SUID-related security bits */
+
+    kernel_cap_t    cap_inheritable; /* caps new processes can inherit */
+    kernel_cap_t    cap_permitted;   /* caps this process may use */
+    kernel_cap_t    cap_effective;   /* caps currently in use */
+    kernel_cap_t    cap_bset;        /* capability bounding set */
+    kernel_cap_t    cap_ambient;     /* ambient capability set */
+
+    struct user_namespace   *user_ns;  /* owning user namespace */
+    struct user_struct      *user;
+    struct group_info       *group_info;
+
+    /* RCU-protected: */
+    struct rcu_head         rcu;
+} __randomize_layout;
+```
+
+### Capability sets
+
+```
+cap_permitted:   maximum capabilities the process can have
+cap_effective:   capabilities currently active (checked by kernel)
+cap_inheritable: capabilities passed across execve
+cap_bset:        bounding set: caps can never exceed this
+cap_ambient:     ambient: automatically inherited without execve magic
+```
+
+### Checking capabilities
+
+```c
+/* kernel/capability.c */
+bool ns_capable(struct user_namespace *ns, int cap)
+{
+    return ns_capable_common(ns, cap, CAP_OPT_NONE);
+}
+
+bool capable(int cap)
+{
+    return ns_capable(&init_user_ns, cap);
+}
+```
+
+When a process calls `capable(CAP_NET_ADMIN)`, the kernel checks whether the process has the capability in the namespace that owns the resource being accessed.
+
+## kuid_t and uid remapping in the kernel
+
+The kernel uses `kuid_t` (kernel UID) throughout to avoid confusion between namespaced and host UIDs:
+
+```c
+/* include/linux/uidgid.h */
+typedef struct {
+    uid_t val;
+} kuid_t;
+
+/* Convert between namespace UID and kernel UID: */
+kuid_t make_kuid(struct user_namespace *from, uid_t uid)
+{
+    /* Map uid through from's uid_map to get host uid */
+    return KUIDT_INIT(map_id_up(&from->uid_map, uid));
+}
+
+uid_t from_kuid(struct user_namespace *to, kuid_t uid)
+{
+    /* Map host uid through to's uid_map to get ns uid */
+    return map_id_down(&to->uid_map, __kuid_val(uid));
+}
+
+/* Example: */
+/* User writes uid=0 to a file owned by uid=0 in namespace */
+/* Kernel converts: kuid = make_kuid(task->user_ns, 0) = host uid 1000 */
+/* File's st_uid = from_kuid(task->user_ns, file->kuid) = 0 (shown as 0 in ns) */
+```
+
+## User namespace security boundaries
+
+### What a user namespace CANNOT do
+
+Even with root inside a user namespace, a process cannot:
+
+```
+✗ Load kernel modules (CAP_SYS_MODULE requires init_user_ns)
+✗ Access raw block devices (CAP_SYS_RAWIO)
+✗ Modify global network interfaces (only ns-owned ones)
+✗ Change system clock (CAP_SYS_TIME)
+✗ Use ptrace on processes outside the namespace
+✗ Access files owned by unmapped uids (/proc, /sys with root ownership)
+```
+
+### Nested user namespaces
+
+User namespaces can be nested (up to 32 levels):
+
+```
+init_user_ns (uid 0 = system root)
+└── container_user_ns (uid 0 → host uid 1000)
+    └── nested_user_ns (uid 0 → host uid 1000)
+        (capabilities are scoped to each level)
+```
+
+## Practical: rootless containers
+
+```bash
+# Run rootless container with Podman (no sudo needed):
+podman run --rm -it fedora bash
+# Inside: whoami → root
+# Host: ps shows process as uid 1000 (your user)
+
+# How it works:
+# 1. Podman creates user namespace
+# 2. Writes uid_map: 0 → 1000 (you), 1-65535 → 100000-165534 (subuid range)
+# 3. Creates other namespaces (pid, mnt, net) owned by user namespace
+# 4. Mounts overlayfs (allowed via user namespace owning mount namespace)
+
+# Inspect the mapping:
+cat /proc/$(pgrep -f "podman.*fedora")/uid_map
+# 0       1000          1
+# 1     100000      65535
+
+# Check capabilities of container process:
+cat /proc/$(pgrep -f "podman.*fedora")/status | grep Cap
+# CapPrm: 000001ffffffffff  ← full in user ns
+# CapEff: 000001ffffffffff
+# CapBnd: 000001ffffffffff
+```
+
+## Security considerations
+
+```bash
+# CVE-2022-0847 (dirty pipe): user namespace enabled exploitation
+# CVE-2021-3493: OverlayFS + user ns privilege escalation
+# Mitigation: restrict unprivileged user namespaces
+
+# Check if unprivileged user namespaces are allowed:
+cat /proc/sys/kernel/unprivileged_userns_clone  # Debian/Ubuntu
+cat /proc/sys/user/max_user_namespaces         # standard kernel
+
+# Restrict (some distros):
+echo 0 > /proc/sys/kernel/unprivileged_userns_clone  # disable
+echo 1 > /proc/sys/user/max_user_namespaces          # allow max 1
+
+# AppArmor: deny unprivileged user ns creation
+# Ubuntu 23.10+: blocks user namespace creation by default for non-root
+# except for known applications (Chrome, Podman, etc.)
+echo 1 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+```
+
+## Observing user namespace activity
+
+```bash
+# Show user namespace hierarchy:
+lsns -t user
+# NS         TYPE  NPROCS   PID USER  COMMAND
+# 4026531837 user     223     1 root  /sbin/init
+# 4026532536 user       2  5434 alice /usr/bin/podman
+
+# Show UID/GID mappings:
+cat /proc/<pid>/uid_map
+cat /proc/<pid>/gid_map
+
+# Trace user namespace creation:
+bpftrace -e '
+kprobe:create_user_ns {
+    printf("user ns created by pid %d (%s)\n", pid, comm);
+}'
+
+# Check which namespace owns a capability check:
+bpftrace -e '
+kprobe:ns_capable {
+    printf("ns_capable: pid=%d cap=%d\n", pid, arg1);
+}'
+
+# strace shows namespace syscalls:
+strace -e clone,unshare,setns podman run ...
+# clone(... CLONE_NEWUSER|CLONE_NEWPID|CLONE_NEWNS|CLONE_NEWNET ...)
+```
+
+## Further reading
+
+- [Credentials](credentials.md) — struct cred, privilege model
+- [Capabilities](capabilities.md) — capability sets and checks
+- [Container Isolation](../cgroups/container-isolation.md) — namespaces together
+- [Network Namespaces](../net/net-namespaces.md) — network isolation
+- [SELinux](selinux.md) — MAC on top of DAC
+- `kernel/user_namespace.c` — uid_map parsing and namespace creation
+- `include/linux/cred.h` — struct cred definition
+- `man 7 user_namespaces` — comprehensive man page
+- `man 1 newuidmap` — subordinate uid mapping helper

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,8 @@ nav:
       - TLB Optimization: mm/tlb-optimization.md
       - CXL Memory Tiering: mm/cxl-memory-tiering.md
       - Memory Tiering: mm/memory-tiering.md
+      - HMM (Heterogeneous Memory Management): mm/hmm.md
+      - userfaultfd: mm/userfaultfd.md
       - vrealloc: mm/vrealloc.md
     - Memory Cgroups:
       - Container Memory Limits: mm/container-memory-limits.md
@@ -268,6 +270,7 @@ nav:
       - Softirqs: interrupts/softirq.md
       - Tasklets: interrupts/tasklets.md
       - Workqueues: interrupts/workqueues.md
+      - Workqueue Internals (cmwq): interrupts/workqueue-internals.md
       - Timers and hrtimers: interrupts/timers.md
   - VFS:
     - Getting Started: vfs/README.md
@@ -364,6 +367,7 @@ nav:
     - seccomp BPF: security/seccomp.md
     - Linux Audit: security/audit.md
     - Credentials and User Namespaces: security/credentials.md
+    - User Namespaces and uid Mapping: security/user-namespaces.md
     - dm-crypt (Block Encryption): security/dm-crypt.md
     - fscrypt (Per-File Encryption): security/fscrypt.md
     - SELinux: security/selinux.md
@@ -410,3 +414,5 @@ nav:
       - Getting Started: arch/arm64/README.md
       - Exception Model: arch/arm64/exception-model.md
       - Memory Model: arch/arm64/memory-model.md
+    - x86:
+      - Exception and Interrupt Handling: arch/x86/exceptions.md


### PR DESCRIPTION
## Summary
- **x86 exception handling** (`arch/x86/exceptions.md`): IDT layout, all 20 CPU exception vectors, exception entry hardware behavior, `struct pt_regs`, TSS/IST, page fault error codes and full handler path, NMI nesting, SYSCALL/SYSRET
- **userfaultfd** (`mm/userfaultfd.md`): userspace page fault interception, all resolution ioctls (COPY/ZEROPAGE/WRITEPROTECT/CONTINUE), complete C example, QEMU post-copy live migration flow, kernel implementation internals
- **HMM** (`mm/hmm.md`): GPU/accelerator unified virtual address spaces, ZONE_DEVICE struct page, `mmu_interval_notifier`, `hmm_range_fault()` snapshot API, device-private VRAM migration, CUDA SVM
- **User namespaces** (`security/user-namespaces.md`): uid/gid mapping via uid_map, newuidmap/subuid/subgid, `struct cred` capability sets, `kuid_t` remapping internals, rootless containers, security boundaries, CVE examples
- **Workqueue internals** (`interrupts/workqueue-internals.md`): cmwq architecture vs old per-CPU threads, worker pool types, concurrency management algorithm, `struct worker_pool`, NUMA affinity, `WQ_MEM_RECLAIM` rescue workers, debugging with bpftrace

## Test plan
- [ ] Verify all new nav entries in `mkdocs.yml` resolve correctly
- [ ] Check cross-links between new pages and existing pages
- [ ] Verify code blocks are syntactically correct

Closes #424