### PR TITLE
Update landing page to list all available subsystems (#507)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,10 +23,31 @@ The kernel has extensive API documentation, but understanding the *rationale* re
 | Subsystem | Status |
 |-----------|--------|
 | [Memory Management (mm/)](mm/README.md) | Available |
-| scheduler/ | Planned |
-| networking/ | Planned |
-| bpf/ | Planned |
-| drivers/ | Planned |
+| [Scheduler (sched/)](sched/README.md) | Available |
+| [Networking (net/)](net/network-stack-overview.md) | Available |
+| [Locking (locking/)](locking/README.md) | Available |
+| [Interrupts (interrupts/)](interrupts/README.md) | Available |
+| [Security (security/)](security/README.md) | Available |
+| [VFS (vfs/)](vfs/README.md) | Available |
+| [BPF (bpf/)](bpf/README.md) | Available |
+| [Block Layer (block/)](block/README.md) | Available |
+| [Filesystems (filesystems/)](filesystems/README.md) | Available |
+| [Drivers (drivers/)](drivers/README.md) | Available |
+| [Cgroups (cgroups/)](cgroups/README.md) | Available |
+| [Tracing (tracing/)](tracing/README.md) | Available |
+| [Debugging (debugging/)](debugging/README.md) | Available |
+| [IPC (ipc/)](ipc/README.md) | Available |
+| [Architecture (arch/)](arch/arm64/README.md) | Available |
+| [Modules (modules/)](modules/README.md) | Available |
+| [Virtualization (virtualization/)](virtualization/README.md) | Available |
+| [Power Management (power/)](power/README.md) | Available |
+| [Time (time/)](time/README.md) | Available |
+| [Syscalls (syscalls/)](syscalls/README.md) | Available |
+| [IO (io/)](io/README.md) | Available |
+| [io_uring (io-uring/)](io-uring/README.md) | Available |
+| [Crypto (crypto/)](crypto/README.md) | Available |
+| [Livepatch (livepatch/)](livepatch/README.md) | Available |
+| [IOMMU (iommu/)](iommu/README.md) | Available |
 
 ## Community
 


### PR DESCRIPTION
## Summary

- The subsystems table on the landing page only listed `mm/` as Available, with scheduler, networking, bpf, and drivers as Planned
- In reality 26 subsystems now have substantial documentation
- Update the table to reflect actual state, with working links to each subsystem's entry page

## What changed

`docs/index.md`: replaced the 5-row placeholder table with a complete 26-row table covering all subsystems that have content: mm, sched, net, locking, interrupts, security, vfs, bpf, block, filesystems, drivers, cgroups, tracing, debugging, ipc, arch, modules, virtualization, power, time, syscalls, io, io-uring, crypto, livepatch, iommu.

## Test plan

- [ ] Verify all linked pages exist and load correctly
- [ ] Confirm landing page renders the table without errors