### PR TITLE
Fix all broken internal links and enforce strict builds in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install mkdocs mkdocs-material
+        run: pip install -r requirements.txt
 
       - name: Build site
-        run: mkdocs build
+        run: mkdocs build --strict
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/docs/io-uring/README.md
+++ b/docs/io-uring/README.md
@@ -269,4 +269,4 @@ io_uring_submit(&ring);
 
 ## Appendix
 
-- **[Glossary](../glossary.md)** — Terminology reference (SQE, CQE, SQPOLL, io-wq, fixed buffer, multishot)
+- **[Glossary](../mm/glossary.md)** — Terminology reference (SQE, CQE, SQPOLL, io-wq, fixed buffer, multishot)

--- a/docs/io/life-of-a-write.md
+++ b/docs/io/life-of-a-write.md
@@ -826,7 +826,7 @@ static void __submit_bio(struct bio *bio)
 
 `blk_mq_submit_bio` places the bio into the appropriate hardware dispatch queue, handles I/O scheduling (BFQ, mq-deadline, none), merges adjacent bios where possible, and ultimately calls the device driver's queue command function.
 
-For a deeper look at request queues, I/O schedulers, and driver dispatch, see the [block layer docs](../block/).
+For a deeper look at request queues, I/O schedulers, and driver dispatch, see the [block layer docs](../block/README.md).
 
 ## Stage 8: Barriers and persistence guarantees
 

--- a/docs/mm/bugs/README.md
+++ b/docs/mm/bugs/README.md
@@ -68,15 +68,15 @@ Bugs with assigned CVEs, typically exploitable for privilege escalation or infor
 | CVE-2024-26759 | Swap slot ABA | swap | Race/corruption | [swapping.md](../swapping.md#case-1-the-swap-slot-aba-problem-cve-2024-26759) |
 | CVE-2023-3269 | StackRot | maple tree | UAF | [fork.md](../fork.md#case-2-stackrot-cve-2023-3269) |
 | CVE-2023-6246 | glibc syslog | glibc heap | Overflow | [life-of-malloc.md](../life-of-malloc.md#case-1-glibc-heap-overflow-cve-2023-6246) |
-| CVE-2022-29582 | io_uring UAF | io_uring/slub | UAF | [slab.md](slab.md#case-2-io_uring-use-after-free-cve-2022-29582) |
-| CVE-2021-22555 | Netfilter heap OOB | netfilter/slub | Heap OOB | [slab.md](slab.md#case-1-netfilter-heap-out-of-bounds-cve-2021-22555) |
-| CVE-2020-29368 | THP COW race | thp | Race | [thp.md](thp.md#case-1-thp-cow-race-cve-2020-29368) |
+| CVE-2022-29582 | io_uring UAF | io_uring/slub | UAF | [slab.md](../slab.md#case-2-io_uring-use-after-free-cve-2022-29582) |
+| CVE-2021-22555 | Netfilter heap OOB | netfilter/slub | Heap OOB | [slab.md](../slab.md#case-1-netfilter-heap-out-of-bounds-cve-2021-22555) |
+| CVE-2020-29368 | THP COW race | thp | Race | [thp.md](../thp.md#case-1-thp-cow-race-cve-2020-29368) |
 | CVE-2018-18281 | mremap TLB race | mremap | TLB race | [fork.md](../fork.md#case-4-tlb-flush-races-in-mremap-cve-2018-18281) |
-| CVE-2017-5754 | Meltdown | CPU/page tables | Side channel | [page-tables.md](page-tables.md#case-1-meltdown-cve-2017-5754) |
-| CVE-2017-5753 | Spectre v1 | CPU | Side channel | [page-tables.md](page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
-| CVE-2017-5715 | Spectre v2 | CPU | Side channel | [page-tables.md](page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
+| CVE-2017-5754 | Meltdown | CPU/page tables | Side channel | [page-tables.md](../page-tables.md#case-1-meltdown-cve-2017-5754) |
+| CVE-2017-5753 | Spectre v1 | CPU | Side channel | [page-tables.md](../page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
+| CVE-2017-5715 | Spectre v2 | CPU | Side channel | [page-tables.md](../page-tables.md#case-2-spectre-cve-2017-5753-cve-2017-5715) |
 | CVE-2016-5195 | Dirty COW | COW | Race | [fork.md](../fork.md#case-1-dirty-cow-cve-2016-5195) |
-| CVE-2012-4398 | OOM deadlock | OOM | Deadlock | [oom.md](../oom.md#case-5-cve-2012-4398---oom-deadlock-denial-of-service) |
+| CVE-2012-4398 | OOM deadlock | OOM | Deadlock | [oom.md](../oom.md#case-5-cve-2012-4398-oom-deadlock-denial-of-service) |
 | CVE-2009-2695 | mmap_min_addr bypass | mmap | Logic | [life-of-malloc.md](../life-of-malloc.md#case-3-mmap_min_addr-bypass-cve-2009-2695) |
 | CVE-2004-0077 | mremap disaster | mremap | Logic | [fork.md](../fork.md#case-3-the-mremap-disaster-cve-2004-0077) |
 
@@ -108,7 +108,7 @@ Bugs causing severe performance degradation.
 |-----|------|-----------|---------|
 | Thrashing livelock | 2010+ | reclaim | [oom.md](../oom.md#case-3-the-thrashing-livelock-2010-mitigated-2018) |
 | Readahead trap | Ongoing | readahead | [swapping.md](../swapping.md#case-5-the-swap-readahead-trap) |
-| khugepaged CPU | Ongoing | thp | [thp.md](thp.md#case-3-khugepaged-cpu-storms) |
+| khugepaged CPU | Ongoing | thp | [thp.md](../thp.md#case-3-khugepaged-cpu-storms) |
 
 ---
 

--- a/docs/mm/oom.md
+++ b/docs/mm/oom.md
@@ -656,7 +656,7 @@ cat /sys/fs/cgroup/mycontainer/memory.events
 
 #### PSI - Pressure Stall Information (v4.20)
 
-Johannes Weiner (Facebook) added PSI to detect pressure *before* OOM (see [Case 3](#case-3-the-thrashing-livelock-2010-present) above).
+Johannes Weiner (Facebook) added PSI to detect pressure *before* OOM (see [Case 3](#case-3-the-thrashing-livelock-2010-mitigated-2018) above).
 
 **Commit**: [eb414681d5a0](https://git.kernel.org/linus/eb414681d5a0) ("psi: pressure stall information for CPU, memory, and IO") | [LKML](https://lore.kernel.org/linux-mm/20180529093107.13939-1-hannes@cmpxchg.org/)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.6.1
+mkdocs-material==9.7.7


### PR DESCRIPTION
## Summary

Closes #540 — first item of the hygiene queue from the roadmap (#126).

**Link fixes** (every warning from a real `mkdocs build`, no regex checkers):
- `mm/bugs/README.md`: 7 case-study links pointed at `bugs/`-local files that never existed; repointed to the actual `#case-*` anchors in `mm/slab.md`, `mm/thp.md`, `mm/page-tables.md`, plus one malformed anchor slug (`---` vs `-`)
- `mm/oom.md`: stale self-anchor after a heading rename
- `io-uring/README.md`: glossary path (`../glossary.md` → `../mm/glossary.md`)
- `io/life-of-a-write.md`: bare directory link → `../block/README.md`

**Build hardening:**
- `requirements.txt` with pinned `mkdocs==1.6.1` / `mkdocs-material==9.7.7` (also shields the build from the announced MkDocs 2.0 breakage)
- `deploy.yml` installs from it and builds with `--strict` — link rot now fails the build instead of deploying silently

## Verification

`mkdocs build --strict` exits 0 locally with zero warnings.