### PR TITLE
index: add missing Devices & Drivers category, fix stale Drivers placement

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,12 @@ The kernel has extensive API documentation, but understanding the *rationale* re
 - [Block Layer (block/)](block/README.md) — the path from a filesystem request to a physical device
 - [I/O Patterns (io/)](io/README.md) — buffered vs. direct, sync vs. async, and the tradeoffs between them
 - [io_uring (io-uring/)](io-uring/README.md) — the ring-based interface for high-performance asynchronous I/O
+
+**Devices & Drivers**
+
 - [Drivers (drivers/)](drivers/README.md) — the device model and how drivers bind to hardware
+- [USB (usb/)](usb/README.md) — the host-scheduled, hot-pluggable peripheral bus: descriptors, endpoints, and URBs
+- [GPU / DRM (drm/)](drm/README.md) — the graphics and display stack: KMS modesetting, GEM buffers, and command submission
 
 **Networking & BPF**
 


### PR DESCRIPTION
## Summary
Found while reviewing the now-complete GPU/DRM epic (#658): `docs/index.md`'s subsystem list predated the "Devices & Drivers" nav category entirely. `Drivers` was still listed under "Storage & I/O", and `USB` / `GPU-DRM` weren't listed at all despite both having shipped real content.

Adds a "Devices & Drivers" section (Drivers, USB, GPU/DRM) matching `mkdocs.yml`'s actual nav structure and `docs/categories/devices.md`'s existing summary, and removes the stale `Drivers` entry from "Storage & I/O".

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Verified `drm/README.md` and `usb/README.md` both exist