### PR TITLE
CI: bump upload-pages-artifact to v5 (drop deprecated Node.js 20 dep)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 


### PR DESCRIPTION
Closes #514.

`actions/upload-pages-artifact@v4` transitively pins `actions/upload-artifact@v4.6.2`, which runs on the now-deprecated Node.js 20 (the exact action named in the CI warning). **v5.0.0** (released 2026-04-10) bumps that internal pin to `upload-artifact@v7.0.0` (Node.js 24), clearing the warning.

- Only input we use is `path: site`, unchanged across v4→v5 — drop-in.
- Note: the deploy job runs only on `main` (workflow_dispatch), so PR CI (`Build (strict)`) doesn't exercise it; the bump is verified on the next deploy after merge.

The issue's deadline (Node 20 forced off runners, 2026-06-02) has already passed, though deploys have kept working — so this clears the lingering warning and removes the risk.