### PR TITLE
usb: wire up cross-links among the USB pages

### DIFF
--- a/docs/usb/README.md
+++ b/docs/usb/README.md
@@ -79,6 +79,13 @@ When a device is plugged in, the hub driver sees the port change, the host **res
 
 Everything above is the **host** side. Linux can also *be* a USB peripheral — a phone presenting itself as storage, an embedded board exposing a serial console or Ethernet over USB. That is the **gadget** side: a USB Device Controller (UDC) driver plus a gadget function, usually composed through configfs. It's a separate stack, covered with the host-controller page.
 
+## The rest of this section
+
+1. **[Enumeration and Descriptors](enumeration.md)** — how a device announces itself and gets a driver bound
+2. **[URBs and Transfer Types](urbs.md)** — the unit of USB I/O and what each of the four transfer types guarantees
+3. **[Host Controllers and Gadget Mode](xhci-gadget.md)** — inside xHCI, and Linux acting as a USB *device*
+4. **[War Stories](war-stories.md)** — BadUSB, a MIDI double-free, and fuzzing the host stack from the device side
+
 ## Further reading
 
 - [Kernel docs: USB driver API](https://docs.kernel.org/driver-api/usb/index.html) — the authoritative reference for usbcore and HCDs

--- a/docs/usb/urbs.md
+++ b/docs/usb/urbs.md
@@ -49,7 +49,7 @@ For one-shot transfers where blocking is fine, usbcore provides synchronous wrap
 
 ## The four transfer types
 
-The endpoint's type (from its descriptor) determines how the core schedules the URB and what guarantees it gets.
+The endpoint's type (from its [descriptor](enumeration.md)) determines how the core schedules the URB and what guarantees it gets.
 
 ### Control — setup, configuration, small commands
 
@@ -84,4 +84,4 @@ Isochronous transfers reserve **guaranteed bandwidth** at configuration time and
 
 - [Kernel docs: USB Request Block (URB)](https://docs.kernel.org/driver-api/usb/URB.html) — the authoritative URB lifecycle reference
 - [Kernel docs: the USB core API](https://docs.kernel.org/driver-api/usb/usb.html) — the submit/complete interface
-- [USB overview](README.md) — where endpoints and their types come from
+- [USB overview](README.md) · [Enumeration and Descriptors](enumeration.md) — where endpoints and their types come from

--- a/docs/usb/war-stories.md
+++ b/docs/usb/war-stories.md
@@ -2,7 +2,7 @@
 
 > Three incidents that all trace back to one fact: USB is a bus where an *untrusted physical device* hands the kernel complex data to parse — and for years the kernel believed it
 
-USB's conveniences — self-describing devices, hot-plug, drivers auto-loaded by the IDs a device claims — are all forms of the kernel *trusting whatever plugs in*. Every story below is that trust being abused: a device lying about what it is, or feeding a descriptor parser input no real device would ever send.
+USB's conveniences — self-describing devices, hot-plug, drivers auto-loaded by the IDs a device claims — are all forms of the kernel *trusting whatever plugs in*. Every story below is that trust being abused: a device lying about what it is, or feeding a [descriptor](enumeration.md) parser input no real device would ever send.
 
 ## 1. BadUSB: the device that lies about what it is (2014)
 

--- a/docs/usb/xhci-gadget.md
+++ b/docs/usb/xhci-gadget.md
@@ -41,7 +41,7 @@ Everything above is the **host**. But a phone presenting itself as a flash drive
 ```
 
 - A **UDC (USB Device Controller) driver** is the device-side counterpart of the HCD: it drives the peripheral controller and presents endpoints to the gadget layer.
-- The **composite framework** lets a device be built from reusable **function** drivers, assembling their interface/endpoint descriptors into the configuration a host will read during enumeration — the same descriptors, now *served* rather than read.
+- The **composite framework** lets a device be built from reusable **function** drivers, assembling their interface/endpoint descriptors into the configuration a host will read during enumeration — the same descriptors from the [enumeration](enumeration.md) page, now *served* rather than read.
 - Functions can be bound at runtime through **configfs** under `/sys/kernel/config/usb_gadget/`: create a gadget, set its vendor/product IDs, instantiate functions (`mass_storage.0`, `acm.0`, `ecm.0`), link them into a configuration, and bind to a UDC to go live. **FunctionFS** goes further, letting a *userspace* program implement a function's endpoints (this is how Android's adb works).
 
 ## Dual-role and OTG


### PR DESCRIPTION
Cross-link pass for the USB section (epic #652), matching the block/tracing #644 pattern. Now that all five pages are on main:
- Restores the three sibling links delinked while pages were unmerged (urbs, xhci-gadget, war-stories → enumeration).
- Adds a **reading-order list** to the [overview](usb/README.md) linking enumeration → URBs → host-controllers → war-stories.

Purely additive linking; `mkdocs build --strict` passes.