### PR TITLE
Add mm/kernel-address-space.md: the kernel half of the address space

### DIFF
--- a/docs/arch/x86/page-tables.md
+++ b/docs/arch/x86/page-tables.md
@@ -303,6 +303,8 @@ perf stat -e tlb:tlb_flush ls
 
 ## Kernel virtual address layout
 
+> Deep dive: [The Kernel Address Space](../../mm/kernel-address-space.md) covers each of these regions — the direct map, vmemmap, vmalloc, KASLR — and the rationale behind the layout.
+
 The 64-bit kernel virtual address space is divided into regions (values are for a typical 4-level paging, non-5-level system with `CONFIG_X86_64`):
 
 ```

--- a/docs/arch/x86/page-tables.md
+++ b/docs/arch/x86/page-tables.md
@@ -310,6 +310,7 @@ The 64-bit kernel virtual address space is divided into regions (values are for 
 ```
 Virtual address layout (x86-64, 4-level paging, kernel 6.x):
 
+ffff880000000000 - ffff887fffffffff  LDT remap area (for KPTI)
 ffff888000000000 - ffffc87fffffffff  Direct mapping of all physical memory (physmap)
                                      Accessed via __va() / __pa()
 ffffc90000000000 - ffffe8ffffffffff  vmalloc / ioremap area
@@ -317,7 +318,7 @@ ffffe90000000000 - ffffe9ffffffffff  Hole
 ffffea0000000000 - ffffeaffffffffff  Virtual memory map (struct page array)
 ffffec0000000000 - fffffbffffffffff  KASAN shadow memory (if CONFIG_KASAN)
 fffffe0000000000 - fffffe7fffffffff  cpu_entry_area (per-CPU entry trampoline, fixmap)
-fffffe8000000000 - fffffeffffffffff  LDT remap area
+fffffe8000000000 - fffffeffffffffff  Hole (LDT remap lived here before 4.20)
 ffffff0000000000 - ffffff7fffffffff  %esp fixup stacks
 ffffffef00000000 - fffffffeffffffff  EFI runtime services mapping
 ffffffff80000000 - ffffffff9fffffff  Kernel text (.text, .rodata)

--- a/docs/mm/README.md
+++ b/docs/mm/README.md
@@ -57,32 +57,33 @@ For comprehensive testing documentation, see [Documentation/dev-tools/testing-ov
 **Address Translation & Process Memory:**
 
 5. **[Page Tables](page-tables.md)** - Virtual address translation
-6. **[Process Address Space](mmap.md)** - VMAs, mmap, demand paging
+6. **[The Kernel Address Space](kernel-address-space.md)** - Direct map, vmemmap, vmalloc space, KASLR
+7. **[Process Address Space](mmap.md)** - VMAs, mmap, demand paging
 
 **Memory Pressure & Reclaim:**
 
-7. **[Page Reclaim](reclaim.md)** - LRU, kswapd, MGLRU
-8. **[Swap](swap.md)** - Extending memory to disk
-9. **[Page Cache](page-cache.md)** - File data caching
+8. **[Page Reclaim](reclaim.md)** - LRU, kswapd, MGLRU
+9. **[Swap](swap.md)** - Extending memory to disk
+10. **[Page Cache](page-cache.md)** - File data caching
 
 **Advanced Topics:**
 
-10. **[Memory Cgroups](memcg.md)** - Container memory limits
-11. **[NUMA](numa.md)** - Multi-node memory management
-12. **[Transparent Huge Pages](thp.md)** - Automatic huge pages
-13. **[Compaction](compaction.md)** - Memory defragmentation
-14. **[KSM](ksm.md)** - Page deduplication for VMs
+11. **[Memory Cgroups](memcg.md)** - Container memory limits
+12. **[NUMA](numa.md)** - Multi-node memory management
+13. **[Transparent Huge Pages](thp.md)** - Automatic huge pages
+14. **[Compaction](compaction.md)** - Memory defragmentation
+15. **[KSM](ksm.md)** - Page deduplication for VMs
 
 **End-to-End Walkthroughs:**
 
 After the fundamentals, these trace operations through the entire stack:
 
-15. **[Life of a malloc](life-of-malloc.md)** - From userspace to physical page
-16. **[Life of a page](life-of-page.md)** - Allocation through reclaim
-17. **[What happens when you fork](fork.md)** - COW mechanics
-18. **[Running out of memory](oom.md)** - The path to OOM kill
-19. **[Life of a file read](life-of-read.md)** - Page cache in action
-20. **[What happens during swapping](swapping.md)** - Swap-out and swap-in
+16. **[Life of a malloc](life-of-malloc.md)** - From userspace to physical page
+17. **[Life of a page](life-of-page.md)** - Allocation through reclaim
+18. **[What happens when you fork](fork.md)** - COW mechanics
+19. **[Running out of memory](oom.md)** - The path to OOM kill
+20. **[Life of a file read](life-of-read.md)** - Page cache in action
+21. **[What happens during swapping](swapping.md)** - Swap-out and swap-in
 
 ### What You'll Learn
 
@@ -119,6 +120,7 @@ After the fundamentals, these trace operations through the entire stack:
 | [vmalloc](vmalloc.md) | Virtually contiguous allocation |
 | [vrealloc](vrealloc.md) | Resizing allocations |
 | [page-tables](page-tables.md) | Virtual address translation |
+| [kernel-address-space](kernel-address-space.md) | The kernel half: direct map, vmemmap, KASLR |
 | [reclaim](reclaim.md) | What happens under memory pressure |
 | [memcg](memcg.md) | Container memory limits |
 | [thp](thp.md) | Transparent Huge Pages - automatic 2MB pages |

--- a/docs/mm/gup.md
+++ b/docs/mm/gup.md
@@ -175,6 +175,7 @@ dmesg | grep -iE "alloc_contig|cma:.*fail|migrat"
 - [VFIO Internals](../iommu/vfio-internals.md) — `pin_user_pages_remote()` for device DMA
 - [CMA](cma.md) — why pinned pages are the top cause of CMA allocation failure
 - [RCU in Memory Management](rcu-mm.md) — the lockless page-table walk fast GUP relies on
+- [The Kernel Address Space](kernel-address-space.md) — where the pages GUP returns actually live (the direct map)
 
 ### LWN articles
 

--- a/docs/mm/kernel-address-space.md
+++ b/docs/mm/kernel-address-space.md
@@ -24,7 +24,7 @@ ffff888000000000 ├────────────────────
                  │ direct map of all physical     │
                  │ memory ("physmap", 64 TB)      │   __va() / __pa()
 ffffc88000000000 ├────────────────────────────────┤
-                 │ hole (1 TB guard)              │
+                 │ hole (0.5 TB guard)            │
 ffffc90000000000 ├────────────────────────────────┤ ← VMALLOC_START
                  │ vmalloc / ioremap (32 TB)      │
 ffffe90000000000 ├────────────────────────────────┤
@@ -85,6 +85,9 @@ This is *the* payoff of 64-bit virtual addresses: 32-bit kernels couldn't map mo
 Two consequences worth internalizing:
 
 - **Every physical page has (at least) two virtual addresses.** A page mapped at `0x00007f...` in some process is *also* visible at `PAGE_OFFSET + phys` in the direct map. `kmalloc()` returns direct-map addresses; that's why `virt_to_phys()` works on kmalloc memory but not on vmalloc memory.
+- **The direct map's page tables are shared and huge.** The kernel maps it with 1 GB and 2 MB pages wherever possible (`init_mem_mapping()` in [arch/x86/mm/init.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/init.c)), so the whole of a large machine's RAM fits in a handful of TLB entries.
+
+One physical page, seen from every region:
 
 ```mermaid
 flowchart LR
@@ -100,7 +103,6 @@ flowchart LR
     V --> P
     M -. "describes" .-> P
 ```
-- **The direct map's page tables are shared and huge.** The kernel maps it with 1 GB and 2 MB pages wherever possible (`init_mem_mapping()` in [arch/x86/mm/init.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/init.c)), so the whole of a large machine's RAM fits in a handful of TLB entries.
 
 ### The cost: fragmentation and attack surface
 
@@ -136,6 +138,7 @@ Third major region: `VMALLOC_START` to `VMALLOC_END`, 32 TB of space for **virtu
 
 - **It's the escape hatch from physical contiguity.** After boot, large physically-contiguous allocations become unreliable (see [Compaction](compaction.md)); vmalloc trades TLB efficiency (4 KB mappings, unlike the direct map's huge pages) for guaranteed success on large sizes.
 - **It's where non-RAM mappings live.** `ioremap()` places device MMIO here; `vmap()` stitches arbitrary page sets into contiguous ranges.
+- **It hosts dynamic per-CPU memory.** When the boot-time per-CPU area fills up, `pcpu_alloc()` grabs new chunks from vmalloc space — that's why `pcpu_alloc` entries show up in `/proc/vmallocinfo`.
 - **Guard pages come free.** Each vmalloc area is separated from the next by an unmapped page, so linear overflows fault. This is exactly why kernel stacks moved into vmalloc space (`CONFIG_VMAP_STACK`, Linux 4.9, [LWN: Virtually mapped kernel stacks](https://lwn.net/Articles/692208/)): a stack overflow now hits a guard page and oopses cleanly instead of silently corrupting whatever was adjacent.
 
 The subtle cost of the region: vmalloc mappings modify the shared kernel page tables at PGD level lazily, which historically required `vmalloc_fault()` — a page-fault path that filled in another process's top-level entries on first touch. Modern kernels pre-populate the shared entries for the whole region at boot to avoid that class of fault entirely ([commit 6eb82f994026](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6eb82f994026), Linux 5.9).
@@ -164,7 +167,7 @@ Everything above describes the *compile-time* layout. With `CONFIG_RANDOMIZE_BAS
 | Direct map base | 1 GB (PUD) | shuffled within the region |
 | vmalloc base | 1 GB (PUD) | shuffled within the region |
 | vmemmap base | 1 GB (PUD) | shuffled within the region |
-| Module load base | small page-granular offset within the module area |
+| Module load base | 4 KB | small offset at the start of the module area |
 
 The region randomization lives in [arch/x86/mm/kaslr.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/kaslr.c): the direct map, vmalloc, and vmemmap keep their *order* but their bases are re-dealt within the available space, so an attacker who leaks a direct-map pointer learns nothing about where vmalloc or the kernel image landed.
 
@@ -178,13 +181,14 @@ The same concepts appear on arm64 ([arm64 memory model](../arch/arm64/memory-mod
 
 ---
 
-## Observing the layout
+## Try It Yourself
 
 ```bash
 # The authoritative map for your running kernel
 sudo cat /sys/kernel/debug/page_tables/kernel     # CONFIG_PTDUMP_DEBUGFS
-# Shows every kernel mapping with size (4K/2M/1G) and permissions —
-# you can watch direct-map huge pages split after loading a module
+# Shows every kernel mapping with size (4K/2M/1G) and permissions,
+# with region markers (vmalloc, vmemmap, ...) — you can watch
+# direct-map huge pages split after loading a module
 
 # Where did KASLR put things this boot?
 sudo grep -E "startup_64|_text" /proc/kallsyms     # kernel text base
@@ -193,11 +197,12 @@ sudo grep -E "startup_64|_text" /proc/kallsyms     # kernel text base
 # Direct map huge-page coverage (watch DirectMap4k grow = fragmentation)
 grep DirectMap /proc/meminfo
 
-# vmalloc region usage
+# vmalloc region usage (note the pcpu_alloc entries — per-CPU chunks)
 sudo cat /proc/vmallocinfo | head -20
 
-# struct page overhead (the vmemmap's population, roughly)
-grep -i memmap /proc/vmstat 2>/dev/null; grep Percpu /proc/meminfo
+# struct page overhead — i.e. how much RAM backs the vmemmap (6.11+)
+grep memmap /proc/vmstat
+# On older kernels, estimate it: MemTotal / 4096 * 64 bytes ≈ 1.6% of RAM
 
 # Prove kmalloc lives in the direct map and vmalloc doesn't:
 sudo cat /proc/vmallocinfo | awk '{print $1}' | head -3   # 0xffffc9... (vmalloc)
@@ -229,6 +234,7 @@ sudo cat /proc/vmallocinfo | awk '{print $1}' | head -3   # 0xffffc9... (vmalloc
 | Virtually-mapped stacks (`VMAP_STACK`) | 4.9 | Stacks moved into vmalloc for guard pages |
 | KPTI | 4.15 | Kernel half hidden while in userspace |
 | `memfd_secret()` | 5.14 | User pages removable from direct map |
+| cpu_entry_area randomization | 6.2 | Per-CPU areas shuffled after a KASLR bypass (CVE-2023-0597) |
 | 5-level paging layout | 4.14+ | Same structure, bigger constants |
 
 ---

--- a/docs/mm/kernel-address-space.md
+++ b/docs/mm/kernel-address-space.md
@@ -1,0 +1,258 @@
+# The Kernel Address Space
+
+> The direct map, vmemmap, vmalloc space, and KASLR — what lives in the kernel half of the address space, and why it's laid out the way it is
+
+Every 64-bit process has an address space split in half: the lower half belongs to userspace and changes on every context switch, while the upper half belongs to the kernel and is (almost) identical in every process. This page is a guided tour of that upper half on x86-64: what each region is *for*, why the regions are placed and sized the way they are, and what the design costs.
+
+If you want the translation mechanics (how a virtual address becomes a physical one), read [Page Tables](page-tables.md) and [x86-64 Page Tables](../arch/x86/page-tables.md) first. If you want to see this layout being *built* instruction by instruction at boot, read [x86_64 Boot Page Table Setup](boot-page-tables.md). This page is about the finished map and its rationale.
+
+---
+
+## The map
+
+The canonical reference is [Documentation/arch/x86/x86_64/mm.rst](https://docs.kernel.org/arch/x86/x86_64/mm.html). For 4-level paging (48-bit virtual addresses), the kernel half looks like this:
+
+```
+x86-64 kernel virtual address space (4-level paging):
+
+ffff800000000000 ┌────────────────────────────────┐ ← start of kernel half
+                 │ guard hole (8 TB, reserved     │
+                 │ for hypervisors)               │
+ffff888000000000 ├────────────────────────────────┤ ← PAGE_OFFSET
+                 │ direct map of all physical     │
+                 │ memory ("physmap", 64 TB)      │   __va() / __pa()
+ffffc88000000000 ├────────────────────────────────┤
+                 │ hole (1 TB guard)              │
+ffffc90000000000 ├────────────────────────────────┤ ← VMALLOC_START
+                 │ vmalloc / ioremap (32 TB)      │
+ffffe90000000000 ├────────────────────────────────┤
+                 │ hole (1 TB guard)              │
+ffffea0000000000 ├────────────────────────────────┤ ← VMEMMAP_START
+                 │ vmemmap: struct page array     │
+                 │ (1 TB)                         │   pfn_to_page() / page_to_pfn()
+ffffeb0000000000 ├────────────────────────────────┤
+                 │ unused hole                    │
+ffffec0000000000 ├────────────────────────────────┤
+                 │ KASAN shadow (16 TB, if        │
+                 │ CONFIG_KASAN)                  │
+fffffe0000000000 ├────────────────────────────────┤
+                 │ cpu_entry_area                 │   entry stacks, GDT, TSS
+fffffe8000000000 ├────────────────────────────────┤
+                 │ LDT remap (PTI), ESPFIX        │
+                 │ stacks, EFI runtime services   │
+ffffffff80000000 ├────────────────────────────────┤ ← __START_KERNEL_map
+                 │ kernel text + data (512 MB /   │
+                 │ 1 GB with KASLR)               │   .text, .rodata, .data, .bss
+ffffffffa0000000 ├────────────────────────────────┤ ← MODULES_VADDR
+                 │ module mapping space (~1.5 GB) │
+ffffffffff000000 ├────────────────────────────────┤
+                 │ fixmap + legacy vsyscall       │
+ffffffffffffffff └────────────────────────────────┘
+```
+
+Three observations before diving into individual regions:
+
+1. **Everything is separated by unmapped guard holes.** A stray pointer that runs off the end of one region faults instead of silently corrupting the next one.
+2. **The regions are absurdly oversized.** 64 TB of direct map, 32 TB of vmalloc — far more than any machine's RAM. Virtual address space in a 48-bit world is nearly free, so the layout spends it generously to keep region math simple and leave room for growth.
+3. **The same map exists in every process.** Kernel mappings use the Global bit and shared page-table pages: every process PGD contains the same entries for the kernel half, so a kernel pointer means the same thing regardless of which process was running when the kernel was entered. ([KPTI](../arch/x86/page-tables.md) complicates this: while running userspace, only a minimal subset of this map is present.)
+
+With 5-level paging (57-bit addresses, `CONFIG_X86_5LEVEL`), the same regions exist with the same ordering, just relocated and scaled up — the direct map grows to 32 PB and moves to `0xff11000000000000`. The layout is designed so the choice of paging depth changes constants, not structure.
+
+### The canonical hole
+
+Bits 63:48 of every valid address must be copies of bit 47 (sign extension). This hardware rule splits the address space into a "low" canonical half (`0x0000...` — userspace) and a "high" canonical half (`0xffff...` — kernel), with an enormous non-canonical gap between. The kernel gets the high half not by convention but because sign-extension makes "high half" cheap to test: any address with the top bit set is a kernel address. This is why kernel pointers all start with `0xffff` — and why a leaked pointer in a log file is instantly recognizable.
+
+---
+
+## The direct map: the kernel's view of RAM
+
+The single most important region is the **direct map** (also called the *linear map* or *physmap*): a mapping of *all* physical memory, in order, starting at `PAGE_OFFSET`.
+
+```c
+/* arch/x86/include/asm/page_64.h (simplified) */
+#define __va(x)  ((void *)((unsigned long)(x) + PAGE_OFFSET))
+#define __pa(x)  ((unsigned long)(x) - PAGE_OFFSET)
+```
+
+### Why map all of RAM permanently?
+
+Because the alternative is unbearable. The kernel constantly needs to touch arbitrary physical pages — a page it just allocated, a page cache page it's filling from disk, a page table page during a walk. Without a standing mapping, every such access would require creating a temporary mapping (as 32-bit kernels did with `kmap()` for highmem — a design so painful that killing it was a major motivation for going 64-bit). With the direct map, physical↔virtual conversion is one addition, no page table modification, no TLB shootdown.
+
+This is *the* payoff of 64-bit virtual addresses: 32-bit kernels couldn't map more than ~1 GB of RAM into their 1 GB kernel half, so "highmem" pages had no permanent kernel address. On x86-64 the address space is large enough that mapping all RAM costs nothing but page-table pages.
+
+Two consequences worth internalizing:
+
+- **Every physical page has (at least) two virtual addresses.** A page mapped at `0x00007f...` in some process is *also* visible at `PAGE_OFFSET + phys` in the direct map. `kmalloc()` returns direct-map addresses; that's why `virt_to_phys()` works on kmalloc memory but not on vmalloc memory.
+
+```mermaid
+flowchart LR
+    subgraph VA["Virtual addresses"]
+        U["user mapping<br/>0x00007f42a000<br/>(some process VMA)"]
+        D["direct-map alias<br/>PAGE_OFFSET + 0x1234000<br/>(always present)"]
+        V["vmalloc mapping<br/>0xffffc900...<br/>(only if vmap'd)"]
+        M["vmemmap entry<br/>vmemmap + pfn<br/>(the page's struct page)"]
+    end
+    P["physical page<br/>0x1234000"]
+    U --> P
+    D --> P
+    V --> P
+    M -. "describes" .-> P
+```
+- **The direct map's page tables are shared and huge.** The kernel maps it with 1 GB and 2 MB pages wherever possible (`init_mem_mapping()` in [arch/x86/mm/init.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/init.c)), so the whole of a large machine's RAM fits in a handful of TLB entries.
+
+### The cost: fragmentation and attack surface
+
+The direct map's huge pages are also its weakness. Features that change permissions on a *single* 4 KB page — `set_memory_ro()` for module text, `set_memory_np()` for [secretmem](https://lwn.net/Articles/812325/), DEBUG_PAGEALLOC — force the kernel to split a 1 GB or 2 MB direct-map page into 4 KB pages, permanently increasing TLB pressure for all kernel memory access. Direct-map fragmentation is a recurring performance topic on the mm lists, and it's why permission-changing APIs are used sparingly.
+
+The security story is sharper. Because *user* pages are also visible through the direct map, a kernel bug that lets an attacker dereference a controlled kernel address can reach user-controlled data at a kernel address — the *ret2dir* attack family. Responses to this shaped several modern features:
+
+- `memfd_secret()` (Linux 5.14) gives userspace pages that are **removed from the direct map** entirely — even a compromised kernel can't casually read them.
+- KVM's `guest_memfd` applies the same idea to confidential-VM guest memory.
+- The direct map is **not executable** (NX set), so having a second writable alias of a page can't be directly turned into code execution.
+
+---
+
+## vmemmap: the struct page array as an address-space trick
+
+The kernel tracks every physical 4 KB page with a `struct page` (see [Life of a page](life-of-page.md)). On a 1 TB machine that's 256 million of them — and the core mm code wants `pfn_to_page()` to be *fast*, because it runs in every allocator hot path:
+
+```c
+/* include/asm-generic/memory_model.h — CONFIG_SPARSEMEM_VMEMMAP */
+#define __pfn_to_page(pfn)  (vmemmap + (pfn))
+#define __page_to_pfn(page) ((unsigned long)((page) - vmemmap))
+```
+
+One addition. No lookup tables, no bounds checks. This works because of a deliberate illusion: `vmemmap` is a **virtually contiguous** array of `struct page` starting at `VMEMMAP_START`, indexed by physical frame number — but it is only *populated* where physical memory actually exists. Real RAM is rarely physically contiguous (firmware reserves holes, devices claim windows, NUMA nodes start at aligned boundaries), so a flat physical array would waste memory on struct pages for holes. Instead, `SPARSEMEM_VMEMMAP` maps the backing pages for the array on demand, section by section, and leaves the holes unmapped virtual space — spending cheap virtual addresses to make the *logical* array contiguous even though the *physical* backing isn't.
+
+The region is sized for the worst case: 64 TB of physical memory / 4 KB per page × 64 bytes per `struct page` = 1 TB of vmemmap. This is also the machinery that makes [memory hotplug](memory-hotplug.md) tractable — plugging in a new DIMM populates a new slice of vmemmap, and `pfn_to_page()` arithmetic never changes. Mike Rapoport's [LWN survey of memory models](https://lwn.net/Articles/789304/) tells the story of how FLATMEM and DISCONTIGMEM lost to this design.
+
+---
+
+## The vmalloc arena
+
+Third major region: `VMALLOC_START` to `VMALLOC_END`, 32 TB of space for **virtually contiguous, physically scattered** allocations. The [vmalloc](vmalloc.md) page covers the allocator itself; from the address-space perspective, what matters is *why this is a separate region*:
+
+- **It's the escape hatch from physical contiguity.** After boot, large physically-contiguous allocations become unreliable (see [Compaction](compaction.md)); vmalloc trades TLB efficiency (4 KB mappings, unlike the direct map's huge pages) for guaranteed success on large sizes.
+- **It's where non-RAM mappings live.** `ioremap()` places device MMIO here; `vmap()` stitches arbitrary page sets into contiguous ranges.
+- **Guard pages come free.** Each vmalloc area is separated from the next by an unmapped page, so linear overflows fault. This is exactly why kernel stacks moved into vmalloc space (`CONFIG_VMAP_STACK`, Linux 4.9, [LWN: Virtually mapped kernel stacks](https://lwn.net/Articles/692208/)): a stack overflow now hits a guard page and oopses cleanly instead of silently corrupting whatever was adjacent.
+
+The subtle cost of the region: vmalloc mappings modify the shared kernel page tables at PGD level lazily, which historically required `vmalloc_fault()` — a page-fault path that filled in another process's top-level entries on first touch. Modern kernels pre-populate the shared PGD entries for the whole region to avoid that class of fault entirely.
+
+---
+
+## The top 2 GB: kernel text and modules
+
+Kernel code doesn't run from the direct map. It gets its own alias at the very top of the address space, `__START_KERNEL_map = 0xffffffff80000000`, with modules immediately after. The placement is not aesthetic — it's an ABI constraint:
+
+- The kernel is compiled with `-mcmodel=kernel`, which lets the compiler assume every symbol fits in a **sign-extended 32-bit immediate** — i.e., lives in the top 2 GB of the address space. That makes every global reference a short instruction instead of a 64-bit constant load.
+- Modules must live within **±2 GB of kernel text** so that direct `call` instructions (32-bit relative displacement) reach kernel symbols without indirection. This is why the module area is glued to the kernel image, and why it's "only" ~1.5 GB in a space where every other region is measured in terabytes.
+
+So kernel text has *three* addresses: its physical address, its direct-map alias, and its `__START_KERNEL_map` alias — and `__pa()` on a text address needs different arithmetic than on a direct-map address (`__phys_addr()` handles both cases).
+
+---
+
+## KASLR: shuffling the map
+
+Everything above describes the *compile-time* layout. With `CONFIG_RANDOMIZE_BASE` and `CONFIG_RANDOMIZE_MEMORY` (both default on), boot-time KASLR randomizes, independently:
+
+| What | Granularity | Entropy source region |
+|------|-------------|----------------------|
+| Kernel text (physical load address) | 2 MB | anywhere RAM allows |
+| Kernel text (virtual) | 2 MB | 1 GB window at `__START_KERNEL_map` |
+| Direct map base | 1 GB (PUD) | shuffled within the region |
+| vmalloc base | 1 GB (PUD) | shuffled within the region |
+| vmemmap base | 1 GB (PUD) | shuffled within the region |
+| Module area base | randomized within its 1.5 GB |
+
+The region randomization lives in [arch/x86/mm/kaslr.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/kaslr.c): the direct map, vmalloc, and vmemmap keep their *order* but their bases are re-dealt within the available space, so an attacker who leaks a direct-map pointer learns nothing about where vmalloc or the kernel image landed.
+
+Honest assessment of the design ([LWN: Kernel address space layout randomization](https://lwn.net/Articles/569635/)): KASLR raises the bar from "compute the address" to "find an info leak first" — and kernel pointer leaks are common enough (`%p` hashing, `kptr_restrict`, and `dmesg_restrict` all exist to fight them) that KASLR is best understood as one layer, not a boundary. Some things deliberately *cannot* be randomized: `cpu_entry_area` stays at a fixed address because the syscall/interrupt entry code must find its stacks before it has loaded any randomized base, and the fixmap region exists precisely to give early boot and special features compile-time-constant addresses.
+
+---
+
+## How arm64 does it differently
+
+The same concepts appear on arm64 ([arm64 memory model](../arch/arm64/memory-model.md)) with one elegant hardware difference: instead of one page-table root (CR3) covering both halves, arm64 has **two** — `TTBR0_EL1` for the low (user) half and `TTBR1_EL1` for the high (kernel) half. The kernel half never changes on context switch, so switching processes touches only TTBR0; and the arm64 equivalent of KPTI (unmapping the kernel while in userspace) is a matter of pointing TTBR1 at a minimal table rather than maintaining paired PGDs. The arm64 layout also places the linear map at the *bottom* of the kernel half and the kernel image in vmalloc space — same ingredients, different plate.
+
+---
+
+## Observing the layout
+
+```bash
+# The authoritative map for your running kernel
+sudo cat /sys/kernel/debug/page_tables/kernel     # CONFIG_PTDUMP_DEBUGFS
+# Shows every kernel mapping with size (4K/2M/1G) and permissions —
+# you can watch direct-map huge pages split after loading a module
+
+# Where did KASLR put things this boot?
+sudo grep -E "startup_64|_text" /proc/kallsyms     # kernel text base
+# (non-root reads show 0000000000000000 — that's kptr_restrict working)
+
+# Direct map huge-page coverage (watch DirectMap4k grow = fragmentation)
+grep DirectMap /proc/meminfo
+
+# vmalloc region usage
+sudo cat /proc/vmallocinfo | head -20
+
+# struct page overhead (the vmemmap's population, roughly)
+grep -i memmap /proc/vmstat 2>/dev/null; grep Percpu /proc/meminfo
+
+# Prove kmalloc lives in the direct map and vmalloc doesn't:
+sudo cat /proc/vmallocinfo | awk '{print $1}' | head -3   # 0xffffc9... (vmalloc)
+# kmalloc pointers (visible in slabinfo debugging) start 0xffff888... (direct map)
+```
+
+---
+
+## Common issues
+
+**`DirectMap4k` keeps growing.** Loading/unloading modules, BPF programs, and anything using `set_memory_*()` splits direct-map huge pages, and splits are (mostly) never merged back. On long-running machines this is a real, measurable TLB-pressure regression — one reason BPF and module allocations moved toward shared executable-memory pools.
+
+**"vmalloc: allocation failure" on 64-bit.** Almost never actual space exhaustion (32 TB); usually it's fragmentation of a *sub*-region with tighter constraints (module space) or memory pressure during the backing-page allocation. Check `/proc/vmallocinfo` before assuming address-space exhaustion — and see [vmalloc](vmalloc.md).
+
+**Oops addresses tell you the region.** `0xffff888...` — direct map (likely slab / page allocator memory, see [SLUB internals](slab-internals.md)); `0xffffc9...` — vmalloc/ioremap; `0xffffea...` — vmemmap, meaning someone handed a bad pfn to `pfn_to_page()`; `0xffffffff8...`/`a...` — kernel text or modules, likely a function pointer gone wrong. Memorizing four prefixes turns raw oops dumps into a map. (KASLR shifts these bases, but the prefixes usually survive well enough to classify.)
+
+**NULL-ish but non-canonical pointer faults.** A "general protection fault" instead of a page fault on a bad dereference means the address was *non-canonical* — often a partially-overwritten pointer (e.g. the low bits of `0xffffffffffffffff` from an error code, or use-after-free poison like `0x6b6b6b6b6b6b6b6b`). The canonical hole is diagnostic gold.
+
+---
+
+## Version notes
+
+| Change | Linux version | Why it matters here |
+|--------|--------------|---------------------|
+| x86-64 port with direct map + high kernel text | 2.4/2.5 era | The layout's basic shape |
+| `SPARSEMEM_VMEMMAP` | 2.6.24 | O(1) `pfn_to_page()` via virtual array |
+| Kernel text KASLR (`RANDOMIZE_BASE`) | 3.14 | Text base randomized |
+| Memory-region KASLR (`RANDOMIZE_MEMORY`) | 4.8 | Direct map/vmalloc/vmemmap bases randomized |
+| Virtually-mapped stacks (`VMAP_STACK`) | 4.9 | Stacks moved into vmalloc for guard pages |
+| KPTI | 4.15 | Kernel half hidden while in userspace |
+| `memfd_secret()` | 5.14 | User pages removable from direct map |
+| 5-level paging layout | 4.14+ | Same structure, bigger constants |
+
+---
+
+## Further reading
+
+### Kernel source & documentation
+
+- [Documentation/arch/x86/x86_64/mm.rst](https://docs.kernel.org/arch/x86/x86_64/mm.html) — the canonical memory-map table (both 4- and 5-level)
+- [arch/x86/mm/kaslr.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/kaslr.c) — memory-region randomization, ~100 very readable lines
+- [arch/x86/mm/init_64.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/init_64.c) — direct map and vmemmap construction
+- [include/asm-generic/memory_model.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/asm-generic/memory_model.h) — `pfn_to_page()` across memory models
+- [Documentation/arch/arm64/memory.rst](https://docs.kernel.org/arch/arm64/memory.html) — the arm64 counterpart map
+
+### Related pages
+
+- [x86-64 Page Tables](../arch/x86/page-tables.md) — the translation machinery beneath this map, KPTI, PCID
+- [x86_64 Boot Page Table Setup](boot-page-tables.md) — how this layout is constructed at boot
+- [vmalloc](vmalloc.md) — the allocator that manages the vmalloc region
+- [Page Tables](page-tables.md) — arch-independent view
+- [Memory Hotplug](memory-hotplug.md) — vmemmap population at runtime
+- [arm64 Memory Model](../arch/arm64/memory-model.md) — the TTBR0/TTBR1 split in depth
+
+### LWN articles
+
+- [Memory: the flat, the discontiguous, and the sparse](https://lwn.net/Articles/789304/) — why vmemmap won; the history of memory models
+- [Kernel address space layout randomization](https://lwn.net/Articles/569635/) — KASLR's design and its honest limitations
+- [Virtually mapped kernel stacks](https://lwn.net/Articles/692208/) — why stacks moved into vmalloc space
+- [Keeping secrets in memfd areas](https://lwn.net/Articles/812325/) — the proposal that became `memfd_secret()`: removing pages from the direct map

--- a/docs/mm/kernel-address-space.md
+++ b/docs/mm/kernel-address-space.md
@@ -18,6 +18,8 @@ x86-64 kernel virtual address space (4-level paging):
 ffff800000000000 ┌────────────────────────────────┐ ← start of kernel half
                  │ guard hole (8 TB, reserved     │
                  │ for hypervisors)               │
+ffff880000000000 ├────────────────────────────────┤
+                 │ LDT remap for KPTI (0.5 TB)    │
 ffff888000000000 ├────────────────────────────────┤ ← PAGE_OFFSET
                  │ direct map of all physical     │
                  │ memory ("physmap", 64 TB)      │   __va() / __pa()
@@ -38,8 +40,8 @@ ffffec0000000000 ├────────────────────
 fffffe0000000000 ├────────────────────────────────┤
                  │ cpu_entry_area                 │   entry stacks, GDT, TSS
 fffffe8000000000 ├────────────────────────────────┤
-                 │ LDT remap (PTI), ESPFIX        │
-                 │ stacks, EFI runtime services   │
+                 │ ESPFIX stacks, EFI runtime     │
+                 │ services (with holes between)  │
 ffffffff80000000 ├────────────────────────────────┤ ← __START_KERNEL_map
                  │ kernel text + data (512 MB /   │
                  │ 1 GB with KASLR)               │   .text, .rodata, .data, .bss
@@ -104,10 +106,10 @@ flowchart LR
 
 The direct map's huge pages are also its weakness. Features that change permissions on a *single* 4 KB page — `set_memory_ro()` for module text, `set_memory_np()` for [secretmem](https://lwn.net/Articles/812325/), DEBUG_PAGEALLOC — force the kernel to split a 1 GB or 2 MB direct-map page into 4 KB pages, permanently increasing TLB pressure for all kernel memory access. Direct-map fragmentation is a recurring performance topic on the mm lists, and it's why permission-changing APIs are used sparingly.
 
-The security story is sharper. Because *user* pages are also visible through the direct map, a kernel bug that lets an attacker dereference a controlled kernel address can reach user-controlled data at a kernel address — the *ret2dir* attack family. Responses to this shaped several modern features:
+The security story is sharper. Because *user* pages are also visible through the direct map, a kernel bug that lets an attacker dereference a controlled kernel address can reach user-controlled data at a kernel address — the *ret2dir* attack family ([Kemerlis et al., USENIX Security 2014](https://www.usenix.org/conference/usenixsecurity14/technical-sessions/presentation/kemerlis)). Responses to this shaped several modern features:
 
-- `memfd_secret()` (Linux 5.14) gives userspace pages that are **removed from the direct map** entirely — even a compromised kernel can't casually read them.
-- KVM's `guest_memfd` applies the same idea to confidential-VM guest memory.
+- `memfd_secret()` (Linux 5.14, [LWN](https://lwn.net/Articles/865256/)) gives userspace pages that are **removed from the direct map** entirely — even a compromised kernel can't casually read them.
+- KVM's `guest_memfd` applies the same idea to confidential-VM guest memory ([LWN: Unmapping guest_memfd from the direct map](https://lwn.net/Articles/981306/)).
 - The direct map is **not executable** (NX set), so having a second writable alias of a page can't be directly turned into code execution.
 
 ---
@@ -136,7 +138,7 @@ Third major region: `VMALLOC_START` to `VMALLOC_END`, 32 TB of space for **virtu
 - **It's where non-RAM mappings live.** `ioremap()` places device MMIO here; `vmap()` stitches arbitrary page sets into contiguous ranges.
 - **Guard pages come free.** Each vmalloc area is separated from the next by an unmapped page, so linear overflows fault. This is exactly why kernel stacks moved into vmalloc space (`CONFIG_VMAP_STACK`, Linux 4.9, [LWN: Virtually mapped kernel stacks](https://lwn.net/Articles/692208/)): a stack overflow now hits a guard page and oopses cleanly instead of silently corrupting whatever was adjacent.
 
-The subtle cost of the region: vmalloc mappings modify the shared kernel page tables at PGD level lazily, which historically required `vmalloc_fault()` — a page-fault path that filled in another process's top-level entries on first touch. Modern kernels pre-populate the shared PGD entries for the whole region to avoid that class of fault entirely.
+The subtle cost of the region: vmalloc mappings modify the shared kernel page tables at PGD level lazily, which historically required `vmalloc_fault()` — a page-fault path that filled in another process's top-level entries on first touch. Modern kernels pre-populate the shared entries for the whole region at boot to avoid that class of fault entirely ([commit 6eb82f994026](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6eb82f994026), Linux 5.9).
 
 ---
 
@@ -162,11 +164,11 @@ Everything above describes the *compile-time* layout. With `CONFIG_RANDOMIZE_BAS
 | Direct map base | 1 GB (PUD) | shuffled within the region |
 | vmalloc base | 1 GB (PUD) | shuffled within the region |
 | vmemmap base | 1 GB (PUD) | shuffled within the region |
-| Module area base | randomized within its 1.5 GB |
+| Module load base | small page-granular offset within the module area |
 
 The region randomization lives in [arch/x86/mm/kaslr.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/kaslr.c): the direct map, vmalloc, and vmemmap keep their *order* but their bases are re-dealt within the available space, so an attacker who leaks a direct-map pointer learns nothing about where vmalloc or the kernel image landed.
 
-Honest assessment of the design ([LWN: Kernel address space layout randomization](https://lwn.net/Articles/569635/)): KASLR raises the bar from "compute the address" to "find an info leak first" — and kernel pointer leaks are common enough (`%p` hashing, `kptr_restrict`, and `dmesg_restrict` all exist to fight them) that KASLR is best understood as one layer, not a boundary. Some things deliberately *cannot* be randomized: `cpu_entry_area` stays at a fixed address because the syscall/interrupt entry code must find its stacks before it has loaded any randomized base, and the fixmap region exists precisely to give early boot and special features compile-time-constant addresses.
+Honest assessment of the design ([LWN: Kernel address space layout randomization](https://lwn.net/Articles/569635/)): KASLR raises the bar from "compute the address" to "find an info leak first" — and kernel pointer leaks are common enough (`%p` hashing, `kptr_restrict`, and `dmesg_restrict` all exist to fight them) that KASLR is best understood as one layer, not a boundary. Some things resist randomization: the `cpu_entry_area` *region* stays at a fixed base because the syscall/interrupt entry code must find its stacks before it has loaded any randomized base, and the fixmap region exists precisely to give early boot and special features compile-time-constant addresses. The fixed `cpu_entry_area` was in fact exploited as a KASLR bypass — since Linux 6.2 the per-CPU areas *within* the region are shuffled in response ([x86/mm: Randomize per-cpu entry area](https://lkml.org/lkml/2022/10/21/1130), CVE-2023-0597).
 
 ---
 

--- a/docs/mm/kernel-address-space.md
+++ b/docs/mm/kernel-address-space.md
@@ -256,6 +256,7 @@ sudo cat /proc/vmallocinfo | awk '{print $1}' | head -3   # 0xffffc9... (vmalloc
 - [vmalloc](vmalloc.md) — the allocator that manages the vmalloc region
 - [Page Tables](page-tables.md) — arch-independent view
 - [Memory Hotplug](memory-hotplug.md) — vmemmap population at runtime
+- [Getting User Pages (GUP)](gup.md) — how the direct-map pages get pinned for DMA
 - [arm64 Memory Model](../arch/arm64/memory-model.md) — the TTBR0/TTBR1 split in depth
 
 ### LWN articles

--- a/docs/mm/vmalloc.md
+++ b/docs/mm/vmalloc.md
@@ -4,7 +4,7 @@
 
 ## What is vmalloc?
 
-`vmalloc()` allocates memory that is contiguous in *virtual* address space but may be backed by non-contiguous physical pages. This makes it suitable for large allocations where physical contiguity isn't required.
+`vmalloc()` allocates memory that is contiguous in *virtual* address space but may be backed by non-contiguous physical pages. This makes it suitable for large allocations where physical contiguity isn't required. (For where the vmalloc region sits relative to the direct map and vmemmap — and why it's a separate region at all — see [The Kernel Address Space](kernel-address-space.md).)
 
 ```c
 void *vmalloc(unsigned long size);

--- a/docs/site-index.md
+++ b/docs/site-index.md
@@ -36,6 +36,7 @@ A complete listing of all documentation, organized by topic.
 | Page | Description |
 |------|-------------|
 | [Page Tables](mm/page-tables.md) | Virtual-to-physical address translation |
+| [The Kernel Address Space](mm/kernel-address-space.md) | Direct map, vmemmap, vmalloc space, KASLR |
 | [Process Address Space](mm/mmap.md) | VMAs, mmap, demand paging, COW |
 
 ### Caching & Reclaim

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Memory Hotplug: mm/memory-hotplug.md
     - Address Translation:
       - Page Tables: mm/page-tables.md
+      - Kernel Address Space: mm/kernel-address-space.md
       - Process Address Space: mm/mmap.md
       - Page Fault Handler: mm/page-fault.md
       - "vDSO: Fast Syscalls Without the Kernel": mm/vdso.md


### PR DESCRIPTION
## Summary

First content item from the refreshed roadmap (#126): a deep-dive on the x86-64 kernel virtual address space — the map itself and the *rationale* per region, complementing the existing translation-mechanics (`arch/x86/page-tables.md`) and boot-construction (`mm/boot-page-tables.md`) pages.

Covers:
- The full 4-level kernel-half map (per `Documentation/arch/x86/x86_64/mm.rst`), guard holes, canonical addressing
- **Direct map**: why all of RAM is permanently mapped, huge-page backing, fragmentation costs, ret2dir → `memfd_secret()`/`guest_memfd` story
- **vmemmap**: the O(1) `pfn_to_page()` design and why SPARSEMEM_VMEMMAP won
- **vmalloc arena**: why a separate region, guard pages, VMAP_STACK
- **Text/modules**: the `-mcmodel=kernel` ±2GB constraint
- **KASLR**: what's randomized at which granularity, what can't be, honest limits
- arm64 TTBR0/TTBR1 contrast, observability commands, oops-address-prefix debugging guide, version-notes table

## Wiring

- mkdocs nav (Address Translation group)
- `mm/README.md` reading order + topic table, `docs/site-index.md`
- Cross-linked from the site's most-visited page (`arch/x86/page-tables.md`)

## Verification

- `mkdocs build`: zero warnings from the new page (pre-existing warnings tracked in #540)
- All 17 internal links resolve
- All four LWN citation titles fetched and confirmed; SPARSEMEM_VMEMMAP=2.6.24 and other version claims spot-checked against sources