### PR TITLE
Refresh section READMEs and add topic inventory to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # Linux Kernel Internals
 
-A community hub for understanding the Linux kernel — documentation and discussions about design decisions, internals, and the journey of contributing.
+A community hub for understanding the Linux kernel — documentation and discussions about design decisions, internals, and the journey of contributing. Where docs.kernel.org explains *what* the kernel does, this site focuses on *why* it's designed that way: the trade-offs, the failed alternatives, and the LKML debates behind them.
 
 **[View the documentation](https://kernel-internals.org/)**
+
+## What's inside
+
+**375+ documents across 28 subsystems**, with sourced citations (kernel commits, LWN, lore) and end-to-end "life of a ..." walkthroughs.
+
+| Area | Sections |
+|------|----------|
+| Memory | [Memory management](docs/mm/) (90+ docs: allocators, reclaim, MGLRU, DAMON, CXL tiering, folios, THP…) · [IOMMU](docs/iommu/) |
+| CPU & scheduling | [Scheduler](docs/sched/) (EEVDF, deadline, EAS…) · [Locking & RCU](docs/locking/) · [Interrupts](docs/interrupts/) · [Time & timers](docs/time/) |
+| I/O & storage | [I/O paths](docs/io/) · [io_uring](docs/io-uring/) · [Block layer](docs/block/) · [VFS](docs/vfs/) · [Filesystems](docs/filesystems/) |
+| Networking | [Network stack](docs/net/) (XDP, AF_XDP, kTLS, netfilter, namespaces…) |
+| Architecture | [x86-64](docs/arch/x86/) (page tables, syscall entry, Spectre/Meltdown) · [arm64](docs/arch/arm64/) |
+| Isolation & security | [Security](docs/security/) (SELinux, Landlock, seccomp…) · [Cgroups & namespaces](docs/cgroups/) · [Virtualization/KVM](docs/virtualization/) |
+| Observability | [Tracing](docs/tracing/) · [BPF](docs/bpf/) · [Debugging](docs/debugging/) |
+| Kernel machinery | [Core kernel](docs/kernel/) · [Syscalls](docs/syscalls/) · [Modules](docs/modules/) · [Livepatch](docs/livepatch/) · [Drivers](docs/drivers/) · [IPC](docs/ipc/) · [Power](docs/power/) · [Crypto](docs/crypto/) |
+
+Or browse the [full site index](docs/site-index.md).
 
 ## Quick Links
 

--- a/docs/drivers/README.md
+++ b/docs/drivers/README.md
@@ -35,6 +35,9 @@ struct device_driver ←── struct pci_driver (driver-specific extension)
 | [Linux Device Model](device-model.md) | struct device, bus, driver, kobject, sysfs |
 | [Platform Drivers](platform-driver.md) | Platform bus, probe/remove, devm_, device tree |
 | [Character and Misc Devices](chardev.md) | cdev, file_operations, ioctl, mmap from driver side |
+| [PCI Drivers](pci-driver.md) | Enumeration, config space, BARs, MSI setup |
+| [I2C and SPI](i2c-spi.md) | Slow-bus drivers, regmap, device addressing |
+| [Device Tree](device-tree.md) | Hardware description for non-discoverable buses |
 
 ## Quick reference
 

--- a/docs/filesystems/README.md
+++ b/docs/filesystems/README.md
@@ -28,8 +28,11 @@ Application: open("/data/file", O_RDONLY)
 | Page | What it covers |
 |------|----------------|
 | [ext4](ext4.md) | On-disk layout, extents, journaling with jbd2 |
-| [tmpfs and ramfs](tmpfs.md) | Memory-backed filesystems, size limits |
+| [ext4 Journaling Deep Dive](ext4-journal.md) | jbd2 internals, ordered vs journaled data |
+| [XFS](xfs.md) | Allocation groups, delayed allocation, log design |
 | [btrfs](btrfs.md) | Copy-on-Write B-tree, subvolumes, snapshots |
+| [tmpfs and ramfs](tmpfs.md) | Memory-backed filesystems, size limits |
+| [overlayfs](overlayfs.md) | Union mounts, copy-up, container layers |
 
 ## Choosing a filesystem
 
@@ -40,5 +43,5 @@ Application: open("/data/file", O_RDONLY)
 | xfs | High-performance servers | High scalability |
 | tmpfs | /tmp, /run, shared memory | RAM-backed, fast |
 | overlayfs | Container images | Union of layers |
-| squashfs | Read-only (LiveCD, containers) | Compressed, read-only |
-| erofs | Android, embedded | Compressed, fast read |
+| squashfs | Read-only (LiveCD, containers) | Compressed, read-only — no dedicated page yet |
+| erofs | Android, embedded | Compressed, fast read — no dedicated page yet |

--- a/docs/net/README.md
+++ b/docs/net/README.md
@@ -1,0 +1,94 @@
+# Networking
+
+> From socket() to the wire: how packets traverse the Linux network stack
+
+## The stack at a glance
+
+```
+Application: send(fd, buf, len)
+        │
+        ▼
+   Socket layer          ← struct socket, protocol-agnostic API
+        │
+        ▼
+   TCP / UDP             ← congestion control, retransmission, ports
+        │
+        ▼
+   IP / routing          ← FIB lookup, netfilter hooks, fragmentation
+        │
+        ▼
+   Traffic control       ← qdiscs, shaping, prioritization
+        │
+        ▼
+   Device driver         ← NAPI, ring buffers, offloads
+        │
+        ▼
+      NIC                ← DMA, interrupts / polling
+```
+
+Every packet is carried by an [sk_buff](sk-buff.md) — start there if you read only one page.
+
+## Pages in this section
+
+### Fundamentals
+
+| Page | What it covers |
+|------|----------------|
+| [Network Stack Overview](network-stack-overview.md) | The layers and how they connect |
+| [Socket Layer](socket-layer.md) | struct socket, file descriptors, protocol families |
+| [sk_buff](sk-buff.md) | The packet data structure everything else shares |
+| [NAPI](napi.md) | Interrupt mitigation: from IRQ storm to polling |
+
+### Packet lifecycle
+
+| Page | What it covers |
+|------|----------------|
+| [Life of a Packet: RX](life-of-packet-rx.md) | NIC to application, step by step |
+| [Life of a Packet: TX](life-of-packet-tx.md) | Application to NIC, step by step |
+| [What Happens in connect()](connect.md) | Three-way handshake from the kernel's side |
+
+### TCP/IP
+
+| Page | What it covers |
+|------|----------------|
+| [TCP Internals](tcp.md) | State machine, buffers, timers |
+| [TCP Congestion Control](tcp-congestion.md) | CUBIC, BBR, pluggable algorithms |
+| [UDP](udp.md) | The thin path, and where it still surprises |
+| [IP Routing](ip-routing.md) | FIB, rules, multipath |
+| [epoll](epoll.md) | Readiness notification at scale |
+
+### Filtering & traffic control
+
+| Page | What it covers |
+|------|----------------|
+| [Netfilter](netfilter.md) | Hooks, tables, chains |
+| [nftables vs iptables](nftables-iptables.md) | Why the replacement happened |
+| [Connection Tracking](conntrack.md) | conntrack entries, NAT, helpers |
+| [Traffic Control (tc/qdisc)](tc-qdisc.md) | Queuing disciplines, shaping, fq_codel |
+
+### High performance & offload
+
+| Page | What it covers |
+|------|----------------|
+| [XDP](xdp.md) | Processing packets before the stack |
+| [AF_XDP](af-xdp.md) | Zero-copy userspace packet I/O |
+| [kTLS](ktls.md) | TLS record processing in the kernel |
+| [Packet Sockets](packet-socket.md) | AF_PACKET, tcpdump's view of the world |
+
+### Namespaces & virtualization
+
+| Page | What it covers |
+|------|----------------|
+| [Network Namespaces](net-namespaces.md) | Per-namespace stacks, veth pairs |
+| [Container Networking](container-networking.md) | Bridges, NAT, overlay basics |
+| [TUN/TAP](tun-tap.md) | Userspace network devices, VPNs |
+
+### Interfaces & observability
+
+| Page | What it covers |
+|------|----------------|
+| [Netlink](netlink.md) | The kernel's network configuration API |
+| [Network Debugging](net-debugging.md) | ss, ethtool, drop diagnostics |
+| [Network Tracing](net-tracing.md) | Tracepoints and BPF on the data path |
+| [Buffer Tuning](net-buffer-tuning.md) | Socket buffers, rmem/wmem, autotuning |
+| [/proc/net/snmp Reference](proc-snmp.md) | Reading the protocol counters |

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -25,8 +25,28 @@ Syscall entry
 
 ## Pages in this section
 
+### Access control
+
 | Page | What it covers |
 |------|----------------|
 | [LSM Framework](lsm.md) | LSM hooks, SELinux, AppArmor architecture |
+| [SELinux](selinux.md) | Labels, policy, AVC — how MAC decisions are made |
+| [Landlock](landlock.md) | Unprivileged sandboxing from userspace |
 | [Capabilities](capabilities.md) | Linux capability model, privilege dropping |
+| [Credentials](credentials.md) | struct cred, uid/euid/fsuid, credential lifecycle |
+| [User Namespaces](user-namespaces.md) | Unprivileged containers and their attack surface |
+
+### Syscall & kernel hardening
+
+| Page | What it covers |
+|------|----------------|
 | [seccomp BPF](seccomp.md) | Syscall filtering, libseccomp, container profiles |
+| [Kernel Hardening](kernel-hardening.md) | Stack protector, CFI, mitigations landscape |
+| [Audit](audit.md) | The audit subsystem, rules, and its cost |
+
+### Storage encryption
+
+| Page | What it covers |
+|------|----------------|
+| [fscrypt](fscrypt.md) | Filesystem-level encryption (ext4/f2fs) |
+| [dm-crypt](dm-crypt.md) | Block-level encryption, LUKS |

--- a/docs/tracing/README.md
+++ b/docs/tracing/README.md
@@ -30,8 +30,11 @@ Linux provides multiple complementary tracing mechanisms:
 | Page | What it covers |
 |------|----------------|
 | [ftrace](ftrace.md) | Function tracing, tracefs, ring buffer, trace-cmd |
+| [ftrace Advanced](ftrace-advanced.md) | Function graph, trigger actions, boot-time tracing |
 | [Kprobes and Tracepoints](kprobes-tracepoints.md) | kprobe/kretprobe, static tracepoints, TRACE_EVENT |
+| [uprobes and USDT](uprobes-usdt.md) | Userspace probes and static markers |
 | [perf Events](perf-events.md) | perf_event_open, PMU counters, sampling, flamegraphs |
+| [perf Profiling](perf-profiling.md) | CPU profiling workflows, flamegraph recipes |
 
 ## Quick reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,6 +212,7 @@ nav:
       - Scheduler Tracing: sched/sched-tracing.md
       - Scheduler Tuning: sched/sched-tuning.md
   - Networking:
+    - Getting Started: net/README.md
     - Fundamentals:
       - "Why Is the Network Stack So Complex?": net/network-stack-overview.md
       - "sk_buff: The Network Buffer": net/sk-buff.md


### PR DESCRIPTION
## Summary

Closes #541 — every section README now lists all of its pages, and the root README finally says what the site actually contains.

- **New `net/README.md`** — the second-largest section (28 docs) had no entry page at all; readers landing in net/ had no map. Now grouped: fundamentals, packet lifecycle, TCP/IP, filtering, high-performance, namespaces, observability. Added to nav.
- **`security/README.md`**: 3 → 12 pages listed, grouped by access control / hardening / storage encryption
- **`filesystems/README.md`**: page table now includes xfs, overlayfs, ext4-journal; the squashfs/erofs comparison rows are marked "no dedicated page yet" so they read as comparison data, not broken promises
- **`drivers/README.md`**: adds pci-driver, i2c-spi, device-tree
- **`tracing/README.md`**: adds ftrace-advanced, uprobes-usdt, perf-profiling
- **Root README**: adds the "why-focused, complements docs.kernel.org" positioning line and a grouped inventory of all 28 sections — prerequisite for the awesome-list submissions in #546

## Verification

`mkdocs build` produces **zero warnings from these changes**. (A full `--strict` pass on this branch still fails on the 8 pre-existing broken links that #548 fixes — merge #548 first, or in either order; the two PRs touch disjoint files.)