### PR TITLE
io: fix 10 wrong LWN citations + label/description errors

### DIFF
--- a/docs/io/README.md
+++ b/docs/io/README.md
@@ -167,10 +167,10 @@ If you want to read the actual kernel code:
 
 - Jens Axboe's blog — [https://axboe.dk/](https://axboe.dk/) — Axboe is the author of io_uring and the block layer; his posts explain design decisions directly from the source
 - LWN.net I/O coverage:
-    - [Folio-enabling the page cache](https://lwn.net/Articles/860537/) — folio conversion and the move away from raw page pointers
+    - [Clarifying memory management with page folios](https://lwn.net/Articles/849538/) — folio conversion and the move away from raw page pointers
     - [Ringing in a new asynchronous I/O API](https://lwn.net/Articles/776703/) — the original io_uring introduction
     - [Buffered I/O without page-cache thrashing](https://lwn.net/Articles/806980/) — `RWF_UNCACHED`, a buffered-I/O mode that avoids polluting the page cache
-    - [per device dirty throttling](https://lwn.net/Articles/244443/) — how dirty throttling was redesigned
+    - [No-I/O dirty throttling](https://lwn.net/Articles/456904/) — how dirty throttling was redesigned
 
 ### Kernel Documentation
 

--- a/docs/io/README.md
+++ b/docs/io/README.md
@@ -167,10 +167,10 @@ If you want to read the actual kernel code:
 
 - Jens Axboe's blog — [https://axboe.dk/](https://axboe.dk/) — Axboe is the author of io_uring and the block layer; his posts explain design decisions directly from the source
 - LWN.net I/O coverage:
-    - [Rethinking the page cache](https://lwn.net/Articles/752765/) — folio conversion and the move away from raw page pointers
-    - [io_uring in 5.1](https://lwn.net/Articles/776703/) — the original io_uring introduction
-    - [Buffered vs. direct I/O](https://lwn.net/Articles/580031/) — when O_DIRECT actually helps
-    - [Writeback and the dirty limit](https://lwn.net/Articles/456528/) — how dirty throttling was redesigned
+    - [Folio-enabling the page cache](https://lwn.net/Articles/860537/) — folio conversion and the move away from raw page pointers
+    - [Ringing in a new asynchronous I/O API](https://lwn.net/Articles/776703/) — the original io_uring introduction
+    - [RFC: Clarifying Direct I/O Semantics](https://lwn.net/Articles/348739/) — when O_DIRECT actually helps
+    - [per device dirty throttling](https://lwn.net/Articles/244443/) — how dirty throttling was redesigned
 
 ### Kernel Documentation
 

--- a/docs/io/README.md
+++ b/docs/io/README.md
@@ -169,7 +169,7 @@ If you want to read the actual kernel code:
 - LWN.net I/O coverage:
     - [Folio-enabling the page cache](https://lwn.net/Articles/860537/) — folio conversion and the move away from raw page pointers
     - [Ringing in a new asynchronous I/O API](https://lwn.net/Articles/776703/) — the original io_uring introduction
-    - [RFC: Clarifying Direct I/O Semantics](https://lwn.net/Articles/348739/) — when O_DIRECT actually helps
+    - [Buffered I/O without page-cache thrashing](https://lwn.net/Articles/806980/) — `RWF_UNCACHED`, a buffered-I/O mode that avoids polluting the page cache
     - [per device dirty throttling](https://lwn.net/Articles/244443/) — how dirty throttling was redesigned
 
 ### Kernel Documentation

--- a/docs/io/life-of-a-write.md
+++ b/docs/io/life-of-a-write.md
@@ -1090,6 +1090,6 @@ cat /sys/class/bdi/*/stats
 
 - [Writeback and control groups](https://lwn.net/Articles/648292/) (2015) — per-cgroup writeback accounting
 - [Dynamic writeback throttling](https://lwn.net/Articles/405076/) (2010) — dirty throttling history
-- [Flushing out pdflush](https://lwn.net/Articles/326552/) — writeback throttling redesign
+- [Flushing out pdflush](https://lwn.net/Articles/326552/) — replacing the single pdflush thread with per-BDI flusher threads
 - [The end of block barriers](https://lwn.net/Articles/400541/) — the move from I/O barriers to the FLUSH/FUA model
-- [The rapid growth of io_uring](https://lwn.net/Articles/810414/) (2020) — async buffered writes via io_uring
+- [The rapid growth of io_uring](https://lwn.net/Articles/810414/) (2020) — the first year of io_uring's feature growth

--- a/docs/io/life-of-a-write.md
+++ b/docs/io/life-of-a-write.md
@@ -1088,8 +1088,8 @@ cat /sys/class/bdi/*/stats
 
 ### LWN articles
 
-- [Writeback and control groups](https://lwn.net/Articles/682782/) (2016) — per-cgroup writeback accounting
-- [Taming the writeback monster](https://lwn.net/Articles/405076/) (2010) — dirty throttling history
-- [Fixing the page writeback code](https://lwn.net/Articles/326552/) (2009) — writeback throttling redesign
-- [Optimising fsync for SSDs](https://lwn.net/Articles/351023/) (2009) — FUA and flush optimisation
-- [io_uring and buffered writes](https://lwn.net/Articles/810414/) (2020) — async buffered writes via io_uring
+- [Writeback and control groups](https://lwn.net/Articles/648292/) (2015) — per-cgroup writeback accounting
+- [Dynamic writeback throttling](https://lwn.net/Articles/405076/) (2010) — dirty throttling history
+- [Flushing out pdflush](https://lwn.net/Articles/326552/) — writeback throttling redesign
+- [block: reimplement FLUSH/FUA to support merge](https://lwn.net/Articles/424086/) — FUA and flush optimisation
+- [The rapid growth of io_uring](https://lwn.net/Articles/810414/) (2020) — async buffered writes via io_uring

--- a/docs/io/life-of-a-write.md
+++ b/docs/io/life-of-a-write.md
@@ -1091,5 +1091,5 @@ cat /sys/class/bdi/*/stats
 - [Writeback and control groups](https://lwn.net/Articles/648292/) (2015) — per-cgroup writeback accounting
 - [Dynamic writeback throttling](https://lwn.net/Articles/405076/) (2010) — dirty throttling history
 - [Flushing out pdflush](https://lwn.net/Articles/326552/) — writeback throttling redesign
-- [block: reimplement FLUSH/FUA to support merge](https://lwn.net/Articles/424086/) — FUA and flush optimisation
+- [The end of block barriers](https://lwn.net/Articles/400541/) — the move from I/O barriers to the FLUSH/FUA model
 - [The rapid growth of io_uring](https://lwn.net/Articles/810414/) (2020) — async buffered writes via io_uring

--- a/docs/io/observability.md
+++ b/docs/io/observability.md
@@ -950,5 +950,5 @@ done
 ### LWN articles
 
 - [LWN: Pressure stall information](https://lwn.net/Articles/759781/) — design and motivation for PSI, by Johannes Weiner
-- [LWN: Block I/O bandwidth management](https://lwn.net/Articles/806396/) — cgroup v2 I/O controller and `io.pressure`
+- [LWN: The io.weight I/O-bandwidth controller](https://lwn.net/Articles/792256/) — cgroup v2 I/O controller and `io.pressure`
 - [LWN: The multiqueue block layer](https://lwn.net/Articles/552904/) — blk-mq design and how it changed queue depth semantics for NVMe

--- a/docs/io/observability.md
+++ b/docs/io/observability.md
@@ -950,5 +950,5 @@ done
 ### LWN articles
 
 - [LWN: Pressure stall information](https://lwn.net/Articles/759781/) — design and motivation for PSI, by Johannes Weiner
-- [LWN: The io.weight I/O-bandwidth controller](https://lwn.net/Articles/792256/) — cgroup v2 I/O controller and `io.pressure`
+- [LWN: The io.weight I/O-bandwidth controller](https://lwn.net/Articles/792256/) — cgroup v2 I/O-bandwidth controller
 - [LWN: The multiqueue block layer](https://lwn.net/Articles/552904/) — blk-mq design and how it changed queue depth semantics for NVMe

--- a/docs/io/observability.md
+++ b/docs/io/observability.md
@@ -949,6 +949,6 @@ done
 
 ### LWN articles
 
-- [LWN: Pressure stall information](https://lwn.net/Articles/759781/) — design and motivation for PSI, by Johannes Weiner
+- [Tracking pressure-stall information](https://lwn.net/Articles/759781/) — design and motivation for PSI
 - [LWN: The io.weight I/O-bandwidth controller](https://lwn.net/Articles/792256/) — cgroup v2 I/O-bandwidth controller
-- [LWN: The multiqueue block layer](https://lwn.net/Articles/552904/) — blk-mq design and how it changed queue depth semantics for NVMe
+- [LWN: The multiqueue block layer](https://lwn.net/Articles/552904/) — blk-mq design

--- a/docs/io/war-stories.md
+++ b/docs/io/war-stories.md
@@ -627,8 +627,8 @@ A second theme is **coherency across abstraction boundaries**: the page cache is
 
 - [LWN: Flushing out pdflush](https://lwn.net/Articles/326552/) — Background on writeback thread design leading to the dirty throttling rework
 - [LWN: When writeback goes wrong](https://lwn.net/Articles/384093/) — Dirty throttling and BDI writeback problems
-- [LWN: Toward better I/O control](https://lwn.net/Articles/442355/) — Fengguang Wu's dirty throttling improvements in v3.1
-- [LWN: ext4 data modes](https://lwn.net/Articles/282520/) — ext4 journaling modes and their crash semantics
+- [LWN: No-I/O dirty throttling](https://lwn.net/Articles/456904/) — Fengguang Wu's dirty throttling improvements in v3.1
+- [LWN: Ext4 breaking the promise of data=ordered?](https://lwn.net/Articles/326524/) — ext4 journaling modes and their crash semantics
 - [Kernel docs: ext4](https://docs.kernel.org/filesystems/ext4/index.html) — Official ext4 documentation including journaling mode descriptions
 - [open(2) man page](https://man7.org/linux/man-pages/man2/open.2.html) — O_DIRECT documentation including the mixed-mode coherency warning
 - [fsync(2) man page](https://man7.org/linux/man-pages/man2/fsync.2.html) — fsync semantics and the note on directory syncing

--- a/docs/io/war-stories.md
+++ b/docs/io/war-stories.md
@@ -628,7 +628,7 @@ A second theme is **coherency across abstraction boundaries**: the page cache is
 - [LWN: Flushing out pdflush](https://lwn.net/Articles/326552/) — Background on writeback thread design leading to the dirty throttling rework
 - [LWN: When writeback goes wrong](https://lwn.net/Articles/384093/) — Dirty throttling and BDI writeback problems
 - [LWN: No-I/O dirty throttling](https://lwn.net/Articles/456904/) — Fengguang Wu's dirty throttling improvements in v3.1
-- [LWN: Ext4 breaking the promise of data=ordered?](https://lwn.net/Articles/326524/) — ext4 journaling modes and their crash semantics
+- [ext4 and data loss](https://lwn.net/Articles/322823/) — ext4 journaling modes and their crash semantics
 - [Kernel docs: ext4](https://docs.kernel.org/filesystems/ext4/index.html) — Official ext4 documentation including journaling mode descriptions
 - [open(2) man page](https://man7.org/linux/man-pages/man2/open.2.html) — O_DIRECT documentation including the mixed-mode coherency warning
 - [fsync(2) man page](https://man7.org/linux/man-pages/man2/fsync.2.html) — fsync semantics and the note on directory syncing
@@ -645,4 +645,4 @@ A second theme is **coherency across abstraction boundaries**: the page cache is
 - [war-stories-regressions.md](../mm/war-stories-regressions.md) — Memory management regressions: THP compaction stalls, NUMA balancing overhead, khugepaged CPU storms, and swap readahead mismatch; the same "optimization correct in theory, wrong for this workload" pattern applies to I/O
 - [Tuning storage I/O](tuning-storage.md) — Practical guidance for dirty ratio tuning, O_DIRECT configuration, and sendfile/splice tuning for production workloads
 - [Filesystem observability](observability.md) — The `/proc/vmstat` counters (`nr_dirty`, `nr_writeback`, `pgpgout`) and tracepoints for diagnosing all five cases documented here
-- [LWN: No `fsync` on a freshly created directory?](https://lwn.net/Articles/457671/) — Further discussion of the directory fsync requirement and filesystem behavior differences across Linux filesystem implementations
+- [Ensuring data reaches disk](https://lwn.net/Articles/457667/) — Jeff Moyer on the directory fsync requirement and filesystem behavior differences across Linux filesystem implementations

--- a/docs/io/war-stories.md
+++ b/docs/io/war-stories.md
@@ -626,7 +626,7 @@ A second theme is **coherency across abstraction boundaries**: the page cache is
 ## External references
 
 - [LWN: Flushing out pdflush](https://lwn.net/Articles/326552/) — Background on writeback thread design leading to the dirty throttling rework
-- [LWN: When writeback goes wrong](https://lwn.net/Articles/384093/) — Dirty throttling and BDI writeback problems
+- [LWN: When writeback goes wrong](https://lwn.net/Articles/384093/) — Direct reclaim recursing into filesystem writeback and overflowing the kernel stack
 - [LWN: No-I/O dirty throttling](https://lwn.net/Articles/456904/) — Fengguang Wu's dirty throttling improvements in v3.1
 - [ext4 and data loss](https://lwn.net/Articles/322823/) — ext4 journaling modes and their crash semantics
 - [Kernel docs: ext4](https://docs.kernel.org/filesystems/ext4/index.html) — Official ext4 documentation including journaling mode descriptions


### PR DESCRIPTION
Fixes found during citation-audit issue #704 (17 LWN citations across `io/`). **This section had the worst error rate of the entire site-wide audit — 8 of 17 original citations were completely wrong articles.** Went through two rounds of independent review before merge; both rounds found real issues in the fixes themselves, not just the original citations — including two more mailing-list-email citations masquerading as articles that survived the first round.

## Wrong articles (replaced)
| Was cited as | Actually is | Replaced with |
|---|---|---|
| "ext4 data modes" (282520) | Sun/OpenSolaris exec interview | [326524](https://lwn.net/Articles/326524/) "Ext4 breaking the promise of data=ordered?" — later found in round 2 to be a **reader comment**, not an article; replaced again with [322823](https://lwn.net/Articles/322823/) "ext4 and data loss" (Corbet editorial) |
| "Optimising fsync for SSDs" (351023) | pty/pgid checkpoint-restart | [424086](https://lwn.net/Articles/424086/) "block: reimplement FLUSH/FUA to support merge" — later found to be a **patchset email** (Tejun Heo → LKML), not an article; replaced again with [400541](https://lwn.net/Articles/400541/) "The end of block barriers" |
| "Toward better I/O control" (442355) | "Stable pages" (unrelated) | [456904](https://lwn.net/Articles/456904/) "No-I/O dirty throttling" |
| "Writeback and the dirty limit" (456528) | Ubuntu 11.10 screenshot tour | [244443](https://lwn.net/Articles/244443/) "per device dirty throttling -v8" — later found to be a **patch cover-letter email** (Peter Zijlstra), not an article; replaced again with [456904](https://lwn.net/Articles/456904/) "No-I/O dirty throttling" |
| "Buffered vs. direct I/O" (580031) | 2014 security-practices article | [348739](https://lwn.net/Articles/348739/) "RFC: Clarifying Direct I/O Semantics" — later found to be an **RFC email** (Ts'o → linux-ext4), not an article; replaced again with [806980](https://lwn.net/Articles/806980/) "Buffered I/O without page-cache thrashing" |
| "Writeback and control groups" (682782) | FSF anti-DRM campaign day | [648292](https://lwn.net/Articles/648292/) — exact same title, Jun 2015, the intended article (digit-transposition typo) |
| "Rethinking the page cache" (752765) | Oracle security alert (librelp) | [860537](https://lwn.net/Articles/860537/) "Folio-enabling the page cache" — later found to be a **46-patch cover-letter email** (Matthew Wilcox), not an article; replaced again with [849538](https://lwn.net/Articles/849538/) "Clarifying memory management with page folios" |
| "Block I/O bandwidth management" (806396) | "Linux 4.19.88" release announcement | [792256](https://lwn.net/Articles/792256/) "The io.weight I/O-bandwidth controller" — description originally over-claimed `io.pressure` coverage (zero mentions in the article; that's already correctly covered by the `759781` citation), clause dropped |
| "No `fsync` on a freshly created directory?" (457671) | a bare code-sample page, not an article | [457667](https://lwn.net/Articles/457667/) "Ensuring data reaches disk" (Jeff Moyer) — contains the directory-fsync claim verbatim |

## Minor label/description fixes (correct article, wrong quoted title or unsupported claim)
- `326552`, `405076`, `776703`, `810414` — real, correctly-topical citations with an inaccurate quoted title in at least one location.
- `326552` in `life-of-a-write.md` — description said "writeback throttling redesign"; reworded to what the article is actually about (per-BDI flusher threads replacing pdflush), matching the accurate framing already used in `war-stories.md`.
- `810414` in `life-of-a-write.md` — description said "async buffered writes via io_uring"; the article is an opcode/feature survey with zero mentions of "buffered". Reworded.
- `384093` "When writeback goes wrong" — mislabeled as "dirty throttling and BDI writeback problems"; the article is actually about direct reclaim recursing into filesystem writeback and overflowing the kernel stack. Fixed.
- `552904` "The multiqueue block layer" — dropped an unsupported "queue depth semantics for NVMe" clause.
- `759781` — invented title/byline ("Pressure stall information" by Johannes Weiner) fixed to the real title "Tracking pressure-stall information" by Jonathan Corbet.

## Clean, unchanged
`601799`, and the `tuning-storage.md` usages — verified accurate.

`mkdocs build --strict` passes.

Part of the site-wide citation audit #688 (sub-issue #704). This completes the full site-wide LWN/lore verification pass, including two independent adversarial review rounds on the fix PRs themselves.
