### PR TITLE
index, categories/foundations: add missing Kernel Internals section

### DIFF
--- a/docs/categories/foundations.md
+++ b/docs/categories/foundations.md
@@ -2,6 +2,7 @@
 
 The groundwork the rest of the kernel builds on: how it boots, meets the hardware, exposes itself to user space, and keeps time.
 
+- [Kernel Internals (kernel/)](../kernel/README.md) — the glue that holds every subsystem together: boot, logging, parameters, panics, and module init
 - [Architecture (arch/)](../arch/arm64/README.md) — where the kernel meets the hardware: boot, CPU features, exceptions, and per-arch specifics (x86, arm64)
 - [System Calls (syscalls/)](../syscalls/README.md) — how user space crosses into the kernel and back
 - [Modules (modules/)](../modules/README.md) — loading, linking, and unloading kernel code at runtime

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ The kernel has extensive API documentation, but understanding the *rationale* re
 
 **Foundations**
 
+- [Kernel Internals (kernel/)](kernel/README.md) — the glue that holds every subsystem together: boot, logging, parameters, panics, and module init
 - [Architecture (arch/)](arch/arm64/README.md) — where the kernel meets the hardware: boot, CPU features, exceptions, and per-arch specifics (x86, arm64)
 - [System Calls (syscalls/)](syscalls/README.md) — how user space crosses into the kernel and back
 - [Modules (modules/)](modules/README.md) — loading, linking, and unloading kernel code at runtime


### PR DESCRIPTION
## Summary
Same class of gap as #732: `kernel/` (7 pages — printk, early-boot, boot-params, panic-oops, initcalls-modules, war-stories) is a full sibling entry in `mkdocs.yml`'s Foundations nav but was never listed in `docs/index.md` or `docs/categories/foundations.md`. Found while a reviewer was checking #732 and cross-referencing every top-level `docs/` directory against `index.md`'s enumeration.

## Test plan
- [x] `mkdocs build --strict` passes