### PR TITLE
Fix wrong LWN citation in mm/kfence.md

### DIFF
--- a/docs/mm/kfence.md
+++ b/docs/mm/kfence.md
@@ -316,7 +316,7 @@ KFENCE was developed at Google. The [v1 RFC](https://lore.kernel.org/lkml/202009
 
 The patch series went through extensive review on LKML: [KFENCE v7 patch series](https://lore.kernel.org/lkml/20201103175841.3495947-1-elver@google.com/) (November 2020, merged for v5.12 in early 2021).
 
-**LWN coverage**: [KFENCE: A low-overhead memory safety error detector](https://lwn.net/Articles/832354/) provides an accessible overview of the design rationale.
+**LWN coverage**: [KFENCE: A low-overhead sampling-based memory safety error detector](https://lwn.net/Articles/830877/) provides an accessible overview of the design rationale.
 
 ### v5.17: Improved Reporting and Coverage
 
@@ -348,7 +348,7 @@ Added a deferrable timer option to reduce overhead on systems where power consum
 
 ### LWN Articles
 
-- [KFENCE: A low-overhead memory safety error detector](https://lwn.net/Articles/832354/) -- overview article from the initial submission
+- [KFENCE: A low-overhead sampling-based memory safety error detector](https://lwn.net/Articles/830877/) -- overview article from the initial submission
 
 ### LKML Discussions
 
@@ -370,7 +370,7 @@ Added a deferrable timer option to reduce overhead on systems where power consum
 
 ### LWN articles
 
-- [KFENCE: A low-overhead memory safety error detector](https://lwn.net/Articles/832354/) — Marco Elver's overview of the design rationale and production deployment model (2021)
+- [KFENCE: A low-overhead sampling-based memory safety error detector](https://lwn.net/Articles/830877/) — Marco Elver's overview of the design rationale and production deployment model (2021)
 
 ### Related docs
 


### PR DESCRIPTION
## Summary

`docs/mm/kfence.md` cited `https://lwn.net/Articles/832354/` three times as "KFENCE: A low-overhead memory safety error detector" (Marco Elver's KFENCE design writeup). That URL resolves (200), but to a completely unrelated 2020 LWN article — "Removing run-time disabling for SELinux in Fedora." The correct URL for the actual KFENCE article is `https://lwn.net/Articles/830877/` ("KFENCE: A low-overhead sampling-based memory safety error detector").

This is worse than a dead link — a reader clicking through gets a plausible-looking but entirely wrong article with no indication anything's off. Fixed all three occurrences, and corrected the link text to match the real article's title.

Found as a side effect of unrelated citation-backfill research on `docs/kernel/`; relevant to the ongoing mm/ citation audit (#563).

## Verification

- Both URLs fetched and their `<title>` tags confirmed (832354 = SELinux article, 830877 = the real KFENCE article), independently re-verified after an initial LWN rate-limit.
- `mkdocs build --strict` passes.

## Test plan

- [ ] Quick review (single isolated URL/text fix, not new content)