### PR TITLE
Improve readability of tables and inline code

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -27,9 +27,9 @@
    noticeable on the many comparison / version-notes / bit-layout tables.
    Nudge those specific spots up; body prose stays at Material's 16px/1.6. */
 
-/* Tables: 0.64rem -> 0.72rem  (~12.8px -> ~14.4px), roomier rows */
+/* Tables: 0.64rem -> 0.78rem  (~12.8px -> ~15.6px), roomier rows */
 .md-typeset table:not([class]) {
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   line-height: 1.5;
 }
 .md-typeset table:not([class]) th,
@@ -37,8 +37,8 @@
   padding: 0.5em 0.8em;
 }
 
-/* Inline code identifiers -> 0.9em (~14.4px). Scoped to inline only so the
+/* Inline code identifiers -> 0.95em (~15.2px). Scoped to inline only so the
    wide ASCII-diagram code blocks are left exactly as-is. */
 .md-typeset :not(pre) > code {
-  font-size: 0.9em;
+  font-size: 0.95em;
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -20,3 +20,25 @@
   font-size: 1.3rem;
   font-weight: 600;
 }
+
+/* --- Typography readability -------------------------------------------------
+   This site is table- and code-dense. Material renders tables at ~12.8px and
+   inline code at ~13.6px, which reads small against the 16px body prose — most
+   noticeable on the many comparison / version-notes / bit-layout tables.
+   Nudge those specific spots up; body prose stays at Material's 16px/1.6. */
+
+/* Tables: 0.64rem -> 0.72rem  (~12.8px -> ~14.4px), roomier rows */
+.md-typeset table:not([class]) {
+  font-size: 0.72rem;
+  line-height: 1.5;
+}
+.md-typeset table:not([class]) th,
+.md-typeset table:not([class]) td {
+  padding: 0.5em 0.8em;
+}
+
+/* Inline code identifiers -> 0.9em (~14.4px). Scoped to inline only so the
+   wide ASCII-diagram code blocks are left exactly as-is. */
+.md-typeset :not(pre) > code {
+  font-size: 0.9em;
+}


### PR DESCRIPTION
Targeted typography fix for the "text too small at times" feedback.

**Diagnosis:** body prose is fine (16px/1.6). The small-text spots are Material's defaults for this unusually table- and code-dense site:
- Tables: `0.64rem` (~12.8px)
- Inline code: `0.85em` (~13.6px)

**Change (`docs/stylesheets/extra.css` only, +22 lines):**
- Tables → `0.78rem` (~15.6px), `line-height: 1.5`, roomier cell padding (`0.5em 0.8em`)
- Inline code → `0.95em` (~15.2px), scoped to `:not(pre) > code` so the wide ASCII-diagram code blocks are left exactly as-is
- Body prose, headings, code blocks, and diagrams unchanged

**Why these selectors win the cascade (verified):** `extra.css` loads after Material's `main`/`palette` CSS; the table rule matches Material's own selector so source order wins, and the inline-code selector is more specific than Material's `.md-typeset code`.

No content changes. Rebased onto current `main`; `mkdocs build --strict` clean. Trivially tuned or reverted (one CSS file).