### PR TITLE
Remove 5 fabricated LWN citations in mm/ (audit batch 1)

### DIFF
--- a/docs/mm/brk-vs-mmap.md
+++ b/docs/mm/brk-vs-mmap.md
@@ -370,7 +370,6 @@ watch -n 0.5 "grep -E 'VmRSS|VmData' /proc/<pid>/status"
 ### LWN articles
 
 - [LWN: Fun with `mmap()`](https://lwn.net/Articles/657338/) — deep dive into anonymous and file-backed mappings
-- [LWN: malloc() internals](https://lwn.net/Articles/250967/) — historical context for the `brk`/`mmap` split in allocators
 
 ### External
 

--- a/docs/mm/contiguous-memory.md
+++ b/docs/mm/contiguous-memory.md
@@ -315,5 +315,4 @@ Background compaction based on fragmentation levels, reducing direct compaction 
 - [Page allocator](page-allocator.md) - Buddy system and migrate types
 - [LWN: CMA](https://lwn.net/Articles/486301/) - CMA design and rationale
 - [LWN: Memory compaction](https://lwn.net/Articles/368869/) - Original compaction proposal
-- [LWN: In defense of fragmentation avoidance](https://lwn.net/Articles/226419/) - Mel Gorman's 2007 explanation of the approach
 - [Kernel docs: DMA API](https://docs.kernel.org/core-api/dma-api.html) - Using the DMA API correctly

--- a/docs/mm/memory-reservation.md
+++ b/docs/mm/memory-reservation.md
@@ -415,7 +415,6 @@ Visible in:
 - [`arch/x86/kernel/setup.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/setup.c) — `setup_arch()` orchestrating all x86 boot reservations in sequence
 - [`kernel/crash_reserve.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/crash_reserve.c) — `reserve_crashkernel_generic()` implementation
 - [LWN: memblock and early memory management](https://lwn.net/Articles/438225/) — how memblock replaced the earlier bootmem allocator and why flat arrays work for boot-time allocation (2011)
-- [LWN: kdump and crashkernel](https://lwn.net/Articles/249508/) — the crashkernel reservation and kexec-based capture kernel design (2007)
 - [memblock.md](memblock.md) — detailed coverage of the memblock allocator lifecycle, region merging, and transition to the buddy allocator
 - [cma.md](cma.md) — how `dma_contiguous_reserve()` carves out CMA regions within the memblock reservation phase
 - [memory-hotplug.md](memory-hotplug.md) — runtime counterpart to boot reservations: adding and removing physical memory after `memblock_free_all()`

--- a/docs/mm/numa-zonelist.md
+++ b/docs/mm/numa-zonelist.md
@@ -411,8 +411,6 @@ for (node = 0; node < nr_nodes; node++)
 
 ### LWN articles
 
-- [NUMA zonelist ordering](https://lwn.net/Articles/251063/) — the history of zonelist ordering modes and why node-order won out over zone-order
-- [Memory policies and the allocator](https://lwn.net/Articles/207848/) — how `MPOL_BIND`, `MPOL_INTERLEAVE`, and `MPOL_PREFERRED` map to zonelist traversal
 - [GFP flags and memory zones](https://lwn.net/Articles/629925/) — how GFP flags select zones and interact with the fallback list
 
 ### Related docs


### PR DESCRIPTION
Part of the mm/ citation audit (#563). Batch 1 of the per-URL verification found five LWN links that point at wrong or nonexistent articles. Verified against lwn.net:

| Page | URL | Claimed | Reality |
|---|---|---|---|
| contiguous-memory.md | 226419 | "In defense of fragmentation avoidance" | a reader comment about **Cinelerra** video editing |
| numa-zonelist.md | 207848 | "Memory policies and the allocator" | **404** |
| numa-zonelist.md | 251063 | "NUMA zonelist ordering" | **404** |
| memory-reservation.md | 249508 | "kdump and crashkernel" | **404** |
| brk-vs-mmap.md | 250967 | "malloc() internals" | Drepper's "What every programmer should know about memory" (off-topic) |

**Removed** rather than replaced — trust-first, so nothing false stays live; correct articles get backfilled later (tracked in #563). Each sits in a list that stays non-empty. Verified with `mkdocs build --strict`.