### PR TITLE
filesystems: wire up cross-links among the new pages

### DIFF
--- a/docs/filesystems/README.md
+++ b/docs/filesystems/README.md
@@ -48,6 +48,10 @@ Familiarity with the [VFS](../vfs/README.md) (the layer above, which dispatches 
 4. **[btrfs](btrfs.md)** — the copy-on-write B-tree, subvolumes, and snapshots
 5. **[tmpfs and ramfs](tmpfs.md)** — a filesystem with no disk at all
 6. **[overlayfs](overlayfs.md)** — union mounts and copy-up, the basis of container images
+7. **[Crash Consistency and Recovery](crash-consistency.md)** — journaling vs. copy-on-write, and what `fsync()` really promises
+8. **[iomap](iomap.md)** — the modern extent-based I/O framework that replaced `buffer_head`
+9. **[FUSE](fuse.md)** — filesystems implemented in userspace
+10. **[War Stories](war-stories.md)** — ext4's `O_PONIES` saga, an overlayfs privilege escalation, and the btrfs write hole
 
 ### What you'll learn
 
@@ -68,6 +72,10 @@ Familiarity with the [VFS](../vfs/README.md) (the layer above, which dispatches 
 | [btrfs](btrfs.md) | Copy-on-Write B-tree, subvolumes, snapshots |
 | [tmpfs and ramfs](tmpfs.md) | Memory-backed filesystems, size limits |
 | [overlayfs](overlayfs.md) | Union mounts, copy-up, container layers |
+| [Crash Consistency and Recovery](crash-consistency.md) | Journaling vs CoW, flush/FUA, and `fsync()` durability |
+| [iomap](iomap.md) | The extent-based I/O framework behind XFS, ext4, and btrfs |
+| [FUSE](fuse.md) | Userspace filesystems: the `/dev/fuse` protocol and its costs |
+| [War Stories](war-stories.md) | ext4 `O_PONIES`, overlayfs CVE-2023-0386, the btrfs write hole |
 
 ## Choosing a filesystem
 

--- a/docs/filesystems/war-stories.md
+++ b/docs/filesystems/war-stories.md
@@ -2,23 +2,23 @@
 
 > Three incidents where a filesystem behaved *exactly as designed* and still lost data or handed out root — and what the kernel changed in response
 
-Filesystems fail in instructive ways. The bugs below aren't sloppy code; each one is a design decision colliding with reality — an optimization that widened a crash window, a container feature that trusted the wrong metadata, a RAID layer with no atomicity for its own updates. They map directly onto the concepts in crash consistency, [overlayfs](overlayfs.md), and [btrfs](btrfs.md).
+Filesystems fail in instructive ways. The bugs below aren't sloppy code; each one is a design decision colliding with reality — an optimization that widened a crash window, a container feature that trusted the wrong metadata, a RAID layer with no atomicity for its own updates. They map directly onto the concepts in [crash consistency](crash-consistency.md), [overlayfs](overlayfs.md), and [btrfs](btrfs.md).
 
 ## 1. ext4 and the empty files: delayed allocation meets `O_PONIES` (2009)
 
 When ext4 became a default, users upgrading from ext3 started reporting a shocking symptom: after a crash or hard power-off, recently-saved files — KDE config, session state, whole dotfiles — came back **zero length**. Data that "had been saved" was simply gone.
 
-Nothing was corrupt. This was delayed allocation working as intended. To choose good on-disk layout, ext4 defers picking physical blocks for freshly written data for up to ~30 seconds. Applications were saving files with the classic "atomic replace" idiom — write a new file, then `rename()` it over the old one — but *without* an `fsync()` in between. On ext3 the shorter allocation window and `data=ordered` behavior had made that pattern *usually* survive a crash. ext4's wider window turned "usually" into "usually not": after a crash, the rename had committed (metadata) but the data blocks were never allocated, leaving a valid directory entry pointing at an empty file.
+Nothing was corrupt. This was [delayed allocation](iomap.md) working as intended. To choose good on-disk layout, ext4 defers picking physical blocks for freshly written data for up to ~30 seconds. Applications were saving files with the classic "atomic replace" idiom — write a new file, then `rename()` it over the old one — but *without* an `fsync()` in between. On ext3 the shorter allocation window and `data=ordered` behavior had made that pattern *usually* survive a crash. ext4's wider window turned "usually" into "usually not": after a crash, the rename had committed (metadata) but the data blocks were never allocated, leaving a valid directory entry pointing at an empty file.
 
 The famous LKML thread that followed was, in effect, a fight over whether applications were owed durability they never asked for — Ted Ts'o's point was that **POSIX guarantees nothing without `fsync()`**, a position critics mockingly labeled the demand for "`O_PONIES`" (magical guarantees). But being *right* about POSIX doesn't help users. Ext4 added heuristics that detect exactly these idioms and force the data out: replacing a file via `rename()`, or truncating a file to zero and rewriting it, triggers writeback of the delayed-allocation blocks. The behavior is controlled by the **`auto_da_alloc`** mount option, on by default and [documented in the ext4 admin guide](https://docs.kernel.org/admin-guide/ext4.html).
 
-**Lesson:** the gap between what the standard promises and what applications *assume* is where data goes to die. A correct optimization that changes observable timing is a compatibility break. `fsync()` remains the only real guarantee.
+**Lesson:** the gap between what the standard promises and what applications *assume* is where data goes to die. A correct optimization that changes observable timing is a compatibility break. See [crash consistency](crash-consistency.md) for why `fsync()` remains the only real guarantee.
 
 ## 2. overlayfs copy-up and a path to root: CVE-2023-0386 (2023)
 
 [overlayfs](overlayfs.md) implements containers' layered images: a read-only lower layer, a writable upper layer, and **copy-up** — the first write to a lower-layer file copies it into the upper layer, preserving its metadata, including the setuid bit.
 
-The vulnerability chained two features. An unprivileged user, inside a user namespace, could set up a FUSE mount that served a file *claiming* to be a setuid-root binary owned by uid 0. Used as an overlayfs lower layer, copy-up faithfully carried the setuid bit and ownership up into the real upper filesystem — where the mapping was no longer confined to the namespace. The result was a genuine setuid-root binary on a normally-mounted filesystem: a straight path from unprivileged user to root.
+The vulnerability chained two features. An unprivileged user, inside a user namespace, could set up a [FUSE](fuse.md) mount that served a file *claiming* to be a setuid-root binary owned by uid 0. Used as an overlayfs lower layer, copy-up faithfully carried the setuid bit and ownership up into the real upper filesystem — where the mapping was no longer confined to the namespace. The result was a genuine setuid-root binary on a normally-mounted filesystem: a straight path from unprivileged user to root.
 
 The fix makes copy-up **verify the uid/gid actually map** into the mounter's namespace and refuse the operation otherwise ([`4f11ada10d0a`](https://git.kernel.org/linus/4f11ada10d0a) "ovl: fail on invalid uid/gid mapping at copy up"). Copying up a file whose owner can't be represented in the caller's credentials is exactly the case that must fail closed.
 
@@ -34,5 +34,6 @@ A RAID5 stripe is several data blocks plus one parity block computed across them
 
 ## Further reading
 
-- [overlayfs](overlayfs.md) · [btrfs](btrfs.md) — the subsystems these incidents live in
+- [Crash Consistency and Recovery](crash-consistency.md) — journaling vs CoW, and why `fsync()` is the only durability contract
+- [overlayfs](overlayfs.md) · [btrfs](btrfs.md) · [FUSE](fuse.md) — the subsystems these incidents live in
 - [Kernel docs: ext4 admin guide](https://docs.kernel.org/admin-guide/ext4.html) — `auto_da_alloc` and the other ext4 mount options


### PR DESCRIPTION
Cross-link pass for the filesystems section, matching the block/tracing #644 and USB #683 pattern. Now that crash-consistency, iomap, FUSE, and war-stories are all on main:
- Extends the [README](filesystems/README.md) suggested-reading-order (6 → 10) and Documentation table to include the four new pages.
- Restores the sibling links delinked while pages were unmerged: war-stories → [crash consistency](filesystems/crash-consistency.md), [delayed allocation/iomap](filesystems/iomap.md), and [FUSE](filesystems/fuse.md).

Purely additive linking; `mkdocs build --strict` passes. This completes the filesystems section wiring.