### PR TITLE
filesystems: expand the README stub into a real overview

### DIFF
--- a/docs/filesystems/README.md
+++ b/docs/filesystems/README.md
@@ -55,7 +55,7 @@ Familiarity with the [VFS](../vfs/README.md) (the layer above, which dispatches 
 |---|---|
 | "The filesystem writes files to disk" | It writes to the [page cache](../mm/page-cache.md); the real disk write is deferred to writeback, which is why [`fsync()`](../io/page-cache-writeback.md) exists |
 | "A journal logs everything" | ext4 defaults to journaling *metadata* only (`data=ordered`); full data journaling exists but roughly halves write throughput |
-| "Copy-on-write means snapshots" | CoW is a *crash-consistency* strategy first; snapshots fall out of it for free, because old tree roots are never overwritten |
+| "Copy-on-write means snapshots" | CoW is a *crash-consistency* strategy first; snapshots then come cheap — a snapshot is just an old tree root kept instead of reclaimed |
 | "Deleting a file frees its space" | Only the metadata immediately; actual reclamation on SSDs involves discard/TRIM, and on CoW filesystems, reference counting |
 
 ## Documentation
@@ -74,7 +74,7 @@ Familiarity with the [VFS](../vfs/README.md) (the layer above, which dispatches 
 | Filesystem | Use case | Key feature |
 |-----------|---------|-------------|
 | ext4 | General purpose, servers | Stable, journaled |
-| btrfs | Desktop, NAS | CoW, snapshots, RAID |
+| btrfs | Desktop, NAS | CoW, snapshots, RAID (0/1/10) |
 | xfs | High-performance servers | High scalability |
 | tmpfs | /tmp, /run, shared memory | RAM-backed, fast |
 | overlayfs | Container images | Union of layers |

--- a/docs/filesystems/README.md
+++ b/docs/filesystems/README.md
@@ -1,8 +1,12 @@
 # Filesystems
 
-> How data is organized and persisted on storage
+> How the kernel turns a flat array of disk blocks into named files with metadata — and keeps them consistent across a crash
 
-## The filesystem stack
+## Getting Started
+
+A block device is a linear array of fixed-size sectors; a *filesystem* is the code that imposes structure on it — a hierarchy of named files, their contents, and the metadata (sizes, timestamps, permissions, block maps) that ties them together. The structure is the easy part. The hard part is keeping it *consistent* when power fails mid-write — and almost every design decision a Linux filesystem makes is, at bottom, an answer to "how do we not corrupt everything on a crash?"
+
+This section explains the *why* behind the major Linux filesystems — the trade-offs behind journaling versus copy-on-write, extents versus block maps, in-place updates versus never overwriting — not just their on-disk formats.
 
 ```
 Application: open("/data/file", O_RDONLY)
@@ -14,7 +18,7 @@ Application: open("/data/file", O_RDONLY)
   Filesystem driver       ← ext4, btrfs, xfs, tmpfs, ...
           │
           ▼
-     Page cache           ← in-memory cache of disk blocks
+     Page cache           ← in-memory cache of file data
           │
           ▼
    Block layer (bio)      ← submits I/O to disk
@@ -23,7 +27,38 @@ Application: open("/data/file", O_RDONLY)
     Block device          ← NVMe, SATA, virtio-blk
 ```
 
-## Pages in this section
+### The one question every filesystem answers
+
+Writing a file touches several places on disk — the data blocks, the block map, the inode, the free-space bitmap. A crash *between* those writes leaves the filesystem inconsistent: an inode pointing at blocks the allocator still thinks are free, or data in blocks the inode doesn't yet reference. There are two dominant strategies:
+
+- **Journaling** (ext4, XFS) — write the intended changes to a **log** first and commit them atomically, then apply them in place. After a crash, replay the log. Updates still happen *in place*, but the journal makes them recoverable.
+- **Copy-on-write** (btrfs) — never overwrite live data. Write new versions into free space, then atomically flip a single pointer to the new tree root. A crash simply leaves the old, consistent tree intact.
+
+Nearly everything else — extents, delayed allocation, snapshots, checksums — follows from committing to one of these.
+
+### Prerequisites
+
+Familiarity with the [VFS](../vfs/README.md) (the layer above, which dispatches operations to these filesystems), the [page cache](../mm/page-cache.md) (where file data lives in memory), and the [block layer](../block/README.md) (below, which carries the I/O to the device).
+
+### Suggested reading order
+
+1. **[ext4](ext4.md)** — the default: extents, and journaling with jbd2
+2. **[ext4 Journaling Deep Dive](ext4-journal.md)** — jbd2 internals; ordered vs. journaled data modes
+3. **[XFS](xfs.md)** — allocation groups, delayed allocation, and a log built for scale
+4. **[btrfs](btrfs.md)** — the copy-on-write B-tree, subvolumes, and snapshots
+5. **[tmpfs and ramfs](tmpfs.md)** — a filesystem with no disk at all
+6. **[overlayfs](overlayfs.md)** — union mounts and copy-up, the basis of container images
+
+### What you'll learn
+
+| Textbook idea | Linux reality |
+|---|---|
+| "The filesystem writes files to disk" | It writes to the [page cache](../mm/page-cache.md); the real disk write is deferred to writeback, which is why [`fsync()`](../io/page-cache-writeback.md) exists |
+| "A journal logs everything" | ext4 defaults to journaling *metadata* only (`data=ordered`); full data journaling exists but roughly halves write throughput |
+| "Copy-on-write means snapshots" | CoW is a *crash-consistency* strategy first; snapshots fall out of it for free, because old tree roots are never overwritten |
+| "Deleting a file frees its space" | Only the metadata immediately; actual reclamation on SSDs involves discard/TRIM, and on CoW filesystems, reference counting |
+
+## Documentation
 
 | Page | What it covers |
 |------|----------------|
@@ -43,5 +78,10 @@ Application: open("/data/file", O_RDONLY)
 | xfs | High-performance servers | High scalability |
 | tmpfs | /tmp, /run, shared memory | RAM-backed, fast |
 | overlayfs | Container images | Union of layers |
-| squashfs | Read-only (LiveCD, containers) | Compressed, read-only — no dedicated page yet |
-| erofs | Android, embedded | Compressed, fast read — no dedicated page yet |
+| squashfs | Read-only (LiveCD, containers) | Compressed, read-only |
+| erofs | Android, embedded | Compressed, fast read |
+
+## Further reading
+
+- [Kernel docs: filesystems](https://docs.kernel.org/filesystems/index.html) — per-filesystem and VFS reference
+- [VFS](../vfs/README.md) · [page cache](../mm/page-cache.md) · [block layer](../block/README.md) — the layers above and below


### PR DESCRIPTION
Expands the filesystems section landing page (234w → ~640w) from a bare stack diagram + tables into a proper getting-started overview, matching the pattern established for block/ and tracing/.

## What changed
- **Framing:** the section now opens on the one question that drives every filesystem's design — *crash consistency* — and contrasts the two dominant strategies (journaling: ext4/XFS; copy-on-write: btrfs). Extents, delayed allocation, snapshots, and checksums are presented as consequences of that choice.
- **Getting Started** orientation + **Prerequisites** linking the layers above and below ([VFS](../vfs/README.md), [page cache](../mm/page-cache.md), [block layer](../block/README.md)).
- **Suggested reading order** over the six existing pages (ext4 → ext4-journal → XFS → btrfs → tmpfs → overlayfs).
- **Textbook-vs-reality** table (page cache vs disk, metadata-only journaling default, CoW-as-consistency, TRIM on delete).
- Kept the existing stack diagram, Documentation table, and Choosing-a-filesystem table.

No new pages linked — iomap / FUSE / crash-consistency (the other #583 sub-issues) will be wired in as they land.

Closes #584. Part of the filesystems epic #583.

`mkdocs build --strict` passes.