### PR TITLE
Add I2C/SPI drivers, SLUB internals, Landlock, and clocksource docs

### DIFF
--- a/docs/drivers/i2c-spi.md
+++ b/docs/drivers/i2c-spi.md
@@ -1,0 +1,391 @@
+# I2C and SPI Bus Drivers
+
+> Writing drivers for I2C and SPI peripheral devices in the Linux kernel
+
+## I2C overview
+
+I2C (Inter-Integrated Circuit) is a two-wire serial protocol for connecting low-speed peripherals (sensors, EEPROMs, touch controllers) to a microprocessor.
+
+```
+Physical wires:
+  SDA (data)  ────────────────────────
+  SCL (clock) ────────────────────────
+              │       │       │
+           Master    Dev1    Dev2
+        (host CPU) (0x48) (0x50)
+                     ↑       ↑
+                  7-bit addresses
+```
+
+### I2C transaction format
+
+```
+Start: SDA falls while SCL is high
+  │
+  └─ [7-bit address] [R/W bit] [ACK]
+     │
+     └─ [data byte 0] [ACK]
+        [data byte 1] [ACK]
+        ...
+Stop: SDA rises while SCL is high
+```
+
+## I2C client driver
+
+### struct i2c_driver
+
+```c
+#include <linux/i2c.h>
+#include <linux/module.h>
+
+/* Device-specific private data */
+struct my_sensor {
+    struct i2c_client *client;
+    struct mutex       lock;
+    int                irq;
+};
+
+/* Match table for device tree / ACPI */
+static const struct of_device_id my_sensor_of_match[] = {
+    { .compatible = "vendor,my-sensor" },
+    { /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, my_sensor_of_match);
+
+static const struct i2c_device_id my_sensor_id[] = {
+    { "my-sensor", 0 },
+    { /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(i2c, my_sensor_id);
+
+/* Called when device is found */
+static int my_sensor_probe(struct i2c_client *client)
+{
+    struct my_sensor *sensor;
+    int ret;
+
+    /* Verify the device supports the operations we need */
+    if (!i2c_check_functionality(client->adapter,
+                                  I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "SMBus byte operations required\n");
+        return -EOPNOTSUPP;
+    }
+
+    sensor = devm_kzalloc(&client->dev, sizeof(*sensor), GFP_KERNEL);
+    if (!sensor)
+        return -ENOMEM;
+
+    sensor->client = client;
+    mutex_init(&sensor->lock);
+    i2c_set_clientdata(client, sensor);
+
+    /* Read and verify device ID register */
+    ret = i2c_smbus_read_byte_data(client, REG_DEVICE_ID);
+    if (ret < 0) {
+        dev_err(&client->dev, "failed to read device ID: %d\n", ret);
+        return ret;
+    }
+    if (ret != EXPECTED_DEVICE_ID) {
+        dev_err(&client->dev, "unexpected device ID: 0x%02x\n", ret);
+        return -ENODEV;
+    }
+
+    /* Register with IIO or hwmon subsystem */
+    return my_sensor_register_iio(sensor);
+}
+
+static void my_sensor_remove(struct i2c_client *client)
+{
+    struct my_sensor *sensor = i2c_get_clientdata(client);
+    my_sensor_unregister_iio(sensor);
+}
+
+static struct i2c_driver my_sensor_driver = {
+    .driver = {
+        .name         = "my-sensor",
+        .of_match_table = my_sensor_of_match,
+    },
+    .probe    = my_sensor_probe,
+    .remove   = my_sensor_remove,
+    .id_table = my_sensor_id,
+};
+module_i2c_driver(my_sensor_driver);
+/* Expands to: module_init + module_exit with i2c_add/del_driver */
+```
+
+## I2C transfer functions
+
+### SMBus (common for simple devices)
+
+```c
+/* Read/write a single byte at a register address: */
+s32 i2c_smbus_read_byte_data(struct i2c_client *client, u8 reg);
+s32 i2c_smbus_write_byte_data(struct i2c_client *client, u8 reg, u8 value);
+
+/* Read/write a 16-bit word: */
+s32 i2c_smbus_read_word_data(struct i2c_client *client, u8 reg);
+s32 i2c_smbus_write_word_data(struct i2c_client *client, u8 reg, u16 value);
+
+/* Read a block of data: */
+s32 i2c_smbus_read_i2c_block_data(struct i2c_client *client, u8 reg,
+                                   u8 length, u8 *values);
+/* values receives `length` bytes starting from register `reg` */
+
+/* Example: read 6 bytes of accelerometer data from reg 0x28: */
+u8 data[6];
+ret = i2c_smbus_read_i2c_block_data(client, 0x28, 6, data);
+```
+
+### Raw I2C messages (for complex protocols)
+
+```c
+/* For devices that don't follow SMBus convention: */
+int i2c_transfer(struct i2c_adapter *adap, struct i2c_msg *msgs, int num);
+
+/* Example: write register address, then read multiple bytes
+   (common register access pattern): */
+static int my_read_regs(struct i2c_client *client, u8 reg,
+                         u8 *buf, size_t len)
+{
+    struct i2c_msg msgs[2] = {
+        {
+            /* Write phase: send register address */
+            .addr  = client->addr,
+            .flags = 0,              /* write */
+            .len   = 1,
+            .buf   = &reg,
+        },
+        {
+            /* Read phase: read `len` bytes */
+            .addr  = client->addr,
+            .flags = I2C_M_RD,      /* read */
+            .len   = len,
+            .buf   = buf,
+        },
+    };
+    return i2c_transfer(client->adapter, msgs, 2);
+}
+```
+
+## regmap: register access abstraction
+
+`regmap` provides a unified API for register access across I2C, SPI, MMIO, and other buses:
+
+```c
+#include <linux/regmap.h>
+
+/* Define the register map configuration: */
+static const struct regmap_config my_regmap_config = {
+    .reg_bits   = 8,    /* register address width */
+    .val_bits   = 8,    /* register value width */
+    .max_register = 0xFF,
+
+    /* Optional: caching for read-only or slow registers */
+    .cache_type = REGCACHE_RBTREE,
+
+    /* Readable/writeable register masks: */
+    .readable_reg = my_readable_reg,
+    .writeable_reg = my_writeable_reg,
+    .volatile_reg  = my_volatile_reg,  /* not cached */
+};
+
+static int my_sensor_probe(struct i2c_client *client)
+{
+    struct my_sensor *sensor;
+    struct regmap *regmap;
+
+    /* Create regmap backed by I2C: */
+    regmap = devm_regmap_init_i2c(client, &my_regmap_config);
+    if (IS_ERR(regmap))
+        return PTR_ERR(regmap);
+
+    sensor->regmap = regmap;
+    /* ... */
+}
+
+/* Use regmap for register access: */
+unsigned int val;
+regmap_read(sensor->regmap, REG_STATUS, &val);
+regmap_write(sensor->regmap, REG_CONFIG, 0x01);
+
+/* Read-modify-write (atomic): */
+regmap_update_bits(sensor->regmap, REG_CONFIG,
+                   BIT(3) | BIT(2),   /* mask */
+                   BIT(3));           /* value: set bit 3, clear bit 2 */
+
+/* Bulk read multiple consecutive registers: */
+u8 buf[6];
+regmap_bulk_read(sensor->regmap, REG_DATA_START, buf, 6);
+```
+
+## SPI overview
+
+SPI (Serial Peripheral Interface) is a synchronous 4-wire protocol:
+
+```
+SCLK  ──────────────────── clock (master-driven)
+MOSI  ──────────────────── master-out slave-in
+MISO  ──────────────────── master-in slave-out
+CS/SS ──────────────────── chip select (one per device, active-low)
+
+Unlike I2C:
+  - Full-duplex (simultaneous TX and RX)
+  - No addressing: CS line selects device
+  - No ACK: master never knows if slave received
+  - Higher speeds (up to 100+ MHz vs I2C's 3.4 MHz)
+```
+
+## SPI device driver
+
+```c
+#include <linux/spi/spi.h>
+
+struct my_spi_dev {
+    struct spi_device *spi;
+    struct mutex       lock;
+};
+
+static const struct of_device_id my_spi_of_match[] = {
+    { .compatible = "vendor,my-spi-sensor" },
+    { }
+};
+
+static int my_spi_probe(struct spi_device *spi)
+{
+    struct my_spi_dev *dev;
+
+    /* Configure SPI parameters: */
+    spi->bits_per_word = 8;
+    spi->mode          = SPI_MODE_0;    /* CPOL=0, CPHA=0 */
+    spi->max_speed_hz  = 10000000;      /* 10 MHz */
+    spi_setup(spi);                      /* apply configuration */
+
+    dev = devm_kzalloc(&spi->dev, sizeof(*dev), GFP_KERNEL);
+    dev->spi = spi;
+    spi_set_drvdata(spi, dev);
+
+    return my_spi_dev_init(dev);
+}
+
+static struct spi_driver my_spi_driver = {
+    .driver = {
+        .name         = "my-spi-sensor",
+        .of_match_table = my_spi_of_match,
+    },
+    .probe = my_spi_probe,
+};
+module_spi_driver(my_spi_driver);
+```
+
+## SPI transfer functions
+
+```c
+/* Simple synchronous read/write: */
+u8 tx_buf[4], rx_buf[4];
+
+/* Full-duplex transfer (TX and RX simultaneously): */
+struct spi_transfer t = {
+    .tx_buf = tx_buf,
+    .rx_buf = rx_buf,
+    .len    = 4,
+    .speed_hz = 5000000,  /* override default speed */
+};
+struct spi_message m;
+spi_message_init(&m);
+spi_message_add_tail(&t, &m);
+ret = spi_sync(spi, &m);
+
+/* Convenience wrappers: */
+spi_write(spi, tx_buf, 4);           /* TX only */
+spi_read(spi, rx_buf, 4);            /* RX only (sends 0x00) */
+spi_write_then_read(spi, tx_buf, 2, rx_buf, 4);  /* CS held low between */
+
+/* regmap for SPI (same API as I2C!): */
+regmap = devm_regmap_init_spi(spi, &my_regmap_config);
+regmap_read(regmap, REG_ID, &val);
+```
+
+## Device Tree instantiation
+
+```dts
+/* Board DTS: */
+&i2c1 {
+    status = "okay";
+    clock-frequency = <400000>;  /* 400 kHz fast mode */
+
+    my_sensor: sensor@48 {
+        compatible = "vendor,my-sensor";
+        reg = <0x48>;            /* I2C address */
+        vdd-supply = <&ldo3>;    /* power supply */
+        interrupt-parent = <&gpio0>;
+        interrupts = <15 IRQ_TYPE_EDGE_FALLING>;
+    };
+};
+
+&spi0 {
+    status = "okay";
+    cs-gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+
+    my_spi_sensor: sensor@0 {
+        compatible = "vendor,my-spi-sensor";
+        reg = <0>;              /* chip select 0 */
+        spi-max-frequency = <10000000>;
+        spi-cpol;               /* SPI_MODE_2: CPOL=1 */
+        spi-cpha;               /* CPHA=1 */
+    };
+};
+```
+
+## Debugging I2C/SPI
+
+```bash
+# List I2C buses:
+ls /dev/i2c-*
+i2cdetect -l
+
+# Scan I2C bus 1 for devices:
+i2cdetect -y 1
+#      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+# 40: -- -- -- -- -- -- -- -- 48 -- -- -- -- -- -- --
+# (device found at address 0x48)
+
+# Read register 0x00 from device at address 0x48:
+i2cget -y 1 0x48 0x00
+
+# Write 0x01 to register 0x10:
+i2cset -y 1 0x48 0x10 0x01
+
+# Decode I2C traffic (if hardware supports):
+# Use /sys/kernel/debug/i2c-0/
+cat /sys/kernel/debug/i2c-0/timing
+
+# SPI trace:
+echo 1 > /sys/kernel/debug/dynamic_debug/control
+# or use spidev_test:
+spidev_test -D /dev/spidev0.0 -s 1000000 -p '\x01\x02\x03'
+
+# regmap debugfs:
+ls /sys/kernel/debug/regmap/
+cat /sys/kernel/debug/regmap/my-sensor-0-0048/registers
+# 00: 01
+# 01: 0f
+# ...
+
+# Trace I2C transactions:
+bpftrace -e '
+kprobe:i2c_transfer {
+    printf("i2c_transfer: adapter=%s num_msgs=%d\n",
+           ((struct i2c_adapter *)arg0)->name, (int)arg2);
+}'
+```
+
+## Further reading
+
+- [Platform Drivers](platform-driver.md) — MMIO register-mapped devices
+- [Device Tree](device-tree.md) — DTS binding for I2C/SPI devices
+- [Device Model](device-model.md) — bus/device/driver framework
+- [DMA API](../iommu/dma-api.md) — DMA for SPI controllers
+- `drivers/i2c/` — I2C subsystem
+- `drivers/spi/` — SPI subsystem
+- `include/linux/regmap.h` — regmap API
+- `Documentation/driver-api/i2c.rst` — I2C driver guide

--- a/docs/mm/slab-internals.md
+++ b/docs/mm/slab-internals.md
@@ -1,0 +1,262 @@
+# SLUB Allocator Internals
+
+> struct kmem_cache, freelist mechanics, per-CPU caches, and slab debugging
+
+## Why a slab allocator?
+
+`kmalloc` could just call the page allocator for every allocation, but that's wasteful:
+- Page allocator minimum granularity: 4096 bytes
+- Typical kernel allocation: 32–512 bytes
+- Objects of the same type are created and freed repeatedly
+
+The slab allocator solves this by:
+1. Allocating objects from pre-divided pages ("slabs")
+2. Caching freed objects for immediate reuse (no page allocator round-trip)
+3. Exploiting constructor patterns: objects are often the same type
+
+Linux uses **SLUB** (the "unqueued" slab allocator) since 2.6.23.
+
+## Architecture overview
+
+```
+kmalloc(128, GFP_KERNEL)
+         │
+         ▼
+kmalloc-128 cache (struct kmem_cache)
+         │
+    ┌────┴─────────────────────────────────┐
+    │ Per-CPU slab (struct kmem_cache_cpu)  │  ← current CPU
+    │   freelist: →obj1 →obj2 →obj3        │  ← hot, no lock
+    └────┬─────────────────────────────────┘
+         │ (per-CPU depleted)
+    ┌────▼─────────────────────────────────┐
+    │ Per-node partial list (struct kmem_cache_node) │
+    │   partial slabs with some free objects │
+    └────┬─────────────────────────────────┘
+         │ (no partial slabs)
+         ▼
+    Page allocator (get a new slab page)
+```
+
+## struct kmem_cache
+
+```c
+/* include/linux/slub_def.h */
+struct kmem_cache {
+    struct kmem_cache_cpu __percpu *cpu_slab; /* per-CPU fast path */
+
+    /* Allocation flags and configuration: */
+    slab_flags_t    flags;
+    unsigned long   min_partial;  /* min partial slabs in node */
+    unsigned int    size;         /* object size (with metadata) */
+    unsigned int    object_size;  /* real object size */
+    struct reciprocal_value reciprocal_size;
+    unsigned int    offset;       /* offset to freelist pointer */
+    struct kmem_cache_order_objects oo; /* order and objects per slab */
+    struct kmem_cache_order_objects max;
+    struct kmem_cache_order_objects min;
+    gfp_t           allocflags;   /* gfp flags for slab allocation */
+    int             refcount;
+    void            (*ctor)(void *);  /* constructor */
+
+    unsigned int    inuse;        /* offset to metadata */
+    unsigned int    align;
+    unsigned int    red_left_pad; /* for redzone debugging */
+    const char      *name;
+    struct list_head list;        /* in slab_caches list */
+
+    struct kmem_cache_node *node[MAX_NUMNODES];
+};
+```
+
+## struct kmem_cache_cpu (per-CPU fast path)
+
+```c
+struct kmem_cache_cpu {
+    void        **freelist;     /* pointer to first free object */
+    unsigned long tid;          /* transaction ID (ABA prevention) */
+    struct slab *slab;          /* current slab being used */
+    /* ... */
+};
+```
+
+The freelist is an **embedded linked list**: each free object's first bytes contain a pointer to the next free object (or NULL at the end of the list).
+
+```
+Slab page layout (objects = 128 bytes, SLUB):
+┌────────┬────────┬────────┬────────┬──────────────────┐
+│ obj[0] │ obj[1] │ obj[2] │ obj[3] │ ... until end    │
+│ free   │ used   │ free   │ free   │                  │
+│ →obj[2]│ [data] │ →obj[3]│ NULL   │                  │
+└────────┴────────┴────────┴────────┴──────────────────┘
+                     ↑
+cpu_slab->freelist = &obj[0] → obj[2] → obj[3] → NULL
+```
+
+## kmalloc path (alloc_cache_obj)
+
+```c
+/* mm/slub.c (simplified) */
+static __always_inline void *__kmalloc(size_t size, gfp_t flags)
+{
+    struct kmem_cache *s;
+
+    /* Round up to the next kmalloc-N size: */
+    s = kmalloc_caches[kmalloc_type(flags, _RET_IP_)][kmalloc_index(size)];
+
+    return slab_alloc(s, NULL, size, flags, _RET_IP_);
+}
+
+static __always_inline void *slab_alloc(struct kmem_cache *s,
+                                         struct list_lru *lru,
+                                         size_t orig_size, gfp_t gfpflags,
+                                         unsigned long addr)
+{
+    void *object;
+    struct kmem_cache_cpu *c;
+    unsigned long tid;
+
+    /* Fast path: per-CPU freelist */
+    c = this_cpu_ptr(s->cpu_slab);
+    tid = c->tid;
+    barrier();
+
+    object = c->freelist;
+    if (unlikely(!object || !__slab_obj_cnt_ok(c, s))) {
+        /* Per-CPU slab exhausted → slow path */
+        object = __slab_alloc(s, gfpflags, NUMA_NO_NODE, addr, c, orig_size);
+    } else {
+        /* Advance the freelist pointer (the embedded next ptr): */
+        void *next = get_freepointer_safe(s, object);
+
+        /* CAS to prevent races with IRQs stealing from same freelist: */
+        if (unlikely(!__update_cpu_freelist_fast(s, object, next, tid))) {
+            object = __slab_alloc(s, gfpflags, NUMA_NO_NODE, addr, c, orig_size);
+        }
+    }
+    return object;
+}
+```
+
+## kfree path
+
+```c
+void kfree(const void *object)
+{
+    struct slab *slab;
+    struct kmem_cache *s;
+
+    /* Get the slab (and thus the cache) from the page: */
+    slab = virt_to_slab(object);
+    if (unlikely(!slab)) {
+        /* Might be a large allocation (compound page) */
+        free_large_kmalloc(page, object);
+        return;
+    }
+
+    s = slab->slab_cache;
+    slab_free(s, slab, object, NULL, &object, 1, _RET_IP_);
+}
+
+static void slab_free(struct kmem_cache *s, struct slab *slab,
+                       void *head, void *tail, void **p, int cnt,
+                       unsigned long addr)
+{
+    struct kmem_cache_cpu *c = this_cpu_ptr(s->cpu_slab);
+
+    /* If freeing to the current slab, just prepend to freelist: */
+    if (slab == c->slab) {
+        /* Fast path: set object's next ptr to current freelist head */
+        set_freepointer(s, head, c->freelist);
+        c->freelist = head;
+        c->tid = next_tid(c->tid);
+        return;
+    }
+
+    /* Slow path: different slab → lock and handle */
+    __slab_free(s, slab, head, tail, cnt, addr);
+}
+```
+
+## kmem_cache_create (named caches)
+
+```c
+/* For frequently allocated objects with a specific type: */
+struct kmem_cache *my_cache;
+
+/* At module init: */
+my_cache = kmem_cache_create(
+    "my_struct",               /* name (shown in /proc/slabinfo) */
+    sizeof(struct my_struct),  /* object size */
+    __alignof__(struct my_struct), /* alignment */
+    SLAB_HWCACHE_ALIGN |       /* align to cache lines */
+    SLAB_PANIC,                /* BUG() if creation fails */
+    my_struct_ctor             /* optional constructor */
+);
+
+/* Allocate and free: */
+struct my_struct *obj = kmem_cache_alloc(my_cache, GFP_KERNEL);
+kmem_cache_free(my_cache, obj);
+
+/* At module exit: */
+kmem_cache_destroy(my_cache);
+```
+
+## SLUB debugging
+
+```bash
+# Enable SLUB debugging at boot (heavy overhead!):
+# SLUB_DEBUG in config, then:
+# slub_debug=FZP (FreeZone, Poison, track Padding)
+# or per-cache: slub_debug=FZP,my_struct
+
+# /proc/slabinfo: cache statistics
+cat /proc/slabinfo
+# name            <active_objs> <num_objs> <objsize> <objperslab> ...
+# kmalloc-128        12453       13000       128         32        ...
+# my_struct             123         256       256         16        ...
+
+# More detailed: slabtop (like top for slab)
+slabtop
+# Active / Total Objects (% used)    : 1234567 / 1500000 (82.3%)
+# Active / Total Slabs (% used)      : 12345 / 15000 (82.3%)
+# ...
+
+# Find which cache holds a pointer:
+# (in crash or gdb with vmlinux):
+# crash> kmem -s <pointer>
+
+# SLUB debug info for a cache:
+ls /sys/kernel/slab/
+cat /sys/kernel/slab/kmalloc-128/alloc_fastpath   # per-CPU alloc count
+cat /sys/kernel/slab/kmalloc-128/free_fastpath
+cat /sys/kernel/slab/kmalloc-128/slabs            # total slab pages
+cat /sys/kernel/slab/kmalloc-128/objects          # total objects
+cat /sys/kernel/slab/kmalloc-128/object_size      # 128
+
+# KASAN: detects use-after-free and out-of-bounds in slab:
+# CONFIG_KASAN=y causes SLUB to insert red zones and poison memory
+```
+
+## Memory poisoning
+
+When `CONFIG_SLUB_DEBUG` is enabled, freed objects are poisoned:
+
+```
+Poison values:
+  0x6b ('k') — object filled with this after free (SLUB_RED_ACTIVE)
+  0x5a ('Z') — padding bytes (SLUB_RED_INACTIVE)
+  0xcc — alignment padding
+
+On the next allocation, SLUB checks that the poison is intact.
+If not: use-after-free detected, kernel dumps the offending allocation.
+```
+
+## Further reading
+
+- [kmalloc and slab](slab.md) — user-facing API
+- [Page Allocator](page-allocator.md) — SLUB gets pages from here
+- [KASAN](kasan.md) — slab memory error detection
+- [KFENCE](kfence.md) — lightweight slab sampling-based detection
+- `mm/slub.c` — SLUB implementation (~10,000 lines)
+- `Documentation/mm/slub.rst` — SLUB documentation

--- a/docs/security/landlock.md
+++ b/docs/security/landlock.md
@@ -1,0 +1,322 @@
+# Landlock: Unprivileged Sandboxing
+
+> Restrict a process's filesystem and network access without root — the new Linux sandbox LSM
+
+## What is Landlock?
+
+Landlock (merged in Linux 5.13) is a Linux Security Module that allows **unprivileged processes** to restrict their own access to the filesystem (and network since 5.19). Unlike seccomp which filters syscalls, Landlock controls resource access at a semantic level.
+
+Key properties:
+- **No root required**: any process can create a Landlock sandbox for itself
+- **Irreversible**: once rules are enforced, they cannot be loosened
+- **Inherited**: child processes inherit the restrictions
+- **Stacked**: rules can only be restricted, never expanded
+
+## Use cases
+
+- Browsers sandboxing renderer processes
+- Language runtimes restricting downloaded code
+- Security-sensitive daemons reducing attack surface
+- Container runtimes as a defense-in-depth layer
+
+## API overview
+
+```c
+#include <linux/landlock.h>
+#include <sys/syscall.h>
+
+/* The three steps: create ruleset → add rules → enforce */
+
+/* Step 1: Create a ruleset */
+struct landlock_ruleset_attr ruleset_attr = {
+    .handled_access_fs =
+        LANDLOCK_ACCESS_FS_EXECUTE |
+        LANDLOCK_ACCESS_FS_WRITE_FILE |
+        LANDLOCK_ACCESS_FS_READ_FILE |
+        LANDLOCK_ACCESS_FS_READ_DIR |
+        LANDLOCK_ACCESS_FS_REMOVE_DIR |
+        LANDLOCK_ACCESS_FS_REMOVE_FILE |
+        LANDLOCK_ACCESS_FS_MAKE_CHAR |
+        LANDLOCK_ACCESS_FS_MAKE_DIR |
+        LANDLOCK_ACCESS_FS_MAKE_REG |
+        LANDLOCK_ACCESS_FS_MAKE_SYM |
+        LANDLOCK_ACCESS_FS_MAKE_SOCK |
+        LANDLOCK_ACCESS_FS_MAKE_FIFO |
+        LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+        LANDLOCK_ACCESS_FS_MAKE_SYM |
+        LANDLOCK_ACCESS_FS_REFER |      /* rename across dirs (v2) */
+        LANDLOCK_ACCESS_FS_TRUNCATE,    /* truncate (v3) */
+    .handled_access_net =
+        LANDLOCK_ACCESS_NET_BIND_TCP |
+        LANDLOCK_ACCESS_NET_CONNECT_TCP,
+};
+
+int ruleset_fd = syscall(SYS_landlock_create_ruleset,
+                          &ruleset_attr, sizeof(ruleset_attr), 0);
+```
+
+### Step 2: Add rules
+
+```c
+/* Allow read access to /usr: */
+int path_fd = open("/usr", O_PATH | O_CLOEXEC);
+
+struct landlock_path_beneath_attr path_attr = {
+    .allowed_access =
+        LANDLOCK_ACCESS_FS_EXECUTE |
+        LANDLOCK_ACCESS_FS_READ_FILE |
+        LANDLOCK_ACCESS_FS_READ_DIR,
+    .parent_fd = path_fd,
+};
+
+syscall(SYS_landlock_add_rule,
+        ruleset_fd,
+        LANDLOCK_RULE_PATH_BENEATH,
+        &path_attr, 0);
+close(path_fd);
+
+/* Allow read-write to /tmp: */
+path_fd = open("/tmp", O_PATH | O_CLOEXEC);
+path_attr.allowed_access =
+    LANDLOCK_ACCESS_FS_READ_FILE |
+    LANDLOCK_ACCESS_FS_WRITE_FILE |
+    LANDLOCK_ACCESS_FS_READ_DIR |
+    LANDLOCK_ACCESS_FS_MAKE_REG |
+    LANDLOCK_ACCESS_FS_REMOVE_FILE;
+path_attr.parent_fd = path_fd;
+
+syscall(SYS_landlock_add_rule,
+        ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &path_attr, 0);
+close(path_fd);
+
+/* Allow TCP connect to port 443: */
+struct landlock_net_port_attr net_attr = {
+    .allowed_access = LANDLOCK_ACCESS_NET_CONNECT_TCP,
+    .port = 443,
+};
+syscall(SYS_landlock_add_rule,
+        ruleset_fd, LANDLOCK_RULE_NET_PORT, &net_attr, 0);
+```
+
+### Step 3: Enforce
+
+```c
+/* Drop ambient capabilities (needed before enforce): */
+prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+
+/* Apply the ruleset to this process (and all its children): */
+syscall(SYS_landlock_restrict_self, ruleset_fd, 0);
+close(ruleset_fd);
+
+/* From this point: filesystem and network accesses are restricted */
+/* Any access not covered by a rule → EACCES */
+```
+
+## Complete sandbox example
+
+```c
+#include <fcntl.h>
+#include <linux/landlock.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+
+static inline int landlock_create_ruleset(
+    const struct landlock_ruleset_attr *attr, size_t size, __u32 flags)
+{
+    return syscall(__NR_landlock_create_ruleset, attr, size, flags);
+}
+static inline int landlock_add_rule(int ruleset_fd, enum landlock_rule_type type,
+                                     const void *attr, __u32 flags)
+{
+    return syscall(__NR_landlock_add_rule, ruleset_fd, type, attr, flags);
+}
+static inline int landlock_restrict_self(int ruleset_fd, __u32 flags)
+{
+    return syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
+}
+
+int sandbox_init(void)
+{
+    /* Check ABI version: */
+    int abi = syscall(__NR_landlock_create_ruleset, NULL, 0,
+                       LANDLOCK_CREATE_RULESET_VERSION);
+    if (abi < 1) {
+        /* Kernel doesn't support Landlock — fall back gracefully */
+        fprintf(stderr, "Landlock not supported (abi=%d)\n", abi);
+        return 0;
+    }
+
+    /* Use only features available in the kernel's ABI version: */
+    __u64 fs_access =
+        LANDLOCK_ACCESS_FS_EXECUTE |
+        LANDLOCK_ACCESS_FS_READ_FILE |
+        LANDLOCK_ACCESS_FS_READ_DIR |
+        LANDLOCK_ACCESS_FS_WRITE_FILE |
+        LANDLOCK_ACCESS_FS_REMOVE_FILE |
+        LANDLOCK_ACCESS_FS_MAKE_REG;
+    if (abi >= 2)
+        fs_access |= LANDLOCK_ACCESS_FS_REFER;
+    if (abi >= 3)
+        fs_access |= LANDLOCK_ACCESS_FS_TRUNCATE;
+
+    struct landlock_ruleset_attr ruleset_attr = {
+        .handled_access_fs = fs_access,
+    };
+    if (abi >= 4) {
+        ruleset_attr.handled_access_net =
+            LANDLOCK_ACCESS_NET_BIND_TCP |
+            LANDLOCK_ACCESS_NET_CONNECT_TCP;
+    }
+
+    int ruleset_fd = landlock_create_ruleset(&ruleset_attr,
+                                              sizeof(ruleset_attr), 0);
+    if (ruleset_fd < 0)
+        return -errno;
+
+    /* Allow read-only access to /usr and /lib: */
+    const char *ro_paths[] = { "/usr", "/lib", "/lib64", NULL };
+    for (int i = 0; ro_paths[i]; i++) {
+        int fd = open(ro_paths[i], O_PATH | O_CLOEXEC);
+        if (fd < 0) continue;
+        struct landlock_path_beneath_attr pa = {
+            .allowed_access = LANDLOCK_ACCESS_FS_EXECUTE |
+                              LANDLOCK_ACCESS_FS_READ_FILE |
+                              LANDLOCK_ACCESS_FS_READ_DIR,
+            .parent_fd = fd,
+        };
+        landlock_add_rule(ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &pa, 0);
+        close(fd);
+    }
+
+    /* Allow read-write to /tmp: */
+    int tmp_fd = open("/tmp", O_PATH | O_CLOEXEC);
+    if (tmp_fd >= 0) {
+        struct landlock_path_beneath_attr pa = {
+            .allowed_access = LANDLOCK_ACCESS_FS_READ_FILE |
+                              LANDLOCK_ACCESS_FS_WRITE_FILE |
+                              LANDLOCK_ACCESS_FS_READ_DIR |
+                              LANDLOCK_ACCESS_FS_MAKE_REG |
+                              LANDLOCK_ACCESS_FS_REMOVE_FILE,
+            .parent_fd = tmp_fd,
+        };
+        landlock_add_rule(ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &pa, 0);
+        close(tmp_fd);
+    }
+
+    prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+    int ret = landlock_restrict_self(ruleset_fd, 0);
+    close(ruleset_fd);
+    return ret;
+}
+```
+
+## Filesystem access rights
+
+```c
+/* File access rights: */
+LANDLOCK_ACCESS_FS_EXECUTE      /* execute a file */
+LANDLOCK_ACCESS_FS_WRITE_FILE   /* write to a file */
+LANDLOCK_ACCESS_FS_READ_FILE    /* open/read a file */
+LANDLOCK_ACCESS_FS_READ_DIR     /* list a directory (opendir) */
+LANDLOCK_ACCESS_FS_REMOVE_DIR   /* rmdir */
+LANDLOCK_ACCESS_FS_REMOVE_FILE  /* unlink */
+LANDLOCK_ACCESS_FS_MAKE_CHAR    /* mknod char device */
+LANDLOCK_ACCESS_FS_MAKE_DIR     /* mkdir */
+LANDLOCK_ACCESS_FS_MAKE_REG     /* create regular file (creat/open O_CREAT) */
+LANDLOCK_ACCESS_FS_MAKE_SOCK    /* create Unix socket */
+LANDLOCK_ACCESS_FS_MAKE_FIFO    /* mkfifo */
+LANDLOCK_ACCESS_FS_MAKE_BLOCK   /* mknod block device */
+LANDLOCK_ACCESS_FS_MAKE_SYM     /* symlink */
+LANDLOCK_ACCESS_FS_REFER        /* rename/link across directories (v2+) */
+LANDLOCK_ACCESS_FS_TRUNCATE     /* truncate (v3+) */
+
+/* Network access rights (v4+): */
+LANDLOCK_ACCESS_NET_BIND_TCP    /* bind() a TCP socket to a port */
+LANDLOCK_ACCESS_NET_CONNECT_TCP /* connect() a TCP socket to a port */
+```
+
+## Kernel implementation
+
+### LSM hook
+
+```c
+/* security/landlock/fs.c */
+static int hook_path_link(struct dentry *old_dentry,
+                           const struct path *new_dir,
+                           struct dentry *new_dentry)
+{
+    const struct landlock_ruleset *dom = landlock_get_current_domain();
+    if (!dom)
+        return 0;  /* not sandboxed */
+
+    /* Check that the process is allowed to create links in new_dir: */
+    return check_access_path(dom, new_dir,
+                             LANDLOCK_ACCESS_FS_MAKE_REG);
+}
+```
+
+### Rule storage
+
+```c
+/* Rules are stored in a red-black tree keyed by inode number: */
+struct landlock_ruleset {
+    struct rb_root_cached  root_inode;  /* FS rules */
+    struct rb_root_cached  root_net;    /* net rules */
+    /* ... */
+};
+
+/* On landlock_add_rule with LANDLOCK_RULE_PATH_BENEATH: */
+/* - open the path_fd → get the inode number */
+/* - insert a node in root_inode with allowed_access bitmask */
+/* - All paths under that inode get the access rights */
+```
+
+## Landlock vs seccomp vs AppArmor
+
+| Feature | seccomp | Landlock | AppArmor |
+|---------|---------|----------|----------|
+| Requires root | No | No | Yes (policy load) |
+| Granularity | Syscall | Resource semantic | Path/capability |
+| Stackable | Yes (AND) | Yes (most restrictive) | No |
+| Runtime performance | Fast (BPF) | Fast (rb-tree) | Fast |
+| Policy language | C/BPF | C API | Text profiles |
+| Filesystem | Via syscall | Direct FS semantic | Yes |
+| Network | Via syscall | TCP port (v4+) | Yes |
+
+## Debugging
+
+```bash
+# Check Landlock support:
+grep LANDLOCK /boot/config-$(uname -r)
+# CONFIG_SECURITY_LANDLOCK=y
+
+# Trace Landlock denials (shows as EACCES with LSM audit):
+ausearch -m AVC | grep landlock
+# or:
+dmesg | grep "landlock"
+
+# Test a sandbox:
+# (requires landlock-abi >= 1)
+unshare --user -- bash -c '
+  python3 -c "
+import ctypes, os
+# ... simplified landlock in Python ...
+"'
+
+# strace shows EACCES for denied operations:
+strace -e open,openat,write ./sandboxed_program 2>&1 | grep EACCES
+```
+
+## Further reading
+
+- [seccomp](seccomp.md) — syscall-level filtering
+- [LSM Framework](lsm.md) — how Landlock hooks into the LSM stack
+- [Capabilities](capabilities.md) — privilege reduction
+- [User Namespaces](user-namespaces.md) — unprivileged isolation
+- `security/landlock/` — kernel implementation
+- `Documentation/userspace-api/landlock.rst` — official kernel docs
+- `samples/landlock/sandboxer.c` — example in kernel tree

--- a/docs/time/clocksource.md
+++ b/docs/time/clocksource.md
@@ -1,0 +1,304 @@
+# Clocksource and Clockevent Drivers
+
+> Hardware timers in the kernel: TSC, HPET, clockevents, and tick_device
+
+## Two clock abstractions
+
+The kernel separates time into two concepts:
+
+```
+clocksource:   reads current time (monotonic counter)
+               "What time is it right now?"
+               Example: TSC counter, HPET counter
+
+clockevent:    programs a future interrupt (one-shot or periodic)
+               "Wake me up in N nanoseconds"
+               Example: Local APIC timer, HPET, ARM generic timer
+```
+
+Together they implement the kernel's timekeeping:
+
+```
+clocksource  →  timekeeping (clock_gettime, ktime_get)
+clockevent   →  tick device  →  scheduler tick, hrtimers, timers
+```
+
+## struct clocksource
+
+```c
+/* include/linux/clocksource.h */
+struct clocksource {
+    /*
+     * read() returns a 64-bit cycle counter.
+     * The counter may wrap around — timekeeping handles this.
+     */
+    u64 (*read)(struct clocksource *cs);
+
+    u64             mask;       /* bitmask to handle counter wrap */
+    u32             mult;       /* cycles to ns: ns = cycles * mult >> shift */
+    u32             shift;
+    u64             max_idle_ns; /* max time between reads before losing accuracy */
+    u32             maxadj;
+    u64             max_cycles; /* max cycles before ns calculation overflows */
+    const char      *name;
+    struct list_head list;
+    int             rating;     /* quality: 500=perfect, 300=good, 100=basic */
+    enum clocksource_ids  id;
+    unsigned long   flags;
+    /* CLOCK_SOURCE_IS_CONTINUOUS: counter never jumps */
+    /* CLOCK_SOURCE_VALID_FOR_HRES: can be used for high-res timers */
+
+    /* For adjusting frequency: */
+    s64             (*vdso_clock_mode)(struct clocksource *cs);
+    void (*suspend)(struct clocksource *cs);
+    void (*resume)(struct clocksource *cs);
+};
+```
+
+## TSC (Time Stamp Counter)
+
+The TSC is the primary clocksource on modern x86:
+
+```c
+/* arch/x86/kernel/tsc.c */
+static struct clocksource clocksource_tsc = {
+    .name                   = "tsc",
+    .rating                 = 300,
+    .read                   = read_tsc,
+    .mask                   = CLOCKSOURCE_MASK(64),
+    .flags                  = CLOCK_SOURCE_IS_CONTINUOUS |
+                              CLOCK_SOURCE_VALID_FOR_HRES,
+};
+
+static u64 read_tsc(struct clocksource *cs)
+{
+    return (u64)rdtsc_ordered();  /* RDTSC instruction */
+}
+
+/* Convert TSC cycles to nanoseconds: */
+/* ns = (cycles * mult) >> shift */
+/* mult and shift are calibrated at boot against HPET or PIT */
+```
+
+```bash
+# Check the current clocksource:
+cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+# tsc
+
+# Available clocksources (sorted by preference):
+cat /sys/devices/system/clocksource/clocksource0/available_clocksource
+# tsc hpet acpi_pm
+
+# TSC frequency:
+dmesg | grep "tsc: Detected"
+# tsc: Detected 3600.000 MHz processor
+
+# TSC stability:
+dmesg | grep tsc | grep -i "unstable\|skew\|reliable"
+```
+
+### TSC reliability issues
+
+```bash
+# TSC may be unreliable:
+# 1. Old multi-socket systems: TSCs not synchronized between sockets
+# 2. CPU frequency scaling: TSC rate changes with frequency (older CPUs)
+# 3. Virtualization: hypervisor may not provide stable TSC
+
+# Modern CPUs have invariant TSC (constant rate regardless of P-state):
+grep "constant_tsc\|nonstop_tsc" /proc/cpuinfo | head -2
+# flags: ... constant_tsc nonstop_tsc ...
+
+# Force a different clocksource:
+echo hpet > /sys/devices/system/clocksource/clocksource0/current_clocksource
+```
+
+## Registering a clocksource
+
+```c
+/* For a custom hardware counter (e.g., in a SoC driver): */
+#include <linux/clocksource.h>
+
+static u64 my_timer_read(struct clocksource *cs)
+{
+    return readl(my_timer_base + TIMER_COUNT_REG);
+}
+
+static struct clocksource my_clocksource = {
+    .name    = "my-hw-timer",
+    .rating  = 200,
+    .read    = my_timer_read,
+    .mask    = CLOCKSOURCE_MASK(32),
+    .flags   = CLOCK_SOURCE_IS_CONTINUOUS,
+};
+
+/* In probe(): */
+clocksource_register_hz(&my_clocksource, 24000000); /* 24 MHz */
+/* Computes mult/shift from frequency */
+```
+
+## struct clock_event_device
+
+```c
+/* include/linux/clockchips.h */
+struct clock_event_device {
+    void (*event_handler)(struct clock_event_device *);
+    /* Called on each timer interrupt (set by tick layer) */
+
+    int  (*set_next_event)(unsigned long evt,
+                           struct clock_event_device *);
+    /* Program the hardware to fire in `evt` cycles */
+
+    int  (*set_next_ktime)(ktime_t expires,
+                           struct clock_event_device *);
+
+    ktime_t             next_event;
+    u64                 max_delta_ns;
+    u64                 min_delta_ns;
+    u32                 mult;
+    u32                 shift;
+
+    enum clock_event_state  state_use_accessors;
+    unsigned int        features;
+    /* CLOCK_EVT_FEAT_PERIODIC: supports periodic mode */
+    /* CLOCK_EVT_FEAT_ONESHOT:  supports one-shot mode */
+    /* CLOCK_EVT_FEAT_C3STOP:   stops in deep idle */
+
+    const char          *name;
+    int                 rating;
+    int                 irq;
+    int                 bound_on;
+    const struct cpumask *cpumask;
+    struct list_head    list;
+};
+```
+
+## Local APIC timer (per-CPU clockevent)
+
+```c
+/* arch/x86/kernel/apic/apic.c */
+static struct clock_event_device lapic_clockevent = {
+    .name                   = "lapic",
+    .features               = CLOCK_EVT_FEAT_PERIODIC |
+                              CLOCK_EVT_FEAT_ONESHOT  |
+                              CLOCK_EVT_FEAT_C3STOP   |
+                              CLOCK_EVT_FEAT_DUMMY,
+    .shift                  = 32,
+    .set_state_shutdown     = lapic_timer_shutdown,
+    .set_state_periodic     = lapic_timer_set_periodic,
+    .set_state_oneshot      = lapic_timer_set_oneshot,
+    .set_next_event         = lapic_next_event,
+    .broadcast              = lapic_timer_broadcast,
+    .rating                 = 100,
+    .irq                    = -1,
+};
+
+static int lapic_next_event(unsigned long delta,
+                             struct clock_event_device *evt)
+{
+    /* Program the APIC timer to fire in `delta` cycles */
+    apic_write(APIC_TMICT, delta);
+    return 0;
+}
+```
+
+## tick device and NOHZ
+
+Each CPU has a **tick device** — the clockevent used for the scheduling tick:
+
+```c
+/* kernel/time/tick-common.c */
+struct tick_device {
+    struct clock_event_device *evtdev;
+    enum tick_device_mode      mode;  /* TICKDEV_MODE_PERIODIC or ONESHOT */
+};
+
+DEFINE_PER_CPU(struct tick_device, tick_cpu_device);
+```
+
+```bash
+# In periodic mode: tick fires every 1/HZ seconds (HZ=250 → 4ms)
+grep "^CONFIG_HZ=" /boot/config-$(uname -r)
+# CONFIG_HZ=250
+
+# In NOHZ (tickless) mode: tick is suppressed when CPU is idle
+# Reduces power consumption and improves real-time latency
+
+# Check NOHZ mode:
+cat /sys/kernel/debug/sched/domains/cpu0/domain0/stats
+# or:
+cat /proc/timer_list | grep "Tick Device" | head -5
+
+# NOHZ_FULL (adaptive tick): suppress tick even when running
+# Requires: isolcpus + nohz_full= boot params (for RT/HPC)
+```
+
+## Timekeeping: clocksource → wall clock
+
+```c
+/* kernel/time/timekeeping.c */
+struct timekeeper {
+    struct tk_read_base     tkr_mono;   /* monotonic clock */
+    struct tk_read_base     tkr_raw;    /* raw hardware clock */
+
+    u64                     xtime_sec;  /* real wall-clock seconds */
+    unsigned long           ktime_sec;  /* monotonic seconds */
+    struct timespec64       wall_to_monotonic; /* offset */
+    ktime_t                 offs_real;  /* monotonic → realtime offset */
+    ktime_t                 offs_boot;  /* boot time offset */
+    ktime_t                 offs_tai;   /* TAI offset */
+
+    u32                     tai_offset; /* TAI - UTC in seconds */
+    u32                     clock_was_set_seq;
+    u8                      cs_was_changed_seq;
+    ktime_t                 next_leap_ktime;
+    s64                     rawtime_sec;
+};
+
+/* Reading current time: */
+ktime_t ktime_get(void)
+{
+    struct tk_read_base *tkr = &tk_core.timekeeper.tkr_mono;
+    u64 cycles = tkr->clock->read(tkr->clock);
+    return base + (cycles * tkr->mult) >> tkr->shift;
+}
+```
+
+## Observing timekeeping
+
+```bash
+# Current time sources and offsets:
+cat /proc/timer_list
+
+# NTP synchronization:
+timedatectl status
+# System clock synchronized: yes
+# NTP service: active
+# RTC in local TZ: no
+
+# Clock error estimation (NTP):
+adjtimex -p | grep -E "offset|freq|error"
+
+# High-resolution timer benchmark:
+cyclictest -n -m -p99 -i200 -l1000000
+# Tests: time from sleep request to actual wakeup (uses hrtimer)
+
+# TSC vs HPET accuracy comparison:
+bpftrace -e '
+BEGIN { @start = nsecs; }
+interval:s:1 {
+    printf("elapsed: %lld ns\n", nsecs - @start);
+    @start = nsecs;
+}'
+```
+
+## Further reading
+
+- [hrtimers](hrtimers.md) — high-resolution timers using clockevent
+- [POSIX Timers](posix-timers.md) — user-facing timer API
+- [cpuidle and C-states](../power/cpuidle.md) — CLOCK_EVT_FEAT_C3STOP
+- [vDSO](../mm/vdso.md) — fast clock_gettime using clocksource
+- [Real-Time Tuning](../sched/rt-tuning.md) — tick suppression for RT
+- `kernel/time/timekeeping.c` — timekeeping core
+- `arch/x86/kernel/tsc.c` — TSC clocksource
+- `arch/x86/kernel/apic/apic.c` — APIC clockevent

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - Fundamentals:
       - Page Allocator: mm/page-allocator.md
       - kmalloc (SLUB): mm/slab.md
+      - SLUB Allocator Internals: mm/slab-internals.md
       - vmalloc: mm/vmalloc.md
       - NUMA: mm/numa.md
     - NUMA Advanced:
@@ -327,6 +328,7 @@ nav:
     - Character and Misc Devices: drivers/chardev.md
     - PCI Drivers: drivers/pci-driver.md
     - Device Tree: drivers/device-tree.md
+    - I2C and SPI Drivers: drivers/i2c-spi.md
   - IPC:
     - Getting Started: ipc/README.md
     - Signals: ipc/signals.md
@@ -376,6 +378,7 @@ nav:
     - fscrypt (Per-File Encryption): security/fscrypt.md
     - SELinux: security/selinux.md
     - Kernel Hardening: security/kernel-hardening.md
+    - Landlock Sandboxing: security/landlock.md
   - Virtualization:
     - Getting Started: virtualization/README.md
     - KVM Architecture: virtualization/kvm-arch.md
@@ -392,6 +395,7 @@ nav:
   - Time:
     - Getting Started: time/README.md
     - Timekeeping and Clocksources: time/timekeeping.md
+    - Clocksource and Clockevent Drivers: time/clocksource.md
     - hrtimers: time/hrtimers.md
     - POSIX Timers and timerfd: time/posix-timers.md
   - IOMMU and DMA:


### PR DESCRIPTION
## Summary
- **I2C and SPI drivers** (`drivers/i2c-spi.md`): I2C wire protocol, `i2c_driver` probe/remove pattern, SMBus helpers and raw `i2c_transfer`, regmap abstraction layer (unified I2C/SPI/MMIO register access), SPI 4-wire protocol, `spi_driver`, DTS device instantiation, `i2cdetect`/regmap debugfs
- **SLUB allocator internals** (`mm/slab-internals.md`): per-CPU freelist with embedded next-pointer, `struct kmem_cache`/`kmem_cache_cpu`, CAS-based fast alloc path, slow path via partial slab list, `kmem_cache_create` for typed caches, memory poisoning, slabtop/`/sys/kernel/slab` debugging
- **Landlock sandboxing** (`security/landlock.md`): three-step API (create_ruleset → add_rule → restrict_self), complete C sandbox implementation with ABI version detection, all 14 FS rights + TCP network rights, rb-tree rule storage internals, comparison with seccomp/AppArmor
- **Clocksource and clockevent** (`time/clocksource.md`): `struct clocksource` vs `clock_event_device`, TSC RDTSC driver, mult/shift frequency conversion, HPET, Local APIC timer, tick device, NOHZ tick suppression, timekeeping internals

## Test plan
- [ ] Verify all new nav entries render correctly
- [ ] Check code block syntax
- [ ] Verify cross-links between pages

Closes #423