### PR TITLE
Fix fabricated LWN citations in cow.md and war-stories-cves.md

### DIFF
--- a/docs/mm/cow.md
+++ b/docs/mm/cow.md
@@ -351,10 +351,9 @@ strace -f -e trace=clone,execve -o /tmp/trace.log /bin/ls
 
 ### LWN articles
 
-- [The Dirty COW vulnerability](https://lwn.net/Articles/704231/) (2016) - Security implications and root cause
-- [Revisiting get_user_pages() and COW](https://lwn.net/Articles/849638/) (2020) - John Hubbard's analysis of the problem
-- [Checking page "dirtiness" on the way out](https://lwn.net/Articles/827171/) (2020) - The FOLL_PIN solution
-- [Tracking page state with PG_anon_exclusive](https://lwn.net/Articles/893906/) (2022) - David Hildenbrand's solution
+- [Dirty COW and clean commit messages](https://lwn.net/Articles/704231/) (2016) - Jonathan Corbet on the Dirty COW race and its fix
+- [Patching until the COWs come home (part 1)](https://lwn.net/Articles/849638/) (2021) - Vlastimil Babka on the GUP-pin vs. COW data-leak problem
+- [get_user_pages() and COW, 2022 edition](https://lwn.net/Articles/895439/) (2022) - David Hildenbrand's PG_anon_exclusive solution
 
 ### Key LKML threads
 

--- a/docs/mm/war-stories-cves.md
+++ b/docs/mm/war-stories-cves.md
@@ -367,10 +367,10 @@ No single mitigation is complete. The value is in the combination: an attacker w
 
 ### LWN coverage
 
-- [The Dirty COW vulnerability](https://lwn.net/Articles/704231/) (2016) — root cause and initial fix
-- [Kernel page-table isolation](https://lwn.net/Articles/741878/) (2018) — KPTI design and performance
-- [Revisiting get_user_pages() and COW](https://lwn.net/Articles/849638/) (2020) — John Hubbard's analysis
-- [Tracking page state with PG_anon_exclusive](https://lwn.net/Articles/893906/) (2022) — David Hildenbrand's solution
+- [Dirty COW and clean commit messages](https://lwn.net/Articles/704231/) (2016) — Jonathan Corbet on the Dirty COW race and its fix
+- [The current state of kernel page-table isolation](https://lwn.net/Articles/741878/) (2017) — KPTI design, the Meltdown mitigation
+- [Patching until the COWs come home (part 1)](https://lwn.net/Articles/849638/) (2021) — Vlastimil Babka on the GUP-pin vs. COW problem
+- [get_user_pages() and COW, 2022 edition](https://lwn.net/Articles/895439/) (2022) — David Hildenbrand's PG_anon_exclusive solution
 
 ### Key kernel commits
 


### PR DESCRIPTION
Closes #561.

The Further-Reading LWN sections in both pages cited titles/authors/dates that don't match their URLs — the #539 fabrication pattern in already-live mm/ pages. Every URL verified against lwn.net.

## Corrections
| URL | Was (wrong) | Now (verified) |
|---|---|---|
| 704231 | "The Dirty COW vulnerability" | "Dirty COW and clean commit messages" (Corbet, 2016) |
| 741878 | "Kernel page-table isolation" (2018) | "The current state of kernel page-table isolation" (Corbet, 2017) |
| 849638 | "Revisiting get_user_pages() and COW" / Hubbard (2020) | "Patching until the COWs come home (part 1)" / Babka (2021) |
| 827171 | "Checking page dirtiness" / FOLL_PIN | **removed** — URL was "madvise MADV_DOEXEC" (unrelated) |
| 893906 | "Tracking page state with PG_anon_exclusive" | **removed** — URL was "The ongoing search for mmap_lock scalability" (unrelated) |
| **895439** | — | **added** "get_user_pages() and COW, 2022 edition" (Corbet, 2022) — the real PG_anon_exclusive source |

849638 was already cited correctly in `gup.md`; this aligns the two stragglers.

## Also checked (unchanged — verified correct)
- All 5 commit hashes in war-stories-cves.md (exist + match descriptions on the torvalds mirror)
- openwall / dirtycow.ninja / meltdownattack disclosure links (reachable)
- The 3 lore.kernel.org LKML threads could **not** be independently fetched (Anubis anti-bot); message-IDs are consistent with the known series but were not confirmed this pass.

## Note
This looks **systemic** — if these two pages' Further-Reading were fabricated this thoroughly, other pages likely are too. Recommend a follow-up audit across docs/ (distinct from #542, which tracks *missing* citations; this is *wrong* ones).

Verified with `mkdocs build --strict`.