### PR TITLE
filesystems: backfill primary-source citations

### DIFF
--- a/docs/filesystems/btrfs.md
+++ b/docs/filesystems/btrfs.md
@@ -334,6 +334,7 @@ bpftrace -e 'kprobe:btrfs_file_write_iter { @[comm] = count(); }'
 - [Page Cache](../mm/page-cache.md) — page cache that Btrfs CoW writes through
 - [Copy-on-Write](../mm/cow.md) — process CoW vs filesystem CoW
 - [xattr](../vfs/xattr.md) — Btrfs stores xattrs in the subvolume tree
-- [Kernel docs: btrfs](https://docs.kernel.org/filesystems/btrfs.html) — features, RAID5/6 status, and administration
+- [Kernel docs: btrfs](https://docs.kernel.org/filesystems/btrfs.html) — feature overview and entry point to the btrfs documentation
+- [btrfs feature status](https://btrfs.readthedocs.io/en/latest/Status.html) — per-feature stability, including the RAID5/6 caveats
 - [A short history of btrfs (LWN)](https://lwn.net/Articles/342892/) — the design rationale, by Valerie Aurora
 - `fs/btrfs/` — Btrfs implementation

--- a/docs/filesystems/btrfs.md
+++ b/docs/filesystems/btrfs.md
@@ -334,5 +334,6 @@ bpftrace -e 'kprobe:btrfs_file_write_iter { @[comm] = count(); }'
 - [Page Cache](../mm/page-cache.md) — page cache that Btrfs CoW writes through
 - [Copy-on-Write](../mm/cow.md) — process CoW vs filesystem CoW
 - [xattr](../vfs/xattr.md) — Btrfs stores xattrs in the subvolume tree
+- [Kernel docs: btrfs](https://docs.kernel.org/filesystems/btrfs.html) — features, RAID5/6 status, and administration
+- [A short history of btrfs (LWN)](https://lwn.net/Articles/342892/) — the design rationale, by Valerie Aurora
 - `fs/btrfs/` — Btrfs implementation
-- `Documentation/filesystems/btrfs.rst`

--- a/docs/filesystems/btrfs.md
+++ b/docs/filesystems/btrfs.md
@@ -1,6 +1,6 @@
 # Btrfs: B-tree Filesystem
 
-> Copy-on-write B-tree layout, snapshots, subvolumes, and RAID. Created by Chris Mason at Oracle and merged into Linux 2.6.29 [(LWN)](https://lwn.net/Articles/342892/).
+> Copy-on-write B-tree layout, snapshots, subvolumes, and RAID. Created by Chris Mason at Oracle and merged into the mainline kernel in Linux 2.6.29. See [A short history of btrfs](https://lwn.net/Articles/342892/) (LWN) for the design story.
 
 ## Why Btrfs?
 

--- a/docs/filesystems/ext4-journal.md
+++ b/docs/filesystems/ext4-journal.md
@@ -314,6 +314,6 @@ blktrace -d /dev/sda1 -o - | blkparse -i - | grep -v "Q  W" | head -50
 - [Life of a write() Syscall](../vfs/life-of-write.md) — write path ending at JBD2
 - [Page Cache](../mm/page-cache.md) — dirty pages that JBD2 journals
 - [IOMMU DMA](../mm/dma.md) — journal I/O uses DMA
+- [Kernel docs: ext4 journal (jbd2)](https://docs.kernel.org/filesystems/ext4/journal.html) — the on-disk journal format
 - `fs/jbd2/` — JBD2 implementation
 - `fs/ext4/` — ext4 JBD2 integration
-- `Documentation/filesystems/ext4/` — ext4 on-disk format

--- a/docs/filesystems/ext4.md
+++ b/docs/filesystems/ext4.md
@@ -270,4 +270,5 @@ cat /proc/fs/ext4/sda1/mb_groups  # buddy allocator per-group state
 - [tmpfs and ramfs](tmpfs.md) — Memory-backed alternative
 - [btrfs](btrfs.md) — Copy-on-Write alternative
 - [VFS: Life of a write()](../vfs/life-of-write.md) — How writes reach ext4
-- `Documentation/filesystems/ext4/` — detailed on-disk format
+- [Kernel docs: ext4 data structures and algorithms](https://docs.kernel.org/filesystems/ext4/index.html) — the detailed on-disk format
+- [Kernel docs: ext4 high-level design](https://docs.kernel.org/filesystems/ext4/overview.html) — blocks, extents, and inodes

--- a/docs/filesystems/overlayfs.md
+++ b/docs/filesystems/overlayfs.md
@@ -277,5 +277,5 @@ df -i /var/lib/docker
 - [VFS: Filesystem Registration and Mounting](../vfs/mounting.md) — how overlayfs registers
 - [VFS: Path Resolution](../vfs/namei.md) — dentry lookup through overlayfs
 - [Memory Management: Copy-on-Write](../mm/cow.md) — page-level CoW vs file-level CoW
+- [Kernel docs: overlay filesystem](https://docs.kernel.org/filesystems/overlayfs.html) — semantics, copy-up, and multiple lower layers
 - `fs/overlayfs/` in the kernel tree — OverlayFS implementation
-- `Documentation/filesystems/overlayfs.rst` in the kernel tree

--- a/docs/filesystems/tmpfs.md
+++ b/docs/filesystems/tmpfs.md
@@ -172,3 +172,4 @@ docker run --tmpfs /tmp:size=512m,mode=1777 ubuntu bash
 - [btrfs](btrfs.md) — CoW persistent alternative
 - [Memory Management: mmap](../mm/mmap.md) — How tmpfs pages are faulted in
 - [IPC: Shared Memory](../ipc/shared-memory.md) — POSIX shm backed by tmpfs
+- [Kernel docs: tmpfs](https://docs.kernel.org/filesystems/tmpfs.html) — mount options (`size`, `nr_inodes`, `huge`) and semantics

--- a/docs/filesystems/xfs.md
+++ b/docs/filesystems/xfs.md
@@ -340,6 +340,8 @@ xfs_db -c 'freesp -d' /dev/sda1
 - [Btrfs](btrfs.md) — CoW filesystem comparison
 - [blk-mq](../block/blk-mq.md) — block layer XFS submits I/O through
 - [Page Cache](../mm/page-cache.md) — XFS uses page cache for buffered I/O
+- [Kernel docs: XFS](https://docs.kernel.org/filesystems/xfs/index.html) — XFS developer documentation
+- [Kernel docs: XFS delayed logging design](https://docs.kernel.org/filesystems/xfs/xfs-delayed-logging-design.html) — the log architecture in depth
+- [Kernel docs: XFS self-describing metadata](https://docs.kernel.org/filesystems/xfs/xfs-self-describing-metadata.html) — v5 on-disk format with per-block CRCs
 - `fs/xfs/` — XFS implementation
-- `Documentation/filesystems/xfs/` — XFS developer documentation
 - `xfsprogs` — mkfs.xfs, xfs_info, xfs_repair, xfs_scrub, xfs_io


### PR DESCRIPTION
Completes the citation backfill for the filesystems section (#585).

## What changed
Every page had its `Documentation/filesystems/...` reference as **plain text**. This converts them to clickable, verified `docs.kernel.org` links and adds landmark kernel-docs citations:

- **ext4** — [ext4 data structures](https://docs.kernel.org/filesystems/ext4/index.html) + [high-level design](https://docs.kernel.org/filesystems/ext4/overview.html)
- **ext4-journal** — [ext4 jbd2 journal format](https://docs.kernel.org/filesystems/ext4/journal.html)
- **xfs** — [XFS docs](https://docs.kernel.org/filesystems/xfs/index.html), [delayed-logging design](https://docs.kernel.org/filesystems/xfs/xfs-delayed-logging-design.html), [self-describing metadata](https://docs.kernel.org/filesystems/xfs/xfs-self-describing-metadata.html)
- **btrfs** — [btrfs kernel docs](https://docs.kernel.org/filesystems/btrfs.html) + ["A short history of btrfs" (LWN)](https://lwn.net/Articles/342892/)
- **tmpfs** — [tmpfs kernel docs](https://docs.kernel.org/filesystems/tmpfs.html)
- **overlayfs** — [overlay filesystem kernel docs](https://docs.kernel.org/filesystems/overlayfs.html)

## Verification
All added URLs return 200. Also **re-confirmed the pre-existing byline citations** against primary sources (they are real, not fabricated): ext4 extents [`a86c61812637`](https://git.kernel.org/linus/a86c61812637) ("ext3: add extent map support", Alex Tomas), overlayfs [`e9be9d5e76e3`](https://git.kernel.org/linus/e9be9d5e76e3) ("overlay filesystem", 3.18), btrfs LWN 342892. `mkdocs build --strict` passes.

Closes #585. **Completes the filesystems epic #583** (all six sub-issues: #584 #585 #586 #587 #588 #589).