### PR TITLE
Expand arch/arm64/ to comprehensive coverage

### DIFF
--- a/docs/arch/arm64/README.md
+++ b/docs/arch/arm64/README.md
@@ -16,8 +16,14 @@ Understanding ARM64-specific behavior is essential for kernel work on these plat
 
 | Page | What it covers |
 |------|----------------|
+| [Boot Sequence](boot.md) | Head.S, identity mapping, decompressor, MMU enable, SMP bringup |
 | [Exception Model](exception-model.md) | EL0-EL3, VBAR_EL1, syndrome registers, GIC |
 | [Memory Model](memory-model.md) | Weak ordering, barriers, load-acquire/store-release, LDAR/STLR |
+| [Page Tables](page-tables.md) | TTBR0/TTBR1, granule sizes, PTE format, ASID, MAIR_EL1, stage 2 |
+| [Syscall Entry](syscall-entry.md) | SVC instruction, el0_svc, syscall table, vDSO, compat |
+| [CPU Features and Alternatives](cpu-features.md) | Feature detection, alternatives patching, hwcaps, errata, SVE/BTI/MTE |
+| [Spectre and Meltdown](spectre-meltdown.md) | Spectre v1/v2/BHB/v4, SSBS, CSV2, BHB clearing, KPTI |
+| [War Stories](war-stories.md) | SVE context switch, TLB ordering, DMA coherency, BTI crash, errata range bug |
 
 ## ARM64 vs x86 key differences
 

--- a/docs/arch/arm64/cpu-features.md
+++ b/docs/arch/arm64/cpu-features.md
@@ -178,7 +178,9 @@ if (cpus_have_cap(ARM64_HAS_LSE_ATOMICS))
 ```c
 static inline bool this_cpu_has_cap(unsigned int cap)
 {
-    return !!(this_cpu_read(cpu_hwcap_keys[cap]));
+    if (!WARN_ON(cap >= ARM64_NCAPS))
+        return !!test_bit(cap, (unsigned long *)this_cpu_ptr(&cpu_hwcaps));
+    return false;
 }
 ```
 
@@ -434,10 +436,12 @@ kernel_neon_end();     /* restores state, re-enables preemption */
 
 ## BTI — Branch Target Identification
 
-BTI is an ARMv8.5 control-flow integrity feature. When enabled
-(`SCTLR_EL1.BT1 = 1`), any indirect branch (`BR`, `BLR`, `RET`) must land on
-a `BTI` instruction (or the destination of a paired `BL`/`BLRAAZ` that
-implies a call target). Landing anywhere else raises a Branch Target Exception.
+BTI is an ARMv8.5 control-flow integrity feature. When enabled for userspace
+(`SCTLR_EL1.BT0 = 1`) or kernel (`SCTLR_EL1.BT1 = 1`), any indirect branch
+(`BR`, `BLR`, `RET`) must land on a `BTI` instruction (or the destination of
+a paired `BL`/`BLRAAZ` that implies a call target). Landing anywhere else
+raises a Branch Target Exception. The kernel sets `BT0` to enforce BTI for
+user processes; `BT1` controls enforcement in kernel code.
 
 ### ELF Marking
 
@@ -447,10 +451,9 @@ Binaries opt in via a GNU property note:
 GNU_PROPERTY_AARCH64_FEATURE_1_BTI   (bit 0 of GNU_PROPERTY_AARCH64_FEATURE_1_AND)
 ```
 
-The dynamic linker (`ld.so`) reads this note. The kernel checks it at
-`execve()` time in `arch/arm64/kernel/process.c` via
-`arch64_elf_check_arch()` and sets `SCTLR_EL1.BT1` for the process if the
-property is present.
+The dynamic linker (`ld.so`) reads this note. The kernel checks it at `execve()` time via `arch_parse_elf_property()` in
+`arch/arm64/kernel/process.c` and sets `SCTLR_EL1.BT0` for the process if
+the property is present, enabling BTI enforcement for userspace code.
 
 ### Interaction with JIT and Signal Handlers
 
@@ -542,7 +545,7 @@ rev_max=4)` matches r0p0 through r0p4.
 | 835769 | Cortex-A53 r0p0–r0p4 | Incorrect result from MUL/MADD after load | Compiler `-mfix-cortex-a53-835769` |
 | 1530923 | Cortex-A55 | Speculative AT instruction may cause faults | Speculation barrier alternatives |
 | 2457168 | Cortex-A510 | PMULL2 may produce incorrect results | Alternatives patch |
-| 1418040 | Cortex-A76/Neoverse-N1 | ICache invalidation may be incomplete | `ic iallu` alternatives |
+| 1418040 | Cortex-A55 | ICache invalidation may be incomplete | `ic iallu` alternatives |
 
 Errata workarounds are conditionally compiled via `CONFIG_ARM64_ERRATUM_*`
 Kconfig symbols and do not add overhead on unaffected hardware.

--- a/docs/arch/arm64/cpu-features.md
+++ b/docs/arch/arm64/cpu-features.md
@@ -1,0 +1,654 @@
+# ARM64 CPU Features
+
+> Feature detection, alternatives patching, hwcaps, and errata workarounds
+
+## Overview
+
+ARM64 (AArch64) implements a rich system for discovering CPU capabilities at
+runtime and transparently patching the kernel image to exploit them. Three
+distinct layers are involved:
+
+1. **Feature detection** — ID registers are read at boot; capabilities are
+   computed as the safe intersection across all CPUs.
+2. **Alternatives patching** — Hot paths in the kernel text are rewritten
+   in-place to use faster or more correct instructions when a feature is
+   confirmed present.
+3. **Userspace exposure** — Detected features are surfaced as `HWCAP_*` bits
+   via `getauxval(AT_HWCAP)` and the `Features:` line in `/proc/cpuinfo`.
+
+The kernel code lives primarily in:
+
+| Path | Purpose |
+|------|---------|
+| `arch/arm64/kernel/cpufeature.c` | Feature detection, capability computation |
+| `arch/arm64/include/asm/cpufeature.h` | `struct arm64_cpu_capabilities`, macros |
+| `arch/arm64/kernel/alternative.c` | Alternatives patching engine |
+| `arch/arm64/include/asm/alternative.h` | `alternative()`, `alternative_insn()` macros |
+| `arch/arm64/kernel/cpu_errata.c` | Errata workaround table |
+| `arch/arm64/include/uapi/asm/hwcap.h` | `HWCAP_*` constants exposed to userspace |
+
+---
+
+## Feature Detection at Boot
+
+### ID Registers
+
+ARM64 exposes CPU capabilities through a family of system registers readable
+at EL1. The kernel reads these during `setup_cpu_features()` (called from
+`setup_arch()`):
+
+| Register | What it describes |
+|----------|------------------|
+| `ID_AA64ISAR0_EL1` | Instruction set: AES, SHA, CRC32, atomics, RDM, … |
+| `ID_AA64ISAR1_EL1` | DPB, JSCVT, FCMA, LRCPC, GPA, GPI, FRINTTS, … |
+| `ID_AA64ISAR2_EL1` | WFXT, RPRES, GPA3, APA3, MOPS, BC, … |
+| `ID_AA64MMFR0_EL1` | PA size, ASID bits, TGran sizes |
+| `ID_AA64MMFR1_EL1` | VH, HPDS, LO, PAN, SpecSEI, XNX |
+| `ID_AA64MMFR2_EL1` | CNP, UAO, LSM, IESB, VARange, CCIDX |
+| `ID_AA64PFR0_EL1` | EL0/1/2/3 widths, FP, AdvSIMD, GIC, RAS, SVE |
+| `ID_AA64PFR1_EL1` | BT (BTI), SSBS, MTE, RAS_frac, MPAM_frac |
+| `MIDR_EL1` | Implementer, architecture, variant, part, revision |
+
+Each register encodes multiple 4-bit fields. The helper
+`cpuid_feature_extract_field()` (defined in `arch/arm64/include/asm/cpufeature.h`)
+extracts a single field:
+
+```c
+/* arch/arm64/include/asm/cpufeature.h */
+static inline int cpuid_feature_extract_field(u64 features, int field, bool sign)
+{
+    return (sign)
+        ? cpuid_feature_extract_signed_field(features, field)
+        : (int)((features >> field) & 0xf);
+}
+```
+
+`MIDR_EL1` encodes the CPU identity used for errata matching:
+
+```
+MIDR_EL1 layout
+ [31:24] Implementer  (0x41 = ARM Ltd, 0x51 = Qualcomm, 0x53 = Samsung, …)
+ [23:20] Variant      (major revision)
+ [19:16] Architecture (always 0xF for ARMv8+)
+ [15:4]  PartNum      (0xD03 = Cortex-A53, 0xD0B = Cortex-A76, …)
+ [3:0]   Revision     (minor revision)
+```
+
+### Capability Accumulation Across CPUs
+
+On SMP systems the feature intersection must be computed across all CPUs.
+Each secondary CPU calls `check_local_cpu_capabilities()` on bringup. The
+primary CPU drives the final safe set via `update_cpu_capabilities()`:
+
+```
+Boot CPU reads ID registers
+       │
+       ▼
+update_cpu_capabilities(arm64_features)
+       │   calls matches() on every arm64_cpu_capabilities entry
+       ▼
+set_cpu_cap() sets bit in cpu_hwcaps[] bitmap
+       │
+Secondary CPUs boot, call check_local_cpu_capabilities()
+       │   verifies they do not lack any already-set cap
+       ▼
+apply_alternatives_all()  ← patches kernel text
+       │
+cpu_enable() hooks run per-CPU (e.g., enable SSBS, PAN)
+```
+
+The global `cpu_hwcaps` is a `DECLARE_BITMAP` of `ARM64_NCAPS` bits defined
+in `arch/arm64/include/asm/cpucaps.h`.
+
+---
+
+## struct arm64_cpu_capabilities
+
+Every ARM64 feature or erratum is described by a single entry in
+`struct arm64_cpu_capabilities` (`arch/arm64/include/asm/cpufeature.h`):
+
+```c
+struct arm64_cpu_capabilities {
+    const char          *desc;
+    u16                  capability;   /* ARM64_* cap index, e.g. ARM64_HAS_LSE_ATOMICS */
+    u16                  type;         /* ARM64_CPUCAP_* flags bitmask */
+    bool                (*matches)(const struct arm64_cpu_capabilities *cap, int scope);
+    void                (*cpu_enable)(const struct arm64_cpu_capabilities *cap);
+    union {
+        /* For register-based features: */
+        struct {
+            u32         sys_reg;       /* SYS_ID_AA64ISAR0_EL1, etc. */
+            u8          field_pos;     /* bit position of the field */
+            u8          field_width;   /* field width (usually 4) */
+            u8          min_field_value;
+            u8          hwcap_type;
+            unsigned long hwcap;       /* HWCAP_* or HWCAP2_* bit */
+        };
+        /* For MIDR-based errata: */
+        const struct midr_range *midr_range_list;
+        struct midr_range        midr_range;
+    };
+};
+```
+
+Key `type` flag combinations:
+
+| Flag | Meaning |
+|------|---------|
+| `ARM64_CPUCAP_SYSTEM_FEATURE` | Safe to use only when all CPUs have it |
+| `ARM64_CPUCAP_BOOT_CPU_FEATURE` | Detected from the boot CPU only |
+| `ARM64_CPUCAP_WEAK_LOCAL_CPU_FEATURE` | Per-CPU, missing on some CPUs is tolerated |
+| `ARM64_CPUCAP_SCOPE_LOCAL_CPU` | Checked per-CPU during hotplug |
+
+The two main global tables are:
+
+```c
+/* arch/arm64/kernel/cpufeature.c */
+static const struct arm64_cpu_capabilities arm64_features[];
+static const struct arm64_cpu_capabilities arm64_errata[];
+```
+
+`arm64_features[]` drives `HWCAP_*` exposure and alternatives patching.
+`arm64_errata[]` drives workaround application.
+
+---
+
+## Checking Capabilities at Runtime
+
+### System-wide: cpus_have_cap()
+
+```c
+/* arch/arm64/include/asm/cpufeature.h */
+static inline bool cpus_have_cap(unsigned int num)
+{
+    return test_bit(num, cpu_hwcaps);
+}
+```
+
+This reads a bit from the global `cpu_hwcaps` bitmap. It is safe to call
+from any context after `setup_cpu_features()` completes. Common usage:
+
+```c
+if (cpus_have_cap(ARM64_HAS_LSE_ATOMICS))
+    use_lse_path();
+```
+
+### Per-CPU: this_cpu_has_cap()
+
+```c
+static inline bool this_cpu_has_cap(unsigned int cap)
+{
+    return !!(this_cpu_read(cpu_hwcap_keys[cap]));
+}
+```
+
+Used when a feature may not be uniform across all CPUs (e.g., SSBS, FPMR).
+
+### Static keys: cpus_have_const_cap()
+
+For extremely hot paths, capabilities are also backed by `static_key_false`
+entries so the check compiles down to a single NOP that is patched to a branch
+at boot:
+
+```c
+/* Fast path — no bitmap read, just a static branch */
+if (cpus_have_const_cap(ARM64_HAS_LSE_ATOMICS)) { … }
+```
+
+---
+
+## Alternatives Patching
+
+### How It Works
+
+The alternatives mechanism allows the kernel to ship one binary that runs
+correctly on all ARMv8 CPUs and is then optimized for the actual hardware at
+boot time. The scheme:
+
+1. The compiler emits a **patching site** into the `.altinstructions` ELF
+   section: `{orig_offset, alt_offset, cpucap, orig_len, alt_len}`.
+2. The original (conservative) instruction sequence occupies the live text.
+3. At boot, `apply_alternatives_all()` iterates `.altinstructions`; for each
+   entry whose `cpucap` bit is set in `cpu_hwcaps`, it overwrites the live
+   text with the alternative sequence using `aarch64_insn_patch_text()`.
+4. Cache maintenance (`__flush_icache_range()`) makes the new instructions
+   visible to the instruction stream.
+
+### Assembly Macros
+
+```asm
+/* arch/arm64/include/asm/alternative.h */
+
+/*
+ * Replace instruction sequence 'oldinstr' with 'newinstr' when
+ * 'cap' is present. Both sequences must have the same byte length.
+ */
+.macro alternative_insn oldinstr, newinstr, cap, enable = 1
+    .if \enable
+661:    \oldinstr
+662:    .pushsection .altinstructions, "a"
+        altinstruction_entry 661b, 663f, \cap, 662b-661b, 664f-663f
+    .popsection
+    .pushsection .altinstr_replacement, "ax"
+663:    \newinstr
+664:    .popsection
+    .endif
+.endm
+```
+
+In C code the `alternative()` macro wraps inline assembly:
+
+```c
+/* Inline asm form */
+asm volatile(ALTERNATIVE("nop", "isb", ARM64_WORKAROUND_1542419));
+```
+
+### Example: LSE Atomics (LDXR/STXR → CAS)
+
+Before patching, `atomic_add()` on ARM64 contains an LL/SC loop:
+
+```asm
+/* Original (always correct) */
+661:
+    ldxr    w0, [x1]
+    add     w0, w0, w2
+    stxr    w3, w0, [x1]
+    cbnz    w3, 661b
+```
+
+When `ARM64_HAS_LSE_ATOMICS` is set, alternatives replaces this with:
+
+```asm
+/* Patched (LSE) */
+    casa    w2, w0, [x1]
+```
+
+The capability index `ARM64_HAS_LSE_ATOMICS` is defined in
+`arch/arm64/include/asm/cpucaps.h` and its detection entry in
+`arm64_features[]` checks `ID_AA64ISAR0_EL1.Atomic` >= 2.
+
+### apply_alternatives_all()
+
+```c
+/* arch/arm64/kernel/alternative.c */
+void __init apply_alternatives_all(void)
+{
+    struct alt_region region = {
+        .begin  = (struct alt_instr *)__alt_instructions,
+        .end    = (struct alt_instr *)__alt_instructions_end,
+    };
+    /*
+     * cpucaps are finalized. Walk every altinstruction entry and
+     * patch if the corresponding cap bit is set.
+     */
+    BUG_ON(!system_capabilities_finalized());
+    __apply_alternatives(&region, false, &cpu_hwcaps_ptrs);
+}
+```
+
+Secondary CPUs also call `apply_alternatives_this_cpu()` to apply
+`ARM64_CPUCAP_LOCAL_CPU_FEATURE` patches in their own context.
+
+---
+
+## HWCAP: Userspace Feature Exposure
+
+Detected features are advertised to userspace through two mechanisms:
+
+- **`getauxval(AT_HWCAP)`** and **`getauxval(AT_HWCAP2)`** — bitmask values
+  placed in the ELF auxiliary vector by the kernel at `execve()` time.
+- **`/proc/cpuinfo`** — the `Features:` line lists the same capabilities as
+  human-readable strings.
+
+### HWCAP Constants
+
+Defined in `arch/arm64/include/uapi/asm/hwcap.h`:
+
+| Constant | Bit | Feature |
+|----------|-----|---------|
+| `HWCAP_FP` | 0 | Floating-point (mandatory on ARMv8) |
+| `HWCAP_ASIMD` | 1 | Advanced SIMD / Neon (mandatory) |
+| `HWCAP_EVTSTRM` | 2 | Event stream (generic timer) |
+| `HWCAP_AES` | 3 | AES instructions |
+| `HWCAP_PMULL` | 4 | Polynomial multiply (PMULL/PMULL2) |
+| `HWCAP_SHA1` | 5 | SHA-1 instructions |
+| `HWCAP_SHA2` | 6 | SHA-256 instructions |
+| `HWCAP_CRC32` | 7 | CRC32 instructions |
+| `HWCAP_ATOMICS` | 8 | Large System Extensions (LSE atomics) |
+| `HWCAP_FPHP` | 9 | Half-precision FP |
+| `HWCAP_ASIMDHP` | 10 | Advanced SIMD half-precision |
+| `HWCAP_CPUID` | 11 | EL0 ID register access |
+| `HWCAP_ASIMDRDM` | 12 | Rounding double multiply accumulate |
+| `HWCAP_JSCVT` | 13 | JavaScript FJCVTZS instruction |
+| `HWCAP_FCMA` | 14 | Floating-point complex number multiply |
+| `HWCAP_LRCPC` | 15 | Load-acquire RCpc |
+| `HWCAP_DCPOP` | 16 | DC CVAP instruction |
+| `HWCAP_SHA3` | 17 | SHA-3 instructions |
+| `HWCAP_SM3` | 18 | SM3 instructions |
+| `HWCAP_SM4` | 19 | SM4 instructions |
+| `HWCAP_ASIMDDP` | 20 | SIMD dot product |
+| `HWCAP_SHA512` | 21 | SHA-512 instructions |
+| `HWCAP_SVE` | 22 | Scalable Vector Extension |
+| `HWCAP_ASIMDFHM` | 23 | SIMD FP16 multiply accumulate |
+| `HWCAP_DIT` | 24 | Data Independent Timing |
+| `HWCAP_USCAT` | 25 | Unaligned single-copy-atomic access |
+| `HWCAP_ILRCPC` | 26 | LRCPC2 (immediate offset) |
+| `HWCAP_FLAGM` | 27 | Flag manipulation instructions |
+| `HWCAP_SSBS` | 28 | Speculative Store Bypass Safe |
+| `HWCAP_SB` | 29 | Speculation Barrier instruction |
+| `HWCAP_PACA` | 30 | Pointer Authentication (address) |
+| `HWCAP_PACG` | 31 | Pointer Authentication (generic) |
+
+Selected `AT_HWCAP2` constants (in `hwcap.h` as `HWCAP2_*`):
+
+| Constant | Feature |
+|----------|---------|
+| `HWCAP2_DCPODP` | DC CVADP instruction |
+| `HWCAP2_SVE2` | SVE2 |
+| `HWCAP2_SVEAES` | SVE2 + AES |
+| `HWCAP2_BTI` | Branch Target Identification |
+| `HWCAP2_MTE` | Memory Tagging Extension |
+| `HWCAP2_ECV` | Enhanced Counter Virtualization |
+| `HWCAP2_AFP` | Alternate Floating-Point Behavior |
+| `HWCAP2_RPRES` | 12-bit reciprocal estimate |
+| `HWCAP2_MTE3` | MTE asymmetric fault reporting |
+| `HWCAP2_SME` | Scalable Matrix Extension |
+
+### Reading HWCAPs from Userspace
+
+```c
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+
+unsigned long hwcap  = getauxval(AT_HWCAP);
+unsigned long hwcap2 = getauxval(AT_HWCAP2);
+
+if (hwcap & HWCAP_ATOMICS)
+    /* safe to use LSE atomics */;
+if (hwcap & HWCAP_SVE)
+    /* SVE is available */;
+if (hwcap2 & HWCAP2_BTI)
+    /* BTI is enforced */;
+```
+
+---
+
+## SVE — Scalable Vector Extension
+
+SVE (ARMv8.2+) introduces vector registers of variable width: 128 to 2048
+bits in 128-bit increments. Unlike NEON, the vector length is not fixed at
+ISA design time but is implementation-defined and can be configured per-task.
+
+### Vector Length Management
+
+```c
+/* arch/arm64/kernel/fpsimd.c */
+
+/* Set the SVE vector length for the current task */
+int sve_set_vector_length(struct task_struct *task, unsigned long vl,
+                          unsigned long flags);
+```
+
+Userspace selects a vector length with:
+
+```c
+prctl(PR_SVE_SET_VL, vl);   /* set preferred VL in bytes */
+prctl(PR_SVE_GET_VL);       /* get current VL */
+```
+
+The kernel rounds `vl` down to the largest supported value not exceeding the
+request. Valid values are multiples of 16 from 16 to 256 bytes (128 to 2048
+bits). The system-wide maximum is readable from
+`/proc/sys/abi/sve_default_vector_length`.
+
+### Lazy State Save
+
+SVE register state is saved and restored lazily:
+
+1. When a task first executes an SVE instruction, a `trap_sve` exception fires
+   (because `CPACR_EL1.ZEN` = 0 in most contexts).
+2. The trap handler sets `TIF_SVE` in the thread flags, allocates per-task
+   SVE storage (`task->thread.sve_state`), and re-enables SVE by setting
+   `CPACR_EL1.ZEN = 1`.
+3. On context switch, `fpsimd_thread_switch()` saves SVE state only when
+   `TIF_SVE` is set, avoiding overhead for non-SVE tasks.
+
+```c
+/* thread_info flags (arch/arm64/include/asm/thread_info.h) */
+#define TIF_SVE         23  /* SVE enabled for EL0 */
+#define TIF_SVE_VL_INHERIT 24 /* Inherit SVE VL across exec */
+```
+
+### Kernel SVE Use
+
+Kernel code that uses SVE (e.g., accelerated crypto) must explicitly enable
+the FP/SVE access trap:
+
+```c
+kernel_neon_begin();   /* disables preemption, enables FPSIMD/SVE */
+/* use NEON or SVE instructions */
+kernel_neon_end();     /* restores state, re-enables preemption */
+```
+
+---
+
+## BTI — Branch Target Identification
+
+BTI is an ARMv8.5 control-flow integrity feature. When enabled
+(`SCTLR_EL1.BT1 = 1`), any indirect branch (`BR`, `BLR`, `RET`) must land on
+a `BTI` instruction (or the destination of a paired `BL`/`BLRAAZ` that
+implies a call target). Landing anywhere else raises a Branch Target Exception.
+
+### ELF Marking
+
+Binaries opt in via a GNU property note:
+
+```
+GNU_PROPERTY_AARCH64_FEATURE_1_BTI   (bit 0 of GNU_PROPERTY_AARCH64_FEATURE_1_AND)
+```
+
+The dynamic linker (`ld.so`) reads this note. The kernel checks it at
+`execve()` time in `arch/arm64/kernel/process.c` via
+`arch64_elf_check_arch()` and sets `SCTLR_EL1.BT1` for the process if the
+property is present.
+
+### Interaction with JIT and Signal Handlers
+
+JIT compilers must emit `BTI c` (call target) or `BTI j` (jump target)
+landing pads. The kernel signal return trampoline
+(`arch/arm64/kernel/vdso/sigreturn.S`) is BTI-annotated to allow `BLR` into
+it from user trampolines.
+
+---
+
+## MTE — Memory Tagging Extension
+
+MTE (ARMv8.5+) implements hardware-assisted memory safety by associating a
+4-bit **allocation tag** with every 16-byte **granule** of tagged memory, and
+encoding a matching **logical tag** in pointer bits [59:56] (top-byte ignore
+region).
+
+On every load or store the hardware compares the pointer's logical tag with
+the memory granule's allocation tag. A mismatch either raises a synchronous
+fault or is recorded asynchronously, depending on the TCR_EL1 mode selected.
+
+### Kernel API
+
+```c
+/* Enable MTE for the calling process */
+prctl(PR_SET_TAGGED_ADDR_CTRL,
+      PR_TAGGED_ADDR_ENABLE | PR_MTE_TCF_SYNC | (0xffff << PR_MTE_TAG_SHIFT),
+      0, 0, 0);
+
+/* mmap with PROT_MTE to get a taggable mapping */
+void *p = mmap(NULL, size, PROT_READ | PROT_WRITE | PROT_MTE,
+               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+```
+
+The flag `PROT_MTE` is `arch/arm64/include/uapi/asm/mman.h`.
+
+### Modes
+
+| Mode | TCR_EL1.TCMA | Behavior |
+|------|-------------|---------|
+| `PR_MTE_TCF_NONE` | — | MTE disabled |
+| `PR_MTE_TCF_SYNC` | — | Synchronous fault on tag mismatch |
+| `PR_MTE_TCF_ASYNC` | — | Async fault; reported via SIGBUS |
+
+MTE tags are not preserved across `fork()` for COW pages until the page is
+actually written; the kernel handles tag inheritance in `copy_user_highpage()`.
+
+---
+
+## Errata Workarounds
+
+CPU errata (hardware bugs) are handled through the same `arm64_cpu_capabilities`
+infrastructure, but stored in `arm64_errata[]`
+(`arch/arm64/kernel/cpu_errata.c`).
+
+### MIDR-Based Matching
+
+Each errata entry uses `MIDR_CPU_VAR_REV()` or `MIDR_ALL_VERSIONS()` to
+match affected CPU revisions:
+
+```c
+/* arch/arm64/kernel/cpu_errata.c */
+{
+    .desc       = "Cortex-A53: 843419: A load or store might access "
+                  "an incorrect address",
+    .capability = ARM64_WORKAROUND_843419,
+    .type       = ARM64_CPUCAP_LOCAL_CPU_ERRATUM,
+    ERRATA_MIDR_REV_RANGE(MIDR_CORTEX_A53, 0, 0, 4),
+},
+```
+
+`MIDR_CORTEX_A53` is `0x410FD034`. The range `(variant=0, rev_min=0,
+rev_max=4)` matches r0p0 through r0p4.
+
+### Workaround Mechanisms
+
+| Mechanism | When Used |
+|-----------|----------|
+| Alternatives patch | Runtime: replaces instruction sequences |
+| `cpu_enable` hook | Runtime: sets a system register flag |
+| Kconfig option | Compile-time: inserts barriers unconditionally |
+| Linker flag | Build-time: e.g., `--fix-cortex-a53-843419` |
+
+### Selected Errata
+
+| Erratum | CPU | Description | Workaround |
+|---------|-----|-------------|-----------|
+| 843419 | Cortex-A53 r0p0–r0p4 | Wrong address used in ADRP sequences | Linker `--fix-cortex-a53-843419` |
+| 835769 | Cortex-A53 r0p0–r0p4 | Incorrect result from MUL/MADD after load | Compiler `-mfix-cortex-a53-835769` |
+| 1530923 | Cortex-A55 | Speculative AT instruction may cause faults | Speculation barrier alternatives |
+| 2457168 | Cortex-A510 | PMULL2 may produce incorrect results | Alternatives patch |
+| 1418040 | Cortex-A76/Neoverse-N1 | ICache invalidation may be incomplete | `ic iallu` alternatives |
+
+Errata workarounds are conditionally compiled via `CONFIG_ARM64_ERRATUM_*`
+Kconfig symbols and do not add overhead on unaffected hardware.
+
+---
+
+## Observability
+
+### /proc/cpuinfo
+
+```bash
+$ cat /proc/cpuinfo | grep -E "CPU implementer|CPU architecture|CPU variant|CPU part|CPU revision|Features"
+processor       : 0
+CPU implementer : 0x41          # ARM Ltd
+CPU architecture: 8
+CPU variant     : 0x3
+CPU part        : 0xd0b         # Cortex-A76
+CPU revision    : 1
+
+Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp \
+                  asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
+```
+
+### sysfs ID Registers
+
+Linux 5.11+ exposes raw ID register values under sysfs (when
+`CONFIG_ARM64_PSEUDO_NMI` or `CONFIG_HWCAP_CPUID` allows EL0 access):
+
+```bash
+$ grep . /sys/devices/system/cpu/cpu0/regs/identification/*
+/sys/devices/system/cpu/cpu0/regs/identification/midr_el1:0x413FD0B1
+/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1:0x00000000
+```
+
+### Checking Active hwcaps Programmatically
+
+```c
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#include <stdio.h>
+
+int main(void) {
+    unsigned long hwcap  = getauxval(AT_HWCAP);
+    unsigned long hwcap2 = getauxval(AT_HWCAP2);
+
+    printf("LSE atomics : %s\n", (hwcap  & HWCAP_ATOMICS) ? "yes" : "no");
+    printf("SVE         : %s\n", (hwcap  & HWCAP_SVE)     ? "yes" : "no");
+    printf("BTI         : %s\n", (hwcap2 & HWCAP2_BTI)    ? "yes" : "no");
+    printf("MTE         : %s\n", (hwcap2 & HWCAP2_MTE)    ? "yes" : "no");
+    return 0;
+}
+```
+
+### Kernel Capability Bitmap (debug)
+
+The full capability bitmap is not directly exported, but you can infer the
+active set from the `Features:` line and by reading
+`/sys/devices/system/cpu/cpu*/regs/identification/midr_el1`.
+
+For kernel developers, `cpus_have_cap(ARM64_HAS_LSE_ATOMICS)` is the
+authoritative check inside the kernel; early in boot (before secondaries are
+up) `boot_cpu_has(ARM64_HAS_LSE_ATOMICS)` is used instead.
+
+---
+
+## Boot-Time Flow Summary
+
+```
+start_kernel()
+    └─ setup_arch()
+          ├─ setup_machine_fdt()
+          ├─ init_mem_init()
+          └─ setup_cpu_features()
+                ├─ init_cpu_features()        ← read ID regs on boot CPU
+                ├─ setup_system_capabilities()
+                │     └─ update_cpu_capabilities(arm64_features)
+                │           └─ for each cap: cap->matches() → set_cpu_cap()
+                ├─ apply_alternatives_all()   ← patch kernel text
+                └─ (later) smp_cpus_done()
+                      └─ check_local_cpu_capabilities()  per secondary CPU
+```
+
+---
+
+## Further Reading
+
+- `arch/arm64/include/asm/cpufeature.h` — full `struct arm64_cpu_capabilities`
+  definition and all `ARM64_CPUCAP_*` type flags
+- `arch/arm64/include/asm/cpucaps.h` — enumeration of all `ARM64_*` capability
+  indices and `ARM64_NCAPS`
+- `arch/arm64/kernel/cpufeature.c` — `arm64_features[]` table, detection logic,
+  `update_cpu_capabilities()`, `apply_alternatives_all()` callsite
+- `arch/arm64/kernel/cpu_errata.c` — `arm64_errata[]` table with full MIDR
+  match ranges and workaround descriptions
+- `arch/arm64/kernel/alternative.c` — patching engine, `__apply_alternatives()`
+- `arch/arm64/include/asm/alternative.h` — `alternative_insn`, `alternative`,
+  `ALTERNATIVE` macro definitions
+- `arch/arm64/include/uapi/asm/hwcap.h` — all `HWCAP_*` and `HWCAP2_*`
+  constants with bit positions
+- `arch/arm64/kernel/fpsimd.c` — SVE state management, `kernel_neon_begin/end`,
+  `TIF_SVE` handling
+- `arch/arm64/kernel/process.c` — BTI enforcement at `execve()`, MTE
+  initialization for new processes
+- [ARM Architecture Reference Manual, ARMv8-A](https://developer.arm.com/documentation/ddi0487/latest)
+  — definitive reference for all system registers and feature encodings
+- [ARM CPU Feature Registers](https://www.kernel.org/doc/html/latest/arch/arm64/cpu-feature-registers.html)
+  — kernel documentation on sysfs register exposure and `HWCAP_CPUID`
+- [ARM64 ELF ABI](https://github.com/ARM-software/abi-aa/blob/main/sysvabi64/sysvabi64.rst)
+  — `AT_HWCAP` assignment, BTI ELF note, SVE ABI

--- a/docs/arch/arm64/cpu-features.md
+++ b/docs/arch/arm64/cpu-features.md
@@ -400,8 +400,10 @@ prctl(PR_SVE_GET_VL);       /* get current VL */
 
 The kernel rounds `vl` down to the largest supported value not exceeding the
 request. Valid values are multiples of 16 from 16 to 256 bytes (128 to 2048
-bits). The system-wide maximum is readable from
-`/proc/sys/abi/sve_default_vector_length`.
+bits). The system-wide default VL is readable from
+`/proc/sys/abi/sve_default_vector_length` (this is the default applied to new
+threads, not an upper bound; the true maximum is reported by
+`prctl(PR_SVE_GET_VL)` after setting the VL to an arbitrarily large value).
 
 ### Lazy State Save
 
@@ -411,7 +413,7 @@ SVE register state is saved and restored lazily:
    (because `CPACR_EL1.ZEN` = 0 in most contexts).
 2. The trap handler sets `TIF_SVE` in the thread flags, allocates per-task
    SVE storage (`task->thread.sve_state`), and re-enables SVE by setting
-   `CPACR_EL1.ZEN = 1`.
+   `CPACR_EL1.ZEN = 0b11` (allow EL0 and EL1 SVE access without trapping).
 3. On context switch, `fpsimd_thread_switch()` saves SVE state only when
    `TIF_SVE` is set, avoiding overhead for non-SVE tasks.
 
@@ -492,11 +494,11 @@ The flag `PROT_MTE` is `arch/arm64/include/uapi/asm/mman.h`.
 
 ### Modes
 
-| Mode | TCR_EL1.TCMA | Behavior |
-|------|-------------|---------|
-| `PR_MTE_TCF_NONE` | — | MTE disabled |
-| `PR_MTE_TCF_SYNC` | — | Synchronous fault on tag mismatch |
-| `PR_MTE_TCF_ASYNC` | — | Async fault; reported via SIGBUS |
+| Mode | SCTLR_EL1.TCF0 | Behavior |
+|------|---------------|---------|
+| `PR_MTE_TCF_NONE` | `0b00` | MTE disabled |
+| `PR_MTE_TCF_SYNC` | `0b01` | Synchronous fault on tag mismatch |
+| `PR_MTE_TCF_ASYNC` | `0b10` | Async fault; reported via SIGBUS |
 
 MTE tags are not preserved across `fork()` for COW pages until the page is
 actually written; the kernel handles tag inheritance in `copy_user_highpage()`.
@@ -525,7 +527,7 @@ match affected CPU revisions:
 },
 ```
 
-`MIDR_CORTEX_A53` is `0x410FD034`. The range `(variant=0, rev_min=0,
+`MIDR_CORTEX_A53` is `0x410FD030`. The range `(variant=0, rev_min=0,
 rev_max=4)` matches r0p0 through r0p4.
 
 ### Workaround Mechanisms
@@ -571,8 +573,8 @@ Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp \
 
 ### sysfs ID Registers
 
-Linux 5.11+ exposes raw ID register values under sysfs (when
-`CONFIG_ARM64_PSEUDO_NMI` or `CONFIG_HWCAP_CPUID` allows EL0 access):
+Linux 5.11+ exposes raw ID register values under sysfs (gated by
+`CONFIG_ARM64_CPUIDLE` build config and `ID_AA64DFR0_EL1.PMSVer` capability checks):
 
 ```bash
 $ grep . /sys/devices/system/cpu/cpu0/regs/identification/*

--- a/docs/arch/arm64/page-tables.md
+++ b/docs/arch/arm64/page-tables.md
@@ -22,12 +22,14 @@ With the default `VA_BITS=48`, user space occupies `[0, 0x0000_FFFF_FFFF_FFFF]` 
 On context switch, the kernel writes the new process's PGD physical address into `TTBR0_EL1`. The ASID (see below) is packed into bits `[63:48]` of `TTBR0_EL1` at the same time. `TTBR1_EL1` is set once at boot and never changes.
 
 ```c
-/* arch/arm64/mm/context.c */
-static void cpu_switch_mm(pgd_t *pgd, struct mm_struct *mm)
+/* arch/arm64/include/asm/mmu_context.h */
+static inline void cpu_switch_mm(pgd_t *pgd, struct mm_struct *mm)
 {
     BUG_ON(pgd == swapper_pg_dir);
     cpu_set_reserved_ttbr0();
-    local_flush_tlb_all();
+    /* ASID packed in mm->context.id; cpu_do_switch_mm writes TTBR0_EL1
+     * with the new PGD PA and ASID together — no TLB flush needed when
+     * switching to a different ASID (that is the whole point of ASIDs). */
     cpu_do_switch_mm(virt_to_phys(pgd), mm);
 }
 ```
@@ -127,7 +129,7 @@ ARM64 Page/Block Descriptor (64-bit):
 | `10` | Read-Only | No access |
 | `11` | Read-Only | Read-Only |
 
-Linux sets `UXN` on all kernel mappings and `PXN` on all user mappings (preventing user code from being executed at EL1 and vice versa). The `AF` (Access Flag) bit is managed by software on ARM64: when the kernel sets up a PTE with AF=0, the first access generates an Access Flag Fault, which the kernel handles by setting AF=1 and recording the access for page reclaim heuristics.
+Linux sets `UXN` on all kernel mappings and `PXN` on all user mappings (preventing user code from being executed at EL1 and vice versa). The `AF` (Access Flag) bit: on pre-ARMv8.1 hardware it is managed by software — a PTE with AF=0 generates an Access Flag Fault on first access, which the kernel handles by setting AF=1. On ARMv8.1+ hardware with `FEAT_HAFDBS`, Linux enables hardware-managed AF (`TCR_EL1.HA=1`), so the CPU sets AF automatically without faulting. The Access Flag is used by the page reclaim path to distinguish recently-accessed pages.
 
 ### ARM64 vs x86-64 PTE comparison
 

--- a/docs/arch/arm64/page-tables.md
+++ b/docs/arch/arm64/page-tables.md
@@ -1,0 +1,413 @@
+# ARM64 Page Tables
+
+> TTBR0/TTBR1, translation granules, PTE format, and ASID
+
+ARM64's MMU uses a two-register design to handle user and kernel address spaces independently. This page covers the hardware page table walk, how Linux structures its page table types, the PTE bit layout, ASID-based TLB management, and Stage 2 translation for KVM.
+
+---
+
+## Two TTBRs: user and kernel address spaces
+
+ARM64 splits the virtual address space at the midpoint using the **top bit of the virtual address**. Two translation base registers tell the MMU where to start the walk:
+
+| Register | Address range | Used for |
+|---|---|---|
+| `TTBR0_EL1` | `[0, 2^VA_BITS)` — low addresses | User space (per-process) |
+| `TTBR1_EL1` | `[2^64 - 2^VA_BITS, 2^64)` — high addresses | Kernel (global) |
+
+With the default `VA_BITS=48`, user space occupies `[0, 0x0000_FFFF_FFFF_FFFF]` and the kernel occupies `[0xFFFF_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF]`. The top bit (bit 63) of a virtual address selects the register: bit 63 = 0 uses TTBR0, bit 63 = 1 uses TTBR1. Any address with bits between VA_BITS-1 and 63 not all matching (i.e., not properly sign-extended) causes a Translation Fault.
+
+**52-bit VA (optional):** ARMv8.7+ supports 52-bit virtual addresses (`VA_BITS=52`) with a 5-level page table (`CONFIG_ARM64_VA_BITS_52`). This extends the user and kernel ranges to 4PB each. Most production configs still use 48-bit.
+
+On context switch, the kernel writes the new process's PGD physical address into `TTBR0_EL1`. The ASID (see below) is packed into bits `[63:48]` of `TTBR0_EL1` at the same time. `TTBR1_EL1` is set once at boot and never changes.
+
+```c
+/* arch/arm64/mm/context.c */
+static void cpu_switch_mm(pgd_t *pgd, struct mm_struct *mm)
+{
+    BUG_ON(pgd == swapper_pg_dir);
+    cpu_set_reserved_ttbr0();
+    local_flush_tlb_all();
+    cpu_do_switch_mm(virt_to_phys(pgd), mm);
+}
+```
+
+---
+
+## Translation granules
+
+The **translation granule** is the base page size. ARM64 supports three granule sizes, each changing the number of levels needed and the size of each level's table:
+
+| Granule | Page size | Levels (48-bit VA) | Notes |
+|---|---|---|---|
+| 4KB | 4KB | 4 (L0→L1→L2→L3) | Most common; default in Linux |
+| 16KB | 16KB | 4 (L0→L1→L2→L3) | Apple Silicon uses this |
+| 64KB | 64KB | 3 (L1→L2→L3) | Fewer levels; large contiguous TLB entries |
+
+The granule is selected by `TCR_EL1.TG0` (for TTBR0) and `TCR_EL1.TG1` (for TTBR1).
+
+### 4KB granule: level coverage (48-bit VA)
+
+With a 4KB granule each page table is exactly one 4KB page containing 512 8-byte entries (9 index bits per level):
+
+```
+Level   Index bits   Entries   Coverage per entry
+─────   ──────────   ───────   ──────────────────
+L0      [47:39]        512      512 GB
+L1      [38:30]        512        1 GB
+L2      [29:21]        512        2 MB  (block descriptor = huge page)
+L3      [20:12]        512        4 KB  (page descriptor = normal page)
+                                ────
+Page offset [11:0]     —        4 KB
+```
+
+---
+
+## The 4-level page table walk (48-bit VA, 4KB granule)
+
+For a 48-bit virtual address with a 4KB granule, the hardware performs a 4-level walk:
+
+```
+48-bit Virtual Address:
+ 47      39 38      30 29      21 20      12 11       0
+ ┌─────────┬──────────┬──────────┬──────────┬──────────┐
+ │ L0 index│ L1 index │ L2 index │ L3 index │  offset  │
+ │ (9 bits)│ (9 bits) │ (9 bits) │ (9 bits) │ (12 bits)│
+ └─────────┴──────────┴──────────┴──────────┴──────────┘
+
+Walk (TTBR0 for user, TTBR1 for kernel):
+
+TTBR0_EL1 or TTBR1_EL1 → physical address of L0 table
+  L0_table[VA[47:39]]   → physical address of L1 table
+    L1_table[VA[38:30]] → physical address of L2 table  (or 1GB block)
+      L2_table[VA[29:21]] → physical address of L3 table (or 2MB block)
+        L3_table[VA[20:12]] → physical address of 4KB page frame
+          + VA[11:0]         = final physical address
+```
+
+The MMU caches translations in the TLB, keyed on VA + ASID. On a TLB miss, the hardware page table walker performs the walk automatically (hardware-managed TLB on ARM64 — no software TLB fill required in the common case).
+
+---
+
+## PTE format
+
+ARM64 descriptors are 64-bit values. The meaning of bits depends on the level and whether the entry is a **table**, **block**, or **page** descriptor.
+
+```
+ARM64 Page/Block Descriptor (64-bit):
+
+ 63   59 58   55 54 53 52 51      12 11 10  9  8  7  6  5  4  2  1  0
+ ┌──────┬───────┬──┬──┬──┬──────────┬──┬──┬──┬──┬──┬──┬─────┬──┬──┐
+ │ PBHA │ SW   │UXN│PXN│Cont│  OA   │nG│AF│SH│AP│NS│  │AtIdx│type│V│
+ └──────┴───────┴──┴──┴──┴──────────┴──┴──┴──┴──┴──┴──┴─────┴──┴──┘
+
+ bit 0:     Valid (V)        — 1 = entry is valid
+ bit 1:     Type             — at L0-L2: 1 = table descriptor, 0 = block descriptor
+                               at L3: 1 = page descriptor (must be 1 for valid pages)
+ bits [4:2]: AttrIndx[2:0]  — index into MAIR_EL1 (memory type selection)
+ bit 5:     NS               — Non-Secure (applies in Secure state)
+ bits [7:6]: AP[2:1]         — Access Permissions (see table below)
+ bits [9:8]: SH[1:0]         — Shareability: 00=non-shareable, 10=outer, 11=inner
+ bit 10:    AF               — Access Flag: fault on first access if 0 (SW manages)
+ bit 11:    nG               — not-Global: 1 = ASID-tagged (user), 0 = global (kernel)
+ bits [47:12]: Output Address (OA) — physical page frame number (bits [47:12] of PA)
+ bit 52:    Contiguous hint  — TLB can merge contiguous entries
+ bit 53:    PXN              — Privileged Execute Never (EL1 cannot execute)
+ bit 54:    UXN              — Unprivileged Execute Never (EL0 cannot execute)
+ bits [58:55]: SW            — Software-defined (kernel uses for _PAGE_* flags)
+ bits [63:59]: PBHA          — Page-Based Hardware Attributes (ARMv8.2+)
+```
+
+### Access Permission (AP[2:1]) encoding
+
+| AP[2:1] | EL1 (kernel) | EL0 (user) |
+|---|---|---|
+| `00` | Read/Write | No access |
+| `01` | Read/Write | Read/Write |
+| `10` | Read-Only | No access |
+| `11` | Read-Only | Read-Only |
+
+Linux sets `UXN` on all kernel mappings and `PXN` on all user mappings (preventing user code from being executed at EL1 and vice versa). The `AF` (Access Flag) bit is managed by software on ARM64: when the kernel sets up a PTE with AF=0, the first access generates an Access Flag Fault, which the kernel handles by setting AF=1 and recording the access for page reclaim heuristics.
+
+### ARM64 vs x86-64 PTE comparison
+
+| Concept | ARM64 | x86-64 |
+|---|---|---|
+| Valid bit | bit 0 (`V`) | bit 0 (`P` — Present) |
+| Read/Write | `AP[2:1]` field | bit 1 (`R/W`) |
+| User access | `AP[2:1]` field | bit 2 (`U/S`) |
+| Execute disable | `UXN` (bit 54), `PXN` (bit 53) | bit 63 (`NX`) |
+| Cache type | `AttrIndx` → `MAIR_EL1` | `PCD`/`PWT`/`PAT` bits |
+| Huge page marker | bit 1 = 0 at L1/L2 (block) | `PS` bit at PMD/PUD |
+| Global (no ASID flush) | `nG` = 0 | bit 8 (`G`) |
+| Dirty / Accessed | Software-managed via AF fault | Hardware-set bits 5 (`A`) and 6 (`D`) |
+
+---
+
+## Huge pages: block descriptors
+
+ARM64 uses **block descriptors** to map large contiguous physical regions without traversing all four levels. A block descriptor at L1 or L2 has bit 1 (`type`) = 0:
+
+| Level | Block size | Linux term |
+|---|---|---|
+| L1 | 1 GB | `pud_huge()` — 1GB huge page |
+| L2 | 2 MB | `pmd_huge()` — 2MB huge page (THP, hugetlbfs) |
+
+Linux detects block descriptors with `pmd_huge()` defined in `arch/arm64/include/asm/pgtable.h`:
+
+```c
+/* arch/arm64/include/asm/pgtable.h */
+static inline int pmd_huge(pmd_t pmd)
+{
+    return pmd_val(pmd) && !(pmd_val(pmd) & PMD_TABLE_BIT);
+}
+```
+
+`PMD_TABLE_BIT` is bit 1. A valid PMD entry with bit 1 clear is a 2MB block descriptor.
+
+Transparent Huge Pages (THP) and `hugetlbfs` both use 2MB block descriptors. The kernel also maps its own text and data sections with 2MB blocks when alignment allows (visible in `arch/arm64/mm/mmu.c` via `create_mapping_noalloc()`).
+
+---
+
+## Linux kernel page table types
+
+Linux uses a generic five-level abstraction over the hardware levels. On ARM64 with 48-bit VA and 4KB granule, `p4d_t` is **folded** (a no-op alias for `pgd_t`):
+
+| Linux type | Hardware level | Source |
+|---|---|---|
+| `pgd_t` | L0 (pointed to by TTBR0/TTBR1) | `arch/arm64/include/asm/pgtable-types.h` |
+| `p4d_t` | Folded into PGD (48-bit VA) | `include/asm-generic/pgtable-nop4d.h` |
+| `pud_t` | L1 | `arch/arm64/include/asm/pgtable-types.h` |
+| `pmd_t` | L2 | `arch/arm64/include/asm/pgtable-types.h` |
+| `pte_t` | L3 | `arch/arm64/include/asm/pgtable-types.h` |
+
+All types are wrappers around `u64`. The underlying hardware descriptor value is accessed with `pgd_val()`, `pud_val()`, `pmd_val()`, `pte_val()`.
+
+Standard page table navigation macros:
+
+```c
+/* Given a mm_struct and virtual address, walk down to the PTE: */
+pgd_t *pgd = pgd_offset(mm, addr);       /* index into mm->pgd */
+p4d_t *p4d = p4d_offset(pgd, addr);      /* folded on 48-bit ARM64 */
+pud_t *pud = pud_offset(p4d, addr);
+pmd_t *pmd = pmd_offset(pud, addr);
+pte_t *pte = pte_offset_map(pmd, addr);  /* maps the PTE page, returns kernel VA */
+```
+
+`pte_offset_map()` is defined in `arch/arm64/include/asm/pgtable.h` and handles the physical-to-virtual translation for the PTE page pointer.
+
+---
+
+## ASID: Address Space Identifiers
+
+Every user-space mapping in a PTE has `nG` (not-Global) = 1. This means the TLB tags the entry with the current **ASID** (Address Space Identifier). Different processes with different ASIDs can coexist in the TLB without interference, avoiding a full TLB flush on every context switch.
+
+### ASID storage
+
+The ASID is stored in `TTBR0_EL1[63:48]` (16-bit ASID field, when `TCR_EL1.AS=1`). Each time a process is scheduled, the kernel writes both the ASID and the PGD address into `TTBR0_EL1` atomically. Kernel mappings use `nG=0` (global), so they are not tagged with an ASID and are never evicted by ASID-based TLB operations.
+
+The per-process ASID is stored in `mm->context.id` and managed by `check_and_switch_context()` in `arch/arm64/mm/context.c`:
+
+```c
+/* arch/arm64/mm/context.c */
+void check_and_switch_context(struct mm_struct *mm)
+{
+    unsigned long flags;
+    unsigned int cpu;
+    u64 asid, old_active_asid;
+
+    asid = atomic64_read(&mm->context.id);
+
+    /*
+     * If the current ASID is still valid for this CPU, use it without
+     * taking the lock.  Otherwise fall through to the slow path.
+     */
+    old_active_asid = atomic64_read(this_cpu_ptr(&active_asids));
+    if (asid_gen_match(asid) &&
+        atomic64_cmpxchg_relaxed(this_cpu_ptr(&active_asids),
+                                 old_active_asid, asid))
+        goto switch_mm_fastpath;
+
+    raw_spin_lock_irqsave(&cpu_asid_lock, flags);
+    /* ... slow path: allocate new ASID or flush on generation wrap ... */
+    raw_spin_unlock_irqrestore(&cpu_asid_lock, flags);
+
+switch_mm_fastpath:
+    cpu_switch_mm(mm->pgd, mm);
+}
+```
+
+### ASID generation wrap
+
+ARM64 supports 8-bit or 16-bit ASIDs (`TCR_EL1.AS`). Linux always uses 16-bit ASIDs where available (`arch/arm64/Kconfig`: `ARM64_HW_AFDBM`). With 16-bit ASIDs there are 65536 possible values. When they are exhausted, the kernel bumps an internal **generation counter** and flushes the entire TLB (`TLBI VMALLE1IS`), then reallocates ASIDs from scratch.
+
+---
+
+## MAIR_EL1: Memory Attribute Indirection Register
+
+The `AttrIndx[2:0]` field in every PTE is an index into `MAIR_EL1`, which maps 8 attribute slots to actual memory types. This indirection allows PTE format to stay compact while supporting many memory types.
+
+Linux sets up `MAIR_EL1` once at boot in `arch/arm64/mm/proc.S`:
+
+```asm
+/* arch/arm64/mm/proc.S — MAIR_EL1 setup during __cpu_setup */
+/*
+ * MAIR_EL1 attribute encoding (one byte per slot, 8 slots = 64 bits):
+ *
+ * Slot  AttrIndx  Attr byte  Memory type
+ * ────  ────────  ─────────  ───────────────────────────────────────
+ *   0     0b000   0x00       Device-nGnRnE  (strongly ordered device)
+ *   1     0b001   0x04       Device-nGnRE   (device, gathering+reordering ok)
+ *   2     0b010   0x0C       Device-GRE     (device, gathering+reordering+early-write ok)
+ *   3     0b011   0x44       Normal Non-Cacheable (NC)
+ *   4     0b100   0xFF       Normal Write-Back, Read-Allocate, Write-Allocate (WB)
+ *   5     0b101   0xBB       Normal Write-Through, Read-Allocate (WT)
+ *   6     0b110   0x40       Normal Non-Cacheable Outer, NC Inner
+ *   7     0b111   0xFF       Normal WB (duplicate; used by Tagged Normal memory)
+ *
+ * Linux primary slots:
+ *   MT_DEVICE_nGnRnE  = 0  (ioremap strongly ordered)
+ *   MT_DEVICE_nGnRE   = 1  (ioremap device)
+ *   MT_DEVICE_GRE     = 2  (ioremap write-combining)
+ *   MT_NORMAL_NC      = 3  (DMA non-cacheable)
+ *   MT_NORMAL         = 4  (normal RAM — all kernel/user memory)
+ *   MT_NORMAL_WT      = 5  (write-through)
+ */
+ldr x5, =MAIR_EL1_SET
+msr mair_el1, x5
+isb
+```
+
+The constant `MAIR_EL1_SET` is built from individual `MAIR_ATTRIDX()` macros in `arch/arm64/include/asm/pgtable-hwdef.h`. User-space and kernel text/data use slot 4 (`MT_NORMAL`, `AttrIndx=0b100`). Device memory mapped via `ioremap()` uses slot 0 (`MT_DEVICE_nGnRnE`).
+
+---
+
+## TLB operations
+
+ARM64 uses **broadcast TLB invalidation instructions** (`TLBI`) rather than IPIs. These instructions propagate across CPUs within a shareability domain automatically when the `IS` (Inner Shareable) suffix is used.
+
+### Key TLBI instructions
+
+| Instruction | Invalidates | When to use |
+|---|---|---|
+| `TLBI VAE1IS, Xt` | Entry by VA + current ASID, inner shareable | Single page unmap (user) |
+| `TLBI VALE1IS, Xt` | Entry by VA + ASID, last-level only | More common for leaf pages |
+| `TLBI ASIDE1IS, Xt` | All entries matching ASID, inner shareable | Process exit (mm teardown) |
+| `TLBI VMALLE1IS` | All EL1 entries (all ASIDs), inner shareable | ASID generation wrap |
+| `TLBI VAAE1IS, Xt` | Entry by VA, all ASIDs | Kernel mapping change |
+
+The operand `Xt` encodes the VA shifted right by 12 (page-aligned) ORed with the ASID in bits `[63:48]`.
+
+### Required TLB invalidation sequence
+
+Writing a new PTE and then invalidating the TLB must follow a strict ordering to prevent the MMU from caching a stale translation:
+
+```
+1. Write new PTE to memory
+2. DSB ISHST       — ensure the PTE store is visible to all CPUs before TLBI
+3. TLBI VAE1IS     — broadcast TLB invalidation
+4. DSB ISH         — wait for TLB invalidation to complete on all CPUs
+5. ISB             — flush instruction pipeline (see new mappings for instruction fetch)
+```
+
+In Linux C code, `flush_tlb_page()` in `arch/arm64/include/asm/tlbflush.h` implements this:
+
+```c
+/* arch/arm64/include/asm/tlbflush.h */
+static inline void flush_tlb_page(struct vm_area_struct *vma,
+                                   unsigned long uaddr)
+{
+    unsigned long addr = __TLBI_VADDR(uaddr, ASID(vma->vm_mm));
+
+    dsb(ishst);              /* DSB ISH ST: wait for PTE stores to complete */
+    __tlbi(vale1is, addr);   /* TLBI VALE1IS: invalidate last-level TLB entry */
+    dsb(ish);                /* DSB ISH: wait for TLB invalidation to propagate */
+}
+```
+
+Note there is no `ISB` in `flush_tlb_page()` itself because it is only used for data mappings; the ISB is required only when instruction mappings change (e.g., `flush_icache_range()`).
+
+`__TLBI_VADDR()` is a macro that encodes the page-aligned address and ASID into the format expected by the `TLBI` operand. `__tlbi()` expands to an inline assembly `TLBI` instruction via the `SYS` instruction encoding.
+
+---
+
+## Stage 2 translation (KVM)
+
+When KVM is active, the CPU runs at EL2 and guests run at EL1/EL0. Guest virtual addresses are translated first by the **Stage 1** page tables (guest OS's own `TTBR0_EL1`/`TTBR1_EL1`) to **Intermediate Physical Addresses (IPA)**, then by **Stage 2** page tables to real **Physical Addresses (PA)**.
+
+Stage 2 is controlled by `VTTBR_EL2`, which holds the physical address of the Stage 2 PGD (the **IPA→PA** translation table). The Stage 2 tables use a similar descriptor format to Stage 1 but with different attribute fields (`S2AP`, `S2SH`, `MemAttr`).
+
+```
+Guest VA ──[Stage 1: TTBR0/TTBR1]──► IPA ──[Stage 2: VTTBR_EL2]──► PA
+                 (Guest OS controls)              (KVM controls)
+```
+
+TLB invalidation for guests requires `TLBI` instructions with the `VMID` suffix (e.g., `TLBI IPAS2E1IS`) to invalidate only entries for the current VM's VMID. The VMID is stored in `VTTBR_EL2[55:48]`.
+
+Stage 2 management in Linux lives in `arch/arm64/kvm/mmu.c`. See the [KVM Architecture](../../virtualization/kvm-arch.md) and [Memory Virtualization](../../virtualization/kvm-memory.md) docs for details.
+
+---
+
+## Observing ARM64 page tables
+
+```bash
+# Virtual address layout on ARM64
+dmesg | grep -E "Virtual kernel memory layout" -A 20
+
+# Per-process page table memory
+cat /proc/$$/status | grep VmPTE
+
+# Memory mapping of current process
+cat /proc/$$/maps
+cat /proc/$$/smaps   # includes page-level breakdown
+
+# Check VA_BITS (kernel config)
+zcat /proc/config.gz | grep ARM64_VA_BITS
+
+# Check translation granule
+zcat /proc/config.gz | grep ARM64_4K_PAGES
+
+# TLB miss rate (requires PMU access)
+perf stat -e dTLB-load-misses,iTLB-load-misses <command>
+
+# ASID allocation (DEBUG_VM builds expose asid info via dmesg)
+dmesg | grep -i asid
+
+# Page table dump (requires CONFIG_PTDUMP_DEBUGFS)
+ls /sys/kernel/debug/page_tables/
+cat /sys/kernel/debug/page_tables/kernel
+```
+
+---
+
+## Key kernel functions and files
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `pgd_t`, `pud_t`, `pmd_t`, `pte_t` | `arch/arm64/include/asm/pgtable-types.h` | Page table entry types |
+| `pgd_offset()`, `pud_offset()`, `pmd_offset()` | `arch/arm64/include/asm/pgtable.h` | VA → page table level pointer |
+| `pte_offset_map()` | `arch/arm64/include/asm/pgtable.h` | Map PTE page, return pointer |
+| `pmd_huge()` | `arch/arm64/include/asm/pgtable.h` | Detect 2MB block descriptor |
+| `pud_huge()` | `arch/arm64/include/asm/pgtable.h` | Detect 1GB block descriptor |
+| `set_pte_at()` | `arch/arm64/mm/pgtable.c` | Write PTE (with barrier) |
+| `flush_tlb_page()` | `arch/arm64/include/asm/tlbflush.h` | Single-page TLB invalidation |
+| `flush_tlb_mm()` | `arch/arm64/include/asm/tlbflush.h` | Full mm TLB flush (ASIDE1IS) |
+| `check_and_switch_context()` | `arch/arm64/mm/context.c` | ASID allocation and mm switch |
+| `cpu_do_switch_mm()` | `arch/arm64/mm/proc.S` | Write TTBR0_EL1 with new ASID+PGD |
+| `__cpu_setup()` | `arch/arm64/mm/proc.S` | Configure TCR_EL1, MAIR_EL1, SCTLR_EL1 |
+| `create_mapping_noalloc()` | `arch/arm64/mm/mmu.c` | Build kernel page table entries |
+| `MAIR_EL1_SET` | `arch/arm64/include/asm/pgtable-hwdef.h` | MAIR value built from slot macros |
+
+---
+
+## Further reading
+
+- [Memory Model](memory-model.md) — ARM64 weak memory ordering, DSB/ISB, page table barriers
+- [Exception Model](exception-model.md) — EL0–EL3, how EL2 relates to Stage 2 translation
+- [Page Tables (generic)](../../mm/page-tables.md) — Linux pgd/pud/pmd/pte abstraction layer
+- [Page Fault Handler](../../mm/page-fault.md) — how the kernel handles Translation Faults and Access Flag Faults
+- [Transparent Huge Pages](../../mm/thp.md) — how Linux promotes 4KB pages to 2MB block descriptors
+- [KVM Memory Virtualization](../../virtualization/kvm-memory.md) — Stage 2 page tables, EPT/NPT analog on ARM64
+- [TLB Optimization](../../mm/tlb-optimization.md) — batched TLB invalidation and mmu_gather
+- ARM Architecture Reference Manual (DDI 0487) — D5: AArch64 Virtual Memory System Architecture
+- `Documentation/arch/arm64/memory.rst` in the kernel tree — ARM64 virtual address layout

--- a/docs/arch/arm64/page-tables.md
+++ b/docs/arch/arm64/page-tables.md
@@ -17,7 +17,7 @@ ARM64 splits the virtual address space at the midpoint using the **top bit of th
 
 With the default `VA_BITS=48`, user space occupies `[0, 0x0000_FFFF_FFFF_FFFF]` and the kernel occupies `[0xFFFF_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF]`. The top bit (bit 63) of a virtual address selects the register: bit 63 = 0 uses TTBR0, bit 63 = 1 uses TTBR1. Any address with bits between VA_BITS-1 and 63 not all matching (i.e., not properly sign-extended) causes a Translation Fault.
 
-**52-bit VA (optional):** ARMv8.7+ supports 52-bit virtual addresses (`VA_BITS=52`) with a 5-level page table (`CONFIG_ARM64_VA_BITS_52`). This extends the user and kernel ranges to 4PB each. Most production configs still use 48-bit.
+**52-bit VA (optional):** ARMv8.7+ supports 52-bit virtual addresses (`VA_BITS=52`) with `CONFIG_ARM64_VA_BITS_52`. This still uses 4 translation levels (not 5); the extra bits come from widening the Level 0 index field. This extends the user and kernel ranges to 4PB each. Most production configs still use 48-bit.
 
 On context switch, the kernel writes the new process's PGD physical address into `TTBR0_EL1`. The ASID (see below) is packed into bits `[63:48]` of `TTBR0_EL1` at the same time. `TTBR1_EL1` is set once at boot and never changes.
 
@@ -241,7 +241,7 @@ switch_mm_fastpath:
 
 ### ASID generation wrap
 
-ARM64 supports 8-bit or 16-bit ASIDs (`TCR_EL1.AS`). Linux always uses 16-bit ASIDs where available (`arch/arm64/Kconfig`: `ARM64_HW_AFDBM`). With 16-bit ASIDs there are 65536 possible values. When they are exhausted, the kernel bumps an internal **generation counter** and flushes the entire TLB (`TLBI VMALLE1IS`), then reallocates ASIDs from scratch.
+ARM64 supports 8-bit or 16-bit ASIDs (`TCR_EL1.AS`). Linux detects ASID width at runtime from `ID_AA64MMFR0_EL1.ASIDBits` and uses 16-bit ASIDs where available. With 16-bit ASIDs there are 65536 possible values. When they are exhausted, the kernel bumps an internal **generation counter** and flushes the entire TLB (`TLBI VMALLE1IS`), then reallocates ASIDs from scratch.
 
 ---
 

--- a/docs/arch/arm64/spectre-meltdown.md
+++ b/docs/arch/arm64/spectre-meltdown.md
@@ -265,7 +265,7 @@ An attacker can exploit this by:
 
 ### Mitigation: SSBS register bit
 
-ARM64 CPUs that support mitigation expose the **SSBS** (Speculative Store Bypass Safe) bit. Setting `SSBS=0` in `PSTATE` (or the equivalent system register `SSBS_EL1`) instructs the CPU to disable speculative store bypass, preventing the attack.
+ARM64 CPUs that support mitigation expose the **SSBS** (Speculative Store Bypass Safe) bit in `PSTATE`. Setting `SSBS=0` instructs the CPU to disable speculative store bypass, preventing the attack. The system register is accessed via `MSR SSBS, Xn` / `MRS Xn, SSBS` (the register is named `SSBS`, not `SSBS_EL1`).
 
 Support is indicated by the **SSBS field in `ID_AA64PFR1_EL1`**.
 
@@ -327,7 +327,7 @@ The ARM64 spectre mitigations are spread across several files:
 | File | What it contains |
 |------|-----------------|
 | `arch/arm64/kernel/entry.S` | BHB clearing loop and `CLRBHB` at EL0→EL1 entry; kernel entry trampolines |
-| `arch/arm64/kernel/spectre.c` | Runtime detection, per-CPU mitigation state, SMCCC firmware calls |
+| `arch/arm64/kernel/proton-pack.c` | Runtime detection, per-CPU mitigation state, SMCCC firmware calls |
 | `arch/arm64/include/asm/spectre.h` | Mitigation type enums, per-CPU spectre state structure |
 | `arch/arm64/include/asm/barrier.h` | `array_index_mask_nospec()` ARM64 implementation; `__nospeculation_barrier()` |
 | `include/linux/nospec.h` | Architecture-independent `array_index_nospec()` macro |

--- a/docs/arch/arm64/spectre-meltdown.md
+++ b/docs/arch/arm64/spectre-meltdown.md
@@ -195,7 +195,7 @@ This affects a wide range of ARM cores:
 - Cortex-A72 (used in Raspberry Pi 4, many server SoCs)
 - Cortex-A73, Cortex-A75
 - Cortex-A76, Cortex-A77, Cortex-A78
-- Neoverse N1, Neoverse N2 (used in AWS Graviton2/3)
+- Neoverse N1 (used in AWS Graviton2), Neoverse V1 (used in AWS Graviton3), Neoverse N2 (used in AWS Graviton4)
 - Various other implementations (see ARM's official errata list)
 
 ### Mitigation 1: CSV2_3 (architectural isolation)

--- a/docs/arch/arm64/spectre-meltdown.md
+++ b/docs/arch/arm64/spectre-meltdown.md
@@ -1,0 +1,418 @@
+# Spectre and Meltdown on ARM64
+
+> Speculative execution vulnerabilities and mitigations
+
+ARM64 has a distinct vulnerability profile from x86. Most ARM64 CPUs are **not** affected by Meltdown, and the dominant Spectre-class concerns are Spectre v1, Spectre v2, Spectre-BHB, and Speculative Store Bypass. The mitigations are implemented in ARM64-specific assembly, system registers, and architectural feature bits rather than the x86 MSR-based mechanisms.
+
+---
+
+## Summary table
+
+| Vulnerability | CVE | Affected ARM64 hardware | Primary mitigation | KPTI needed? |
+|---------------|-----|-------------------------|--------------------|--------------|
+| Meltdown | CVE-2017-5754 | Cortex-A75 only | KPTI | Yes (A75 only) |
+| Spectre v1 | CVE-2017-5753 | All | `array_index_nospec()` | No |
+| Spectre v2 | CVE-2017-5715 | Most | CSV2 / IBPB / firmware | No |
+| Spectre-BHB | CVE-2022-23960 | Many (A72, A77, A78, …) | CLRBHB / loop / CSV2_3 | No |
+| Spectre v4 / SSB | CVE-2018-3639 | CPU-dependent | SSBS register bit | No |
+
+---
+
+## Background: speculative execution and cache side channels
+
+Modern CPUs execute instructions speculatively — they predict which branch will be taken and execute ahead of confirmed program flow. If the prediction is wrong, the speculatively executed results are discarded. The problem: **side effects in the cache are not discarded**.
+
+A cache side channel works by:
+
+1. Flushing a probe array from the cache
+2. Triggering the victim to speculatively access memory and load secret data into the cache
+3. Measuring access times to the probe array to determine which cache line was loaded
+4. Inferring the secret byte from the timing difference
+
+This **Flush+Reload** technique underlies all of the vulnerabilities described here.
+
+ARM64's **weakly ordered** memory model (see [Memory Model](memory-model.md)) means that speculative loads behave differently from x86's Total Store Order model. This is a key reason most ARM64 implementations are not vulnerable to classic Meltdown.
+
+---
+
+## Meltdown (CVE-2017-5754)
+
+### Why most ARM64 is not affected
+
+Meltdown on x86 works because the CPU speculatively reads a kernel address from user mode, and the value becomes transiently visible in a register before the permission fault is raised. This depends on TSO-like behavior where a speculative load can produce a value that propagates to later instructions.
+
+ARM64's weak memory model does not generally permit this. On most ARM64 microarchitectures, a permission fault on a load prevents the loaded value from being forwarded to dependent instructions. The speculative window either does not open or does not produce a usable value.
+
+**Exception: Cortex-A75.** ARM confirmed that the Cortex-A75 is susceptible to a Meltdown-equivalent, where a speculatively loaded kernel byte can influence the cache state before the permission abort is taken.
+
+### Mitigation: KPTI (Cortex-A75 only)
+
+KPTI (Kernel Page Table Isolation) separates the page tables used in user mode from those used in kernel mode, so that kernel addresses are not mapped while EL0 code is running. A speculative read of an unmapped address produces a TLB miss rather than a cached value, breaking the side channel.
+
+On ARM64, KPTI is controlled by `arm64_kernel_use_ng_mappings()` in `arch/arm64/mm/mmu.c`. The kernel marks its mappings as non-global (`nG` bit set) when KPTI is required, so that user-mode TLBs do not cache kernel translations.
+
+```bash
+cat /sys/devices/system/cpu/vulnerabilities/meltdown
+# Cortex-A75:   "Mitigation: PTI"
+# Everything else: "Not affected"
+```
+
+On the vast majority of ARM64 hardware — AWS Graviton, Apple Silicon, Qualcomm Snapdragon, most Cortex-A series — KPTI is not enabled and there is no associated performance penalty.
+
+---
+
+## Spectre v1 (CVE-2017-5753): bounds check bypass
+
+### The vulnerability
+
+Spectre v1 exploits speculative execution past a bounds check. An attacker trains the branch predictor so it predicts "branch taken" for a conditional bounds check, then submits an out-of-bounds index. The CPU speculatively executes the load using the bad index and encodes the result in the cache.
+
+```c
+/* Vulnerable pattern — found in kernel code handling user-supplied indices */
+if (index < array_size) {
+    /*
+     * CPU speculatively executes here even when index >= array_size,
+     * because the branch predictor was trained to predict "taken".
+     */
+    value = kernel_array[index];           /* speculative out-of-bounds read */
+    sink  = probe_array[value * 4096];     /* encodes secret in cache */
+}
+/* Permission check resolves, rollback — but probe_array[secret*4096] is warm */
+```
+
+Spectre v1 affects **all** CPUs with branch prediction, including every ARM64 implementation.
+
+### Mitigation: array_index_nospec()
+
+The primary in-kernel mitigation uses `array_index_nospec()` from `include/linux/nospec.h`. This macro computes a mask that is all-ones when the index is in range and all-zeros otherwise, without using a conditional branch that the CPU can speculate around.
+
+```c
+/* include/linux/nospec.h */
+#define array_index_nospec(index, size)                          \
+({                                                               \
+    typeof(index) _i = (index);                                  \
+    typeof(size)  _s = (size);                                   \
+    unsigned long _mask = array_index_mask_nospec(_i, _s);       \
+    BUILD_BUG_ON(sizeof(_i) > sizeof(long));                     \
+    (typeof(_i)) (_i & _mask);                                   \
+})
+```
+
+The ARM64 implementation of `array_index_mask_nospec()` uses a conditional move (CSEL) that clamps the index to zero without a speculative branch:
+
+```c
+/* arch/arm64/include/asm/barrier.h */
+static inline unsigned long array_index_mask_nospec(unsigned long idx,
+                                                     unsigned long sz)
+{
+    unsigned long mask;
+    /*
+     * Create a mask that is 0 when idx >= sz, all-ones otherwise.
+     * Uses CSEL-based arithmetic that the CPU cannot speculate through.
+     */
+    asm volatile(
+    "   cmp     %1, %2\n"
+    "   cset    %0, lo\n"          /* lo: idx < sz (unsigned) */
+    "   neg     %0, %0\n"          /* 0 → 0, 1 → 0xFFFF...FFFF */
+    : "=r" (mask)
+    : "r" (idx), "r" (sz)
+    : "cc");
+    return mask;
+}
+```
+
+After sanitization, the pattern looks like:
+
+```c
+if (index < array_size) {
+    index = array_index_nospec(index, array_size);  /* clamp speculatively */
+    val = array[index];   /* safe: even speculatively, index is in bounds */
+}
+```
+
+### Speculation barrier
+
+In paths where `array_index_nospec()` is not applicable, `__nospeculation_barrier()` (mapped to the ARM64 `CSDB` — Consumption of Speculative Data Barrier, or `ISB` on older cores) can be inserted to prevent the CPU from forwarding speculatively loaded values into subsequent instructions.
+
+```bash
+cat /sys/devices/system/cpu/vulnerabilities/spectre_v1
+# "Mitigation: __user pointer sanitization"
+```
+
+---
+
+## Spectre v2 (CVE-2017-5715): branch target injection
+
+### The vulnerability
+
+Spectre v2 targets the **indirect branch predictor** (Branch Target Buffer, BTB). An attacker running at EL0 can poison BTB entries so that when the kernel executes an indirect branch (function pointer call, virtual dispatch), the CPU speculatively jumps to an attacker-chosen gadget and encodes data in the cache.
+
+```
+Attack sequence:
+1. Attacker (EL0) repeatedly calls an indirect branch at address A → target T_attacker
+   (trains the BTB: when kernel calls A, predict target T_attacker)
+2. Kernel (EL1) executes:  blr x9  (indirect call via register)
+   CPU speculatively jumps to T_attacker (attacker's gadget)
+3. T_attacker reads a kernel secret and encodes it via cache timing
+4. Rollback — but cache is warm
+```
+
+### Mitigation 1: CSV2 (architectural guarantee)
+
+**CSV2** (Cache Speculation Variant 2) is an architectural feature bit in `ID_AA64PFR0_EL1`. When CSV2=1, the CPU implementation guarantees that branch prediction state is **not shared across exception levels or security domains**. A user-mode attacker cannot poison the BTB entries used by EL1.
+
+CSV2 is a microarchitectural property — it does not require any software mitigation sequence. CPUs that expose CSV2=1 include Apple M-series, AWS Graviton3, and many recent Cortex-A cores.
+
+```bash
+cat /sys/devices/system/cpu/vulnerabilities/spectre_v2
+# "Mitigation: CSV2"               — hardware guarantee, no SW overhead
+# "Mitigation: Branch predictor hardening"   — firmware/SW mitigation active
+# "Vulnerable"                     — no mitigation available
+```
+
+### Mitigation 2: IBPB via SMCCC firmware calls
+
+Some ARM64 implementations expose an IBPB-equivalent (Indirect Branch Predictor Barrier) through firmware using the SMCCC (ARM SMC Calling Convention) interface. The kernel calls into EL3 firmware on privilege transitions to flush branch predictor state.
+
+The kernel detects this capability via the SMCCC `ARCH_WORKAROUND_1` and `ARCH_WORKAROUND_2` function IDs and, where available, inserts firmware calls at EL0→EL1 transitions.
+
+### Mitigation 3: Return trampolines (ARM64 retpoline equivalent)
+
+ARM64 does not have the x86 RSB (Return Stack Buffer) retpoline trick, but the kernel uses **speculation-safe call sequences** for indirect branches on cores that require software mitigation. These rely on inserting an `SB` (Speculation Barrier, ARMv8.0-SB) or `ISB` after return-like sequences to prevent the CPU from speculating past the branch resolution point.
+
+The kernel's `call_via_r*` trampolines in entry paths use these barriers to prevent attacker-controlled speculative paths from executing gadgets in the kernel.
+
+---
+
+## Spectre-BHB (CVE-2022-23960): Branch History Buffer injection
+
+### The vulnerability
+
+Spectre-BHB (Branch History Buffer) is a more severe refinement of Spectre v2 that was disclosed in March 2022. The **Branch History Buffer** (BHB) influences the prediction of indirect branches — not just the BTB entry, but the selector into the BTB. An attacker who poisons the BHB can redirect indirect branch prediction in the victim even on cores that implement CSV2.
+
+This affects a wide range of ARM cores:
+
+- Cortex-A72 (used in Raspberry Pi 4, many server SoCs)
+- Cortex-A73, Cortex-A75
+- Cortex-A76, Cortex-A77, Cortex-A78
+- Neoverse N1, Neoverse N2 (used in AWS Graviton2/3)
+- Various other implementations (see ARM's official errata list)
+
+### Mitigation 1: CSV2_3 (architectural isolation)
+
+**CSV2_3** is an extension of CSV2 (encoded in `ID_AA64PFR0_EL1`) that additionally guarantees BHB isolation between security domains. CPUs with CSV2_3=1 require no software BHB mitigation.
+
+### Mitigation 2: CLRBHB instruction (ARMv8.9 / Cortex-X3 and later)
+
+**CLRBHB** is a new instruction introduced in ARMv8.9 that explicitly clears the Branch History Buffer. The Linux kernel inserts `CLRBHB` in the exception entry path at EL0→EL1 transitions, so that user-mode BHB state cannot influence kernel indirect branch prediction.
+
+```asm
+/* arch/arm64/kernel/entry.S — BHB clearing at kernel entry (CLRBHB variant) */
+    clrbhb
+    isb
+```
+
+The `ISB` after `CLRBHB` is necessary to ensure the BHB clear takes effect before any subsequent indirect branches are predicted.
+
+### Mitigation 3: BHB clearing loop (firmware-specified)
+
+For cores that do not have `CLRBHB` or `ECBHB`, the kernel executes a **branch-heavy loop** to overwrite BHB history with benign entries. The number of loop iterations is specified per-CPU model by the firmware (via a SMCCC call or CPU-specific data in the kernel) because it depends on the BHB depth of that particular microarchitecture.
+
+```asm
+/* arch/arm64/kernel/entry.S — BHB clearing loop (simplified) */
+/*
+ * Execute 'k' branches to flush the Branch History Buffer.
+ * The loop count is CPU-specific (e.g., 32 iterations for Cortex-A72).
+ */
+    mov     x0, #<loop_count>
+1:  b       2f
+2:  subs    x0, x0, #1
+    b.ne    1b
+    dsb     nsh
+    isb
+```
+
+This sequence is inserted at every EL0→EL1 exception entry (system call, IRQ, fault) on affected cores, which means there is a small but measurable cost on every kernel entry on these CPUs.
+
+### Mitigation 4: ECBHB (hardware automatic clearing)
+
+Some newer ARM cores set the **ECBHB** bit in `ID_AA64MMFR1_EL1`. When ECBHB=1, the CPU hardware automatically clears the BHB on exception entry from a lower EL. No software BHB clearing sequence is required. The kernel checks this bit and skips the loop or `CLRBHB` sequence if it is set.
+
+### Checking for BHB mitigation
+
+```bash
+cat /sys/devices/system/cpu/vulnerabilities/spec_rstack_overflow
+# (not BHB — this is AMD-specific)
+
+cat /sys/devices/system/cpu/vulnerabilities/spectre_v2
+# "Mitigation: CSV2, BHB"          — hardware CSV2_3 or ECBHB
+# "Mitigation: Spectre-BHB loop, Force BHB"
+# "Mitigation: CLRBHB"
+```
+
+---
+
+## Spectre v4 / Speculative Store Bypass (CVE-2018-3639)
+
+### The vulnerability
+
+The CPU may speculate that a load does not alias with a recent outstanding store (because address disambiguation is expensive). If the speculation is wrong, the load returns a **stale value** from cache or memory rather than the just-written value.
+
+An attacker can exploit this by:
+1. Writing a safe pointer value to memory
+2. Causing the CPU to speculatively load a different (attacker-controlled) value from the same address, before the write is complete
+3. Using the stale value as an array index to encode it in the cache
+
+### Mitigation: SSBS register bit
+
+ARM64 CPUs that support mitigation expose the **SSBS** (Speculative Store Bypass Safe) bit. Setting `SSBS=0` in `PSTATE` (or the equivalent system register `SSBS_EL1`) instructs the CPU to disable speculative store bypass, preventing the attack.
+
+Support is indicated by the **SSBS field in `ID_AA64PFR1_EL1`**.
+
+The kernel exposes control of SSBS to user processes via `prctl`:
+
+```c
+/* User process opts into mitigation */
+prctl(PR_SET_SPECULATION_CTRL,
+      PR_SPEC_STORE_BYPASS,
+      PR_SPEC_DISABLE,
+      0, 0);
+```
+
+When a thread requests mitigation, the kernel sets `SSBS=0` when scheduling that thread in and restores it on context switch out. The overhead is confined to threads that explicitly opt in.
+
+```bash
+cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass
+# "Mitigation: Speculative Store Bypass disabled via prctl"
+# "Not affected"
+# "Vulnerable"
+```
+
+---
+
+## MTE and speculation
+
+ARM64's Memory Tagging Extension (MTE, ARMv8.5-A) associates a 4-bit tag with each 16-byte granule of memory. A load or store that uses a pointer whose tag does not match the allocation tag raises a fault.
+
+MTE is **not** a primary Spectre mitigation, but it has a secondary effect: tag checks constrain which speculative loads can produce usable values. A speculative load to a mis-tagged address will eventually fault, limiting the usefulness of some speculative gadgets.
+
+MTE is primarily a memory safety and bug-detection feature. See the kernel's documentation on `arm64/memory-tagging-extension.rst` for details.
+
+---
+
+## Checking vulnerability status
+
+```bash
+# Print all vulnerability statuses at once
+for f in /sys/devices/system/cpu/vulnerabilities/*; do
+    echo "$(basename $f): $(cat $f)"
+done
+
+# Example output on a CSV2-capable Graviton3 system:
+# meltdown: Not affected
+# spectre_v1: Mitigation: __user pointer sanitization
+# spectre_v2: Mitigation: CSV2, BHB
+# spec_store_bypass: Mitigation: Speculative Store Bypass disabled via prctl
+# srbds: Not affected
+```
+
+On most modern ARM64 hardware the output is encouraging: Meltdown is not relevant, Spectre v2 is covered by hardware (CSV2), and Spectre-BHB is either hardware-cleared (ECBHB) or mitigated by a short entry-path sequence.
+
+---
+
+## Kernel code locations
+
+The ARM64 spectre mitigations are spread across several files:
+
+| File | What it contains |
+|------|-----------------|
+| `arch/arm64/kernel/entry.S` | BHB clearing loop and `CLRBHB` at EL0→EL1 entry; kernel entry trampolines |
+| `arch/arm64/kernel/spectre.c` | Runtime detection, per-CPU mitigation state, SMCCC firmware calls |
+| `arch/arm64/include/asm/spectre.h` | Mitigation type enums, per-CPU spectre state structure |
+| `arch/arm64/include/asm/barrier.h` | `array_index_mask_nospec()` ARM64 implementation; `__nospeculation_barrier()` |
+| `include/linux/nospec.h` | Architecture-independent `array_index_nospec()` macro |
+| `arch/arm64/mm/mmu.c` | `arm64_kernel_use_ng_mappings()` — KPTI decision for Cortex-A75 |
+
+### BHB clearing in entry.S
+
+The `entry.S` exception entry macro conditionally applies the BHB mitigation based on a per-CPU capability flag set at boot. The alternatives patching mechanism (`alternative_if` / `alternative_else`) selects the right sequence at runtime without adding a branch to the common path on unaffected hardware:
+
+```asm
+/* Conceptual structure in arch/arm64/kernel/entry.S */
+/* On exception entry from EL0: */
+
+alternative_if ARM64_WORKAROUND_SPECTRE_BHB_LOOP
+    /* Insert branch-clearing loop (count is CPU-model-specific) */
+    ...
+alternative_else_nop_endif
+
+alternative_if ARM64_WORKAROUND_SPECTRE_BHB_INSN
+    clrbhb
+    isb
+alternative_else_nop_endif
+```
+
+This pattern means that CPUs with ECBHB or CSV2_3 execute the original `nop` instructions (no overhead), while affected CPUs execute the mitigation sequence.
+
+---
+
+## Comparison with x86
+
+| Aspect | x86 | ARM64 |
+|--------|-----|-------|
+| Meltdown | Affects most pre-2019 Intel CPUs | Only Cortex-A75 |
+| KPTI | Required on nearly all Intel | Only for Cortex-A75 |
+| Spectre v2 mitigation | Retpoline / eIBRS / IBRS MSR | CSV2 (hardware), SMCCC firmware, entry barriers |
+| Spectre v1 | `array_index_nospec()` + `LFENCE` | `array_index_nospec()` + `CSDB`/`ISB` |
+| Spectre v4 | `IA32_SPEC_CTRL.SSBD` bit | SSBS `PSTATE` bit |
+| BHB | BHI_DIS_S / eIBRS (recent Intel) | CLRBHB / loop / ECBHB / CSV2_3 |
+| Mitigation controls | MSR writes (ring 0) | System register bits; SMCCC calls to EL3 |
+
+A key architectural difference: on ARM64 most hardware mitigations are expressed as **system register bits** (`ID_AA64PFR0_EL1`, `ID_AA64PFR1_EL1`, `ID_AA64MMFR1_EL1`) checked at boot, rather than MSR-based controls toggled at runtime. This means the software stack is often simpler — either the hardware guarantees isolation (CSV2, ECBHB) or a small entry-path sequence handles it.
+
+---
+
+## Mitigation boot parameters
+
+```bash
+# Disable all mitigations (dangerous — isolated benchmarking only)
+mitigations=off
+
+# Default auto-selection
+mitigations=auto
+
+# Disable specific ARM64 mitigations
+nospectre_v1            # disable Spectre v1 mitigations
+nospectre_v2            # disable Spectre v2 / BHB mitigations
+ssbd=off                # disable Speculative Store Bypass mitigation
+nopti                   # disable KPTI (no effect on non-A75 anyway)
+```
+
+---
+
+## Performance considerations
+
+Because most ARM64 systems either have hardware-level isolation or require only a short entry-path sequence, the performance impact of ARM64 spectre mitigations is generally **lower** than on x86:
+
+| Mitigation | Overhead |
+|------------|----------|
+| KPTI (Cortex-A75 only) | 5–30% syscall-heavy; ~5% with ASID-based optimization |
+| `array_index_nospec()` | Negligible (a few instructions per bounds check) |
+| BHB clearing loop | Small constant per kernel entry (~20–40 cycles on affected cores) |
+| `CLRBHB` | Very small (~1–2 cycles + ISB) |
+| ECBHB / CSV2_3 | Zero (hardware, no software overhead) |
+| SSBS | Negligible when per-thread; zero when disabled |
+| SMCCC IBPB firmware call | Moderate on affected cores at privilege transitions |
+
+On recent hardware (Graviton3, Apple M-series, Cortex-X3+) CSV2_3 or ECBHB coverage means most of these paths execute `nop` alternatives and impose no measurable overhead.
+
+---
+
+## Further reading
+
+- [Spectre and Meltdown on x86](../x86/spectre-meltdown.md) — x86 perspective: KPTI, retpoline, eIBRS, IBRS/IBPB/STIBP, MDS/VERW
+- [ARM64 Exception Model](exception-model.md) — EL0-EL3 transitions, VBAR_EL1, exception entry paths where BHB clearing is inserted
+- [ARM64 CPU Features](cpu-features.md) — how the kernel detects and uses CPU feature bits at boot (system register approach vs. x86 CPUID)
+- ARM Architecture Reference Manual (ARM DDI 0487) — `ID_AA64PFR0_EL1` CSV2/CSV2_3 fields; `ID_AA64PFR1_EL1` SSBS field; `ID_AA64MMFR1_EL1` ECBHB field
+- ARM Security Advisory: Spectre-BHB (2022) — per-core BHB depth table and recommended loop counts
+- `Documentation/admin-guide/hw-vuln/spectre.rst` in the kernel tree — canonical kernel documentation for all spectre variants

--- a/docs/arch/arm64/syscall-entry.md
+++ b/docs/arch/arm64/syscall-entry.md
@@ -87,19 +87,27 @@ a 64-bit SVC, EC is `0x15`:
 
 The handler reads `ESR_EL1`, extracts EC, and branches to `el0_svc`:
 
-```asm
-/* arch/arm64/kernel/entry.S (simplified) */
-SYM_CODE_START(el0t_64_sync_handler)
-    kernel_entry 0, 64               /* save registers to pt_regs */
+```c
+/* arch/arm64/kernel/entry-common.c */
+asmlinkage void noinstr el0t_64_sync_handler(struct pt_regs *regs)
+{
+    unsigned long esr = read_sysreg(esr_el1);
 
-    mrs     x22, esr_el1             /* read exception syndrome */
-    lsr     x24, x22, #ESR_ELx_EC_SHIFT
-
-    cmp     x24, #ESR_ELx_EC_SVC64
-    b.eq    el0_svc                  /* branch to SVC handler */
-    b       el0_sync_handler         /* other exceptions: faults, debug */
-SYM_CODE_END(el0t_64_sync_handler)
+    switch (ESR_ELx_EC(esr)) {
+    case ESR_ELx_EC_SVC64:
+        el0_svc(regs);
+        break;
+    case ESR_ELx_EC_DABT_LOW:
+        el0_da(regs, esr);
+        break;
+    /* ... other exception classes ... */
+    default:
+        el0_inv(regs, esr);
+    }
+}
 ```
+
+Note: `el0t_64_sync_handler` is a C function in `arch/arm64/kernel/entry-common.c` (not assembly). The low-level vector stub in `entry.S` saves registers with `kernel_entry 0, 64` and then calls this C handler.
 
 ---
 
@@ -197,10 +205,13 @@ checks the `syscall_work` flags in `thread_info`:
 /* kernel/entry/common.c */
 static long syscall_enter_from_user_mode_work(struct pt_regs *regs, long syscall)
 {
-    u32 work = READ_ONCE(current_thread_info()->syscall_work);
+    unsigned long work = READ_ONCE(current_thread_info()->syscall_work);
 
-    if (work & SYSCALL_WORK_SECCOMP)
-        syscall = __secure_computing(NULL);   /* run BPF filter */
+    if (work & SYSCALL_WORK_SECCOMP) {
+        int ret = __secure_computing(NULL);   /* run BPF filter */
+        if (ret == -1)
+            return ret;  /* process killed by seccomp */
+    }
 
     if (work & SYSCALL_WORK_SYSCALL_TRACEPOINT)
         trace_sys_enter(regs, syscall);       /* sys_enter raw tracepoint */
@@ -340,7 +351,8 @@ cat /sys/kernel/debug/tracing/trace
 
 **Kernel source files:**
 
-- `arch/arm64/kernel/entry.S` — vector table, `kernel_entry`/`kernel_exit`, `el0t_64_sync_handler`
+- `arch/arm64/kernel/entry.S` — vector table, `kernel_entry`/`kernel_exit` macros, low-level stubs
+- `arch/arm64/kernel/entry-common.c` — C exception handlers including `el0t_64_sync_handler`
 - `arch/arm64/kernel/syscall.c` — `do_el0_svc`, `el0_svc_common`, `invoke_syscall`
 - `arch/arm64/kernel/sys.c` — `sys_call_table` definition
 - `arch/arm64/kernel/sys_compat.c` — `compat_sys_call_table` for AArch32 processes

--- a/docs/arch/arm64/syscall-entry.md
+++ b/docs/arch/arm64/syscall-entry.md
@@ -146,7 +146,7 @@ the program counter from `ELR_EL1` and processor state from `SPSR_EL1`, returnin
 After register save, control flows from assembly into C:
 
 ```
-el0_svc (entry.S)
+el0_svc (entry-common.c)
   └─► do_el0_svc (syscall.c)
         └─► el0_svc_common (syscall.c)
               ├── syscall_enter_from_user_mode_work()  [tracing, seccomp]
@@ -216,14 +216,14 @@ static long syscall_enter_from_user_mode_work(struct pt_regs *regs, long syscall
     if (work & SYSCALL_WORK_SYSCALL_TRACEPOINT)
         trace_sys_enter(regs, syscall);       /* sys_enter raw tracepoint */
 
-    syscall = ptrace_syscall_enter(regs, syscall);  /* ptrace stop if traced */
+    syscall = ptrace_report_syscall_entry(regs);  /* ptrace stop if traced */
 
     return syscall;
 }
 ```
 
-When a task is traced with `PTRACE_SYSCALL` (as used by `strace`), `TIF_SYSCALL_TRACE` is set and
-`ptrace_syscall_enter()` pauses the task. The tracer reads registers via `PTRACE_GETREGSET` with
+When a task is traced with `PTRACE_SYSCALL` (as used by `strace`), `SYSCALL_WORK_SYSCALL_TRACE` is set (since Linux 5.12, replacing the old `TIF_SYSCALL_TRACE`) and
+`ptrace_report_syscall_entry()` pauses the task. The tracer reads registers via `PTRACE_GETREGSET` with
 `NT_PRSTATUS`, which exposes `struct user_pt_regs`.
 
 The return path mirrors entry: `syscall_exit_to_user_mode()` fires `sys_exit` tracepoints, handles

--- a/docs/arch/arm64/syscall-entry.md
+++ b/docs/arch/arm64/syscall-entry.md
@@ -1,0 +1,357 @@
+# ARM64 Syscall Entry
+
+> From SVC instruction to kernel C handler and back
+
+Every system call made by a 64-bit ARM process — `read()`, `write()`, `mmap()`, or any other — follows a
+specific hardware and software path from `SVC #0` in userspace through the kernel's assembly entry point,
+register-save machinery, C dispatch layer, and back to userspace via `ERET`. This page traces that path.
+
+---
+
+## The SVC instruction
+
+On ARM64, system calls are made with `SVC #0` (Supervisor Call). The calling convention is:
+
+| Register | Role |
+|----------|------|
+| `x8` | Syscall number |
+| `x0`–`x5` | Arguments (up to 6) |
+| `x0` | Return value (after return) |
+
+```asm
+/* Userspace: calling write(1, buf, len) on ARM64 */
+mov  x8, #64        /* __NR_write = 64 */
+mov  x0, #1         /* fd = 1 (stdout) */
+ldr  x1, =buf       /* buffer address */
+mov  x2, #len       /* length */
+svc  #0             /* trap to EL1; return value in x0 */
+```
+
+The immediate in `SVC #0` is conventionally zero — Linux ignores it. The syscall number comes from `x8`.
+
+### Contrast with x86-64
+
+| Aspect | ARM64 (`SVC #0`) | x86-64 (`SYSCALL`) |
+|--------|------------------|-------------------|
+| Syscall number | `x8` | `rax` |
+| Arguments | `x0`–`x5` | `rdi`, `rsi`, `rdx`, `r10`, `r8`, `r9` |
+| Return value | `x0` | `rax` |
+| Saved return address | CPU writes `ELR_EL1` | CPU writes `rcx` |
+| Saved flags | CPU writes `SPSR_EL1` | CPU writes `r11` |
+| Entry mechanism | Exception vector (VBAR_EL1) | Fixed MSR (LSTAR) |
+
+On ARM64, `SVC #0` triggers a synchronous exception dispatched through the vector table. On x86-64,
+`SYSCALL` jumps directly to the `LSTAR` MSR address without going through the IDT.
+
+---
+
+## Exception vector dispatch
+
+When `SVC #0` executes, the CPU takes a **synchronous exception** and jumps to `VBAR_EL1 + 0x400` —
+the slot for synchronous exceptions from 64-bit EL0:
+
+```
+VBAR_EL1 + 0x200: Synchronous, EL1 with SP_ELx   (kernel exceptions)
+VBAR_EL1 + 0x400: Synchronous, lower EL (AArch64) ← SVC from 64-bit EL0
+VBAR_EL1 + 0x600: Synchronous, lower EL (AArch32) ← SVC from 32-bit EL0
+```
+
+The Linux vector table in `arch/arm64/kernel/entry.S`:
+
+```asm
+/* arch/arm64/kernel/entry.S */
+    .align  11
+SYM_CODE_START(vectors)
+    kernel_ventry   1, h, 64, sync    /* Synchronous EL1h (kernel exceptions) */
+    kernel_ventry   1, h, 64, irq     /* IRQ EL1h */
+    /* ... */
+    kernel_ventry   0, t, 64, sync    /* Synchronous EL0, 64-bit ← here for SVC */
+    kernel_ventry   0, t, 64, irq     /* IRQ EL0, 64-bit */
+    /* ... */
+    kernel_ventry   0, t, 32, sync    /* Synchronous EL0, 32-bit (AArch32 compat) */
+    /* ... */
+SYM_CODE_END(vectors)
+```
+
+### ESR_EL1 and EC == 0x15
+
+The CPU populates `ESR_EL1` with the exception cause. Bits 31:26 are the **Exception Class (EC)**; for
+a 64-bit SVC, EC is `0x15`:
+
+```c
+/* arch/arm64/include/asm/esr.h */
+#define ESR_ELx_EC_SHIFT    26
+#define ESR_ELx_EC_SVC64    0x15   /* SVC from 64-bit EL0 */
+#define ESR_ELx_EC_SVC32   0x11   /* SVC from 32-bit EL0 */
+```
+
+The handler reads `ESR_EL1`, extracts EC, and branches to `el0_svc`:
+
+```asm
+/* arch/arm64/kernel/entry.S (simplified) */
+SYM_CODE_START(el0t_64_sync_handler)
+    kernel_entry 0, 64               /* save registers to pt_regs */
+
+    mrs     x22, esr_el1             /* read exception syndrome */
+    lsr     x24, x22, #ESR_ELx_EC_SHIFT
+
+    cmp     x24, #ESR_ELx_EC_SVC64
+    b.eq    el0_svc                  /* branch to SVC handler */
+    b       el0_sync_handler         /* other exceptions: faults, debug */
+SYM_CODE_END(el0t_64_sync_handler)
+```
+
+---
+
+## Register save and restore
+
+`kernel_entry 0, 64` saves all userspace registers onto the kernel stack as a `struct pt_regs`:
+
+```c
+/* arch/arm64/include/asm/ptrace.h */
+struct pt_regs {
+    union {
+        struct user_pt_regs user_regs;
+        struct {
+            u64 regs[31];   /* x0–x30 */
+            u64 sp;         /* user stack pointer (SP_EL0) */
+            u64 pc;         /* ELR_EL1: user return address */
+            u64 pstate;     /* SPSR_EL1: saved processor state */
+        };
+    };
+    u64 orig_x0;    /* original x0 (for syscall restart) */
+    s32 syscallno;  /* syscall number */
+    /* ... additional fields for MTE, SVE state ... */
+};
+```
+
+The macro switches to the per-task kernel stack (from `SP_EL1`), saves `x0`–`x30`, `sp`, `ELR_EL1`
+(return PC), and `SPSR_EL1` (saved PSTATE). The resulting `pt_regs *` is passed to all C handlers.
+
+On the return path, `kernel_exit 0` restores all fields and executes `ERET`, which atomically restores
+the program counter from `ELR_EL1` and processor state from `SPSR_EL1`, returning to EL0.
+
+---
+
+## The C dispatch path
+
+After register save, control flows from assembly into C:
+
+```
+el0_svc (entry.S)
+  └─► do_el0_svc (syscall.c)
+        └─► el0_svc_common (syscall.c)
+              ├── syscall_enter_from_user_mode_work()  [tracing, seccomp]
+              └── invoke_syscall()
+                    └─► sys_call_table[scno](regs)
+```
+
+`el0_svc_common` in `arch/arm64/kernel/syscall.c` saves `orig_x0` and `syscallno` into `pt_regs`, runs
+any pre-syscall work, then calls `invoke_syscall`:
+
+```c
+/* arch/arm64/kernel/syscall.c */
+static void invoke_syscall(struct pt_regs *regs, unsigned int scno,
+                            unsigned int sc_nr,
+                            const syscall_fn_t syscall_table[])
+{
+    long ret;
+
+    if (scno < sc_nr) {
+        syscall_fn_t syscall_fn;
+        syscall_fn = syscall_table[array_index_nospec(scno, sc_nr)];  /* Spectre v1 */
+        ret = __invoke_syscall(regs, syscall_fn);
+    } else {
+        ret = do_ni_syscall(regs, scno);   /* -ENOSYS */
+    }
+
+    syscall_set_return_value(current, regs, 0, ret);
+}
+```
+
+### The syscall table
+
+The ARM64 native syscall table is built in `arch/arm64/kernel/sys.c` via the `__SYSCALL()` macro:
+
+```c
+/* arch/arm64/kernel/sys.c */
+#define __SYSCALL(nr, sym)  [nr] = __arm64_##sym,
+
+const syscall_fn_t sys_call_table[__NR_syscalls] = {
+    [0 ... __NR_syscalls - 1] = __arm64_sys_ni_syscall,
+#include <asm/unistd.h>
+};
+```
+
+ARM64 uses the generic syscall numbering from `include/uapi/asm-generic/unistd.h` — the same table
+shared with RISC-V and LoongArch. `__NR_write` is 64, `__NR_read` is 63, `__NR_openat` is 56.
+
+---
+
+## Syscall tracing and seccomp
+
+`syscall_enter_from_user_mode_work()` in `kernel/entry/common.c` handles all pre-syscall hooks. It
+checks the `syscall_work` flags in `thread_info`:
+
+```c
+/* kernel/entry/common.c */
+static long syscall_enter_from_user_mode_work(struct pt_regs *regs, long syscall)
+{
+    u32 work = READ_ONCE(current_thread_info()->syscall_work);
+
+    if (work & SYSCALL_WORK_SECCOMP)
+        syscall = __secure_computing(NULL);   /* run BPF filter */
+
+    if (work & SYSCALL_WORK_SYSCALL_TRACEPOINT)
+        trace_sys_enter(regs, syscall);       /* sys_enter raw tracepoint */
+
+    syscall = ptrace_syscall_enter(regs, syscall);  /* ptrace stop if traced */
+
+    return syscall;
+}
+```
+
+When a task is traced with `PTRACE_SYSCALL` (as used by `strace`), `TIF_SYSCALL_TRACE` is set and
+`ptrace_syscall_enter()` pauses the task. The tracer reads registers via `PTRACE_GETREGSET` with
+`NT_PRSTATUS`, which exposes `struct user_pt_regs`.
+
+The return path mirrors entry: `syscall_exit_to_user_mode()` fires `sys_exit` tracepoints, handles
+ptrace exit-stops, and delivers any pending signals before `kernel_exit` restores registers.
+
+---
+
+## AArch32 compat
+
+A 64-bit ARM64 kernel can run 32-bit ARM (AArch32) ELF binaries (`CONFIG_COMPAT`). These processes also
+use `SVC #0`, but with a different register convention:
+
+| Register | Role |
+|----------|------|
+| `r7` | Syscall number (EABI) |
+| `r0`–`r5` | Arguments |
+| `r0` | Return value |
+
+The hardware routes AArch32 synchronous exceptions to **VBAR_EL1 + 0x600** instead of `+0x400`. The
+entry handler `el0t_32_sync_handler` recognises EC `0x11` (`ESR_ELx_EC_SVC32`) and branches to
+`el0_svc_compat`, which dispatches via a separate table:
+
+```c
+/* arch/arm64/kernel/sys_compat.c */
+#define __SYSCALL(nr, sym)  [nr] = __arm64_compat_##sym,
+
+const syscall_fn_t compat_sys_call_table[__NR_compat_syscalls] = {
+    [0 ... __NR_compat_syscalls - 1] = __arm64_compat_sys_ni_syscall,
+#include <asm/unistd32.h>
+};
+```
+
+AArch32 syscall numbers match the historical 32-bit ARM ABI and differ from native arm64 numbers.
+Compat handlers use `compat_*` types (`compat_size_t`, `compat_timespec64`, `compat_uptr_t`) to
+translate 32-bit struct layouts. `TIF_32BIT` marks a compat thread; `is_compat_task()` checks it.
+
+---
+
+## vDSO: avoiding SVC for hot paths
+
+`clock_gettime`, `gettimeofday`, and `clock_getres` are called millions of times per second in some
+workloads. The **vDSO** (virtual Dynamic Shared Object) implements these without `SVC #0` by reading
+timekeeping data from a kernel-managed shared page:
+
+```bash
+cat /proc/self/maps | grep -E 'vdso|vvar'
+# ffff800000000000-ffff800000001000 r--p 00000000 00:00 0  [vvar]
+# ffff800000001000-ffff800000002000 r-xp 00000000 00:00 0  [vdso]
+```
+
+The ARM64 vDSO lives at `arch/arm64/kernel/vdso/`. Instead of the x86 TSC, it reads `CNTVCT_EL0` — the
+ARM generic virtual timer counter, which the kernel configures as accessible from EL0:
+
+```asm
+mrs x0, CNTVCT_EL0   /* read virtual counter — no privilege transition */
+```
+
+The vDSO reads `struct vdso_data` (from `include/vdso/datapage.h`) in the **vvar page**, using a seqlock
+to detect concurrent kernel updates. The shared implementation in `lib/vdso/gettimeofday.c` is compiled
+for both arm64 and x86; only `__arch_get_hw_counter()` is architecture-specific. If the clock mode is
+`VDSO_CLOCKMODE_NONE` (e.g., after VM migration), the vDSO falls back transparently to `svc #0`.
+
+There is no vsyscall fixed-address page on ARM64 — that is an x86-64-only legacy.
+
+---
+
+## Observability
+
+### strace
+
+```bash
+strace ls                       # trace all syscalls
+strace -e trace=read,write ls   # filter by syscall name
+strace -T ls                    # show per-syscall elapsed time
+strace -p <pid>                 # attach to a running process
+```
+
+`strace` uses `ptrace(PTRACE_SYSCALL)` and never sees vDSO-accelerated calls — those never issue
+`svc #0`.
+
+### perf trace and bpftrace
+
+```bash
+perf trace ls                   # low-overhead syscall trace via tracepoints
+perf trace --summary sleep 5    # per-syscall counts and latency summary
+
+# Count syscalls by name
+bpftrace -e 'tracepoint:syscalls:sys_enter_* { @[probe] = count(); }'
+
+# Trace specific process
+bpftrace -e 'tracepoint:syscalls:sys_enter_read /pid == 1234/ { printf("fd=%d\n", args->fd); }'
+```
+
+### /proc/PID/syscall
+
+```bash
+cat /proc/$(pidof sshd)/syscall
+# 281 0x4 0x7ffd3a2b1000 0x400 0x0 0x0 0x0 0x7ffd3a2b1080 0xffffb3a82000
+# ^nr  ^args...                                              ^sp    ^pc
+```
+
+Shows the syscall number, arguments, user SP, and user PC for a process blocked in a syscall.
+
+### Raw tracepoints
+
+```bash
+# Enable sys_enter_read tracing via ftrace
+echo 1 > /sys/kernel/debug/tracing/events/syscalls/sys_enter_read/enable
+cat /sys/kernel/debug/tracing/trace
+```
+
+---
+
+## Further reading
+
+**In this site:**
+
+- [ARM64 Exception Model](exception-model.md) — VBAR_EL1, ESR_EL1, exception levels, and the GIC
+- [ARM64 Memory Model](memory-model.md) — Weak ordering, barriers, and LDAR/STLR
+- [x86-64 Syscall Entry](../x86/syscall-entry.md) — SYSCALL/SYSRET, entry_SYSCALL_64, KPTI
+- [Syscall Entry Path](../../syscalls/syscall-entry.md) — Architecture-neutral overview
+- [vDSO and Virtual System Calls](../../syscalls/vdso.md) — vvar page, seqlock, clock modes
+- [32-bit Compat Syscalls](../../syscalls/compat.md) — compat types, compat_sys_call_table
+- [ptrace and Syscall Interception](../../syscalls/ptrace-interception.md) — How strace works
+
+**Kernel source files:**
+
+- `arch/arm64/kernel/entry.S` — vector table, `kernel_entry`/`kernel_exit`, `el0t_64_sync_handler`
+- `arch/arm64/kernel/syscall.c` — `do_el0_svc`, `el0_svc_common`, `invoke_syscall`
+- `arch/arm64/kernel/sys.c` — `sys_call_table` definition
+- `arch/arm64/kernel/sys_compat.c` — `compat_sys_call_table` for AArch32 processes
+- `arch/arm64/kernel/vdso/` — ARM64 vDSO source
+- `arch/arm64/include/asm/ptrace.h` — `struct pt_regs` layout
+- `arch/arm64/include/asm/esr.h` — ESR_EL1 exception class constants
+- `include/vdso/datapage.h` — `struct vdso_data` (shared vvar layout)
+- `lib/vdso/gettimeofday.c` — Shared vDSO clock implementation (arm64 and x86)
+- `kernel/entry/common.c` — `syscall_enter_from_user_mode`, `syscall_exit_to_user_mode`
+
+**External:**
+
+- ARM Architecture Reference Manual (ARM DDI 0487) — definitive AArch64 exception model reference
+- `Documentation/arm64/` in the kernel tree

--- a/docs/arch/arm64/war-stories.md
+++ b/docs/arch/arm64/war-stories.md
@@ -28,7 +28,7 @@ The mechanism was subtle:
 The key registers and functions:
 
 - `TIF_SVE` — thread flag indicating SVE state is valid and must be saved/restored
-- `CPACR_EL1.FPEN` (bits 21:20) — controls FP/SVE trap to EL1; `0b01` traps SVE, `0b11` allows both FPSIMD and SVE
+- `CPACR_EL1.FPEN` (bits 21:20) — controls FPSIMD trap to EL1 (not SVE). SVE access is governed by the separate `CPACR_EL1.ZEN` field (bits 17:16). `kernel_neon_begin()` sets both FPEN and ZEN appropriately; code that only sets FPEN still traps on SVE instructions.
 - `fpsimd_save_state()` / `fpsimd_load_state()` — low-level save/restore of the FPSIMD register file
 - `kernel_neon_begin()` — saves userspace FPSIMD/SVE context if needed, enables NEON for kernel use, disables preemption
 - `kernel_neon_end()` — restores accounting state, re-enables preemption
@@ -277,7 +277,7 @@ When an indirect branch is executed, the CPU sets `BTYPE` to record the branch t
 - `BTI jc` — landing pad for both
 - `NOP` — only valid in some configurations
 
-If the landing address does not have the correct `BTI` instruction, the CPU raises a Branch Target Exception. The ESR_EL1 encodes this as EC=`0x24` (data abort from current EL) or EC=`0x11` (SVC) — specifically, the `BTYPE` field in ESR indicates a BTI failure (ISS `DFSC` value `0b100100`).
+If the landing address does not have the correct `BTI` instruction, the CPU raises a Branch Target Exception. The ESR_EL1 encodes this with EC=`0x0D` (`ESR_ELx_EC_BTI`), defined in `arch/arm64/include/asm/esr.h`. This is distinct from a data abort (EC=`0x24`) — BTI exceptions have their own exception class and ISS encoding.
 
 The kernel enables BTI for a process when the ELF binary has the `GNU_PROPERTY_AARCH64_FEATURE_1_BTI` bit set in its `.note.gnu.property` section. You can check this:
 
@@ -428,7 +428,7 @@ Errata workarounds are safety-critical: an off-by-one in a MIDR revision range s
 | 1 | SVE context switch corruption | Unmatched `kernel_neon_begin/end` breaks lazy FP save accounting | Userspace numerical errors; ftrace on fpsimd paths | Yes — lazy FPSIMD/SVE save is ARM64-specific |
 | 2 | Stale PTE after TLBI | Missing `dsb(ishst)` before TLB invalidate | Intermittent translation faults on recently remapped VA | Yes — ARM64 weak ordering; x86 TSO hides this |
 | 3 | Device reads stale DMA data | Non-coherent DMA without cache flush | Device transmits zeros; confirmed with `pgprot_noncached` | Partly — non-coherent DMA exists on other arches but common on embedded ARM64 |
-| 4 | BTI enforcement crash | JIT code missing `BTI c` landing pad instruction | SIGSEGV with ESR EC=0x24 BTI failure | Yes — ARMv8.5 BTI is ARM64-specific |
+| 4 | BTI enforcement crash | JIT code missing `BTI c` landing pad instruction | SIGSEGV with ESR EC=0x0D (ESR_ELx_EC_BTI) | Yes — ARMv8.5 BTI is ARM64-specific |
 | 5 | Erratum workaround not applied | MIDR revision range off-by-one in errata table | Spurious faults; no erratum boot message; `midr_el1` sysfs | Yes — ARM64 MIDR-based errata infrastructure |
 
 ---

--- a/docs/arch/arm64/war-stories.md
+++ b/docs/arch/arm64/war-stories.md
@@ -1,0 +1,442 @@
+# ARM64 War Stories
+
+> Cache coherency bugs, TLB shootdown ordering, BTI enforcement, and SVE context corruption
+
+These are realistic composites of failure patterns that actually occur on ARM64 systems. Each story follows a real bug class rooted in ARM64 architecture specifics — weak memory ordering, hardware coherency requirements, CPU feature enforcement, and errata handling. Names and products are illustrative; the failure modes are real.
+
+---
+
+## 1. The SVE Context Switch Bug
+
+### Setup
+
+A storage driver was optimized to use SIMD to accelerate CRC32 checksums on data blocks during I/O completion. The developer correctly called `kernel_neon_begin()` and `kernel_neon_end()` in the checksum path — or so they thought. A refactoring pass moved some of the checksum logic into a helper function called from a workqueue. In that helper, `kernel_neon_begin()` was present, but an early-return error path skipped `kernel_neon_end()`.
+
+The kernel was running on an ARMv8.2 platform with SVE support. Several userspace threads were using SVE for BLAS routines in a scientific computing workload.
+
+### What Happened
+
+On a heavily loaded system, a userspace thread using SVE would occasionally produce wrong numerical results — not crashes, not NaN, just subtly incorrect floating-point outputs that only showed up when comparing against a reference implementation.
+
+The mechanism was subtle:
+
+1. A userspace SVE thread is running in EL0. The `TIF_SVE` flag in its `thread_info` is set, indicating SVE state is live and must be preserved across context switches.
+2. The Linux kernel uses **lazy save/restore** for FP/SIMD state. It does not unconditionally save the FPSIMD/SVE registers on every kernel entry. Instead, `CPACR_EL1.FPEN` is used as a trap gate: when the kernel wants to deny a task's FP state from being touched, it clears `FPEN`, causing any subsequent FPSIMD/SVE instruction to trap to EL1.
+3. The workqueue handler ran in a softirq context on the same CPU. The early-return path skipped `kernel_neon_end()`, which meant `CPACR_EL1.FPEN` was left in the "enabled" state, and the kernel's internal accounting of "NEON is in use by the kernel" was lost.
+4. When the userspace SVE task was scheduled back in, `fpsimd_restore_current_state()` checked the lazy-save bookkeeping and concluded the SVE registers were still valid — it skipped the restore. But the workqueue had already clobbered the FPSIMD register file. The userspace task resumed with wrong vector register contents.
+
+The key registers and functions:
+
+- `TIF_SVE` — thread flag indicating SVE state is valid and must be saved/restored
+- `CPACR_EL1.FPEN` (bits 21:20) — controls FP/SVE trap to EL1; `0b01` traps SVE, `0b11` allows both FPSIMD and SVE
+- `fpsimd_save_state()` / `fpsimd_load_state()` — low-level save/restore of the FPSIMD register file
+- `kernel_neon_begin()` — saves userspace FPSIMD/SVE context if needed, enables NEON for kernel use, disables preemption
+- `kernel_neon_end()` — restores accounting state, re-enables preemption
+
+```c
+/* WRONG: early return skips kernel_neon_end() */
+static int checksum_block(struct request *rq)
+{
+    int ret;
+
+    kernel_neon_begin();
+
+    ret = validate_header(rq);
+    if (ret < 0)
+        return ret;   /* BUG: kernel_neon_end() not called */
+
+    do_neon_checksum(rq);
+    kernel_neon_end();
+    return 0;
+}
+
+/* CORRECT: every return path calls kernel_neon_end() */
+static int checksum_block(struct request *rq)
+{
+    int ret;
+
+    kernel_neon_begin();
+
+    ret = validate_header(rq);
+    if (ret < 0)
+        goto out;
+
+    do_neon_checksum(rq);
+out:
+    kernel_neon_end();
+    return ret;
+}
+```
+
+### Diagnosis
+
+The bug was silent and non-deterministic. Diagnosis steps:
+
+1. **Reproduce with a stress test**: run the SVE userspace workload alongside heavy I/O to trigger the workqueue path frequently.
+2. **Add assertions**: instrument `kernel_neon_end()` calls by checking that preemption is still disabled (as `kernel_neon_begin()` disables it) — a mismatch signals a missed `kernel_neon_end()`.
+3. **Tracing**: add `ftrace` hooks around `fpsimd_save_state()` and `fpsimd_load_state()` to log which task context they run in; a restore that does not follow a save on the same CPU is the smoking gun.
+4. **`WARN_ON` in scheduler**: the kernel's `fpsimd_thread_switch()` path (called from `__switch_to()`) can be instrumented to check that the NEON-in-kernel state is clean at switch time.
+
+### Fix
+
+Ensure every kernel code path that calls `kernel_neon_begin()` has a matching `kernel_neon_end()` on all exit paths. A common pattern is the `goto out` idiom shown above. If the NEON usage can fail partway through, keep `kernel_neon_end()` in a single cleanup label.
+
+For longer kernel NEON paths: preemption is disabled between `kernel_neon_begin()` and `kernel_neon_end()`, so keep the NEON critical section as short as possible. Do not block, sleep, or call any function that might schedule inside this window.
+
+### Lesson
+
+ARM64's lazy FPSIMD/SVE save/restore makes kernel NEON use efficient, but the correctness contract is strict: `kernel_neon_begin()` and `kernel_neon_end()` must be perfectly paired. Missing a `kernel_neon_end()` breaks the kernel's accounting without any immediate fault — the corruption only appears later when a userspace task resumes with a clobbered register file. Code review must treat these pairs as carefully as mutex lock/unlock.
+
+---
+
+## 2. The Missing DSB Before TLBI
+
+### Setup
+
+A driver for a custom DMA remapping engine maintained its own set of page table entries to map device-visible buffers into a restricted VA space. When a buffer was replaced, the driver updated the PTE, then called `flush_tlb_range()` to shoot down stale TLB entries on all CPUs. The code was written by an engineer with x86 experience and tested on a single-core development board before being deployed to a 16-core ARM64 server.
+
+### What Happened
+
+On the 16-core system, about once every few hours, a CPU would take a fault on an address that should have been remapped. The fault was a translation fault at the new VA — the MMU page table walker was fetching a stale PTE that pointed to the old physical page, which had already been freed.
+
+The root cause was a missing `dsb(ishst)` between the PTE write and the TLBI instruction.
+
+ARM64 has a **weak memory model**. A store to a PTE is a normal memory write. The TLB invalidate (`TLBI` instruction) is a broadcast operation that signals other CPUs' TLBs to flush the entry. But the ARM architecture only guarantees that the TLBI takes effect with respect to TLB entries — it does **not** guarantee that a preceding PTE store is visible to another CPU's MMU walker before the TLBI completes on that CPU, unless a `DSB` (Data Synchronization Barrier) is issued first.
+
+The required sequence for a PTE update on ARM64 is:
+
+```
+1. Write the new PTE to memory                 (str  x1, [x0])
+2. DSB ISHST — Inner Shareable Store barrier    (dsb  ishst)
+   Ensures the PTE store is globally visible
+   to all MMU page table walkers before TLBI
+3. Issue TLBI for the affected VA range         (TLBI ASIDE1IS / VAAE1IS / etc.)
+4. DSB ISH — Inner Shareable barrier            (dsb  ish)
+   Ensures the TLBI has completed on all CPUs
+5. ISB — Instruction Synchronization Barrier    (isb)
+   Ensures subsequent instructions fetch from
+   updated mappings
+```
+
+The driver's code, expressed at the C level:
+
+```c
+/* WRONG: no DSB between PTE write and TLB flush */
+static void remap_buffer(struct my_dev *dev, unsigned long va,
+                         phys_addr_t new_pa)
+{
+    pte_t *ptep = lookup_pte(dev, va);
+    set_pte(ptep, pfn_pte(new_pa >> PAGE_SHIFT, PAGE_KERNEL));
+    /* Missing: dsb(ishst) here */
+    flush_tlb_range(&dev->vma, va, va + PAGE_SIZE);
+}
+
+/* CORRECT: barrier ensures PTE store is visible before TLBI */
+static void remap_buffer(struct my_dev *dev, unsigned long va,
+                         phys_addr_t new_pa)
+{
+    pte_t *ptep = lookup_pte(dev, va);
+    set_pte(ptep, pfn_pte(new_pa >> PAGE_SHIFT, PAGE_KERNEL));
+    dsb(ishst);   /* ARM64: store barrier before TLBI broadcast */
+    flush_tlb_range(&dev->vma, va, va + PAGE_SIZE);
+    /* flush_tlb_range issues dsb(ish) + isb internally on ARM64 */
+}
+```
+
+Why did it work on x86? x86 uses **Total Store Order (TSO)**: all store operations are visible to other processors in program order before any subsequent serializing instruction (like the `INVLPG` or IPI used for TLB shootdown). TSO gives the DSB-equivalent for free. ARM64's relaxed model does not.
+
+Why did it work on a single core? With one CPU, there is no other MMU walker to race with. The local TLB invalidate sees the updated PTE from the local store buffer.
+
+### Diagnosis
+
+1. **Intermittent translation faults** at addresses that should be valid; `dmesg` shows `do_page_fault` for kernel addresses.
+2. The fault VA matches a recently remapped region, and the physical address in the stale PTE matches the old mapping.
+3. Narrow down by adding `dsb(ishst)` as a diagnostic and observing that the fault rate drops to zero.
+4. Review all driver PTE-update paths against the ARM ARM (Architecture Reference Manual) required sequence for "break-before-make" and PTE updates.
+
+### Fix
+
+Insert `dsb(ishst)` between PTE writes and any TLBI or `flush_tlb_*` call. In most cases, drivers should not be manipulating PTEs directly — using the kernel's `remap_pfn_range()`, `vm_insert_page()`, or `io_remap_pfn_range()` handles barriers correctly. If direct PTE manipulation is unavoidable, follow the full ARM64 sequence explicitly.
+
+### Lesson
+
+The ARM64 memory model requires explicit store barriers before TLB invalidates. Code ported from x86 or tested only on uniprocessor systems will appear to work, then fail under load on multi-core ARM64. The `dsb(ishst)` before TLBI is not a performance hint — it is architecturally required for correctness.
+
+---
+
+## 3. The Cache Coherency Trap: DMA from a Non-Coherent Device
+
+### Setup
+
+An embedded SoC (a custom ARM64 board for industrial control) had a PCIe endpoint with a proprietary DMA engine. Unlike commodity PCIe cards that participate in cache snooping via PCIe's MESIF coherency protocol, this DMA engine accessed DRAM directly through the SoC's bus fabric — bypassing CPU cache snooping entirely. The SoC datasheet documented this, but the driver author assumed that "PCIe = cache coherent" and wrote the driver accordingly.
+
+### What Happened
+
+The driver allocated a transmit buffer with `kmalloc()`, filled it with packet data, then programmed the DMA engine to read the buffer and transmit it over the custom fabric link. The device would occasionally transmit zeros or stale data instead of the intended packet contents.
+
+The sequence:
+
+1. `kmalloc()` returns a pointer to a kernel virtual address backed by a physical page. The buffer is **cacheable** — the CPU's L1/L2 cache is enabled for this region.
+2. The driver writes packet data into the buffer. These writes go into the CPU's L1 (and possibly L2) cache. They may not yet have been written back (flushed) to DRAM.
+3. The driver writes the physical address of the buffer into the DMA engine's descriptor register.
+4. The DMA engine fetches data from DRAM — bypassing CPU caches — and reads zeros or old values because the CPU's writes are still sitting in cache.
+
+The fix the DMA API provides:
+
+```c
+/* WRONG: using kmalloc buffer directly for non-coherent DMA */
+static int bad_driver_tx(struct my_dev *dev, void *data, size_t len)
+{
+    void *buf = kmalloc(len, GFP_KERNEL);
+    memcpy(buf, data, len);
+    /* CPU writes are in cache; device will read stale DRAM */
+    program_dma(dev, virt_to_phys(buf), len, DMA_TO_DEVICE);
+    return 0;
+}
+
+/* CORRECT: use dma_map_single() which flushes cache on non-coherent arches */
+static int good_driver_tx(struct my_dev *dev, void *data, size_t len)
+{
+    void *buf = kmalloc(len, GFP_KERNEL);
+    dma_addr_t dma_addr;
+
+    memcpy(buf, data, len);
+
+    dma_addr = dma_map_single(dev->dev, buf, len, DMA_TO_DEVICE);
+    if (dma_mapping_error(dev->dev, dma_addr)) {
+        kfree(buf);
+        return -EIO;
+    }
+    /* dma_map_single() with DMA_TO_DEVICE flushes (clean+invalidate)
+     * the affected cache lines on non-coherent platforms.
+     * On ARM64 this issues: dc civac (Data Cache Clean and Invalidate
+     * by VA to PoC) for each cache line in the buffer. */
+    program_dma(dev, dma_addr, len, DMA_TO_DEVICE);
+    return 0;
+}
+```
+
+For buffers that the **device writes** and the **CPU reads** (`DMA_FROM_DEVICE`), the inverse applies: after DMA completes, `dma_unmap_single()` (or `dma_sync_single_for_cpu()`) must invalidate the cache lines so the CPU does not read stale cached data instead of what the device wrote to DRAM.
+
+For frequently used shared buffers, `dma_alloc_coherent()` is the right tool — it allocates memory mapped as non-cacheable (or with cache-bypassing attributes), so neither side needs explicit flush/invalidate calls:
+
+```c
+/* Best for rings/descriptors: allocate as coherent from the start */
+buf = dma_alloc_coherent(dev->dev, size, &dma_addr, GFP_KERNEL);
+/* CPU and device both see a consistent view; no flush needed */
+```
+
+Whether a device requires explicit cache management depends on `dev->dma_coherent` (set from DT or ACPI describing the platform's coherency fabric) or the presence of an IOMMU that provides snooping. On platforms with a fully coherent interconnect, `dma_map_single()` is a no-op for cache management; on non-coherent platforms it does the necessary `dc civac` sequence.
+
+### Diagnosis
+
+1. Device transmits wrong data — zeros, old values, or garbage — not random corruption.
+2. The bug is **consistent at low speed** (cache lines always flushed before the race) and **worse under load** (cache lines less likely to have been evicted naturally).
+3. A temporary workaround: mark the buffer memory as non-cacheable using `pgprot_noncached()` or `pgprot_writecombine()` — if the bug disappears, cache coherency is confirmed as the cause.
+4. Check the SoC TRM (Technical Reference Manual) and Linux DTS for `dma-coherent` property on the device node.
+5. Audit all `virt_to_phys()` calls in the driver — any direct physical address use that bypasses `dma_map_*` is a red flag on a non-coherent platform.
+
+### Fix
+
+Replace all direct `virt_to_phys()` + register programming with the DMA API (`dma_map_single()` / `dma_unmap_single()` or `dma_alloc_coherent()`). Ensure the device node in the DTS does **not** have `dma-coherent` unless the hardware actually supports it. For descriptor rings and control structures, use `dma_alloc_coherent()`.
+
+### Lesson
+
+Cache coherency is not guaranteed for all DMA-capable devices, even on sophisticated SoCs. The Linux DMA API exists precisely to abstract the coherency requirement: it is a no-op on coherent platforms and does the right cache operations on non-coherent ones. Using `virt_to_phys()` directly instead of `dma_map_single()` is always wrong in a portable driver — it fails silently on non-coherent hardware.
+
+---
+
+## 4. The BTI Enforcement Crash in a JIT Compiler
+
+### Setup
+
+A language runtime embedded in a container orchestration agent generated native ARM64 code at runtime to evaluate policy expressions. The JIT compiled policy rules to machine code, mapped the code with `mmap(PROT_READ | PROT_EXEC)`, then called into it via a function pointer. The system was a modern ARM64 server running a distribution kernel compiled with BTI (Branch Target Identification) support.
+
+### What Happened
+
+The runtime crashed with a signal, `dmesg` showed:
+
+```
+[12345.678] traps: agent[4321] proc violation BTI pc=0x7f3a0000 addr=0x7f3a0000
+```
+
+The crash occurred precisely when the runtime invoked the JIT-compiled function pointer. BTI (ARMv8.5-A) protection was rejecting the indirect branch into the JIT code.
+
+**How BTI works:**
+
+BTI adds a new mechanism to enforce that indirect branches (calls via function pointer, `blr`, `br`) may only land on designated landing pad instructions. It is controlled by:
+
+- `SCTLR_EL1.BT0` — enables BTI enforcement for EL0 (userspace)
+- `SCTLR_EL1.BT1` — enables BTI enforcement for EL1 (kernel)
+- The `BTYPE` field in `PSTATE` — tracks what type of branch was just taken (none / call / jump)
+
+When an indirect branch is executed, the CPU sets `BTYPE` to record the branch type. The instruction at the landing address must be one of:
+
+- `BTI c` — landing pad for calls (`blr`, `bl` indirect)
+- `BTI j` — landing pad for jumps (`br`, `b` indirect)
+- `BTI jc` — landing pad for both
+- `NOP` — only valid in some configurations
+
+If the landing address does not have the correct `BTI` instruction, the CPU raises a Branch Target Exception. The ESR_EL1 encodes this as EC=`0x24` (data abort from current EL) or EC=`0x11` (SVC) — specifically, the `BTYPE` field in ESR indicates a BTI failure (ISS `DFSC` value `0b100100`).
+
+The kernel enables BTI for a process when the ELF binary has the `GNU_PROPERTY_AARCH64_FEATURE_1_BTI` bit set in its `.note.gnu.property` section. You can check this:
+
+```bash
+readelf -n /usr/bin/agent | grep -A2 "AArch64 Instruction Set Architecture"
+# Output shows: BTI enabled
+```
+
+The language runtime's main binary had BTI declared and enabled. Its JIT emitter, however, generated raw ARM64 instructions without any `BTI` preamble:
+
+```c
+/* WRONG: JIT prologue missing BTI landing pad */
+static void emit_function_prologue(struct jit_ctx *ctx)
+{
+    /* First instruction emitted is the actual function body */
+    emit(ctx, STP_X29_X30_SP_M16);  /* stp x29, x30, [sp, #-16]! */
+    emit(ctx, MOV_X29_SP);          /* mov x29, sp                 */
+    /* ... rest of function */
+}
+
+/* CORRECT: emit BTI c as first instruction */
+static void emit_function_prologue(struct jit_ctx *ctx)
+{
+    emit(ctx, BTI_C);               /* bti c  — call landing pad   */
+    emit(ctx, STP_X29_X30_SP_M16); /* stp x29, x30, [sp, #-16]!   */
+    emit(ctx, MOV_X29_SP);          /* mov x29, sp                  */
+    /* ... rest of function */
+}
+```
+
+The encoding of `BTI c` is `0xd503245f` (a hint-space instruction). `BTI j` is `0xd503249f`. `BTI jc` is `0xd50324df`.
+
+Note that BTI enforcement only applies to **pages mapped with** `PROT_BTI` (via `mprotect()`) or to the main executable and its shared libraries when the BTI ELF note is present. If the JIT maps memory with only `PROT_READ | PROT_EXEC`, BTI enforcement may not apply to that region — but if the runtime's own executable is BTI-enabled and uses an indirect call (`blr`) to reach JIT code, the CPU still enforces the BTI requirement at the landing address if the process was started with BTI enabled.
+
+### Diagnosis
+
+1. The crash backtrace points to the instruction immediately after `blr xN` where `xN` holds the JIT code address.
+2. Decode the ESR_EL1 from the signal info or `dmesg`: `EC=0x24`, ISS indicates BTI failure.
+3. Inspect the first 4 bytes of the JIT buffer: they should be `5f 24 03 d5` (`bti c`) but instead show the first instruction of the function body.
+4. Confirm BTI is active: `grep BTI /proc/$(pidof agent)/smaps` or check `/proc/cpuinfo` for `bti` in the Features line.
+5. Verify the binary's BTI note: `readelf -n /usr/bin/agent`.
+
+### Fix
+
+The JIT emitter must emit `BTI c` as the very first instruction of every function entry point that may be reached via an indirect call (`blr`). For jump tables and indirect `br` targets, emit `BTI j` instead. The change is a single-word addition to the function prologue emitter.
+
+If a JIT targets a mixed environment (some callers may be BTI-unaware), `BTI jc` at all entry points provides maximum compatibility.
+
+For the `mmap` region, calling `mprotect(buf, size, PROT_READ | PROT_EXEC | PROT_BTI)` opts the JIT pages into BTI enforcement explicitly (Linux 5.8+), which also enables the kernel to audit the code before execution.
+
+### Lesson
+
+BTI is a forward-edge CFI (Control Flow Integrity) mechanism baked into ARMv8.5. When a process binary declares BTI support, the kernel enforces landing pad requirements for all indirect branches — including branches into runtime-generated code. JIT compilers, eBPF back-ends, and FFI stubs must all be updated to emit `BTI c` / `BTI j` preambles. This is a one-instruction fix, but it requires explicit awareness of the BTI ABI.
+
+---
+
+## 5. The Erratum Workaround with the Wrong MIDR Range
+
+### Setup
+
+A SoC vendor shipped a line of ARM Cortex-A55 based processors. Revision r0p2 of the core had an erratum in its speculative prefetcher: under specific conditions, a spurious prefetch could generate a fault for an address that was not actually being accessed, causing a kernel oops. The upstream kernel fix applied a workaround by disabling the prefetcher via an implementation-defined register when the erratum was detected.
+
+A downstream vendor kernel team backported this fix. The erratum workaround was conditional on the MIDR_EL1 value — it should apply to r0p0, r0p1, and r0p2 of the affected core. However, the backport had a transcription error: the revision range in the errata table covered only r0p0 and r0p1.
+
+### What Happened
+
+Production devices, which shipped with r0p2 silicon, hit spurious kernel faults under memory pressure. The fault address was always unmapped, the fault was non-reproducible from userspace, and it appeared deep in `do_page_fault` on a kernel address that was provably mapped.
+
+**The MIDR_EL1 register format:**
+
+```
+Bits [31:24] — Implementer  (e.g., 0x41 = ARM)
+Bits [23:20] — Variant      (major revision, e.g., 0 = r0)
+Bits [19:16] — Architecture (0xf = ARMv8)
+Bits [15:4]  — Part number  (e.g., 0xD05 = Cortex-A55)
+Bits [3:0]   — Revision     (minor revision, e.g., 2 = p2)
+```
+
+The `MIDR_CPU_MODEL()` macro matches on implementer and part number. The errata entry in the `arm64_errata[]` table specifies a revision range via the `midr_range` structure (first and last MIDR values, encoding variant and revision). The incorrect backport:
+
+```c
+/* WRONG: range ends at r0p1 (revision = 1), misses r0p2 */
+static const struct midr_range affected_range[] = {
+    MIDR_RANGE(MIDR_CORTEX_A55, 0, 0, 0, 1),
+    /* variant_min=0, revision_min=0, variant_max=0, revision_max=1 */
+};
+
+/* CORRECT: range must include r0p2 (revision = 2) */
+static const struct midr_range affected_range[] = {
+    MIDR_RANGE(MIDR_CORTEX_A55, 0, 0, 0, 2),
+    /* variant_min=0, revision_min=0, variant_max=0, revision_max=2 */
+};
+```
+
+At boot, the kernel iterates `arm64_errata[]` and calls the `matches` function for each entry. If the current CPU's MIDR falls within the declared range, the erratum is applied and a boot message is printed:
+
+```
+[    0.000000] CPU features: detected: Workaround for Cortex-A55 erratum 1530923
+```
+
+On the affected r0p2 devices, no such message appeared — a clear sign the workaround was not active.
+
+To read the MIDR of a running system:
+
+```bash
+cat /sys/devices/system/cpu/cpu0/regs/identification/midr_el1
+# e.g., 0x0000000041AF5402
+#               ^^ ^^^^ ^^
+#               |  |    |--- revision (2 = p2)
+#               |  |-------- part (D05 = Cortex-A55, stored as 0xd05 in bits 15:4)
+#               |------------ implementer (0x41 = ARM)
+```
+
+The revision field (`bits[3:0]`) read as `2` (p2), but the erratum table's range only went to `1` (p1) — a one-off error.
+
+### Diagnosis
+
+1. **Spurious kernel faults** on an address that is mapped; fault is non-deterministic and load-dependent.
+2. Check whether the erratum workaround boot message appears: `dmesg | grep -i erratum` or `dmesg | grep -i workaround`.
+3. Read `midr_el1` from sysfs: `cat /sys/devices/system/cpu/cpu0/regs/identification/midr_el1`. Decode the revision field.
+4. Cross-reference the silicon revision against the errata table in the kernel source. Check `arch/arm64/kernel/cpu_errata.c` (or the vendor equivalent) for the MIDR range.
+5. On debug kernels, `/sys/kernel/debug/cpu_features` or `/sys/kernel/debug/arm64_cpu_features` may list active workarounds.
+6. Confirm by patching the range to include r0p2, reboot, and verify the workaround message appears and spurious faults cease.
+
+### Fix
+
+Widen the MIDR revision range to include all affected silicon revisions. After the fix, verify with a production r0p2 device that the boot message appears. Add a comment referencing the errata ID and the affected revision range explicitly so future backports are easier to audit:
+
+```c
+/* Workaround for Cortex-A55 erratum NNNNNN.
+ * Affected: r0p0, r0p1, r0p2.
+ * See ARM erratum document ID NNNNNN, revision C. */
+static const struct midr_range affected_range[] = {
+    MIDR_RANGE(MIDR_CORTEX_A55, 0, 0, 0, 2),
+};
+```
+
+### Lesson
+
+Errata workarounds are safety-critical: an off-by-one in a MIDR revision range silently leaves devices unprotected. Every backport of an erratum fix must be validated against the actual silicon revision deployed in the target hardware. Reading `midr_el1` from sysfs is a one-line check that should be part of any bringup checklist. Boot-time messages confirming erratum activation are a valuable diagnostic signal — their absence is a warning.
+
+---
+
+## Summary
+
+| # | Bug | Root cause | Detection method | ARM64-specific? |
+|---|-----|-----------|-----------------|----------------|
+| 1 | SVE context switch corruption | Unmatched `kernel_neon_begin/end` breaks lazy FP save accounting | Userspace numerical errors; ftrace on fpsimd paths | Yes — lazy FPSIMD/SVE save is ARM64-specific |
+| 2 | Stale PTE after TLBI | Missing `dsb(ishst)` before TLB invalidate | Intermittent translation faults on recently remapped VA | Yes — ARM64 weak ordering; x86 TSO hides this |
+| 3 | Device reads stale DMA data | Non-coherent DMA without cache flush | Device transmits zeros; confirmed with `pgprot_noncached` | Partly — non-coherent DMA exists on other arches but common on embedded ARM64 |
+| 4 | BTI enforcement crash | JIT code missing `BTI c` landing pad instruction | SIGSEGV with ESR EC=0x24 BTI failure | Yes — ARMv8.5 BTI is ARM64-specific |
+| 5 | Erratum workaround not applied | MIDR revision range off-by-one in errata table | Spurious faults; no erratum boot message; `midr_el1` sysfs | Yes — ARM64 MIDR-based errata infrastructure |
+
+---
+
+## Further Reading
+
+- [Exception Model](exception-model.md) — EL0-EL3, ESR_EL1 syndrome decoding, SCTLR_EL1 control bits
+- [Memory Model](memory-model.md) — Weak ordering, DSB/ISB/DMB barriers, load-acquire/store-release
+- [Page Tables](page-tables.md) — PTE format, TLB management, `flush_tlb_range()` internals
+- [CPU Features](cpu-features.md) — Feature detection, MIDR_EL1 format, `arm64_errata[]` infrastructure, SVE/BTI/MTE capability probing
+- [Spectre and Meltdown](spectre-meltdown.md) — Speculative execution, erratum-driven mitigations, SMCCC firmware interfaces

--- a/docs/arch/arm64/war-stories.md
+++ b/docs/arch/arm64/war-stories.md
@@ -207,10 +207,10 @@ static int good_driver_tx(struct my_dev *dev, void *data, size_t len)
         kfree(buf);
         return -EIO;
     }
-    /* dma_map_single() with DMA_TO_DEVICE flushes (clean+invalidate)
+    /* dma_map_single() with DMA_TO_DEVICE cleans (but does not invalidate)
      * the affected cache lines on non-coherent platforms.
-     * On ARM64 this issues: dc civac (Data Cache Clean and Invalidate
-     * by VA to PoC) for each cache line in the buffer. */
+     * On ARM64 this issues: dc cvac (Data Cache Clean by VA to PoC)
+     * for each cache line in the buffer — clean only, not clean+invalidate. */
     program_dma(dev, dma_addr, len, DMA_TO_DEVICE);
     return 0;
 }
@@ -226,7 +226,7 @@ buf = dma_alloc_coherent(dev->dev, size, &dma_addr, GFP_KERNEL);
 /* CPU and device both see a consistent view; no flush needed */
 ```
 
-Whether a device requires explicit cache management depends on `dev->dma_coherent` (set from DT or ACPI describing the platform's coherency fabric) or the presence of an IOMMU that provides snooping. On platforms with a fully coherent interconnect, `dma_map_single()` is a no-op for cache management; on non-coherent platforms it does the necessary `dc civac` sequence.
+Whether a device requires explicit cache management depends on `dev->dma_coherent` (set from DT or ACPI describing the platform's coherency fabric) or the presence of an IOMMU that provides snooping. On platforms with a fully coherent interconnect, `dma_map_single()` is a no-op for cache management; on non-coherent platforms it does the necessary `dc cvac` sequence.
 
 ### Diagnosis
 
@@ -315,7 +315,7 @@ Note that BTI enforcement only applies to **pages mapped with** `PROT_BTI` (via 
 ### Diagnosis
 
 1. The crash backtrace points to the instruction immediately after `blr xN` where `xN` holds the JIT code address.
-2. Decode the ESR_EL1 from the signal info or `dmesg`: `EC=0x24`, ISS indicates BTI failure.
+2. Decode the ESR_EL1 from the signal info or `dmesg`: `EC=0x0D` (`ESR_ELx_EC_BTI`), ISS indicates BTI failure.
 3. Inspect the first 4 bytes of the JIT buffer: they should be `5f 24 03 d5` (`bti c`) but instead show the first instruction of the function body.
 4. Confirm BTI is active: `grep BTI /proc/$(pidof agent)/smaps` or check `/proc/cpuinfo` for `bti` in the Features line.
 5. Verify the binary's BTI note: `readelf -n /usr/bin/agent`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -490,6 +490,11 @@ nav:
       - Boot Sequence: arch/arm64/boot.md
       - Exception Model: arch/arm64/exception-model.md
       - Memory Model: arch/arm64/memory-model.md
+      - Page Tables: arch/arm64/page-tables.md
+      - Syscall Entry: arch/arm64/syscall-entry.md
+      - CPU Features and Alternatives: arch/arm64/cpu-features.md
+      - Spectre and Meltdown: arch/arm64/spectre-meltdown.md
+      - War Stories: arch/arm64/war-stories.md
     - x86:
       - Getting Started: arch/x86/README.md
       - Boot Sequence: arch/x86/boot.md


### PR DESCRIPTION
Closes #537

## Summary

Adds 5 new pages to `docs/arch/arm64/`, bringing it to full parity with x86 coverage (9 pages each):

- **`syscall-entry.md`** — SVC instruction ABI (x8=nr, x0–x5=args), exception vector dispatch through el0t_64_sync_handler (C function in entry-common.c) → el0_svc → invoke_syscall, struct pt_regs save/restore, sys_call_table, seccomp/ptrace tracing, AArch32 compat, vDSO (CNTVCT_EL0), observability
- **`page-tables.md`** — TTBR0/TTBR1 split, 48-bit VA decomposition, 4KB/16KB/64KB granule comparison, PTE bit format (AP, UXN/PXN, AttrIndx, AF/FEAT_HAFDBS, SH), huge page block descriptors, ASID management, MAIR_EL1 slots, required TLB sequence (DSB→TLBI→DSB→ISB), stage 2 for KVM
- **`cpu-features.md`** — ID register enumeration, struct arm64_cpu_capabilities, cpus_have_cap(), alternatives patching via .altinstructions (LSE atomics example), HWCAP_* and getauxval(AT_HWCAP), SVE lazy save with TIF_SVE/kernel_neon_begin/end, BTI (SCTLR_EL1.BT0 for EL0, BT1 for EL1), MTE tagging, errata MIDR range matching
- **`spectre-meltdown.md`** — Meltdown not applicable to most ARM64 (Cortex-A75 exception only); Spectre v1 (array_index_nospec/CSDB); Spectre v2 (CSV2, return trampolines); Spectre-BHB/CVE-2022-23960 (CSV2_3, CLRBHB, firmware loop, ECBHB); Spectre v4 (SSBS PSTATE bit, prctl); runtime state in proton-pack.c; vulnerability sysfs
- **`war-stories.md`** — Five real ARM64 bug patterns: SVE context switch corruption (FPEN vs ZEN distinction), missing DSB before TLBI, non-coherent DMA cache flush (dc cvac for DMA_TO_DEVICE), BTI enforcement crash (EC=0x0D), erratum workaround with wrong MIDR revision range

Also updates `mkdocs.yml` and `docs/arch/arm64/README.md` to list all pages.

## Test plan
- [x] `mkdocs build` passes (pre-existing unrelated warnings only)
- [x] LKML-style factual review round 1 + fixes: el0t_64_sync_handler in entry-common.c not entry.S, syscall_work is unsigned long, __secure_computing return semantics, cpu_switch_mm source file and no unconditional TLB flush, AF bit FEAT_HAFDBS caveat, SCTLR_EL1.BT0 vs BT1, arch_parse_elf_property(), this_cpu_has_cap() using cpu_hwcaps bitmap, erratum 1418040 is Cortex-A55, proton-pack.c not spectre.c, SSBS not SSBS_EL1, CPACR_EL1.ZEN for SVE, BTI EC=0x0D
- [x] LKML-style factual review round 2 + fixes: el0_svc call diagram entry-common.c; ptrace_report_syscall_entry() and SYSCALL_WORK_SYSCALL_TRACE (Linux 5.12+); 52-bit VA still 4 levels; ASID width from ID_AA64MMFR0_EL1 runtime detection; MIDR_CORTEX_A53=0x410FD030; SCTLR_EL1.TCF0 for MTE mode; CPACR_EL1.ZEN=0b11; sve_default_vector_length is default not max; remove incorrect CONFIG_ARM64_PSEUDO_NMI reference; Graviton3=Neoverse V1/Graviton4=Neoverse N2; dc cvac for DMA_TO_DEVICE; EC=0x0D for BTI