### PR TITLE
Add TUN/TAP, UDP internals, page-walk API, and NUMA balancing docs

### DIFF
--- a/docs/mm/page-walk.md
+++ b/docs/mm/page-walk.md
@@ -1,0 +1,292 @@
+# Walking Page Tables Programmatically
+
+> pagewalk API, apply_to_page_range, and ptdump — reading page tables from kernel code
+
+## Why walk page tables?
+
+The kernel needs to inspect or modify page table entries programmatically in many contexts:
+- **KVM**: scan guest memory to find dirty pages
+- **Migration**: find all PTEs mapping a page before moving it
+- **Debugging**: `ptdump` dumps page tables to `/sys/kernel/debug/kernel_page_tables`
+- **mprotect**: change protection bits on a VA range
+- **userfaultfd**: set up write-protection on a range
+- **NUMA balancing**: scan PTEs to detect hot/cold pages across NUMA nodes
+
+## The pagewalk API
+
+```c
+#include <linux/pagewalk.h>
+
+/* Callbacks invoked as the walker traverses the page table hierarchy */
+struct mm_walk_ops {
+    /* Called for each PGD entry (top level) */
+    int (*pgd_entry)(pgd_t *pgd, unsigned long addr, unsigned long next,
+                     struct mm_walk *walk);
+
+    /* Called for each P4D (5-level paging), or not at all if 4-level */
+    int (*p4d_entry)(p4d_t *p4d, unsigned long addr, unsigned long next,
+                     struct mm_walk *walk);
+
+    /* Called for each PUD entry */
+    int (*pud_entry)(pud_t *pud, unsigned long addr, unsigned long next,
+                     struct mm_walk *walk);
+
+    /* Called for each PMD entry */
+    int (*pmd_entry)(pmd_t *pmd, unsigned long addr, unsigned long next,
+                     struct mm_walk *walk);
+
+    /* Called for each PTE (leaf, most common) */
+    int (*pte_entry)(pte_t *pte, unsigned long addr, unsigned long next,
+                     struct mm_walk *walk);
+
+    /* Called for holes (no VMA found): */
+    int (*pte_hole)(unsigned long addr, unsigned long next,
+                    int depth, struct mm_walk *walk);
+
+    /* Called before and after entering a huge page PMD/PUD */
+    int (*hugetlb_entry)(pte_t *pte, unsigned long hmask,
+                         unsigned long addr, unsigned long next,
+                         struct mm_walk *walk);
+
+    /* Called for each VMA before walking its range */
+    int (*pre_vma)(unsigned long start, unsigned long end,
+                   struct mm_walk *walk);
+
+    /* Called for each VMA after walking its range */
+    void (*post_vma)(struct mm_walk *walk);
+
+    /* Test whether to walk this VMA (return 0=skip, 1=walk) */
+    int (*test_walk)(unsigned long start, unsigned long end,
+                     struct mm_walk *walk);
+};
+
+/* mm_walk carries context through the callbacks */
+struct mm_walk {
+    const struct mm_walk_ops *ops;
+    struct mm_struct         *mm;
+    pgd_t                    *pgd;   /* current PGD being walked */
+    struct vm_area_struct    *vma;   /* current VMA */
+    void                     *private; /* caller private data */
+    bool                      no_vma;  /* walk without VMA lookup */
+};
+```
+
+## Walk a user address range
+
+```c
+static int count_present_pte(pte_t *pte, unsigned long addr,
+                               unsigned long next, struct mm_walk *walk)
+{
+    long *count = walk->private;
+    if (pte_present(*pte))
+        (*count)++;
+    return 0;
+}
+
+static const struct mm_walk_ops count_ops = {
+    .pte_entry = count_present_pte,
+};
+
+long count_resident_pages(struct mm_struct *mm, unsigned long start,
+                           unsigned long end)
+{
+    long count = 0;
+    mmap_read_lock(mm);
+    walk_page_range(mm, start, end, &count_ops, &count);
+    mmap_read_unlock(mm);
+    return count;
+}
+```
+
+## Walk the kernel address space
+
+```c
+/* Walk kernel page tables (no mm, no VMA): */
+static int dump_pte_entry(pte_t *pte, unsigned long addr,
+                           unsigned long next, struct mm_walk *walk)
+{
+    if (pte_present(*pte)) {
+        pr_info("  %016lx: PTE=%016llx pfn=%lx %s%s%s\n",
+                addr, (u64)pte_val(*pte),
+                pte_pfn(*pte),
+                pte_write(*pte) ? "W" : "r",
+                pte_exec(*pte) ? "X" : "-",
+                pte_dirty(*pte) ? "D" : "-");
+    }
+    return 0;
+}
+
+static const struct mm_walk_ops kernel_walk_ops = {
+    .pte_entry = dump_pte_entry,
+};
+
+/* Walk kernel vmalloc range: */
+walk_page_range_novma(&init_mm, VMALLOC_START, VMALLOC_END,
+                       &kernel_walk_ops, NULL, NULL);
+```
+
+## Modifying PTEs during the walk
+
+```c
+/* Write-protect a range (used by userfaultfd, KVM dirty tracking): */
+static int wp_pte(pte_t *pte, unsigned long addr,
+                  unsigned long next, struct mm_walk *walk)
+{
+    struct vm_area_struct *vma = walk->vma;
+    spinlock_t *ptl = pte_lockptr(walk->mm, pte);
+
+    spin_lock(ptl);
+
+    if (pte_present(*pte) && pte_write(*pte)) {
+        pte_t old_pte = *pte;
+        pte_t new_pte = pte_wrprotect(old_pte);
+
+        /* Atomically update the PTE */
+        set_pte_at(walk->mm, addr, pte, new_pte);
+
+        /* Flush TLB for this address */
+        flush_tlb_page(vma, addr);
+    }
+
+    spin_unlock(ptl);
+    return 0;
+}
+```
+
+## apply_to_page_range: set up mappings
+
+`apply_to_page_range` allocates page table pages as needed and calls a function on each PTE:
+
+```c
+/* Signature: */
+int apply_to_page_range(struct mm_struct *mm, unsigned long addr,
+                         unsigned long size, pte_fn_t fn, void *data);
+
+/* Example: map a range of physical pages into kernel vmalloc space */
+static int set_pte_fn(pte_t *pte, unsigned long addr,
+                       unsigned long next, void *data)
+{
+    phys_addr_t phys = *(phys_addr_t *)data + (addr - start_addr);
+    pte_t new_pte = pfn_pte(phys >> PAGE_SHIFT,
+                             PAGE_KERNEL);  /* RW, NX */
+    set_pte_at(&init_mm, addr, pte, new_pte);
+    return 0;
+}
+
+apply_to_page_range(&init_mm, vaddr, size, set_pte_fn, &phys_base);
+```
+
+## ptdump: debugging page tables
+
+```bash
+# Kernel page table dump (requires CONFIG_PTDUMP_DEBUGFS=y):
+cat /sys/kernel/debug/kernel_page_tables | head -50
+# 0xffff888000000000-0xffffc87fffffffff   131072G PGD  RW NX  SZ=1G
+# 0xffffc90000000000-0xffffe8ffffffffff     32768G PGD  RW NX  SZ=2M
+# 0xffffea0000000000-0xffffeb7fffffffff      3072G PGD  RW NX  SZ=2M  dirty
+# 0xffffffff80000000-0xffffffff9fffffff       512M PGD  ro  X  SZ=2M  (kernel text)
+# 0xffffffff9fffffff-0xffffffffa0000000         0 PGD (hole)
+# 0xffffffffa0000000-0xffffffffb0000fffff      ~1G PGD  RW NX  (modules)
+
+# User process page table:
+cat /sys/kernel/debug/page_tables/pid_<PID>
+
+# Decode a page table entry manually:
+python3 -c "
+pte = 0x8000000004021025  # from ptdump
+pfn = (pte >> 12) & 0xFFFFFFFFF
+present = pte & 1
+rw = (pte >> 1) & 1
+user = (pte >> 2) & 1
+nx = pte >> 63
+print(f'PFN: {pfn:#x}  present={present} rw={rw} user={user} NX={nx}')
+"
+```
+
+## PTE bit manipulation functions
+
+```c
+/* Read PTE properties: */
+pte_present(pte)      /* page is in RAM (P bit set) */
+pte_write(pte)        /* writable */
+pte_exec(pte)         /* executable (NX bit clear on x86) */
+pte_dirty(pte)        /* page was written (hardware sets this) */
+pte_young(pte)        /* page was accessed (hardware sets this) */
+pte_soft_dirty(pte)   /* software dirty tracking bit */
+pte_special(pte)      /* special mapping (no struct page) */
+pte_devmap(pte)       /* device memory (ZONE_DEVICE) */
+pte_pfn(pte)          /* physical frame number */
+
+/* Modify PTE properties: */
+pte_mkwrite(pte)          /* set writable */
+pte_wrprotect(pte)        /* clear writable */
+pte_mkdirty(pte)          /* set dirty */
+pte_mkclean(pte)          /* clear dirty */
+pte_mkyoung(pte)          /* set accessed */
+pte_mkold(pte)            /* clear accessed */
+pte_mkspecial(pte)        /* set special */
+
+/* Create a PTE from a PFN and protection flags: */
+pte_t pte = pfn_pte(pfn, PAGE_KERNEL);      /* kernel RW NX */
+pte_t pte = pfn_pte(pfn, PAGE_KERNEL_EXEC); /* kernel RX */
+pte_t pte = pfn_pte(pfn, PAGE_SHARED);      /* user RW */
+
+/* Get the struct page from a PTE: */
+struct page *page = pte_page(pte);           /* via pfn_to_page() */
+```
+
+## Huge page PTEs
+
+```c
+/* PMD-level huge page (2MB): */
+pmd_t *pmd = pmd_offset(pud, addr);
+if (pmd_large(*pmd)) {
+    /* This is a 2MB leaf PTE, not a pointer to PT */
+    phys_addr_t phys = (phys_addr_t)pmd_pfn(*pmd) << PAGE_SHIFT;
+    phys += addr & ~PMD_MASK;  /* offset within 2MB page */
+}
+
+/* PUD-level huge page (1GB): */
+pud_t *pud = pud_offset(p4d, addr);
+if (pud_large(*pud)) {
+    /* 1GB leaf */
+    phys_addr_t phys = (phys_addr_t)pud_pfn(*pud) << PAGE_SHIFT;
+    phys += addr & ~PUD_MASK;
+}
+```
+
+## NUMA balancing page table scan
+
+The NUMA balancer uses page table walking to find pages that should be migrated:
+
+```c
+/* kernel/sched/fair.c (simplified) */
+static void task_numa_work(struct callback_head *work)
+{
+    struct task_struct *p = current;
+    struct mm_struct *mm = p->mm;
+    unsigned long start = p->mm->numa_scan_offset;
+
+    /* Walk a chunk of the process address space: */
+    walk_page_range(mm, start, start + NUMA_SCAN_SIZE,
+                    &numa_walk_ops, p);
+
+    /* numa_walk_ops.pte_entry does:
+     *   - pte_mkold() to clear the Accessed bit
+     *   - On next access, CPU sets Accessed bit → NUMA fault
+     *   - task_numa_fault() records the NUMA node of the access
+     *   - Scheduler uses this to prefer running the task
+     *     near its hot pages
+     */
+}
+```
+
+## Further reading
+
+- [Page Tables](page-tables.md) — page table structure and format
+- [Page Fault Handler](page-fault.md) — how faults are resolved
+- [NUMA](numa.md) — NUMA balancing using page walk
+- [KVM Memory](../virtualization/kvm-memory.md) — dirty page tracking
+- [userfaultfd](userfaultfd.md) — write-protect via page walk
+- `mm/pagewalk.c` — pagewalk implementation
+- `arch/x86/mm/dump_pagetables.c` — ptdump debugfs

--- a/docs/net/tun-tap.md
+++ b/docs/net/tun-tap.md
@@ -1,0 +1,329 @@
+# TUN/TAP Virtual Network Devices
+
+> Userspace networking: how VPNs, QEMU, and container networks work
+
+## What are TUN and TAP?
+
+TUN and TAP are virtual network devices implemented entirely in software. They let userspace programs **send and receive network traffic** by reading and writing to a file descriptor.
+
+```
+Normal NIC:             Wire (hardware)
+     ↕                         ↕
+  kernel network stack  ←→  NIC driver
+     ↕
+  Application (socket)
+
+TUN/TAP:               Userspace program (VPN, VM, etc.)
+     ↕                         ↕
+  kernel network stack  ←→  /dev/net/tun (file descriptor)
+     ↕
+  Application (socket)
+```
+
+| Feature | TUN | TAP |
+|---------|-----|-----|
+| Layer | Layer 3 (IP) | Layer 2 (Ethernet) |
+| Frames | Raw IP packets | Full Ethernet frames (with MAC) |
+| Use case | VPN tunnels (OpenVPN, WireGuard) | VM networking (QEMU), bridge |
+
+## Creating a TUN interface
+
+```c
+#include <linux/if_tun.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+int tun_alloc(char *dev, int flags)
+{
+    struct ifreq ifr = {};
+    int fd, err;
+
+    /* Open the clone device */
+    fd = open("/dev/net/tun", O_RDWR);
+    if (fd < 0)
+        return fd;
+
+    /* IFF_TUN  = TUN (IP) device */
+    /* IFF_TAP  = TAP (Ethernet) device */
+    /* IFF_NO_PI = don't prepend packet info header */
+    ifr.ifr_flags = flags;  /* e.g., IFF_TUN | IFF_NO_PI */
+    if (*dev)
+        strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+
+    /* Register the TUN/TAP device */
+    err = ioctl(fd, TUNSETIFF, &ifr);
+    if (err < 0) {
+        close(fd);
+        return err;
+    }
+
+    /* dev is now filled with the assigned interface name, e.g., "tun0" */
+    strcpy(dev, ifr.ifr_name);
+    return fd;  /* fd is bound to the tun interface */
+}
+
+/* Usage: */
+char tun_name[IFNAMSIZ] = "tun0";
+int tun_fd = tun_alloc(tun_name, IFF_TUN | IFF_NO_PI);
+
+/* Configure interface (equivalent to: ip link set tun0 up) */
+/* ip addr add 10.0.0.1/24 dev tun0 */
+```
+
+## Reading and writing packets
+
+```c
+/* Reading: a packet arrived on the TUN interface */
+uint8_t buf[65536];
+ssize_t n = read(tun_fd, buf, sizeof(buf));
+/* buf[0..n-1] is a raw IP packet (with IFF_NO_PI) */
+
+/* Writing: inject a packet into the kernel network stack */
+ssize_t sent = write(tun_fd, packet, packet_len);
+/* The kernel treats this as if a packet arrived on tun0 */
+```
+
+## Minimal VPN server implementation
+
+```c
+/* Simplified: userspace VPN using TUN */
+
+#define REMOTE_PORT 51820
+#define MTU         1500
+
+int main(void)
+{
+    /* Create TUN interface */
+    char tun_name[IFNAMSIZ] = "vpn0";
+    int tun_fd = tun_alloc(tun_name, IFF_TUN | IFF_NO_PI);
+
+    /* UDP socket to the remote peer */
+    int udp_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    struct sockaddr_in remote = {
+        .sin_family = AF_INET,
+        .sin_port = htons(REMOTE_PORT),
+    };
+    inet_pton(AF_INET, "192.168.1.1", &remote.sin_addr);
+
+    uint8_t buf[MTU + 28];  /* IP header headroom */
+
+    /* Main forwarding loop */
+    struct pollfd fds[2] = {
+        { .fd = tun_fd, .events = POLLIN },
+        { .fd = udp_fd, .events = POLLIN },
+    };
+
+    while (1) {
+        poll(fds, 2, -1);
+
+        if (fds[0].revents & POLLIN) {
+            /* Packet from local applications → encrypt and send to peer */
+            ssize_t n = read(tun_fd, buf, MTU);
+            /* encrypt(buf, n) */
+            sendto(udp_fd, buf, n, 0,
+                   (struct sockaddr *)&remote, sizeof(remote));
+        }
+
+        if (fds[1].revents & POLLIN) {
+            /* Packet from remote peer → decrypt and inject locally */
+            ssize_t n = recv(udp_fd, buf, sizeof(buf), 0);
+            /* decrypt(buf, n) */
+            write(tun_fd, buf, n);
+        }
+    }
+}
+```
+
+## WireGuard's TUN usage
+
+WireGuard is implemented as a kernel module but uses the same TUN concept:
+
+```bash
+# WireGuard creates a virtual interface (wg0) backed by TUN internally
+ip link add wg0 type wireguard
+wg set wg0 private-key /etc/wireguard/privatekey \
+           listen-port 51820 \
+           peer <pubkey> allowed-ips 0.0.0.0/0 endpoint 1.2.3.4:51820
+ip link set wg0 up
+ip addr add 10.0.0.2/24 dev wg0
+
+# Traffic to 10.0.0.0/24 → WireGuard encrypts → UDP to 1.2.3.4:51820
+# Received UDP → WireGuard decrypts → appears to arrive on wg0
+```
+
+## TAP for VM networking (QEMU)
+
+```bash
+# QEMU uses TAP for full L2 networking (Ethernet frames):
+ip tuntap add mode tap tap0
+ip link set tap0 up
+
+# Bridge tap0 with physical eth0:
+ip link add br0 type bridge
+ip link set eth0 master br0
+ip link set tap0 master br0
+ip link set br0 up
+
+# QEMU uses tap0:
+qemu-system-x86_64 \
+    -netdev tap,id=net0,ifname=tap0,script=no,downscript=no \
+    -device virtio-net-pci,netdev=net0 \
+    ...
+# Guest gets a full Ethernet interface, appears on the bridge
+# Can get DHCP from the LAN, communicate with other VMs via br0
+```
+
+## Kernel implementation
+
+### struct tun_struct
+
+```c
+/* drivers/net/tun.c */
+struct tun_struct {
+    struct tun_file __rcu   *tfiles[MAX_TAP_QUEUES]; /* file descriptors */
+    unsigned int             numqueues;
+
+    struct net_device       *dev;      /* the tun0/tap0 netdev */
+    netdev_features_t        set_features;
+
+    int                      vnet_hdr_sz;  /* for vhost/virtio zero-copy */
+    int                      sndbuf;
+    unsigned long            flags;
+    /* IFF_TUN, IFF_TAP, IFF_NO_PI, IFF_VNET_HDR, IFF_MULTI_QUEUE */
+
+    struct sock_fprog        fprog;    /* BPF filter on received packets */
+    bool                     filter_attached;
+
+    u32                      msg_enable;
+    spinlock_t               lock;
+    struct hlist_head        flows[TUN_NUM_FLOW_ENTRIES]; /* flow table */
+    struct timer_list        flow_gc_timer;
+
+    struct net               *net;     /* network namespace */
+};
+```
+
+### Packet flow: write to TUN fd → kernel
+
+```c
+/* When userspace writes a packet to the TUN file descriptor: */
+static ssize_t tun_chr_write_iter(struct kiocb *iocb, struct iov_iter *from)
+{
+    struct tun_file *tfile = file->private_data;
+    struct tun_struct *tun = tun_get(tfile);
+    struct sk_buff *skb;
+
+    /* Build sk_buff from the userspace data */
+    skb = tun_alloc_skb(tfile, align, len, gso.hdr_len, noblock);
+    if (copy_from_iter(skb_put(skb, len), len, from) != len)
+        goto drop;
+
+    /* Set skb->protocol based on first byte (TUN) or Ethernet header (TAP) */
+    skb->protocol = eth_type_trans(skb, tun->dev);
+
+    /* Inject into the kernel network stack */
+    netif_rx(skb);  /* → goes up through IP stack to sockets */
+
+    return len;
+}
+```
+
+### Packet flow: kernel → read from TUN fd
+
+```c
+/* When a packet is routed to the TUN device (written to userspace): */
+static netdev_tx_t tun_net_xmit(struct sk_buff *skb, struct net_device *dev)
+{
+    struct tun_struct *tun = netdev_priv(dev);
+    struct tun_file *tfile;
+
+    /* Pick the appropriate queue (for multiqueue TUN) */
+    tfile = rcu_dereference(tun->tfiles[txq]);
+
+    /* Enqueue the sk_buff to the receive queue of the file descriptor */
+    if (ptr_ring_produce(&tfile->tx_ring, skb))
+        goto drop;
+
+    /* Wake up userspace (poll/read will return POLLIN) */
+    wake_up_interruptible_poll(&tfile->wq.wait, EPOLLIN | EPOLLRDNORM);
+
+    return NETDEV_TX_OK;
+drop:
+    dev_kfree_skb(skb);
+    return NETDEV_TX_OK;
+}
+```
+
+## Multiqueue TUN (for performance)
+
+```c
+/* Enable multiqueue to use multiple CPU queues: */
+ifr.ifr_flags = IFF_TUN | IFF_NO_PI | IFF_MULTI_QUEUE;
+
+/* Open multiple fds, each is a separate queue: */
+int fds[NUM_QUEUES];
+for (int i = 0; i < NUM_QUEUES; i++) {
+    char name[IFNAMSIZ] = "tun0";
+    fds[i] = tun_alloc(name, IFF_TUN | IFF_NO_PI | IFF_MULTI_QUEUE);
+    /* Each fd is pinned to a different CPU thread */
+}
+/* Kernel hashes packets to queues based on flow 5-tuple */
+```
+
+## vhost: kernel-accelerated TUN for QEMU
+
+For VMs, **vhost** moves the TUN packet forwarding from QEMU userspace into the kernel, eliminating context switches:
+
+```
+Without vhost:
+  Guest (VM) → virtio device → KVM VM exit → QEMU → write(tap_fd) → kernel
+
+With vhost:
+  Guest (VM) → virtio device → KVM VM exit → kernel vhost worker → tap_fd
+  (no QEMU context switch for data path!)
+```
+
+```bash
+# QEMU uses vhost automatically for virtio-net:
+qemu-system-x86_64 \
+    -netdev tap,id=net0,vhost=on \
+    -device virtio-net-pci,netdev=net0 \
+    ...
+```
+
+## Observing TUN/TAP
+
+```bash
+# List TUN/TAP interfaces:
+ip tuntap list
+# tun0: tun MULTI_QUEUE
+
+# Interface stats:
+ip -s link show tun0
+
+# Trace TUN writes (packets from userspace):
+bpftrace -e '
+kprobe:tun_do_read {
+    printf("TUN read: pid=%d dev=%s\n", pid,
+           ((struct tun_struct *)arg0)->dev->name);
+}'
+
+# tcpdump on the TUN interface:
+tcpdump -i tun0 -n
+
+# Check vhost worker activity:
+ps aux | grep vhost
+cat /proc/$(pgrep vhost)/status
+```
+
+## Further reading
+
+- [virtio](../virtualization/virtio.md) — paravirtual networking using TAP
+- [Network Namespaces](net-namespaces.md) — isolated network stacks with veth pairs
+- [NAPI](napi.md) — receive processing for real NICs
+- [sk_buff](sk-buff.md) — packet data structure
+- [XDP](xdp.md) — bypass the kernel stack entirely
+- `drivers/net/tun.c` — complete TUN/TAP implementation

--- a/docs/net/udp.md
+++ b/docs/net/udp.md
@@ -1,0 +1,356 @@
+# UDP Socket Internals
+
+> struct udp_sock, sendmsg/recvmsg paths, UDP segmentation offload, and multicast
+
+## UDP in the kernel
+
+UDP is connectionless: there is no handshake, no retransmission, no flow control. The kernel's job is minimal — add a UDP header and hand the packet to IP.
+
+```
+Application:
+    sendto(fd, buf, len, 0, &dest, sizeof(dest))
+         │
+    ┌────▼────────────────────────────────────────────────────┐
+    │ sock_sendmsg → udp_sendmsg                              │
+    │   1. Build sk_buff                                      │
+    │   2. Set UDP header (src port, dst port, len, checksum) │
+    │   3. ip_make_skb → route lookup                         │
+    │   4. udp_send_skb → ip_send_skb                         │
+    └─────────────────────────────────────────────────────────┘
+         │
+    IP layer → routing → Ethernet → wire
+```
+
+## struct udp_sock
+
+```c
+/* include/linux/udp.h */
+struct udp_sock {
+    /* inet_sock must be first: */
+    struct inet_sock inet;   /* contains: struct sock sk as first member */
+
+    int       pending;       /* Any pending frames? */
+    unsigned int corkflag;   /* Cork by setting UDP_CORK socket option */
+    __u8      encap_type;    /* Is this a UDP encap socket? */
+    unsigned char no_check6_tx:1, no_check6_rx:1;
+    unsigned char encap_enabled:1;
+    unsigned char gro_enabled:1;
+    unsigned char accept_udp_l4:1;
+    unsigned char accept_udp_fraglist:1;
+
+    __u16     len;           /* total length of pending frames */
+    __u16     gso_size;      /* UDP GSO fragment size */
+
+    /* Receive path: */
+    int       (*encap_rcv)(struct sock *sk, struct sk_buff *skb);
+    int       (*encap_err_rcv)(struct sock *sk, struct sk_buff *skb, int err,
+                               __be16 port, u32 info, u8 *payload);
+    void      (*encap_destroy)(struct sock *sk);
+    struct sk_buff *(*gro_receive)(struct sock *sk, struct list_head *head,
+                                   struct sk_buff *skb);
+    int       (*gro_complete)(struct sock *sk, struct sk_buff *skb, int nhoff);
+};
+```
+
+## UDP send path
+
+### udp_sendmsg
+
+```c
+/* net/ipv4/udp.c */
+int udp_sendmsg(struct sock *sk, struct msghdr *msg, size_t len)
+{
+    struct inet_sock *inet = inet_sk(sk);
+    struct udp_sock  *up   = udp_sk(sk);
+    struct flowi4     fl4;
+    struct rtable    *rt = NULL;
+    struct sk_buff   *skb;
+
+    /* 1. Determine destination address and port */
+    if (msg->msg_name) {
+        struct sockaddr_in *usin = (struct sockaddr_in *)msg->msg_name;
+        daddr = usin->sin_addr.s_addr;
+        dport = usin->sin_port;
+    } else {
+        /* Connected socket: use cached dst */
+        daddr = inet->inet_daddr;
+        dport = inet->inet_dport;
+    }
+
+    /* 2. Route lookup */
+    flowi4_init_output(&fl4, sk->sk_bound_dev_if, sk->sk_mark,
+                       tos, RT_SCOPE_UNIVERSE, IPPROTO_UDP,
+                       sk->sk_flags, daddr, saddr, dport, sport, ...);
+    rt = ip_route_output_flow(net, &fl4, sk);
+
+    /* 3. Build the sk_buff with UDP header + data */
+    skb = ip_make_skb(sk, &fl4, getfrag, msg, ulen,
+                      sizeof(struct udphdr), &ipc, &rt,
+                      msg->msg_flags);
+
+    /* 4. Add UDP header */
+    struct udphdr *uh = udp_hdr(skb);
+    uh->source = inet->inet_sport;
+    uh->dest   = dport;
+    uh->len    = htons(ulen);
+    uh->check  = 0;  /* compute checksum below */
+
+    /* 5. Compute checksum (or offload to hardware) */
+    udp4_hwcsum(skb, fl4.saddr, fl4.daddr);
+
+    /* 6. Hand to IP */
+    return udp_send_skb(skb, &fl4, &cork.base);
+}
+```
+
+### UDP corking (MSG_MORE)
+
+```c
+/* Corking: accumulate data before sending (like TCP_CORK) */
+setsockopt(fd, IPPROTO_UDP, UDP_CORK, &one, sizeof(one));
+/* or MSG_MORE flag on each sendmsg: */
+
+/* Multiple small sendmsg calls → one UDP packet: */
+sendmsg(fd, &msg1, MSG_MORE);  /* buffered */
+sendmsg(fd, &msg2, MSG_MORE);  /* buffered */
+sendmsg(fd, &msg3, 0);         /* flush: all three sent in one UDP packet */
+```
+
+## UDP receive path
+
+### Incoming packet routing
+
+```c
+/* net/ipv4/udp.c */
+int udp_rcv(struct sk_buff *skb)
+{
+    return __udp4_lib_rcv(skb, &udp_table, IPPROTO_UDP);
+}
+
+static int __udp4_lib_rcv(struct sk_buff *skb, struct udp_table *udptable,
+                            int proto)
+{
+    struct udphdr *uh = udp_hdr(skb);
+    __be32 saddr = ip_hdr(skb)->saddr;
+    __be32 daddr = ip_hdr(skb)->daddr;
+    __u16  ulen  = ntohs(uh->len);
+
+    /* 1. Validate UDP header and checksum */
+    if (udp4_csum_init(skb, uh, proto))
+        goto csum_error;
+
+    /* 2. Lookup socket by dst port/addr (hash table) */
+    sk = __udp4_lib_lookup_skb(skb, uh->source, uh->dest, udptable);
+    if (sk)
+        return udp_unicast_rcv_skb(sk, skb, uh);
+
+    /* 3. No socket found — send ICMP port unreachable */
+    icmp_send(skb, ICMP_DEST_UNREACH, ICMP_PORT_UNREACH, 0);
+    return 0;
+}
+```
+
+### Delivering to socket receive queue
+
+```c
+static int udp_queue_rcv_one_skb(struct sock *sk, struct sk_buff *skb)
+{
+    struct udp_sock *up = udp_sk(sk);
+
+    /* Run BPF socket filter if installed */
+    if (sk_filter_trim_cap(sk, skb, sizeof(struct udphdr)))
+        goto drop;
+
+    /* Enqueue to sk->sk_receive_queue */
+    if (likely(sk_receive_skb(sk, skb, 1) == NET_RX_SUCCESS))
+        return 0;
+
+    return -1;
+}
+
+/* recvmsg: userspace reads from the queue */
+int udp_recvmsg(struct sock *sk, struct msghdr *msg, size_t len, ...)
+{
+    struct sk_buff *skb;
+
+    /* Wait for and dequeue a packet */
+    skb = __skb_recv_udp(sk, flags, &off, &err);
+    if (!skb)
+        return err;
+
+    /* Copy to userspace */
+    copied = skb->len - sizeof(struct udphdr) - off;
+    err = skb_copy_datagram_msg(skb, sizeof(struct udphdr) + off, msg, copied);
+
+    /* Return source address if requested (MSG_NAME) */
+    if (msg->msg_name) {
+        struct sockaddr_in *sin = (struct sockaddr_in *)msg->msg_name;
+        sin->sin_addr.s_addr = ip_hdr(skb)->saddr;
+        sin->sin_port        = udp_hdr(skb)->source;
+    }
+
+    return copied;
+}
+```
+
+## UDP socket hash table
+
+```c
+/* Sockets are stored in a hash table keyed by local port: */
+struct udp_table {
+    struct udp_hslot    *hash;      /* hash by port */
+    struct udp_hslot    *hash2;     /* hash by port+addr (4-tuple) */
+    unsigned int         mask;
+    unsigned int         log;
+};
+
+/* Lookup: */
+/* 1. Hash by {dest_port} → candidates list */
+/* 2. Check addr match for each candidate */
+/* 3. If multiple match, prefer connected sockets (4-tuple match) */
+```
+
+## UDP GSO (Generic Segmentation Offload)
+
+For high-throughput UDP (e.g., QUIC, game servers), UDP GSO allows sending multiple UDP payloads in one syscall:
+
+```c
+/* Send 10 x 1400-byte UDP datagrams in one syscall: */
+char buf[10 * 1400];
+fill_data(buf, sizeof(buf));
+
+struct msghdr msg = {};
+struct iovec iov = { .iov_base = buf, .iov_len = sizeof(buf) };
+msg.msg_iov    = &iov;
+msg.msg_iovlen = 1;
+
+/* Destination: */
+struct sockaddr_in dest = { .sin_family = AF_INET, .sin_port = htons(9000) };
+inet_pton(AF_INET, "192.168.1.1", &dest.sin_addr);
+msg.msg_name = &dest;
+msg.msg_namelen = sizeof(dest);
+
+/* GSO control message: segment size */
+char cmsg_buf[CMSG_SPACE(sizeof(uint16_t))];
+struct cmsghdr *cm = (struct cmsghdr *)cmsg_buf;
+cm->cmsg_level = SOL_UDP;
+cm->cmsg_type  = UDP_SEGMENT;
+cm->cmsg_len   = CMSG_LEN(sizeof(uint16_t));
+*(uint16_t *)CMSG_DATA(cm) = 1400;  /* segment size */
+
+msg.msg_control    = cmsg_buf;
+msg.msg_controllen = sizeof(cmsg_buf);
+
+sendmsg(fd, &msg, 0);
+/* Kernel sends 10 separate UDP packets, one syscall! */
+```
+
+### UDP GRO (Generic Receive Offload)
+
+```c
+/* Enable UDP GRO on receive: */
+int one = 1;
+setsockopt(fd, SOL_UDP, UDP_GRO, &one, sizeof(one));
+
+/* Now recvmsg with MSG_TRUNC to get the full coalesced buffer */
+/* Check cmsg for UDP_GRO segment size */
+char cmsg_buf[256];
+msg.msg_control    = cmsg_buf;
+msg.msg_controllen = sizeof(cmsg_buf);
+
+ssize_t n = recvmsg(fd, &msg, 0);
+for (struct cmsghdr *cm = CMSG_FIRSTHDR(&msg); cm;
+     cm = CMSG_NXTHDR(&msg, cm)) {
+    if (cm->cmsg_level == SOL_UDP && cm->cmsg_type == UDP_GRO) {
+        uint16_t seg_size = *(uint16_t *)CMSG_DATA(cm);
+        /* n bytes received, each segment is seg_size bytes */
+    }
+}
+```
+
+## Multicast
+
+```c
+/* Join a multicast group: */
+struct ip_mreq mreq = {
+    .imr_multiaddr.s_addr = inet_addr("239.0.0.1"),
+    .imr_interface.s_addr = INADDR_ANY,
+};
+setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
+
+/* Bind to multicast port: */
+struct sockaddr_in addr = {
+    .sin_family = AF_INET,
+    .sin_port   = htons(5000),
+    .sin_addr.s_addr = inet_addr("239.0.0.1"),  /* or INADDR_ANY */
+};
+bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+
+/* Send to multicast group: */
+struct sockaddr_in dest = {
+    .sin_family = AF_INET,
+    .sin_port   = htons(5000),
+    .sin_addr.s_addr = inet_addr("239.0.0.1"),
+};
+sendto(fd, data, len, 0, (struct sockaddr *)&dest, sizeof(dest));
+```
+
+### Kernel multicast delivery
+
+```c
+/* net/ipv4/udp.c: deliver to multiple sockets in multicast group */
+static int __udp4_lib_mcast_deliver(struct net *net, struct sk_buff *skb,
+                                     struct udphdr *uh, ...)
+{
+    /* Find all sockets subscribed to this group/port */
+    struct hlist_head *head = &udptable->hash[hash];
+    struct sock *sk;
+
+    sk_for_each_from(sk) {
+        /* Check: port matches, multicast group joined, interface matches */
+        if (udp_multicast_demux_lookup(sk, skb, uh)) {
+            /* Clone skb for each receiving socket */
+            struct sk_buff *skb2 = skb_clone(skb, GFP_ATOMIC);
+            udp_queue_rcv_one_skb(sk, skb2);
+        }
+    }
+}
+```
+
+## UDP performance tuning
+
+```bash
+# Increase receive buffer (reduces drops under load):
+sysctl -w net.core.rmem_max=26214400        # 25 MB max
+sysctl -w net.core.rmem_default=26214400
+sysctl -w net.ipv4.udp_mem="102400 873800 16777216"
+
+# Increase send buffer:
+sysctl -w net.core.wmem_max=26214400
+
+# Check UDP drop stats:
+cat /proc/net/snmp | grep Udp
+# UdpInDatagrams, UdpNoPorts, UdpInErrors, UdpOutDatagrams
+# UdpRcvbufErrors: dropped because socket receive buffer full
+
+netstat -su | grep -i error
+ss -upe  # show UDP socket stats including drops
+
+# Per-socket stats:
+ss -u -n -e | grep ":9000"
+
+# Trace UDP drops:
+bpftrace -e '
+kprobe:udp_fail_queue_rcv_skb {
+    @drops = count();
+}'
+```
+
+## Further reading
+
+- [TCP](tcp.md) — connection-oriented transport
+- [Socket Layer](socket-layer.md) — socket() create, bind, sendmsg
+- [sk_buff](sk-buff.md) — packet data structure
+- [NAPI](napi.md) — receive scaling
+- [XDP](xdp.md) — bypass kernel for extreme UDP throughput
+- `net/ipv4/udp.c` — UDP implementation

--- a/docs/sched/numa-balancing.md
+++ b/docs/sched/numa-balancing.md
@@ -1,0 +1,287 @@
+# NUMA Automatic Balancing
+
+> How the scheduler detects and fixes NUMA locality mismatches
+
+## The problem
+
+On NUMA systems, memory access latency depends on which NUMA node holds the physical page:
+
+```
+Node 0:                 Node 1:
+  CPU 0, CPU 1            CPU 2, CPU 3
+  Memory 0 (fast)         Memory 1 (fast)
+       │                        │
+       └──────── QPI/UPI ────────┘
+                (slow: ~2× penalty)
+
+Task running on CPU 2 reading pages on Node 0:
+  → every cache miss → remote memory access → 2× latency!
+```
+
+**Automatic NUMA balancing** (CONFIG_NUMA_BALANCING) detects this situation and migrates pages to the node where they're being used.
+
+## How it works
+
+### Phase 1: Mark pages as inaccessible (PROT_NONE)
+
+The NUMA balancer periodically scans a process's page tables and changes the PTE of accessed pages to `PROT_NONE` (unmaps them without freeing):
+
+```c
+/* kernel/sched/fair.c */
+static void task_numa_work(struct callback_head *work)
+{
+    struct task_struct *p = current;
+    unsigned long start = p->numa_scan_offset;
+
+    /* Walk a chunk of VA space, NUMA-fault the PTEs: */
+    change_prot_numa(p->mm, start, start + NUMA_SCAN_SIZE);
+    /* Sets PTE to PROT_NONE with _PAGE_NUMA flag */
+
+    p->numa_scan_offset = start + NUMA_SCAN_SIZE;
+    if (p->numa_scan_offset >= p->mm->highest_vm_end)
+        p->numa_scan_offset = 0;  /* wrap around */
+}
+```
+
+### Phase 2: Catch NUMA page faults
+
+When the task accesses the PROT_NONE page, a page fault fires:
+
+```c
+/* mm/memory.c: do_numa_page() */
+static vm_fault_t do_numa_page(struct vm_fault *vmf)
+{
+    struct page *page = vm_normal_page(vmf->vma, vmf->address, vmf->orig_pte);
+    int page_nid    = page_to_nid(page);   /* current NUMA node of page */
+    int this_nid    = numa_node_id();       /* CPU's NUMA node */
+
+    /* Record the access for statistics */
+    task_numa_fault(last_cpupid, page_nid, 1, flags);
+
+    /* Should we migrate this page? */
+    if (page_nid != this_nid) {
+        /* Migrate the page to this_nid */
+        migrate_misplaced_page(page, vmf->vma, this_nid);
+    }
+
+    /* Restore the PTE (make it accessible again) */
+    pte_t pte = pte_modify(vmf->orig_pte, vma->vm_page_prot);
+    set_pte_at(vmf->vma->vm_mm, vmf->address, vmf->pte, pte);
+
+    return 0;
+}
+```
+
+### Phase 3: Task migration
+
+If the task has most of its pages on Node 1 but runs on Node 0, the scheduler may migrate the **task** instead of (or in addition to) the pages:
+
+```c
+/* kernel/sched/fair.c */
+static bool task_numa_compare(struct task_numa_env *env,
+                               long taskimp, long groupimp, bool maymove)
+{
+    /*
+     * Compare: task running on preferred_node vs current_node
+     * taskimp: improvement score from moving task
+     * groupimp: improvement from moving entire task group
+     */
+    long imp = env->p->numa_group ? groupimp : taskimp;
+    if (imp <= env->best_imp)
+        return false;
+    /* Better NUMA locality → update best candidate */
+    env->best_imp  = imp;
+    env->best_task = env->dst_task;
+    env->best_cpu  = env->dst_cpu;
+    return true;
+}
+```
+
+## NUMA statistics per task
+
+```c
+/* task_struct NUMA fields: */
+struct task_struct {
+    /* ... */
+    int             numa_preferred_nid;   /* preferred NUMA node */
+    unsigned long   numa_migrate_retry;
+    u64             node_stamp;           /* last numa balancing work */
+    u64             last_task_numa_placement;
+    u64             last_sum_exec_runtime;
+    struct callback_head    numa_work;
+
+    struct numa_group __rcu *numa_group;  /* task group for shared memory */
+
+    unsigned long   *numa_faults;         /* faults per node per access type */
+    /* [2 * nr_nodes]: [local faults, remote faults] for each node */
+    /* [2]: cpu vs mem accesses */
+};
+```
+
+## NUMA groups: shared memory balancing
+
+When multiple tasks share memory (e.g., a multithreaded program), they form a **NUMA group**:
+
+```c
+struct numa_group {
+    refcount_t          refcount;
+    spinlock_t          lock;
+    int                 nr_tasks;
+    pid_t               gid;
+    int                 active_nodes;
+
+    /* Fault statistics per node: */
+    unsigned long       total_faults;
+    unsigned long       max_faults_cpu;
+
+    unsigned long       *faults;       /* faults[node][type] */
+    unsigned long       *faults_cpu;
+
+    struct rcu_head     rcu;
+    unsigned long       nodes[];       /* online nodes participating */
+};
+
+/* Tasks in a group are migrated together to preserve shared memory locality */
+```
+
+## Balancing scan rate
+
+The scan rate adapts based on how many NUMA faults are found:
+
+```c
+/* How often to scan (pages per second): */
+/* Controlled by: /proc/sys/kernel/numa_balancing_scan_period_min/max */
+
+static void update_task_scan_period(struct task_struct *p,
+                                     unsigned long shared, unsigned long private)
+{
+    /* More faults → scan more aggressively (lower period) */
+    /* Fewer faults → scan less often (higher period) */
+
+    unsigned int period = p->numa_scan_period;
+    if (faults > p->numa_faults_locality[2])
+        period = max(period / 2, task_scan_min(p));  /* speed up */
+    else
+        period = min(period * 2, task_scan_max(p));  /* slow down */
+
+    p->numa_scan_period = period;
+}
+```
+
+## Configuration
+
+```bash
+# Enable/disable automatic NUMA balancing:
+echo 1 > /proc/sys/kernel/numa_balancing   # enable (default)
+echo 0 > /proc/sys/kernel/numa_balancing   # disable
+
+# Scan period (milliseconds) — how often to scan each task's VAS:
+cat /proc/sys/kernel/numa_balancing_scan_period_min_ms  # default 1000
+cat /proc/sys/kernel/numa_balancing_scan_period_max_ms  # default 60000
+
+# Scan size — bytes scanned per interval:
+cat /proc/sys/kernel/numa_balancing_scan_size_mb  # default 256
+
+# Time a page must be "hot" before migrating:
+cat /proc/sys/kernel/numa_balancing_hot_threshold_ms  # default 1000
+
+# Tune for a database workload (aggressive):
+echo 100  > /proc/sys/kernel/numa_balancing_scan_period_min_ms
+echo 5000 > /proc/sys/kernel/numa_balancing_scan_period_max_ms
+echo 1024 > /proc/sys/kernel/numa_balancing_scan_size_mb
+```
+
+## Observing NUMA balancing
+
+```bash
+# Per-process NUMA stats:
+cat /proc/<pid>/sched  # numa_faults, numa_preferred_nid, ...
+cat /proc/<pid>/numa_maps
+# 7f1234000000 default anon=12 dirty=12 N0=8 N1=4
+#                                         ↑N0  ↑N1 = pages on each node
+
+# System-wide NUMA balancing stats:
+cat /proc/vmstat | grep numa
+# numa_hint_faults      12345   ← PROT_NONE faults triggered
+# numa_hint_faults_local 8000  ← faults already on preferred node
+# numa_pages_migrated    4345  ← pages migrated
+# numa_pte_updates       50000 ← PTEs marked PROT_NONE
+
+# NUMA misses in perf:
+perf stat -e dtlb_load_misses.miss_causes_a_walk,node_loads,node_stores \
+          -p <pid> sleep 5
+
+# numastat: per-node allocation stats
+numastat <pid>
+numastat -m  # system memory per node
+
+# Trace NUMA page fault + migration:
+bpftrace -e '
+kprobe:do_numa_page {
+    @numa_faults[tid] = count();
+}
+kprobe:migrate_misplaced_page {
+    @migrations = count();
+}'
+
+# Check NUMA topology:
+numactl --hardware
+# available: 2 nodes (0-1)
+# node 0 cpus: 0 1 2 3
+# node 1 cpus: 4 5 6 7
+# node distances:
+# node   0   1
+#   0:  10  21
+#   1:  21  10
+```
+
+## When to disable NUMA balancing
+
+```bash
+# Disable for workloads where it hurts:
+# 1. Already NUMA-pinned workloads:
+numactl --cpunodebind=0 --membind=0 ./myapp
+# (explicit placement beats auto-balancing)
+
+# 2. Latency-sensitive workloads:
+# NUMA faults add ~10µs per fault — avoid for RT tasks
+echo 0 > /proc/sys/kernel/numa_balancing
+
+# 3. tmpfs/huge page workloads:
+# Pages in tmpfs or huge pages aren't scanned by NUMA balancer
+# No benefit to enable
+
+# 4. Mostly sequential single-node access:
+# If the app already accesses data on the local node, balancing adds
+# overhead (scan + faults) with no benefit
+```
+
+## NUMA-aware memory allocation
+
+For applications that want explicit NUMA control:
+
+```c
+/* Link with -lnuma */
+#include <numa.h>
+
+/* Allocate on node 0: */
+void *mem = numa_alloc_onnode(size, 0);
+
+/* Allocate on the local node (where this thread runs): */
+void *mem = numa_alloc_local(size);
+
+/* Set memory policy for subsequent allocations: */
+struct bitmask *mask = numa_bitmask_alloc(numa_num_configured_nodes());
+numa_bitmask_setbit(mask, 0);
+numa_set_membind(mask);   /* only allocate from node 0 */
+```
+
+## Further reading
+
+- [NUMA](../mm/numa.md) — NUMA architecture and zonelist
+- [NUMA Distance](../mm/numa-distance.md) — ACPI SRAT and distance matrices
+- [NUMA Reclaim](../mm/numa-reclaim.md) — reclaim policies per node
+- [CFS Load Balancing](load-balancing.md) — CPU scheduler load balancing
+- [NUMA Zonelist](../mm/numa-zonelist.md) — memory allocation fallback
+- `kernel/sched/fair.c` — task_numa_work, do_numa_page
+- `mm/migrate.c` — migrate_misplaced_page

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - Memory Tiering: mm/memory-tiering.md
       - HMM (Heterogeneous Memory Management): mm/hmm.md
       - userfaultfd: mm/userfaultfd.md
+      - Page Table Walking API: mm/page-walk.md
       - vrealloc: mm/vrealloc.md
     - Memory Cgroups:
       - Container Memory Limits: mm/container-memory-limits.md
@@ -200,6 +201,7 @@ nav:
       - CPU Affinity: sched/cpu-affinity.md
     - Advanced:
       - Load Balancing: sched/load-balancing.md
+      - NUMA Automatic Balancing: sched/numa-balancing.md
       - Energy-Aware Scheduling: sched/eas.md
       - Preemption Model: sched/preemption.md
       - The Scheduling Tick: sched/sched-tick.md
@@ -222,6 +224,7 @@ nav:
     - TCP/IP:
       - TCP Implementation: net/tcp.md
       - TCP Congestion Control: net/tcp-congestion.md
+      - UDP Internals: net/udp.md
       - IP Routing: net/ip-routing.md
     - Filtering:
       - Netfilter Architecture: net/netfilter.md
@@ -234,6 +237,7 @@ nav:
     - Advanced:
       - Container Networking: net/container-networking.md
       - Network Namespaces: net/net-namespaces.md
+      - TUN/TAP Virtual Devices: net/tun-tap.md
       - Kernel TLS (kTLS): net/ktls.md
       - Netlink: net/netlink.md
     - Debugging & Observability:


### PR DESCRIPTION
## Summary
- **TUN/TAP** (`net/tun-tap.md`): virtual network devices for VPNs/VMs, packet read/write API, minimal VPN implementation, QEMU TAP+bridge setup, struct tun_struct internals, multiqueue, vhost kernel acceleration
- **UDP internals** (`net/udp.md`): struct udp_sock, full sendmsg/recvmsg paths, socket hash table lookup, UDP corking, UDP GSO/GRO for high-throughput, multicast kernel delivery, receive buffer tuning
- **Page table walking API** (`mm/page-walk.md`): `mm_walk_ops` callbacks, walking user and kernel address spaces, `apply_to_page_range`, PTE bit manipulation, huge page PTEs, NUMA balancing scanner, `ptdump` debugfs
- **NUMA automatic balancing** (`sched/numa-balancing.md`): PROT_NONE scan-and-fault mechanism, `do_numa_page` migration, NUMA groups for shared memory, adaptive scan rates, sysctl knobs, when to disable

## Test plan
- [ ] Verify all new nav entries render correctly
- [ ] Check cross-links to existing pages are valid
- [ ] Verify code blocks are syntactically correct