### PR TITLE
io-polling: fix stray nvme_process_cq reference

### DIFF
--- a/docs/io/io-polling.md
+++ b/docs/io/io-polling.md
@@ -285,7 +285,7 @@ CQ ring (4 entries):
   Driver detects it: phase bit at cq_head matches expected phase → new entry
 ```
 
-On the interrupt path, the driver does the same `nvme_process_cq()` work — but triggered by the interrupt handler rather than the poll loop. The code path from `nvme_process_cq()` onward is shared.
+On the interrupt path, the driver does the same `nvme_poll_cq()` work — but triggered by the interrupt handler (`nvme_irq()`) rather than the poll loop. The code path from `nvme_poll_cq()` onward is shared.
 
 ---
 


### PR DESCRIPTION
Follow-up to #559. One prose reference still named `nvme_process_cq()`, which does not exist in the kernel — both the poll loop and the IRQ handler (`nvme_irq()`) call `nvme_poll_cq()`. Corrected the name. Missed in the #559 snippet audit.

`mkdocs build --strict` passes.