### PR TITLE
block, tracing: wire up cross-links among the new pages

### DIFF
--- a/docs/block/README.md
+++ b/docs/block/README.md
@@ -43,11 +43,15 @@ The relevant directories are `block/` (core, blk-mq, schedulers), `drivers/nvme/
 ### Suggested reading order
 
 1. **[Block Layer Overview](block-overview.md)** — the key structures and the submission path end to end
-2. **[bio and request structures](bio-request.md)** — the I/O descriptor objects, and how a `bio` becomes a `request`
-3. **[blk-mq: Multi-Queue Block Layer](blk-mq.md)** — software/hardware queues, tag allocation, and the driver interface
-4. **[I/O Schedulers](io-schedulers.md)** — BFQ, mq-deadline, and Kyber: what each optimizes for
-5. **[NVMe Driver](nvme.md)** — how a real modern driver plugs into blk-mq via submission/completion queues
-6. **[Device Mapper: dm-verity](dm-verity.md)** — stacking a virtual block device for integrity verification
+2. **[Life of a Block I/O](life-of-block-io.md)** — one I/O traced from `submit_bio()` down to the device and back
+3. **[bio and request structures](bio-request.md)** — the I/O descriptor objects, and how a `bio` becomes a `request`
+4. **[blk-mq: Multi-Queue Block Layer](blk-mq.md)** — software/hardware queues, tag allocation, and the driver interface
+5. **[I/O Schedulers](io-schedulers.md)** — BFQ, mq-deadline, and Kyber: what each optimizes for
+6. **[Block Cgroup (I/O Control)](blk-cgroup.md)** — dividing a device's bandwidth between cgroups
+7. **[NVMe Driver](nvme.md)** — how a real modern driver plugs into blk-mq via submission/completion queues
+8. **[Device Mapper: dm-verity](dm-verity.md)** — stacking a virtual block device for integrity verification
+9. **[Observability](block-observability.md)** — seeing what the block layer is doing, from counters to blktrace
+10. **[War Stories](war-stories.md)** — real block-layer bugs and what they taught
 
 ### What you'll learn
 
@@ -63,11 +67,15 @@ The relevant directories are `block/` (core, blk-mq, schedulers), `drivers/nvme/
 | Document | What you'll learn |
 |---|---|
 | [Block Layer Overview](block-overview.md) | Key structures (`bio`, `request`, `request_queue`) and the submission path |
+| [Life of a Block I/O](life-of-block-io.md) | One I/O traced end to end, submission through completion |
 | [bio and request structures](bio-request.md) | The I/O descriptor objects and their lifecycle |
 | [blk-mq: Multi-Queue Block Layer](blk-mq.md) | Software/hardware queues, tags, and the modern driver interface |
 | [I/O Schedulers](io-schedulers.md) | BFQ, mq-deadline, and Kyber |
+| [Block Cgroup (I/O Control)](blk-cgroup.md) | Dividing device bandwidth per cgroup (`io.max` / `io.weight` / `io.latency`) |
 | [NVMe Driver](nvme.md) | PCIe SSD architecture, submission/completion queues, blk-mq integration |
 | [Device Mapper: dm-verity](dm-verity.md) | Merkle-tree block integrity verification (Android, ChromeOS) |
+| [Observability](block-observability.md) | `/proc/diskstats`, `blktrace`, and BPF for block I/O |
+| [War Stories](war-stories.md) | Real block-layer incidents and their lessons |
 
 ## Further reading
 

--- a/docs/block/block-observability.md
+++ b/docs/block/block-observability.md
@@ -21,7 +21,7 @@ iostat -x 1 /dev/nvme0n1
 
 ## Level 2: per-request tracing — blktrace
 
-When the aggregates say "await is high" but not *where* the time went, `blktrace` records an event for **every stage of every request**. `blkparse` renders the trace, and each line is tagged with an action letter — the stages a request passes through on its way down the [block layer](block-overview.md):
+When the aggregates say "await is high" but not *where* the time went, `blktrace` records an event for **every stage of every request**. `blkparse` renders the trace, and each line is tagged with an action letter — the stages a request passes through on its way down, exactly as traced in [Life of a Block I/O](life-of-block-io.md):
 
 | Action | Meaning |
 |---|---|
@@ -59,7 +59,7 @@ bpftrace -e 'tracepoint:block:block_rq_complete { @[args->dev] = avg(nsecs); }'
 A practical diagnosis flow:
 
 1. **`iostat -x`** first. High `await` with low throughput and modest `%util` → the time is *upstream* (queuing, throttling, scheduler). High throughput at the device's known limit → simply saturated.
-2. If it looks upstream, **`blktrace | btt`** and compare **Q2D vs D2C**. Large Q2D means the block layer is holding the I/O — check the [I/O scheduler](io-schedulers.md) and any [cgroup I/O throttling](../cgroups/io-cgroup.md). Large D2C means the device (or its firmware) is the bottleneck.
+2. If it looks upstream, **`blktrace | btt`** and compare **Q2D vs D2C**. Large Q2D means the block layer is holding the I/O — check the [I/O scheduler](io-schedulers.md) and any [cgroup I/O throttling](blk-cgroup.md). Large D2C means the device (or its firmware) is the bottleneck.
 3. To attribute latency to *processes*, reach for **`biosnoop`** / **`biotop`**.
 
 ## Further reading

--- a/docs/tracing/README.md
+++ b/docs/tracing/README.md
@@ -76,11 +76,15 @@ Comfort with the shell and basic kernel concepts (processes, syscalls, interrupt
 | Page | What it covers |
 |------|----------------|
 | [ftrace](ftrace.md) | Function tracing, tracefs, ring buffer, trace-cmd |
-| [ftrace Advanced](ftrace-advanced.md) | Function graph, trigger actions, boot-time tracing |
+| [ftrace Advanced](ftrace-advanced.md) | Function graph, triggers, and how ftrace patches functions |
+| [Ring Buffer and tracefs](ring-buffer.md) | The lockless per-CPU buffer and the tracefs control surface |
+| [Trace Events and Dynamic Events](trace-events.md) | TRACE_EVENT, filters, triggers, and runtime kprobe/uprobe events |
 | [Kprobes and Tracepoints](kprobes-tracepoints.md) | kprobe/kretprobe, static tracepoints, TRACE_EVENT |
 | [uprobes and USDT](uprobes-usdt.md) | Userspace probes and static markers |
+| [BPF for Tracing](bpf-tracing.md) | bpftrace and BCC — in-kernel aggregation of events |
 | [perf Events](perf-events.md) | perf_event_open, PMU counters, sampling, flamegraphs |
 | [perf Profiling](perf-profiling.md) | CPU profiling workflows, flamegraph recipes |
+| [War Stories](war-stories.md) | Real tracing/observability incidents and their lessons |
 
 ## Quick reference
 

--- a/docs/tracing/trace-events.md
+++ b/docs/tracing/trace-events.md
@@ -2,7 +2,7 @@
 
 > The kernel's thousands of built-in instrumentation points — how they're defined, filtered, and triggered — and how to add your own at runtime
 
-The [ftrace](ftrace.md) ring buffer records events; **trace events** are what fills it. The kernel ships with thousands of them, and lets you attach your own. Understanding this layer is what turns "I can run a canned trace" into "I can ask the kernel a precise question."
+The [ring buffer](ring-buffer.md) records events; **trace events** are what fills it. The kernel ships with thousands of them, and lets you attach your own. Understanding this layer is what turns "I can run a canned trace" into "I can ask the kernel a precise question."
 
 ## Static trace events: `TRACE_EVENT`
 


### PR DESCRIPTION
Follow-up after merging the block (#569) and tracing (#576) epics. Each page could only link already-merged content while on its own branch; now that all 10 pages are on main, this connects them:

- **block/README** — reading order and Documentation table extended with Life-of-a-block-I/O, Block Cgroup, Observability, War Stories
- **tracing/README** — Documentation table extended with Ring Buffer, Trace Events, BPF-for-Tracing, War Stories
- **Prose links restored** — trace-events → ring-buffer; observability → Life-of-a-block-I/O and blk-cgroup (these were stubbed to main-resident pages during the batch)

Verified with `mkdocs build --strict`.