### PR TITLE
war-stories: reformat metadata line as a definition list

### DIFF
--- a/docs/bpf/war-stories/alu32-bitwise-bounds.md
+++ b/docs/bpf/war-stories/alu32-bitwise-bounds.md
@@ -2,7 +2,23 @@
 
 > CVE-2021-3490 — a comment that checked a 32-bit condition and relied on a 64-bit guarantee
 
-**Disclosed:** May 11, 2021 (oss-security) &nbsp;·&nbsp; **Reported by:** Manfred Paul (@_manfp) of the RedRocket CTF team, working with Trend Micro's Zero Day Initiative (ZDI-CAN-13590), and Thadeu Lima de Souza Cascardo of Canonical — both carried as `Reported-by:` on the fix &nbsp;·&nbsp; **CVSS:** 7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`, NVD primary); Ubuntu's secondary score is also 7.8, with a different vector (`AC:H`, `S:C`) &nbsp;·&nbsp; **Fixed in:** [`049c4e13714e`](https://github.com/torvalds/linux/commit/049c4e13714ecbca567b4d5f6d563f05d431c80e), mainline v5.13-rc4; stable 5.12.4, 5.11.21, 5.10.37 &nbsp;·&nbsp; **Exploit tool:** yes — NVD tags a public Packet Storm entry, "Linux eBPF ALU32 32-bit Invalid Bounds Tracking Local Privilege Escalation", as `Exploit`. No Exploit-DB entry &nbsp;·&nbsp; **Actively exploited:** no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2021-3490))
+Disclosed
+:   May 11, 2021 (oss-security)
+
+Reported by
+:   Manfred Paul (@_manfp) of the RedRocket CTF team, working with Trend Micro's Zero Day Initiative (ZDI-CAN-13590), and Thadeu Lima de Souza Cascardo of Canonical — both carried as `Reported-by:` on the fix
+
+CVSS
+:   7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`, NVD primary); Ubuntu's secondary score is also 7.8, with a different vector (`AC:H`, `S:C`)
+
+Fixed in
+:   [`049c4e13714e`](https://github.com/torvalds/linux/commit/049c4e13714ecbca567b4d5f6d563f05d431c80e), mainline v5.13-rc4; stable 5.12.4, 5.11.21, 5.10.37
+
+Exploit tool
+:   yes — NVD tags a public Packet Storm entry, "Linux eBPF ALU32 32-bit Invalid Bounds Tracking Local Privilege Escalation", as `Exploit`. No Exploit-DB entry
+
+Actively exploited
+:   no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2021-3490))
 
 *Part of [War Stories: BPF Verifier Bugs and CVEs](../war-stories.md).*
 

--- a/docs/bpf/war-stories/alu32-unsigned-bounds.md
+++ b/docs/bpf/war-stories/alu32-unsigned-bounds.md
@@ -2,7 +2,23 @@
 
 > CVE-2021-31440 — a fix landed four and a half months earlier had corrected the signed half of a two-line pattern and left the unsigned half standing
 
-**Disclosed:** May 3, 2021 ([ZDI-21-503](https://www.zerodayinitiative.com/advisories/ZDI-21-503/), ZDI-CAN-13661; NVD record published May 21, 2021) &nbsp;·&nbsp; **Reported by:** Manfred Paul (per the fix commit's `Reported-by:` tag), via Trend Micro's Zero Day Initiative &nbsp;·&nbsp; **CVSS:** 7.0 HIGH (`CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H`, NVD primary); 8.8 HIGH (`CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H`) from ZDI as secondary scorer &nbsp;·&nbsp; **Fixed in:** [`10bf4e83167c`](https://github.com/torvalds/linux/commit/10bf4e83167cc68595b85fd73bb91e8f2c086e36), mainline v5.13-rc1 &nbsp;·&nbsp; **Exploit tool:** none catalogued on Exploit-DB; NVD lists no reference tagged `Exploit` &nbsp;·&nbsp; **Actively exploited:** no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2021-31440))
+Disclosed
+:   May 3, 2021 ([ZDI-21-503](https://www.zerodayinitiative.com/advisories/ZDI-21-503/), ZDI-CAN-13661; NVD record published May 21, 2021)
+
+Reported by
+:   Manfred Paul (per the fix commit's `Reported-by:` tag), via Trend Micro's Zero Day Initiative
+
+CVSS
+:   7.0 HIGH (`CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H`, NVD primary); 8.8 HIGH (`CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H`) from ZDI as secondary scorer
+
+Fixed in
+:   [`10bf4e83167c`](https://github.com/torvalds/linux/commit/10bf4e83167cc68595b85fd73bb91e8f2c086e36), mainline v5.13-rc1
+
+Exploit tool
+:   none catalogued on Exploit-DB; NVD lists no reference tagged `Exploit`
+
+Actively exploited
+:   no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2021-31440))
 
 *Part of [War Stories: BPF Verifier Bugs and CVEs](../war-stories.md).*
 

--- a/docs/bpf/war-stories/jmp32-bounds.md
+++ b/docs/bpf/war-stories/jmp32-bounds.md
@@ -2,7 +2,26 @@
 
 > CVE-2020-8835 — a precision patch was auto-selected into a stable kernel by a machine-learning classifier that mistook it for a bug fix, and it turned out to be a privilege escalation
 
-**Disclosed:** March 30, 2020 (oss-security) &nbsp;·&nbsp; **Demonstrated by:** Manfred Paul, as part of ZDI's Pwn2Own 2020 competition (ZDI-CAN-10780); the hang that led to the fix was reported by Anatoly Trosinenko, fuzzing with the kBdysch harness &nbsp;·&nbsp; **CVSS:** 7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`, NVD primary); Ubuntu's secondary score is also 7.8, with a different vector (`AC:H`, `S:C`) &nbsp;·&nbsp; **Introduced in:** [`581738a681b6`](https://github.com/torvalds/linux/commit/581738a681b6faae5725c2555439189ca81c0f1f) (v5.5), backported into 5.4-stable &nbsp;·&nbsp; **Fixed in:** [`f2d67fec0b43`](https://github.com/torvalds/linux/commit/f2d67fec0b43edce8c416101cdc52e71145b5fef), mainline v5.7-rc1; stable 5.6.1, 5.5.14, 5.4.29 &nbsp;·&nbsp; **Exploit tool:** no Exploit-DB entry; NVD tags a later oss-security post as `Exploit` &nbsp;·&nbsp; **Actively exploited:** no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2020-8835))
+Disclosed
+:   March 30, 2020 (oss-security)
+
+Demonstrated by
+:   Manfred Paul, as part of ZDI's Pwn2Own 2020 competition (ZDI-CAN-10780); the hang that led to the fix was reported by Anatoly Trosinenko, fuzzing with the kBdysch harness
+
+CVSS
+:   7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`, NVD primary); Ubuntu's secondary score is also 7.8, with a different vector (`AC:H`, `S:C`)
+
+Introduced in
+:   [`581738a681b6`](https://github.com/torvalds/linux/commit/581738a681b6faae5725c2555439189ca81c0f1f) (v5.5), backported into 5.4-stable
+
+Fixed in
+:   [`f2d67fec0b43`](https://github.com/torvalds/linux/commit/f2d67fec0b43edce8c416101cdc52e71145b5fef), mainline v5.7-rc1; stable 5.6.1, 5.5.14, 5.4.29
+
+Exploit tool
+:   no Exploit-DB entry; NVD tags a later oss-security post as `Exploit`
+
+Actively exploited
+:   no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2020-8835))
 
 *Part of [War Stories: BPF Verifier Bugs and CVEs](../war-stories.md).*
 

--- a/docs/bpf/war-stories/sign-extension.md
+++ b/docs/bpf/war-stories/sign-extension.md
@@ -2,7 +2,26 @@
 
 > CVE-2017-16995 — the verifier sign-extended a 32-bit immediate that the machine zero-extends, so its model of the register and the register itself disagreed from the very first instruction
 
-**Disclosed:** December 21, 2017 (oss-security) &nbsp;·&nbsp; **Reported by:** Jann Horn, Google Project Zero &nbsp;·&nbsp; **CVSS:** 7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`, NVD primary) &nbsp;·&nbsp; **Introduced in:** [`484611357c19`](https://github.com/torvalds/linux/commit/484611357c19f9e19ef742ebef4505a07d243cc9) ("bpf: allow access into map value arrays", v4.9) &nbsp;·&nbsp; **Fixed in:** [`95a762e2c8c9`](https://github.com/torvalds/linux/commit/95a762e2c8c942780948091f8f2a4f32fce1ac6f), mainline v4.15-rc5 &nbsp;·&nbsp; **Exploit tool:** yes — three Exploit-DB entries, including a [Metasploit module](https://www.exploit-db.com/exploits/45058) &nbsp;·&nbsp; **Actively exploited:** no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2017-16995))
+Disclosed
+:   December 21, 2017 (oss-security)
+
+Reported by
+:   Jann Horn, Google Project Zero
+
+CVSS
+:   7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`, NVD primary)
+
+Introduced in
+:   [`484611357c19`](https://github.com/torvalds/linux/commit/484611357c19f9e19ef742ebef4505a07d243cc9) ("bpf: allow access into map value arrays", v4.9)
+
+Fixed in
+:   [`95a762e2c8c9`](https://github.com/torvalds/linux/commit/95a762e2c8c942780948091f8f2a4f32fce1ac6f), mainline v4.15-rc5
+
+Exploit tool
+:   yes — three Exploit-DB entries, including a [Metasploit module](https://www.exploit-db.com/exploits/45058)
+
+Actively exploited
+:   no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2017-16995))
 
 *Part of [War Stories: BPF Verifier Bugs and CVEs](../war-stories.md).*
 

--- a/docs/bpf/war-stories/spectre-verifier.md
+++ b/docs/bpf/war-stories/spectre-verifier.md
@@ -2,7 +2,23 @@
 
 > CVE-2021-33624 — the verifier only walks paths that can actually execute, so it never saw the path the branch predictor would take
 
-**Disclosed:** June 21, 2021 (oss-security; NVD record published June 23, 2021) &nbsp;·&nbsp; **Reported by:** Adam Morrison and Ofek Kirzner, and independently Benedict Schlueter and Piotr Krysiuk (per the fix commit's `Reported-by:` tags) &nbsp;·&nbsp; **CVSS:** 4.7 MEDIUM (`CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N`, NVD primary) &nbsp;·&nbsp; **Fixed in:** [`9183671af6db`](https://github.com/torvalds/linux/commit/9183671af6dbf60a1219371d4ed73e23f43b49db), mainline v5.13-rc7; stable 5.12.13 and 5.10.46 &nbsp;·&nbsp; **Exploit tool:** multiple proofs-of-concept were sent privately to `security@kernel.org`; NVD's reference list tags a public oss-security post as `Exploit` and links a public PoC repository. No Exploit-DB entry &nbsp;·&nbsp; **Actively exploited:** no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2021-33624))
+Disclosed
+:   June 21, 2021 (oss-security; NVD record published June 23, 2021)
+
+Reported by
+:   Adam Morrison and Ofek Kirzner, and independently Benedict Schlueter and Piotr Krysiuk (per the fix commit's `Reported-by:` tags)
+
+CVSS
+:   4.7 MEDIUM (`CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N`, NVD primary)
+
+Fixed in
+:   [`9183671af6db`](https://github.com/torvalds/linux/commit/9183671af6dbf60a1219371d4ed73e23f43b49db), mainline v5.13-rc7; stable 5.12.13 and 5.10.46
+
+Exploit tool
+:   multiple proofs-of-concept were sent privately to `security@kernel.org`; NVD's reference list tags a public oss-security post as `Exploit` and links a public PoC repository. No Exploit-DB entry
+
+Actively exploited
+:   no confirmed cases ([not on CISA KEV](https://nvd.nist.gov/vuln/detail/CVE-2021-33624))
 
 *Part of [War Stories: BPF Verifier Bugs and CVEs](../war-stories.md).*
 

--- a/docs/bpf/war-stories/unprivileged-bpf-off.md
+++ b/docs/bpf/war-stories/unprivileged-bpf-off.md
@@ -2,7 +2,20 @@
 
 > Not a CVE — the hardening response to years of them, and an admission that "safely unprivileged BPF" was a goal the subsystem had stopped pursuing
 
-**Landed:** May 11, 2021 &nbsp;·&nbsp; **Author:** Daniel Borkmann &nbsp;·&nbsp; **Merged in:** [`08389d888287`](https://github.com/torvalds/linux/commit/08389d888287c3823f80b0216766b71e17f0aba5), mainline v5.13-rc4 &nbsp;·&nbsp; **Mechanism:** `CONFIG_BPF_UNPRIV_DEFAULT_OFF` &nbsp;·&nbsp; **Context:** [LWN 796328](https://lwn.net/Articles/796328/), "Reconsidering unprivileged BPF" (Jonathan Corbet, August 2019)
+Landed
+:   May 11, 2021
+
+Author
+:   Daniel Borkmann
+
+Merged in
+:   [`08389d888287`](https://github.com/torvalds/linux/commit/08389d888287c3823f80b0216766b71e17f0aba5), mainline v5.13-rc4
+
+Mechanism
+:   `CONFIG_BPF_UNPRIV_DEFAULT_OFF`
+
+Context
+:   [LWN 796328](https://lwn.net/Articles/796328/), "Reconsidering unprivileged BPF" (Jonathan Corbet, August 2019)
 
 *Part of [War Stories: BPF Verifier Bugs and CVEs](../war-stories.md).*
 

--- a/docs/net/war-stories/af-packet.md
+++ b/docs/net/war-stories/af-packet.md
@@ -2,7 +2,23 @@
 
 > CVE-2017-7308 — a single `(int)` cast around an unsigned subtraction defeated a ring-buffer bounds check, found by syzkaller and turned into local root by Project Zero
 
-**Disclosed:** March 29, 2017 &nbsp;·&nbsp; **Reported by:** Andrey Konovalov, Google Project Zero (via syzkaller + KASAN) &nbsp;·&nbsp; **CVSS:** 7.8 HIGH &nbsp;·&nbsp; **Fixed in:** mainline March 2017, backported to 4.10.x and earlier stable branches &nbsp;·&nbsp; **Exploit tool:** yes (2 Exploit-DB entries, incl. a [Metasploit module](https://www.exploit-db.com/exploits/44654)) &nbsp;·&nbsp; **Actively exploited:** no confirmed cases (not on CISA KEV)
+Disclosed
+:   March 29, 2017
+
+Reported by
+:   Andrey Konovalov, Google Project Zero (via syzkaller + KASAN)
+
+CVSS
+:   7.8 HIGH
+
+Fixed in
+:   mainline March 2017, backported to 4.10.x and earlier stable branches
+
+Exploit tool
+:   yes (2 Exploit-DB entries, incl. a [Metasploit module](https://www.exploit-db.com/exploits/44654))
+
+Actively exploited
+:   no confirmed cases (not on CISA KEV)
 
 *Part of [War Stories: Network Stack Bugs and CVEs](../war-stories.md).*
 

--- a/docs/net/war-stories/challenge-ack.md
+++ b/docs/net/war-stories/challenge-ack.md
@@ -2,7 +2,23 @@
 
 > CVE-2016-5696 — a global rate-limit counter meant as an internal implementation detail became an off-path attacker's window into a victim's TCP connections
 
-**Disclosed:** August 2016 &nbsp;·&nbsp; **Reported by:** Yue Cao, Zhiyun Qian, et al. (UC Riverside, with Lisa Marvel, US Army Research Laboratory) &nbsp;·&nbsp; **CVSS:** 4.8 MEDIUM &nbsp;·&nbsp; **Fixed in:** mainline 4.7 &nbsp;·&nbsp; **Exploit tool:** yes ([`mountain_goat`](https://github.com/Gnoxter/mountain_goat) PoC) &nbsp;·&nbsp; **Actively exploited:** no confirmed cases (not on CISA KEV)
+Disclosed
+:   August 2016
+
+Reported by
+:   Yue Cao, Zhiyun Qian, et al. (UC Riverside, with Lisa Marvel, US Army Research Laboratory)
+
+CVSS
+:   4.8 MEDIUM
+
+Fixed in
+:   mainline 4.7
+
+Exploit tool
+:   yes ([`mountain_goat`](https://github.com/Gnoxter/mountain_goat) PoC)
+
+Actively exploited
+:   no confirmed cases (not on CISA KEV)
 
 *Part of [War Stories: Network Stack Bugs and CVEs](../war-stories.md).*
 

--- a/docs/net/war-stories/netfilter-xtables.md
+++ b/docs/net/war-stories/netfilter-xtables.md
@@ -2,7 +2,20 @@
 
 > CVE-2021-22555 — a 15-year-old bounds-check gap in the iptables compat layer, sitting unactioned in syzbot's inbox for 8 months, became "Turning \x00\x00 into 10000$" and a Kubernetes pod escape
 
-**Disclosed:** July 2021 (fixed April 2021) &nbsp;·&nbsp; **Reported by:** syzbot (August 2020, unanswered) and Andy Nguyen, Google (April 2021) &nbsp;·&nbsp; **CVSS:** 8.3 HIGH (Google's CNA score) / 7.8 HIGH (NVD primary) &nbsp;·&nbsp; **Bug present since:** 2.6.19-rc1 (2006) &nbsp;·&nbsp; **Actively exploited:** yes — added to CISA's KEV catalog in October 2025 (per [NVD](https://nvd.nist.gov/vuln/detail/CVE-2021-22555))
+Disclosed
+:   July 2021 (fixed April 2021)
+
+Reported by
+:   syzbot (August 2020, unanswered) and Andy Nguyen, Google (April 2021)
+
+CVSS
+:   8.3 HIGH (Google's CNA score) / 7.8 HIGH (NVD primary)
+
+Bug present since
+:   2.6.19-rc1 (2006)
+
+Actively exploited
+:   yes — added to CISA's KEV catalog in October 2025 (per [NVD](https://nvd.nist.gov/vuln/detail/CVE-2021-22555))
 
 *Part of [War Stories: Network Stack Bugs and CVEs](../war-stories.md).*
 

--- a/docs/net/war-stories/sack-panic.md
+++ b/docs/net/war-stories/sack-panic.md
@@ -2,7 +2,23 @@
 
 > CVE-2019-11477 / CVE-2019-11478 / CVE-2019-11479 — a remote peer could crash any Linux TCP endpoint with a carefully crafted sequence of SACK blocks
 
-**Disclosed:** June 17, 2019 &nbsp;·&nbsp; **Reported by:** Jonathan Looney (Netflix) &nbsp;·&nbsp; **CVSS:** 7.5 HIGH (all three) &nbsp;·&nbsp; **Fixed in:** 4.4.182, 4.9.182, 4.14.127, 4.19.52, 5.1.11 &nbsp;·&nbsp; **Exploit tool:** none published — the crafted-packet sequence is the whole attack &nbsp;·&nbsp; **Actively exploited:** no confirmed cases (not on CISA KEV)
+Disclosed
+:   June 17, 2019
+
+Reported by
+:   Jonathan Looney (Netflix)
+
+CVSS
+:   7.5 HIGH (all three)
+
+Fixed in
+:   4.4.182, 4.9.182, 4.14.127, 4.19.52, 5.1.11
+
+Exploit tool
+:   none published — the crafted-packet sequence is the whole attack
+
+Actively exploited
+:   no confirmed cases (not on CISA KEV)
 
 *Part of [War Stories: Network Stack Bugs and CVEs](../war-stories.md).*
 

--- a/docs/net/war-stories/segmentsmack.md
+++ b/docs/net/war-stories/segmentsmack.md
@@ -2,7 +2,23 @@
 
 > CVE-2018-5390 — tiny, deliberately-scattered out-of-order TCP segments could pin a CPU core at 100% with roughly 2 kpps of traffic
 
-**Disclosed:** August 6, 2018 &nbsp;·&nbsp; **Reported by:** Juha-Matti Tilli (Aalto University / Nokia Bell Labs) &nbsp;·&nbsp; **CVSS:** 7.5 HIGH &nbsp;·&nbsp; **Fixed in:** 4.9.116, 4.14.59, 4.17.11, mainline 4.18 &nbsp;·&nbsp; **Exploit tool:** none published — a documented traffic pattern is the whole attack &nbsp;·&nbsp; **Actively exploited:** no confirmed cases (not on CISA KEV)
+Disclosed
+:   August 6, 2018
+
+Reported by
+:   Juha-Matti Tilli (Aalto University / Nokia Bell Labs)
+
+CVSS
+:   7.5 HIGH
+
+Fixed in
+:   4.9.116, 4.14.59, 4.17.11, mainline 4.18
+
+Exploit tool
+:   none published — a documented traffic pattern is the whole attack
+
+Actively exploited
+:   no confirmed cases (not on CISA KEV)
 
 *Part of [War Stories: Network Stack Bugs and CVEs](../war-stories.md).*
 

--- a/docs/net/war-stories/udp-ufo.md
+++ b/docs/net/war-stories/udp-ufo.md
@@ -2,7 +2,23 @@
 
 > CVE-2017-1000112 — a per-call heuristic that should have been a per-datagram invariant let two `send()` calls disagree about how a UDP datagram was being built, syzkaller-found and embargo-disclosed in one week
 
-**Disclosed:** August 10, 2017 &nbsp;·&nbsp; **Reported by:** Andrey Konovalov (via syzkaller) &nbsp;·&nbsp; **CVSS:** 7.0 HIGH &nbsp;·&nbsp; **Bug present since:** October 2005 &nbsp;·&nbsp; **Exploit tool:** yes (Konovalov's own PoC + a [Metasploit module](https://www.exploit-db.com/exploits/45147)) &nbsp;·&nbsp; **Actively exploited:** no confirmed cases (not on CISA KEV)
+Disclosed
+:   August 10, 2017
+
+Reported by
+:   Andrey Konovalov (via syzkaller)
+
+CVSS
+:   7.0 HIGH
+
+Bug present since
+:   October 2005
+
+Exploit tool
+:   yes (Konovalov's own PoC + a [Metasploit module](https://www.exploit-db.com/exploits/45147))
+
+Actively exploited
+:   no confirmed cases (not on CISA KEV)
 
 *Part of [War Stories: Network Stack Bugs and CVEs](../war-stories.md).*
 

--- a/docs/security/war-stories/dirty-pipe.md
+++ b/docs/security/war-stories/dirty-pipe.md
@@ -12,7 +12,10 @@ CVSS
 :   7.8 HIGH (`AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` — NVD primary and Red Hat's CNA score agree)
 
 Bug present since
-:   4.9 (2016); exploitable since 5.8 (2020)
+:   4.9 (2016)
+
+Exploitable since
+:   5.8 (2020)
 
 Fixed in
 :   5.16.11, 5.15.25, 5.10.102 (all released February 23, 2022)

--- a/docs/security/war-stories/dirty-pipe.md
+++ b/docs/security/war-stories/dirty-pipe.md
@@ -2,7 +2,26 @@
 
 > CVE-2022-0847 — one missing `buf->flags = 0;` let any user who could *read* a file overwrite it in the page cache, including immutable files, read-only btrfs snapshots, and read-only mounts
 
-**Disclosed:** March 7, 2022 (fix merged February 22, 2022) &nbsp;·&nbsp; **Reported by:** Max Kellermann, CM4all GmbH / IONOS SE &nbsp;·&nbsp; **CVSS:** 7.8 HIGH (`AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` — NVD primary and Red Hat's CNA score agree) &nbsp;·&nbsp; **Bug present since:** 4.9 (2016); **exploitable since:** 5.8 (2020) &nbsp;·&nbsp; **Fixed in:** 5.16.11, 5.15.25, 5.10.102 (all released February 23, 2022) &nbsp;·&nbsp; **Exploit tool:** yes — the reporter published a working PoC in the disclosure itself &nbsp;·&nbsp; **Actively exploited:** yes — added to CISA's KEV catalog April 25, 2022 (per [NVD](https://nvd.nist.gov/vuln/detail/CVE-2022-0847))
+Disclosed
+:   March 7, 2022 (fix merged February 22, 2022)
+
+Reported by
+:   Max Kellermann, CM4all GmbH / IONOS SE
+
+CVSS
+:   7.8 HIGH (`AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` — NVD primary and Red Hat's CNA score agree)
+
+Bug present since
+:   4.9 (2016); exploitable since 5.8 (2020)
+
+Fixed in
+:   5.16.11, 5.15.25, 5.10.102 (all released February 23, 2022)
+
+Exploit tool
+:   yes — the reporter published a working PoC in the disclosure itself
+
+Actively exploited
+:   yes — added to CISA's KEV catalog April 25, 2022 (per [NVD](https://nvd.nist.gov/vuln/detail/CVE-2022-0847))
 
 *Part of [War Stories: Linux Security Bugs and CVEs](../war-stories.md).*
 

--- a/docs/security/war-stories/fscontext-overflow.md
+++ b/docs/security/war-stories/fscontext-overflow.md
@@ -2,7 +2,26 @@
 
 > CVE-2022-0185 — a bounds check written as `PAGE_SIZE - 2 - size` in unsigned arithmetic let `unshare -Urm` plus a loop of `fsconfig()` calls write past the end of a 4 KB slab object, and turned Google's hardened Kubernetes CTF cluster into a $31,337 payout
 
-**Disclosed:** 18 January 2022 &nbsp;·&nbsp; **Reported by:** the Crusaders of Rust CTF team — Alec Petridis, Hrvoje Mišetić, Isaac Badipe, Jamie Hill-Daniel, Philip Papurt and William Liu — after independent discoveries by syzbot (31 December 2021, on an Android tree) and by StarLabs &nbsp;·&nbsp; **CVSS:** 8.4 HIGH (`CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`, NVD primary) &nbsp;·&nbsp; **Bug present since:** 5.1-rc1 (2019) &nbsp;·&nbsp; **Fixed in:** 5.4.173, 5.10.93, 5.15.16, 5.16.2 (all 20 January 2022), mainline 5.17-rc1 &nbsp;·&nbsp; **Exploit tool:** yes — two independent public exploits, no Exploit-DB or Metasploit entry &nbsp;·&nbsp; **Actively exploited:** yes — added to CISA's KEV catalog on 21 August 2024 (per [NVD](https://nvd.nist.gov/vuln/detail/CVE-2022-0185))
+Disclosed
+:   18 January 2022
+
+Reported by
+:   the Crusaders of Rust CTF team — Alec Petridis, Hrvoje Mišetić, Isaac Badipe, Jamie Hill-Daniel, Philip Papurt and William Liu — after independent discoveries by syzbot (31 December 2021, on an Android tree) and by StarLabs
+
+CVSS
+:   8.4 HIGH (`CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`, NVD primary)
+
+Bug present since
+:   5.1-rc1 (2019)
+
+Fixed in
+:   5.4.173, 5.10.93, 5.15.16, 5.16.2 (all 20 January 2022), mainline 5.17-rc1
+
+Exploit tool
+:   yes — two independent public exploits, no Exploit-DB or Metasploit entry
+
+Actively exploited
+:   yes — added to CISA's KEV catalog on 21 August 2024 (per [NVD](https://nvd.nist.gov/vuln/detail/CVE-2022-0185))
 
 *Part of [War Stories: Linux Security Bugs and CVEs](../war-stories.md).*
 

--- a/docs/security/war-stories/nested-userns-uid-mapping.md
+++ b/docs/security/war-stories/nested-userns-uid-mapping.md
@@ -2,7 +2,26 @@
 
 > CVE-2018-18955 — a performance optimization kept two sorted copies of the ID map, the kernel translated only one of them, and a desktop user could read `/etc/shadow`
 
-**Disclosed:** November 16, 2018 (fix authored November 5, 2018; mainline in v4.20-rc2) &nbsp;·&nbsp; **Reported by:** Jann Horn, Google Project Zero (issue 1712) &nbsp;·&nbsp; **CVSS:** 7.0 HIGH (NVD primary, `CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H`) &nbsp;·&nbsp; **Bug present since:** 4.15 (commit `6397fac4915a`, October 2017) &nbsp;·&nbsp; **Fixed in:** 4.18.19, 4.19.2 (mainline `d2f007dbe7e4`) &nbsp;·&nbsp; **Exploit tool:** yes — Exploit-DB 45886 (Project Zero PoC) and 45915 (Metasploit module) &nbsp;·&nbsp; **Actively exploited:** no confirmed cases (not on CISA KEV)
+Disclosed
+:   November 16, 2018 (fix authored November 5, 2018; mainline in v4.20-rc2)
+
+Reported by
+:   Jann Horn, Google Project Zero (issue 1712)
+
+CVSS
+:   7.0 HIGH (NVD primary, `CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H`)
+
+Bug present since
+:   4.15 (commit `6397fac4915a`, October 2017)
+
+Fixed in
+:   4.18.19, 4.19.2 (mainline `d2f007dbe7e4`)
+
+Exploit tool
+:   yes — Exploit-DB 45886 (Project Zero PoC) and 45915 (Metasploit module)
+
+Actively exploited
+:   no confirmed cases (not on CISA KEV)
 
 *Part of [War Stories: Linux Security Bugs and CVEs](../war-stories.md).*
 

--- a/docs/security/war-stories/stale-ptracer-creds.md
+++ b/docs/security/war-stories/stale-ptracer-creds.md
@@ -2,7 +2,26 @@
 
 > CVE-2019-13272 — `PTRACE_TRACEME` recorded the credentials of the *parent* it drafted as tracer rather than those of the child that actually requested the relationship, so an unprivileged child could obtain a root-marked ptrace relationship no privileged code ever asked for — and keep it after that parent dropped privileges and became attacker-controlled
 
-**Disclosed:** July 17, 2019 (fix authored July 4, 2019) &nbsp;·&nbsp; **Reported by:** Jann Horn, Google Project Zero (issue 1903) &nbsp;·&nbsp; **CVSS:** 7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` — NVD primary and CISA-ADP's secondary score agree; CVSS 2.0: 7.2 HIGH) &nbsp;·&nbsp; **Bug present since:** 4.10 (commit `64b875f7ac8a`, November 2016) &nbsp;·&nbsp; **Fixed in:** 5.2 upstream; stable 5.1.17, 4.19.58, 4.14.133, 4.9.185, 4.4.185 (all announced July 10, 2019), 3.16.71 &nbsp;·&nbsp; **Exploit tool:** yes — four Exploit-DB entries (three PoCs, one Metasploit module) &nbsp;·&nbsp; **Actively exploited:** yes — added to CISA's KEV catalog December 10, 2021 (per [NVD](https://nvd.nist.gov/vuln/detail/CVE-2019-13272))
+Disclosed
+:   July 17, 2019 (fix authored July 4, 2019)
+
+Reported by
+:   Jann Horn, Google Project Zero (issue 1903)
+
+CVSS
+:   7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` — NVD primary and CISA-ADP's secondary score agree; CVSS 2.0: 7.2 HIGH)
+
+Bug present since
+:   4.10 (commit `64b875f7ac8a`, November 2016)
+
+Fixed in
+:   5.2 upstream; stable 5.1.17, 4.19.58, 4.14.133, 4.9.185, 4.4.185 (all announced July 10, 2019), 3.16.71
+
+Exploit tool
+:   yes — four Exploit-DB entries (three PoCs, one Metasploit module)
+
+Actively exploited
+:   yes — added to CISA's KEV catalog December 10, 2021 (per [NVD](https://nvd.nist.gov/vuln/detail/CVE-2019-13272))
 
 *Part of [War Stories: Linux Security Bugs and CVEs](../war-stories.md).*
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -43,3 +43,22 @@ html { font-size: 150%; }                                              /* 125%  
 .md-typeset :not(pre) > code {
   font-size: 0.95em;
 }
+
+/* Definition lists: two-column grid (label left, value right) instead of
+   Material's default stacked layout — used for the war-stories metadata
+   block so seven facts read as seven scannable rows, not one dense line. */
+.md-typeset dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  row-gap: 0.5em;
+  column-gap: 1.2em;
+  margin: 1em 0;
+}
+.md-typeset dl dt {
+  font-weight: 600;
+  white-space: nowrap;
+  margin: 0;
+}
+.md-typeset dl dd {
+  margin: 0;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ theme:
 markdown_extensions:
   - tables
   - admonition
+  - def_list
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.superfences:


### PR DESCRIPTION
## Summary
The dek line (Disclosed/Reported by/CVSS/Fixed in/Exploit tool/Actively exploited) on every war-stories incident page was one dense prose paragraph joined with middot separators — seven facts running together as a single 300-400 character sentence, hard to scan.

- Converted the metadata block on all 16 war-stories pages that use this format to Markdown definition-list syntax (`Term` / `:   Definition`).
- Added `def_list` to `mkdocs.yml`'s markdown_extensions (required for the syntax to render as `<dl>` rather than plain text).
- Added CSS in `extra.css` rendering `<dl>` as a two-column grid (label left, value right) instead of Material's default stacked layout, so each fact reads as its own row rather than doubling the vertical space.

Content is unchanged — every label, value, link, and code span in the new list form was diffed against the original prose line programmatically; all 16 files match exactly once formatting-only differences (the literal `:` after each label) are normalized out.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Rendered HTML spot-checked on 3 pages — confirmed a single well-formed `<dl>` per page with all expected `<dt>`/`<dd>` pairs and working links
- [x] Automated content diff: 16/16 files match the original prose line exactly (formatting-only differences excluded)