### PR TITLE
Add sourced Further Reading sections across arch/ docs

### DIFF
--- a/docs/arch/arm64/boot.md
+++ b/docs/arch/arm64/boot.md
@@ -306,6 +306,7 @@ cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq
 - [ARM64 Memory Model](memory-model.md) — TTBR0/TTBR1, page table format
 - [Page Tables](../../mm/page-tables.md) — host-side page table internals
 - [SMP](../../sched/context-switch.md) — secondary CPU initialization
-- `arch/arm64/kernel/head.S` — complete boot assembly
-- `arch/arm64/mm/mmu.c` — page table creation
+- [arch/arm64/kernel/head.S](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/kernel/head.S) — complete boot assembly
+- [arch/arm64/mm/mmu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/mm/mmu.c) — page table creation
+- [Booting AArch64 Linux](https://docs.kernel.org/arch/arm64/booting.html) — the boot contract between firmware/bootloader and kernel
 - ARM Architecture Reference Manual (ARM DDI 0487) — authoritative reference

--- a/docs/arch/arm64/cpu-features.md
+++ b/docs/arch/arm64/cpu-features.md
@@ -638,7 +638,7 @@ start_kernel()
   definition and all `ARM64_CPUCAP_*` type flags
 - `arch/arm64/include/asm/cpucaps.h` — enumeration of all `ARM64_*` capability
   indices and `ARM64_NCAPS`
-- `arch/arm64/kernel/cpufeature.c` — `arm64_features[]` table, detection logic,
+- [arch/arm64/kernel/cpufeature.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/kernel/cpufeature.c) — `arm64_features[]` table, detection logic,
   `update_cpu_capabilities()`, `apply_alternatives_all()` callsite
 - `arch/arm64/kernel/cpu_errata.c` — `arm64_errata[]` table with full MIDR
   match ranges and workaround descriptions

--- a/docs/arch/arm64/memory-model.md
+++ b/docs/arch/arm64/memory-model.md
@@ -291,4 +291,4 @@ dmesg | grep "data-race"
 - [Locking: RCU](../../locking/rcu.md) — how RCU uses barriers
 - [Memory Management: page tables](../../mm/page-tables.md) — page table barrier requirements
 - ARM Architecture Reference Manual — B2: The AArch64 Application Level Memory Model
-- `Documentation/memory-barriers.txt` in the kernel tree
+- [Documentation/memory-barriers.txt](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/memory-barriers.txt) — the kernel's memory-ordering bible

--- a/docs/arch/arm64/page-tables.md
+++ b/docs/arch/arm64/page-tables.md
@@ -412,4 +412,4 @@ cat /sys/kernel/debug/page_tables/kernel
 - [KVM Memory Virtualization](../../virtualization/kvm-memory.md) — Stage 2 page tables, EPT/NPT analog on ARM64
 - [TLB Optimization](../../mm/tlb-optimization.md) — batched TLB invalidation and mmu_gather
 - ARM Architecture Reference Manual (DDI 0487) — D5: AArch64 Virtual Memory System Architecture
-- `Documentation/arch/arm64/memory.rst` in the kernel tree — ARM64 virtual address layout
+- [Documentation/arch/arm64/memory.rst](https://docs.kernel.org/arch/arm64/memory.html) — ARM64 virtual address layout

--- a/docs/arch/arm64/spectre-meltdown.md
+++ b/docs/arch/arm64/spectre-meltdown.md
@@ -415,4 +415,5 @@ On recent hardware (Graviton3, Apple M-series, Cortex-X3+) CSV2_3 or ECBHB cover
 - [ARM64 CPU Features](cpu-features.md) — how the kernel detects and uses CPU feature bits at boot (system register approach vs. x86 CPUID)
 - ARM Architecture Reference Manual (ARM DDI 0487) — `ID_AA64PFR0_EL1` CSV2/CSV2_3 fields; `ID_AA64PFR1_EL1` SSBS field; `ID_AA64MMFR1_EL1` ECBHB field
 - ARM Security Advisory: Spectre-BHB (2022) — per-core BHB depth table and recommended loop counts
-- `Documentation/admin-guide/hw-vuln/spectre.rst` in the kernel tree — canonical kernel documentation for all spectre variants
+- [Spectre Side Channels](https://docs.kernel.org/admin-guide/hw-vuln/spectre.html) — canonical kernel documentation for all spectre variants
+- [LWN: Notes from the Intelpocalypse](https://lwn.net/Articles/742702/) — the disclosure and the kernel's response

--- a/docs/arch/arm64/war-stories.md
+++ b/docs/arch/arm64/war-stories.md
@@ -440,3 +440,5 @@ Errata workarounds are safety-critical: an off-by-one in a MIDR revision range s
 - [Page Tables](page-tables.md) — PTE format, TLB management, `flush_tlb_range()` internals
 - [CPU Features](cpu-features.md) — Feature detection, MIDR_EL1 format, `arm64_errata[]` infrastructure, SVE/BTI/MTE capability probing
 - [Spectre and Meltdown](spectre-meltdown.md) — Speculative execution, erratum-driven mitigations, SMCCC firmware interfaces
+- [Documentation/arch/arm64/silicon-errata.rst](https://docs.kernel.org/arch/arm64/silicon-errata.html) — the kernel's list of every worked-around erratum (Case 5's world)
+- [arch/arm64/kernel/cpu_errata.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/kernel/cpu_errata.c) — MIDR match ranges for erratum workarounds

--- a/docs/arch/x86/boot.md
+++ b/docs/arch/x86/boot.md
@@ -442,3 +442,19 @@ systemd-analyze blame
 - **5-level paging at boot**: if the CPU supports LA57 and the kernel is configured with `CONFIG_X86_5LEVEL=y`, `startup_64` sets up 5-level page tables. Introduced in Linux 4.14.
 - **UEFI stub**: the in-kernel EFI stub (`CONFIG_EFI_STUB`) was introduced in Linux 3.3, allowing kernels to be booted directly by UEFI without a bootloader.
 - **Compressed kernel formats**: gzip is the oldest; lz4, lzma, xz, zstd support was added incrementally; zstd (fastest decompression) was added in Linux 5.9.
+
+---
+
+## Further reading
+
+### Kernel source & documentation
+
+- [The Linux/x86 Boot Protocol](https://docs.kernel.org/arch/x86/boot.html) — the setup header, entry conventions, and protocol history
+- [arch/x86/boot/](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/boot/) — the real-mode setup code walked through above
+- [arch/x86/kernel/head_64.S](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/head_64.S) — `startup_64` and early paging setup
+
+### Related pages
+
+- [x86_64 Boot Page Table Setup](../../mm/boot-page-tables.md) — the early page tables in depth, KASLR, 5-level enablement
+- [memblock](../../mm/memblock.md) — the boot-time memory allocator this sequence hands off to
+- [ARM64 Boot Sequence](../arm64/boot.md) — the same journey on the other major architecture

--- a/docs/arch/x86/cpu-features.md
+++ b/docs/arch/x86/cpu-features.md
@@ -398,3 +398,19 @@ dmesg | grep -i pcid
 | UMIP enforcement | 4.19 | Automatically enabled if supported |
 | FSGSBASE instructions in kernel | 5.9 | `CR4.FSGSBASE` enabled |
 | `X86_BUG_*` flags for speculative execution | 4.15 | Meltdown/Spectre era |
+
+---
+
+## Further reading
+
+### Kernel source & documentation
+
+- [arch/x86/include/asm/cpufeatures.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/include/asm/cpufeatures.h) — the full feature-bit vocabulary (`X86_FEATURE_*`)
+- [arch/x86/kernel/cpu/common.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/common.c) — `get_cpu_cap()` and boot-time detection
+- [arch/x86/kernel/alternative.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/alternative.c) — the runtime patching engine behind `ALTERNATIVE`
+- [Intel SDM](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html) — Vol. 2A documents every CPUID leaf
+
+### Related pages
+
+- [ARM64 CPU Features](../arm64/cpu-features.md) — the system-register equivalent of CPUID, and arm64's alternatives engine
+- [Kernel Hardening](../../security/kernel-hardening.md) — mitigations selected via these feature/bug bits

--- a/docs/arch/x86/exceptions.md
+++ b/docs/arch/x86/exceptions.md
@@ -522,7 +522,7 @@ cat /proc/interrupts | head -5
 - [IRQ Handling](../../interrupts/interrupts.md) — external interrupt delivery
 - [Syscall Entry](../../syscalls/syscall-entry.md) — SYSCALL/SYSRET path in detail
 - [Kernel Hardening](../../security/kernel-hardening.md) — SMEP/SMAP, KPTI
-- `arch/x86/kernel/traps.c` — exception handler implementations
-- `arch/x86/mm/fault.c` — page fault handler
-- `arch/x86/entry/entry_64.S` — exception/syscall entry assembly
-- Intel SDM Vol 3A, Chapter 6 — Interrupt and Exception Handling
+- [arch/x86/kernel/traps.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/traps.c) — exception handler implementations
+- [arch/x86/mm/fault.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/fault.c) — page fault handler
+- [arch/x86/entry/entry_64.S](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/entry_64.S) — exception/syscall entry assembly
+- [Intel SDM](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html) Vol 3A, Chapter 6 — Interrupt and Exception Handling

--- a/docs/arch/x86/page-tables.md
+++ b/docs/arch/x86/page-tables.md
@@ -383,3 +383,26 @@ dmesg | grep -i "huge\|2M\|PMD"
 | 5-level paging (LA57) | 4.14 | `CONFIG_X86_5LEVEL`, CR4.LA57 |
 | KPTI (Meltdown fix) | 4.15 | Two PGDs, CR3 switch on entry/exit |
 | KPTI + PCID optimization | 4.15 | Dual-ASID scheme, `bit 63` no-flush |
+
+---
+
+## Further reading
+
+### Kernel source & documentation
+
+- [Documentation/arch/x86/x86_64/mm.rst](https://docs.kernel.org/arch/x86/x86_64/mm.html) — the canonical virtual memory layout tables
+- [arch/x86/include/asm/pgtable_types.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/include/asm/pgtable_types.h) — every `_PAGE_*` bit defined
+- [arch/x86/mm/tlb.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/mm/tlb.c) — CR3 switching, PCID/ASID management, KPTI CR3 assembly
+
+### Related pages
+
+- [Page Tables (generic)](../../mm/page-tables.md) — the arch-independent pgd/pud/pmd/pte view
+- [x86_64 Boot Page Table Setup](../../mm/boot-page-tables.md) — how these structures are first built
+- [TLB Optimization](../../mm/tlb-optimization.md) — flush batching above the architecture layer
+- [ARM64 Page Tables](../arm64/page-tables.md) — TTBR0/TTBR1 instead of one CR3
+
+### LWN articles
+
+- [KAISER: hiding the kernel from user space](https://lwn.net/Articles/738975/) — the design that became KPTI, written pre-Meltdown
+- [Notes from the Intelpocalypse](https://lwn.net/Articles/742702/) — Meltdown/Spectre and what they meant for the kernel
+- [Kernel address space layout randomization](https://lwn.net/Articles/569635/) — KASLR design and limitations

--- a/docs/arch/x86/spectre-meltdown.md
+++ b/docs/arch/x86/spectre-meltdown.md
@@ -437,3 +437,24 @@ grep . /sys/devices/system/cpu/vulnerabilities/*
 | May 2019 | MDS (Zombieload) disclosed; kernel 5.1 adds VERW flush |
 | Nov 2019 | TAA (TSX Async Abort); kernel 5.4 adds mitigation |
 | 2020+ | Continued stream of microarchitectural vulnerabilities; mitigations added per release |
+
+---
+
+## Further reading
+
+### Kernel source & documentation
+
+- [Spectre Side Channels](https://docs.kernel.org/admin-guide/hw-vuln/spectre.html) — the kernel's own admin-facing documentation of variants and mitigation controls
+- [arch/x86/kernel/cpu/bugs.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/bugs.c) — where every mitigation is selected and reported
+- [meltdownattack.com](https://meltdownattack.com/) — the original Meltdown and Spectre papers
+
+### Related pages
+
+- [Spectre and Meltdown on ARM64](../arm64/spectre-meltdown.md) — the same vulnerabilities through arm64's lens
+- [x86-64 Page Tables](page-tables.md) — KPTI mechanics: dual PGDs, PCID
+- [Kernel Hardening](../../security/kernel-hardening.md) — the broader mitigation landscape
+
+### LWN articles
+
+- [Notes from the Intelpocalypse](https://lwn.net/Articles/742702/) — the disclosure week, explained calmly
+- [KAISER: hiding the kernel from user space](https://lwn.net/Articles/738975/) — the KASLR defense that turned out to stop Meltdown

--- a/docs/arch/x86/syscall-entry.md
+++ b/docs/arch/x86/syscall-entry.md
@@ -431,3 +431,27 @@ grep entry_SYSCALL_64 /proc/kallsyms
 modprobe msr
 rdmsr 0xC0000082   # LSTAR — should match the above address
 ```
+
+---
+
+## Further reading
+
+### Kernel source & documentation
+
+- [arch/x86/entry/entry_64.S](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/entry_64.S) — `entry_SYSCALL_64` itself; unusually well commented
+- [arch/x86/entry/syscall_64.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/syscall_64.c) — the syscall table and `do_syscall_64()`
+
+### Man pages
+
+- [`syscall(2)`](https://man7.org/linux/man-pages/man2/syscall.2.html) — calling conventions for every architecture in one table
+- [`vdso(7)`](https://man7.org/linux/man-pages/man7/vdso.7.html) — which syscalls never enter the kernel
+
+### Related pages
+
+- [Syscall Entry Path](../../syscalls/syscall-entry.md) — the architecture-neutral view
+- [ARM64 Syscall Entry](../arm64/syscall-entry.md) — SVC instead of SYSCALL
+- [vDSO](../../mm/vdso.md) — the fast path in depth
+
+### LWN articles
+
+- [Anatomy of a system call, part 1](https://lwn.net/Articles/604287/) — the classic walkthrough of this exact path

--- a/docs/arch/x86/war-stories.md
+++ b/docs/arch/x86/war-stories.md
@@ -408,7 +408,7 @@ This case is also a good example of why the kernel's feature detection and alter
 
 ### Sources
 
-- [CVE-2012-0217 (NVD)](https://nvd.nist.gov/vuln/detail/CVE-2012-0217) — the AMD SYSRET canonical-address privilege escalation
+- [CVE-2012-0217 (NVD)](https://nvd.nist.gov/vuln/detail/CVE-2012-0217) — CVE-2012-0217, the SYSRET non-canonical-address privilege escalation (the vulnerable behavior is Intel's SYSRET; AMD CPUs are unaffected)
 - [arch/x86/kernel/tsc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/tsc.c) — TSC calibration and watchdog, scene of Case 2
 - [Spectre Side Channels](https://docs.kernel.org/admin-guide/hw-vuln/spectre.html) — retpoline and its interaction with indirect calls (Case 4)
 

--- a/docs/arch/x86/war-stories.md
+++ b/docs/arch/x86/war-stories.md
@@ -401,3 +401,19 @@ perf stat -e dTLB-load-misses,iTLB-load-misses -p $$ sleep 5
 CPUID feature bits cannot be assumed to be complete, consistent, or independent. A CPU can report PCID support while lacking INVPCID — a configuration that is useful in isolation (PCID works for normal context switches) but that the kernel's KPTI path could not use correctly without both. The fix required treating PCID and INVPCID as independent features and implementing the correct fallback for every combination.
 
 This case is also a good example of why the kernel's feature detection and alternative patching infrastructure exists: `X86_FEATURE_*` flags and the `cpu_has()` family of functions provide a single authoritative source of truth for capability checks, making it possible to audit all the places a feature is required and add missing checks consistently.
+
+---
+
+## Further reading
+
+### Sources
+
+- [CVE-2012-0217 (NVD)](https://nvd.nist.gov/vuln/detail/CVE-2012-0217) — the AMD SYSRET canonical-address privilege escalation
+- [arch/x86/kernel/tsc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/tsc.c) — TSC calibration and watchdog, scene of Case 2
+- [Spectre Side Channels](https://docs.kernel.org/admin-guide/hw-vuln/spectre.html) — retpoline and its interaction with indirect calls (Case 4)
+
+### Related pages
+
+- [x86-64 Syscall Entry](syscall-entry.md) — the SYSRET path exploited in Case 3
+- [Spectre and Meltdown](spectre-meltdown.md) — background for the KPTI and retpoline cases
+- [x86 CPU Features](cpu-features.md) — feature detection, INVPCID fallback (Case 5)


### PR DESCRIPTION
## Summary

First checkbox of #542 — and the highest-priority one: `arch/` holds the site's most-visited page (x86 page tables) yet had zero citations to LWN/lore/git.kernel.org/docs.kernel.org anywhere in 17 files.

**New sections** (6 x86 pages had no Further Reading at all): boot, cpu-features, page-tables, spectre-meltdown, syscall-entry, war-stories. Each follows the house style: kernel source links → docs → related pages → LWN.

**Augmented sections** (9 pages had link-free Further Reading): plain-text references like `` `arch/x86/kernel/traps.c` `` are now git.kernel.org links; `Documentation/...rst` mentions now point at docs.kernel.org (arm64 memory map, AArch64 booting contract, Spectre side channels, silicon errata registry); Intel SDM and ARM ARM references link to the vendors.

Notable citations: [KAISER](https://lwn.net/Articles/738975/) (the pre-Meltdown design that became KPTI), [Notes from the Intelpocalypse](https://lwn.net/Articles/742702/), [Anatomy of a system call](https://lwn.net/Articles/604287/), NVD entry for the SYSRET CVE, and the original Meltdown/Spectre papers.

## Verification

- **Every external URL was fetched and its title verified** before inclusion — no from-memory article numbers
- All new relative links resolve; `mkdocs build` shows zero warnings from these changes (full `--strict` goes green once #548 lands)