### PR TITLE
io-uring: fix 5 wrong LWN citations + label/description errors

### DIFF
--- a/docs/io-uring/README.md
+++ b/docs/io-uring/README.md
@@ -243,9 +243,9 @@ io_uring_submit(&ring);
 
 ### LWN Articles
 
-- [*The rapid growth of io_uring*](https://lwn.net/Articles/810414/) (2019) — early overview of capabilities and design rationale
-- [*An introduction to the io_uring asynchronous I/O framework*](https://lwn.net/Articles/776703/) (2019) — how it compares to existing async interfaces
-- [*io_uring and seccomp*](https://lwn.net/Articles/877165/) (2021) — security model and seccomp interaction
+- [*The rapid growth of io_uring*](https://lwn.net/Articles/810414/) (2020) — early overview of capabilities and design rationale
+- [*Ringing in a new asynchronous I/O API*](https://lwn.net/Articles/776703/) (2019) — how it compares to existing async interfaces
+- [*Operations restrictions for io_uring*](https://lwn.net/Articles/826053/) (2020) — security model and seccomp interaction
 
 ### Userspace Library
 

--- a/docs/io-uring/life-of-request.md
+++ b/docs/io-uring/life-of-request.md
@@ -1064,5 +1064,4 @@ The common thread: **io_uring's performance comes from eliminating synchronizati
 - [Ringing in a new asynchronous I/O API](https://lwn.net/Articles/776703/) (2019) — Original io_uring introduction by Jonathan Corbet
 - [The rapid growth of io_uring](https://lwn.net/Articles/810414/) (2020) — Feature expansion through 5.7
 - [io_uring and security](https://lwn.net/Articles/902466/) (2022) — Security concerns and mitigations
-- [io_uring in Android](https://lwn.net/Articles/945584/) (2023) — Production deployment considerations
-- [Avoiding the page cache with io_uring](https://lwn.net/Articles/863071/) (2021) — Direct I/O and fixed buffers
+- [Buffered I/O without page-cache thrashing](https://lwn.net/Articles/806980/) (2019) — Direct I/O and avoiding page-cache thrashing

--- a/docs/io-uring/life-of-request.md
+++ b/docs/io-uring/life-of-request.md
@@ -1063,5 +1063,5 @@ The common thread: **io_uring's performance comes from eliminating synchronizati
 
 - [Ringing in a new asynchronous I/O API](https://lwn.net/Articles/776703/) (2019) — Original io_uring introduction by Jonathan Corbet
 - [The rapid growth of io_uring](https://lwn.net/Articles/810414/) (2020) — Feature expansion through 5.7
-- [io_uring and security](https://lwn.net/Articles/902466/) (2022) — Security concerns and mitigations
-- [Buffered I/O without page-cache thrashing](https://lwn.net/Articles/806980/) (2019) — Direct I/O and avoiding page-cache thrashing
+- [Security requirements for new kernel features](https://lwn.net/Articles/902466/) (2022) — What new-feature submissions (io_uring included) are expected to address on the security front
+- [Buffered I/O without page-cache thrashing](https://lwn.net/Articles/806980/) (2019) — `RWF_UNCACHED`, a buffered-I/O mode that avoids polluting the page cache

--- a/docs/io-uring/life-of-request.md
+++ b/docs/io-uring/life-of-request.md
@@ -1062,6 +1062,6 @@ The common thread: **io_uring's performance comes from eliminating synchronizati
 ### LWN articles
 
 - [Ringing in a new asynchronous I/O API](https://lwn.net/Articles/776703/) (2019) — Original io_uring introduction by Jonathan Corbet
-- [The rapid growth of io_uring](https://lwn.net/Articles/810414/) (2020) — Feature expansion through 5.7
+- [The rapid growth of io_uring](https://lwn.net/Articles/810414/) (2020) — Feature expansion through 5.6
 - [Security requirements for new kernel features](https://lwn.net/Articles/902466/) (2022) — What new-feature submissions (io_uring included) are expected to address on the security front
 - [Buffered I/O without page-cache thrashing](https://lwn.net/Articles/806980/) (2019) — `RWF_UNCACHED`, a buffered-I/O mode that avoids polluting the page cache

--- a/docs/io-uring/security.md
+++ b/docs/io-uring/security.md
@@ -199,5 +199,5 @@ The kernel audit subsystem emits records for `io_uring_setup` and `io_uring_regi
 - `io_uring/rsrc.c` — fixed buffer and credential registration, CVE-2023-2598 site
 - `io_uring/io-wq.c` — worker thread pool implementation
 - `include/uapi/linux/io_uring.h` — `IORING_RESTRICTION_*` constants and `struct io_uring_restriction`
-- [Linux 5.12 LSM io_uring hooks](https://lwn.net/Articles/853478/) — LWN article on SELinux/AppArmor io_uring object class
+- [Auditing io_uring](https://lwn.net/Articles/858023/) — LWN article on LSM/audit hooks for io_uring, including SELinux and AppArmor
 - [CVE-2022-29582 writeup (Qualys)](https://www.qualys.com/2022/05/02/cve-2022-29582/lpe-io-uring.txt) — detailed exploitation analysis

--- a/docs/io-uring/security.md
+++ b/docs/io-uring/security.md
@@ -199,5 +199,5 @@ The kernel audit subsystem emits records for `io_uring_setup` and `io_uring_regi
 - `io_uring/rsrc.c` — fixed buffer and credential registration, CVE-2023-2598 site
 - `io_uring/io-wq.c` — worker thread pool implementation
 - `include/uapi/linux/io_uring.h` — `IORING_RESTRICTION_*` constants and `struct io_uring_restriction`
-- [Auditing io_uring](https://lwn.net/Articles/858023/) — LWN article on LSM/audit hooks for io_uring, including SELinux and AppArmor
+- [Auditing io_uring](https://lwn.net/Articles/858023/) — LWN article on adding LSM and audit hooks to io_uring
 - [CVE-2022-29582 writeup (Qualys)](https://www.qualys.com/2022/05/02/cve-2022-29582/lpe-io-uring.txt) — detailed exploitation analysis

--- a/docs/io-uring/war-stories.md
+++ b/docs/io-uring/war-stories.md
@@ -468,7 +468,7 @@ Bugs in io_uring tend to be discovered not through fuzzing the normal path but t
 - [CVE-2022-29582 — NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2022-29582) — Affected versions and CVSS scoring
 - [Qualys CVE-2022-29582 exploitation writeup](https://www.qualys.com/2022/05/02/cve-2022-29582/lpe-io-uring.txt) — Detailed analysis of the UAF and privilege escalation technique
 - [CVE-2023-2598 — NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2023-2598) — Fixed buffer integer overflow
-- [Security topics: io_uring, VM attestation, and random-reseed notifications](https://lwn.net/Articles/943239/) — LWN coverage of Google's "safe only for trusted components" stance and the `kernel.io_uring_disabled` sysctl
+- [Security topics: io_uring, VM attestation, and random-reseed notifications](https://lwn.net/Articles/943239/) — LWN coverage of Google's "safe only for use by trusted components" stance and the `kernel.io_uring_disabled` sysctl
 - [Auditing io_uring](https://lwn.net/Articles/858023/) — LWN article on adding LSM and audit hooks to io_uring
 - [io_uring/rsrc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/rsrc.c) — Fixed file and buffer registration (site of both CVE-2022-29582 and CVE-2023-2598)
 - [io_uring/io-wq.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/io-wq.c) — Worker thread pool (async execution path underlying the seccomp bypass)

--- a/docs/io-uring/war-stories.md
+++ b/docs/io-uring/war-stories.md
@@ -468,8 +468,8 @@ Bugs in io_uring tend to be discovered not through fuzzing the normal path but t
 - [CVE-2022-29582 — NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2022-29582) — Affected versions and CVSS scoring
 - [Qualys CVE-2022-29582 exploitation writeup](https://www.qualys.com/2022/05/02/cve-2022-29582/lpe-io-uring.txt) — Detailed analysis of the UAF and privilege escalation technique
 - [CVE-2023-2598 — NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2023-2598) — Fixed buffer integer overflow
-- [LWN: Some io_uring security concerns](https://lwn.net/Articles/902466/) — LWN coverage of the seccomp bypass and platform responses
-- [Auditing io_uring](https://lwn.net/Articles/858023/) — SELinux and AppArmor LSM/audit hooks for io_uring
+- [Security topics: io_uring, VM attestation, and random-reseed notifications](https://lwn.net/Articles/943239/) — LWN coverage of Google's "safe only for trusted components" stance and the `kernel.io_uring_disabled` sysctl
+- [Auditing io_uring](https://lwn.net/Articles/858023/) — LWN article on adding LSM and audit hooks to io_uring
 - [io_uring/rsrc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/rsrc.c) — Fixed file and buffer registration (site of both CVE-2022-29582 and CVE-2023-2598)
 - [io_uring/io-wq.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/io-wq.c) — Worker thread pool (async execution path underlying the seccomp bypass)
 - [io_uring man page](https://man7.org/linux/man-pages/man7/io_uring.7.html) — `io_uring_params`, ring flags, and feature bits

--- a/docs/io-uring/war-stories.md
+++ b/docs/io-uring/war-stories.md
@@ -469,7 +469,7 @@ Bugs in io_uring tend to be discovered not through fuzzing the normal path but t
 - [Qualys CVE-2022-29582 exploitation writeup](https://www.qualys.com/2022/05/02/cve-2022-29582/lpe-io-uring.txt) — Detailed analysis of the UAF and privilege escalation technique
 - [CVE-2023-2598 — NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2023-2598) — Fixed buffer integer overflow
 - [LWN: Some io_uring security concerns](https://lwn.net/Articles/902466/) — LWN coverage of the seccomp bypass and platform responses
-- [Linux 5.12 LSM io_uring hooks](https://lwn.net/Articles/853478/) — SELinux and AppArmor io_uring object class
+- [Auditing io_uring](https://lwn.net/Articles/858023/) — SELinux and AppArmor LSM/audit hooks for io_uring
 - [io_uring/rsrc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/rsrc.c) — Fixed file and buffer registration (site of both CVE-2022-29582 and CVE-2023-2598)
 - [io_uring/io-wq.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/io-wq.c) — Worker thread pool (async execution path underlying the seccomp bypass)
 - [io_uring man page](https://man7.org/linux/man-pages/man7/io_uring.7.html) — `io_uring_params`, ring flags, and feature bits


### PR DESCRIPTION
Fixes found during citation-audit issue #701 (7 LWN citations across io-uring/). **This section had the highest error rate of the whole site-wide audit — 4 of 7 original citations were completely wrong articles.** Went through two rounds of independent review before merge; both rounds found real issues in the fixes themselves, not just the original citations.

## Wrong articles (replaced)
- **`853478`** — cited in `security.md` and `war-stories.md` as "Linux 5.12 LSM io_uring hooks", actually **"Debian's election results"**. Replaced with [`858023`](https://lwn.net/Articles/858023/) "Auditing io_uring" (Jun 2021, Corbet) — confirmed real, covers LSM/audit hooks for io_uring. (Round 2: dropped an over-claimed "including SELinux and AppArmor" clause — those terms only appear in reader comments, not the article body.)
- **`863071`** — cited in `life-of-request.md` as "Avoiding the page cache with io_uring", actually **"Descriptorless files for io_uring"** (a different feature entirely). Replaced with [`806980`](https://lwn.net/Articles/806980/) "Buffered I/O without page-cache thrashing" (Dec 2019, Corbet) — confirmed real, `RWF_UNCACHED` mentioned 5x, correctly framed as a buffered-I/O mode (not direct I/O).
- **`877165`** — cited in `README.md` as "io_uring and seccomp", actually **an RT-patch release announcement** (5.10.78-rt56). Replaced with [`826053`](https://lwn.net/Articles/826053/) "Operations restrictions for io_uring" (Jul 2020) — confirmed real, covers the seccomp/io_uring gap.
- **`945584`** — cited in `life-of-request.md` as "io_uring in Android", actually **about WiFi regulatory domain settings**. No confident replacement found; removed.
- **`902466`** in `war-stories.md` — originally marked "clean, unchanged" but a first independent review found the "seccomp bypass and platform responses" framing was entirely unsupported (zero relevant mentions in the article body). Replaced with [`943239`](https://lwn.net/Articles/943239/) "Security topics: io_uring, VM attestation, and random-reseed notifications" (Sep 2023) — confirmed real, covers Google's "safe only for use by trusted components" stance and the `kernel.io_uring_disabled` sysctl. `902466` is kept in `life-of-request.md` with its real title ("Security requirements for new kernel features") since that context's claim is more generic and accurate.

## Minor label/description fixes (correct article, wrong label or overclaimed description)
- `776703` — README.md's title label didn't match the real title ("Ringing in a new asynchronous I/O API"); life-of-request.md already had it right.
- `810414` — README.md labeled it "(2019)"; actually dated Jan 2020. Separately, `life-of-request.md` overclaimed "Feature expansion through 5.7" — the article explicitly covers only through 5.6.

`mkdocs build --strict` passes.

Part of the site-wide citation audit #688 (sub-issue #701).
