### PR TITLE
Add citations to docs/debugging/ (issue #542)

### DIFF
--- a/docs/debugging/dynamic-debug-lockdep.md
+++ b/docs/debugging/dynamic-debug-lockdep.md
@@ -291,14 +291,14 @@ CONFIG_LOCK_STAT=y              # enables /proc/lock_stat
 
 ## Lockdep limits
 
-Lockdep maintains a compile-time-bounded data structure:
+Lockdep maintains a compile-time-bounded data structure. `MAX_LOCKDEP_KEYS` is a fixed cap; the others are Kconfig-tunable (`CONFIG_LOCKDEP_BITS`, `CONFIG_LOCKDEP_CHAINS_BITS`, `CONFIG_LOCKDEP_STACK_TRACE_BITS`), each defaulting to the value shown below (`MAX_STACK_TRACE_ENTRIES` defaults higher, to 2M, under `CONFIG_KASAN`):
 
 ```c
-/* kernel/locking/lockdep.c */
-#define MAX_LOCKDEP_KEYS        8192   /* max lock classes */
-#define MAX_LOCKDEP_ENTRIES     (1UL << 14)  /* 16384 lock-class entries */
-#define MAX_LOCKDEP_CHAINS      (1UL << 16)  /* 65536 dependency chains */
-#define MAX_STACK_TRACE_ENTRIES (1UL << 20)  /* 1M stack trace entries */
+/* include/linux/lockdep_types.h, kernel/locking/lockdep_internals.h */
+#define MAX_LOCKDEP_KEYS        8192   /* max lock classes (fixed) */
+#define MAX_LOCKDEP_ENTRIES     (1UL << CONFIG_LOCKDEP_BITS)         /* default 32768 */
+#define MAX_LOCKDEP_CHAINS      (1UL << CONFIG_LOCKDEP_CHAINS_BITS)  /* default 65536 */
+#define MAX_STACK_TRACE_ENTRIES (1UL << CONFIG_LOCKDEP_STACK_TRACE_BITS)  /* default 524288 */
 ```
 
 Once the tables are full, new lock classes are silently dropped — lockdep stops tracking them. Check usage at runtime:
@@ -309,11 +309,11 @@ cat /proc/lockdep_stats
 
 ```
 lock-classes:                          3456 [max: 8192]
-direct dependencies:                  12345 [max: 16384]
+direct dependencies:                  12345 [max: 32768]
 indirect dependencies:                56789
 all direct dependencies:              23456
 dependency chains:                     8901 [max: 65536]
-stack-trace entries:                 234567 [max: 1048576]
+stack-trace entries:                 234567 [max: 524288]
 ```
 
 If `lock-classes` is near the maximum, consider booting with a config that has fewer drivers, or increase `MAX_LOCKDEP_KEYS` in the source.
@@ -392,10 +392,31 @@ dmesg | grep -A 80 "possible circular locking"
 
 ## Further reading
 
+### Kernel source
+
+- [kernel/locking/lockdep.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/locking/lockdep.c) — the validator implementation; `lock_acquire()` and `lock_release()` are the hooks that `spin_lock()`/`mutex_lock()` and friends call internally
+- [kernel/locking/lockdep_internals.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/locking/lockdep_internals.h) — `MAX_LOCKDEP_ENTRIES`, `MAX_LOCKDEP_CHAINS`, `MAX_STACK_TRACE_ENTRIES`; on current kernels these are derived from the `CONFIG_LOCKDEP_BITS`/`CONFIG_LOCKDEP_CHAINS_BITS`/`CONFIG_LOCKDEP_STACK_TRACE_BITS` Kconfig options rather than fixed at compile time
+- [include/linux/lockdep_types.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/lockdep_types.h) — `MAX_LOCKDEP_KEYS_BITS`/`MAX_LOCKDEP_KEYS`, the fixed cap on lock classes
+- [kernel/locking/lockdep_proc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/locking/lockdep_proc.c) — `/proc/lockdep_stats` and `/proc/lock_stat` output formatting (`lock-classes`, `con-bounces`, `contentions`, `waittime-min`, etc.)
+- [include/linux/fs.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/fs.h) — the `I_MUTEX_NORMAL`/`I_MUTEX_PARENT`/`I_MUTEX_CHILD`/`I_MUTEX_XATTR`/`I_MUTEX_NONDIR2` subclass enum used with `lockdep_set_subclass()`
+- [include/linux/spinlock.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/spinlock.h) — `spin_lock_init()`, which allocates the per-call-site `lock_class_key`
+- [scripts/faddr2line](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/faddr2line) — resolves `func+0x123/0x456`-style offsets from a splat back to source lines
+- [Documentation/locking/lockdep-design.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/locking/lockdep-design.rst) — lockdep's own design document
+- [Documentation/locking/lockstat.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/locking/lockstat.rst) — `/proc/lock_stat` design document
+
+### Related pages
+
 - [Lockdep fundamentals](../locking/lockdep.md) — dependency graph, lock classes, basic splat reading
 - [Lock Contention Debugging](../locking/lock-debugging.md) — `/proc/lock_stat`, perf lock
 - [KASAN and KFENCE](kasan-kfence.md) — complementary memory error detectors
 - [KCSAN](kcsan.md) — data race detection
-- `kernel/locking/lockdep.c` — lockdep implementation
-- `Documentation/locking/lockdep-design.rst`
-- `Documentation/locking/lockstat.rst`
+
+### LWN articles
+
+- [Enhancing lockdep with crossrelease](https://lwn.net/Articles/709849/) — Byungchul Park lays out lockdep's dependency-graph fundamentals (lock classes, cycle detection) before proposing the crossrelease extension (December 2016)
+- [The dependency tracker for complex deadlock detection](https://lwn.net/Articles/1036222/) — Jonathan Corbet on DEPT, a proposed lockdep alternative; explains what lockdep does and does not catch (September 2025)
+
+### External
+
+- [docs.kernel.org: Runtime locking correctness validator](https://docs.kernel.org/locking/lockdep-design.html) — rendered version of lockdep-design.rst
+- [docs.kernel.org: Lock Statistics](https://docs.kernel.org/locking/lockstat.html) — rendered version of lockstat.rst

--- a/docs/debugging/kasan-kfence.md
+++ b/docs/debugging/kasan-kfence.md
@@ -31,15 +31,15 @@ The shadow byte encoding:
 |---|---|
 | `0` | All 8 bytes are accessible |
 | `1`–`7` | First N bytes are accessible; bytes N+1–8 are in a redzone |
-| `0xFB` (`KASAN_KMALLOC_FREE`) | Object was freed (use-after-free) |
-| `0xFC` (`KASAN_KMALLOC_REDZONE`) | kmalloc right redzone |
+| `0xFB` (`KASAN_SLAB_FREE`) | Object was freed (use-after-free) |
+| `0xFC` (`KASAN_SLAB_REDZONE`) | kmalloc right redzone |
 | `0xf9` (`KASAN_GLOBAL_REDZONE`) | Global variable redzone |
 | `0xF1` (`KASAN_STACK_LEFT`) | Left stack redzone |
 | `0xF2` (`KASAN_STACK_MID`) | Stack mid-redzone |
 | `0xF3` (`KASAN_STACK_RIGHT`) | Right stack redzone |
 | `0xF4` (`KASAN_STACK_PARTIAL`) | Partial stack frame redzone |
 
-These constants are defined in `mm/kasan/kasan.h` (older kernels) and `include/linux/kasan-tags.h`.
+These constants are defined in `mm/kasan/kasan.h`. (`include/linux/kasan-tags.h` defines a separate set of pointer-tag constants — `KASAN_TAG_KERNEL`, `KASAN_TAG_INVALID`, etc. — used by the SW-tag/HW-tag modes below, not these poison/redzone values.)
 
 ### Compiler instrumentation
 
@@ -56,7 +56,7 @@ __asan_store4(ptr);
 These functions are implemented in `mm/kasan/generic.c` (`kasan_check_range()` is the common entry point). They compute the shadow address, read the shadow byte, and report if the access is invalid.
 
 ```c
-/* Simplified shadow check (mm/kasan/shadow.c): */
+/* Simplified shadow check (mm/kasan/generic.c): */
 static __always_inline bool memory_is_poisoned_1(unsigned long addr)
 {
     s8 shadow_value = *(s8 *)kasan_mem_to_shadow((void *)addr);
@@ -81,20 +81,26 @@ KASAN hooks into the slab allocator via functions defined in `mm/kasan/common.c`
 - `kasan_unpoison_pages(page, order, init)` — called from `__alloc_pages()` to unpoison a newly allocated page
 - `kasan_poison_pages(page, order, init)` — called on page free to poison the region
 - `kasan_slab_alloc(cache, object, flags, init)` — unpoisons a slab object returned to the caller
-- `kasan_slab_free(cache, object, ip)` — poisons a freed slab object with `KASAN_KMALLOC_FREE (0xFB)`
+- `kasan_slab_free(cache, object, ...)` — poisons a freed slab object with `KASAN_SLAB_FREE (0xFB)`
 
 For use-after-free detection, KASAN also records allocation and free stack traces:
 
 - `kasan_save_stack(flags)` — captures the current call stack into a ring buffer of stack records
-- `kasan_set_track(track, flags)` — stores the captured stack in the object's `kasan_track` metadata
+- `kasan_set_track(track, stack)` — stores the captured stack in the object's `kasan_track` metadata
 
-The metadata is stored in a `struct kasan_alloc_meta` appended to each object:
+The allocation-side metadata is stored in a `struct kasan_alloc_meta`, held inside the object's redzone; free-side metadata lives in a separate `struct kasan_free_meta`, stored within the freed object's own memory:
 
 ```c
-/* include/linux/kasan.h */
+/* mm/kasan/kasan.h */
 struct kasan_alloc_meta {
     struct kasan_track alloc_track;
-    struct kasan_track free_track[KASAN_NR_FREE_STACKS];
+    /* Free track is stored in kasan_free_meta. */
+    depot_stack_handle_t aux_stack[2];
+};
+
+struct kasan_free_meta {
+    struct qlist_node quarantine_link;
+    struct kasan_track free_track;
 };
 ```
 
@@ -159,7 +165,7 @@ Key sections:
 1. **Bug type and location** — access type, size, address, offending function
 2. **Allocation stack** — where the object was originally allocated
 3. **Free stack** — where the object was freed
-4. **Shadow dump** — surrounding shadow bytes; `fb` = `KASAN_KMALLOC_FREE` (freed slab object)
+4. **Shadow dump** — surrounding shadow bytes; `fb` = `KASAN_SLAB_FREE` (freed slab object)
 
 ### Overhead
 
@@ -214,23 +220,23 @@ For **use-after-free** detection: when a KFENCE object is freed, its page is mar
 
 ### Sampling
 
-KFENCE is not invoked for every allocation. Instead, the slab allocator calls `kfence_alloc()` at a configurable rate:
+KFENCE is not invoked for every allocation. Instead, the slab allocator calls `__kfence_alloc()` at a configurable rate:
 
 ```c
-/* mm/kfence/core.c — called from slab allocator hot path */
+/* mm/kfence/core.c — simplified; called from slab allocator hot path */
 void *__kfence_alloc(struct kmem_cache *s, size_t size, gfp_t flags)
 {
-    /* Gate is set to 1 by a periodic timer every kfence_sample_interval ms */
-    if (!atomic_read(&kfence_allocation_gate))
-        return NULL;        /* not time to sample yet */
-    /* Atomically claim the slot; only one allocation per interval wins */
-    if (atomic_cmpxchg(&kfence_allocation_gate, 1, 0) != 1)
-        return NULL;
-    return kfence_alloc(s, size, flags);
+    /* Each call claims one tick of the gate; only the call that brings
+     * it from 0 to 1 samples this allocation into the KFENCE pool. */
+    int allocation_gate = atomic_inc_return(&kfence_allocation_gate);
+    if (allocation_gate > 1)
+        return NULL;         /* not this allocation's turn */
+
+    return kfence_guarded_alloc(s, size, flags, ...);
 }
 ```
 
-A periodic timer fires every `kfence_sample_interval` milliseconds and sets `kfence_allocation_gate` to `1`. When the slab allocator calls `kfence_alloc()`, it atomically tests and clears the gate: if the gate is `1` (timer has fired), this allocation is redirected into the KFENCE pool. The sampling is purely time-driven — the gate is never decremented per allocation.
+A periodic work item (`toggle_allocation_gate()`) fires every `kfence_sample_interval` milliseconds and resets `kfence_allocation_gate` to `-kfence_burst` — allowing a burst of up to `kfence_burst + 1` samples per interval, not just one (`kfence_burst` defaults to 0, i.e. one sample per interval). Each call to `__kfence_alloc()` atomically increments the gate via `atomic_inc_return()`; only the call whose result is `≤ 1` gets redirected into the KFENCE pool. When `CONFIG_KFENCE_STATIC_KEYS` is enabled, a static branch (`kfence_allocation_key`) also gates the fast path so non-sampled allocations skip this check almost entirely.
 
 ### Configuration
 
@@ -300,7 +306,7 @@ KFENCE only catches errors in the sampled allocations. An OOB or UAF in a non-sa
 | Deterministic | Yes | No (sampling) |
 | Production use | No | Yes |
 | OOB detection | Shadow byte check | Guard page fault |
-| UAF detection | Shadow byte (`KASAN_KMALLOC_FREE`, 0xFB) | Guard page (mprotect) |
+| UAF detection | Shadow byte (`KASAN_SLAB_FREE`, 0xFB) | Guard page (mprotect) |
 | Allocation stack | Yes | Yes |
 | Free stack | Yes | Yes |
 | Kernel version | 4.0+ | 5.12+ |
@@ -320,12 +326,22 @@ CONFIG_KFENCE=y
 
 ## Further reading
 
+### Kernel source
+
+- [mm/kasan/report.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/report.c) — `kasan_report()` and `print_report()`: the report-generation code behind the KASAN report format shown above
+- [mm/kasan/kasan.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/kasan.h) — internal header holding the actual shadow-byte constants (`KASAN_SLAB_FREE`, `KASAN_SLAB_REDZONE`, etc.) and the `kasan_alloc_meta`/`kasan_free_meta` layout
+- [mm/kfence/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/core.c) — `__kfence_alloc()` and the `kfence_allocation_gate` sampling counter referenced above
+- [mm/kfence/report.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/report.c) — `kfence_report_error()`: the report-generation code behind the KFENCE report format shown above
+
+### Related pages
+
 - [KCSAN](kcsan.md) — data race detection (complements KASAN)
 - [syzkaller](syzkaller.md) — fuzzer that uses KASAN to find bugs automatically
 - [Oops Analysis](oops-analysis.md) — decoding stack traces from KASAN reports
-- [KASAN in mm/](../mm/kasan.md) — memory-management perspective
-- [KFENCE in mm/](../mm/kfence.md) — allocator integration details
-- `mm/kasan/` — KASAN implementation
-- `mm/kfence/` — KFENCE implementation
-- `Documentation/dev-tools/kasan.rst`
-- `Documentation/dev-tools/kfence.rst`
+- [KASAN in mm/](../mm/kasan.md) — shadow memory layout, the three tagging modes, and compiler instrumentation in depth
+- [KFENCE in mm/](../mm/kfence.md) — pool layout, guard-page mechanics, and sampling design in depth
+
+### External
+
+- [KASAN official documentation](https://docs.kernel.org/dev-tools/kasan.html) — report-format reference, boot parameters (`kasan.mode`, `kasan.fault`, `kasan.stacktrace`), and how to run the KUnit test suite
+- [KFENCE official documentation](https://docs.kernel.org/dev-tools/kfence.html) — report-format reference, the `/sys/kernel/debug/kfence/{stats,objects}` interface, and boot/sysfs tuning parameters

--- a/docs/debugging/kasan-kfence.md
+++ b/docs/debugging/kasan-kfence.md
@@ -207,14 +207,14 @@ KFENCE pool layout (one slot):
 ┌─────────────────┐  ← unmapped guard page (4 KB)
 │  GUARD PAGE     │    OOB access here → page fault → KFENCE report
 ├─────────────────┤
-│  object (N bytes)│   ← the actual allocation (right-aligned in page)
+│  object (N bytes)│   ← the actual allocation (left- or right-aligned, chosen at random)
 ├─────────────────┤
 │  GUARD PAGE     │  ← unmapped guard page (4 KB)
 │                 │    OOB access here → page fault → KFENCE report
 └─────────────────┘
 ```
 
-Objects are **right-aligned** within their page so that a one-byte overrun immediately hits the following guard page.
+Each object is placed against **either the left or right page boundary, chosen at random per allocation** (`get_random_u32_below(2)` in `mm/kfence/core.c`), so that a one-byte overrun in that direction immediately hits the adjacent guard page.
 
 For **use-after-free** detection: when a KFENCE object is freed, its page is marked inaccessible (similar to `mprotect(PROT_NONE)`). Any subsequent access faults and triggers a KFENCE report.
 
@@ -258,7 +258,7 @@ echo 50 > /sys/module/kfence/parameters/sample_interval
 
 ### KFENCE pool size
 
-With `CONFIG_KFENCE_NUM_OBJECTS=255` and 2 pages (8 KB) per slot, the pool uses ~2 MB of physical memory. Each slot is a fixed-size region; objects smaller than a page are right-aligned within the slot's data page.
+With `CONFIG_KFENCE_NUM_OBJECTS=255` and 2 pages (8 KB) per slot, the pool uses ~2 MB of physical memory. Each slot is a fixed-size region; objects smaller than a page are placed against a randomly chosen left or right boundary within the slot's data page.
 
 The pool is allocated at boot in `kfence_init()` (`mm/kfence/core.c`) and registered with the page allocator to keep it from being reclaimed.
 

--- a/docs/debugging/kcsan.md
+++ b/docs/debugging/kcsan.md
@@ -202,10 +202,30 @@ echo 100 > /sys/kernel/debug/kcsan/delay_task  # force 100µs delay
 
 ## Further reading
 
+### Kernel source
+
+- [kernel/kcsan/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/kcsan/core.c) — the watchpoint-based race detection engine
+- [kernel/kcsan/report.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/kcsan/report.c) — report formatting: the two racing call stacks and the "value changed" line
+- [kernel/kcsan/debugfs.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/kcsan/debugfs.c) — the `/sys/kernel/debug/kcsan` control file (on/off, blacklist/whitelist)
+- [lib/Kconfig.kcsan](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/lib/Kconfig.kcsan) — Kconfig options and defaults (`KCSAN_NUM_WATCHPOINTS` defaults to 64, `KCSAN_REPORT_ONCE_IN_MS` defaults to 3000, `KCSAN_DELAY_RANDOMIZE` defaults to y)
+- [include/linux/compiler.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/compiler.h) — `data_race()` macro definition
+- [include/linux/compiler_types.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/compiler_types.h) — `__no_kcsan` function attribute definition
+- [Documentation/dev-tools/kcsan.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/dev-tools/kcsan.rst) — official KCSAN documentation
+- [tools/memory-model/](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/memory-model/) — Linux Kernel Memory Model (LKMM) formal specification
+
+### Related pages
+
 - [KASAN](../mm/kasan.md) — memory error detection (use-after-free, OOB)
 - [KFENCE](../mm/kfence.md) — lightweight sampling memory error detector
 - [Atomics and Memory Barriers](../locking/atomics.md) — correct concurrent access
 - [RCU](../locking/rcu.md) — RCU is a race-free read-mostly pattern
 - [Spinlock](../locking/spinlock.md) — spinlocks prevent races
-- `Documentation/dev-tools/kcsan.rst`
-- `tools/memory-model/` — Linux Kernel Memory Model (LKMM) formal specification
+
+### LWN articles
+
+- [Finding race conditions with KCSAN](https://lwn.net/Articles/802128/) — Jonathan Corbet's introduction to KCSAN shortly after it was merged (October 2019)
+- [Concurrency bugs should fear the big bad data-race detector](https://lwn.net/Articles/816850/) — a joint writeup by the KCSAN and Linux Kernel Memory Model developers on how the two projects fit together (April 2020)
+
+### External
+
+- [docs.kernel.org: Kernel Concurrency Sanitizer (KCSAN)](https://docs.kernel.org/dev-tools/kcsan.html) — rendered official documentation, including the debugfs interface and tuning parameters

--- a/docs/debugging/kcsan.md
+++ b/docs/debugging/kcsan.md
@@ -223,7 +223,7 @@ echo 100 > /sys/kernel/debug/kcsan/delay_task  # force 100µs delay
 
 ### LWN articles
 
-- [Finding race conditions with KCSAN](https://lwn.net/Articles/802128/) — Jonathan Corbet's introduction to KCSAN shortly after it was merged (October 2019)
+- [Finding race conditions with KCSAN](https://lwn.net/Articles/802128/) — Jonathan Corbet's introduction to KCSAN shortly after it was announced (October 2019, ahead of its eventual merge in 5.8)
 - [Concurrency bugs should fear the big bad data-race detector](https://lwn.net/Articles/816850/) — a joint writeup by the KCSAN and Linux Kernel Memory Model developers on how the two projects fit together (April 2020)
 
 ### External

--- a/docs/debugging/kdump.md
+++ b/docs/debugging/kdump.md
@@ -273,7 +273,7 @@ echo 120 > /proc/sys/kernel/hung_task_timeout_secs
 ### LWN articles
 
 - [Crash dumps with kexec](https://lwn.net/Articles/108595/) — Jonathan Corbet on the original kexec-based crash dump design (2004)
-- [Persistent storage for a kernel's "dying breath"](https://lwn.net/Articles/434821/) — Jake Edge's introduction to pstore, the mechanism behind ramoops (2011)
+- [Persistent storage for a kernel's "dying breath"](https://lwn.net/Articles/434821/) — Jake Edge's introduction to pstore (2011); ramoops, then a separate mechanism, was later refactored into a pstore backend, which is how it works today
 
 ### External
 

--- a/docs/debugging/kdump.md
+++ b/docs/debugging/kdump.md
@@ -251,8 +251,31 @@ echo 120 > /proc/sys/kernel/hung_task_timeout_secs
 
 ## Further reading
 
+### Kernel source
+
+- [kernel/panic.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/panic.c) — `panic_timeout` and `panic_on_oops`: the variables behind the `kernel.panic` and `kernel.panic_on_oops` sysctl entries in `kern_panic_table[]`
+- [kernel/watchdog.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/watchdog.c) — `softlockup_panic`: the variable behind `kernel.softlockup_panic`, checked when the soft lockup watchdog fires
+- [kernel/hung_task.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/hung_task.c) — `sysctl_hung_task_timeout_secs`: backs `kernel.hung_task_timeout_secs`
+- [fs/pstore/ram.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/pstore/ram.c) — `mem_address`/`mem_size` module parameters: back the `ramoops.mem_address=`/`ramoops.mem_size=` boot parameters used to reserve the ramoops region
+
+### Man pages
+
+- [`kexec_load(2)`](https://man7.org/linux/man-pages/man2/kexec_load.2.html) — documents `KEXEC_ON_CRASH`, the flag that registers a kernel image as the crash kernel loaded into the memory reserved by `crashkernel=`
+
+### Related pages
+
 - [Oops analysis](oops-analysis.md) — reading oops without crash tool
 - [KGDB](kgdb.md) — live kernel debugging
+- [Kernel Panic and Oops](../kernel/panic-oops.md) — the `die()`/`panic()` code path that actually triggers kdump (`crash_kexec()`/`__crash_kexec()`)
 - [Memory Management: KASAN](../mm/kasan.md) — catching use-after-free before crashes
 - [Memory Management: KFENCE](../mm/kfence.md) — lightweight memory error detection
-- `Documentation/admin-guide/kdump/kdump.rst` in the kernel tree
+
+### LWN articles
+
+- [Crash dumps with kexec](https://lwn.net/Articles/108595/) — Jonathan Corbet on the original kexec-based crash dump design (2004)
+- [Persistent storage for a kernel's "dying breath"](https://lwn.net/Articles/434821/) — Jake Edge's introduction to pstore, the mechanism behind ramoops (2011)
+
+### External
+
+- [Kdump](https://docs.kernel.org/admin-guide/kdump/kdump.html) — official kdump setup guide: `crashkernel=` syntax, `/proc/vmcore`, `makedumpfile` usage
+- [Ramoops oops/panic logger](https://docs.kernel.org/admin-guide/ramoops.html) — the ramoops pstore backend, including the `mem_address`/`mem_size` parameters

--- a/docs/debugging/kgdb.md
+++ b/docs/debugging/kgdb.md
@@ -160,7 +160,7 @@ The kernel ships Python-based GDB scripts (`scripts/gdb/`) that add kernel-speci
 # Pretty-printers: struct task_struct, list_head, etc.
 (gdb) p $lx_per_cpu("runqueues", 0)  # runqueue of CPU 0
 (gdb) p $lx_current()               # current task
-(gdb) $lx_container_of(ptr, "struct task_struct", "mm")
+(gdb) $container_of(ptr, "struct task_struct", "mm")
 ```
 
 ## Debugging a kernel module
@@ -240,8 +240,27 @@ KDB (`CONFIG_KGDB_KDB=y`) provides a simpler text-based debugger that runs entir
 
 ## Further reading
 
+### Kernel source
+
+- [Documentation/process/debugging/kgdb.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/debugging/kgdb.rst) — the canonical kgdb/kdb documentation: config options, `kgdboc` syntax, and the kdb command reference (note: this file lived at `Documentation/dev-tools/kgdb.rst` in older trees; it was relocated to `Documentation/process/debugging/`)
+- [kernel/debug/debug_core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/debug/debug_core.c) — the debug core shared by both kgdb and kdb: exception entry and breakpoint handling
+- [kernel/debug/kdb/kdb_main.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/debug/kdb/kdb_main.c) — the kdb command table (`ps`, `bt`, `btp`, `go`, `dmesg`, `lsmod`, `md`, `mm`, `help`, ...)
+- [drivers/tty/serial/kgdboc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/tty/serial/kgdboc.c) — the `kgdboc` I/O driver that binds kgdb to a serial console
+- [scripts/gdb/vmlinux-gdb.py](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/gdb/vmlinux-gdb.py) — entry point that loads the `lx-*` GDB helper commands (`lx-ps`, `lx-dmesg`, `lx-lsmod`, `lx-symbols`, ...) and convenience functions (`$lx_current()`, `$lx_per_cpu()`, `$container_of()`) from `scripts/gdb/linux/`
+
+### Related pages
+
 - [kdump and crash](kdump.md) — post-mortem crash analysis
 - [Oops analysis](oops-analysis.md) — decoding oops without a debugger
 - [Kernel Modules](../modules/module-basics.md) — loading module debug symbols
 - [Tracing: ftrace](../tracing/ftrace.md) — lighter-weight alternative to breakpoints
-- `Documentation/dev-tools/kgdb.rst` in the kernel tree
+
+### LWN articles
+
+- [Bringing kgdb into 2.6](https://lwn.net/Articles/70465/) (2004) — the early, contested push to get kgdb merged, over Linus Torvalds's historical resistance to in-tree debuggers
+- [Merging kdb and kgdb](https://lwn.net/Articles/374633/) (2010) — Jason Wessel's work to unify the kdb shell and kgdb's gdb-remote stub around a common debug core, extending kdb beyond x86
+
+### External
+
+- [Using kgdb, kdb and the kernel debugger internals](https://docs.kernel.org/process/debugging/kgdb.html) — docs.kernel.org rendering of the canonical documentation
+- [GDB kernel debugging](https://docs.kernel.org/process/debugging/gdb-kernel-debugging.html) — docs.kernel.org page on the `scripts/gdb/` Python helpers and convenience functions

--- a/docs/debugging/oops-analysis.md
+++ b/docs/debugging/oops-analysis.md
@@ -43,7 +43,7 @@ The error code `0000`:
 G — all loaded modules are GPL-compatible (no proprietary modules)
 P — proprietary (non-GPL) module loaded
 F — forced module load (bad signature or version mismatch)
-S — SMP unsafe module (obsolete)
+S — kernel running on a CPU/system out of specification
 M — machine check exception
 B — bad page
 U — user (userspace explicitly loaded)
@@ -51,7 +51,7 @@ D — died (OOPS has been recorded, tainted from now on)
 A — ACPI table overridden
 W — warning (taint on WARN())
 C — staging driver loaded
-I — ACPI workaround applied
+I — workaround for a bug in platform firmware applied
 K — live patched
 ```
 
@@ -257,9 +257,27 @@ echo 1                > /sys/kernel/config/netconsole/target1/enabled
 
 ## Further reading
 
+### Kernel source
+
+- [arch/x86/include/asm/trap_pf.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/include/asm/trap_pf.h) — the `X86_PF_*` bit definitions behind the page-fault `error_code` breakdown (bit 0 = not-present/protection, bit 1 = read/write, bit 2 = kernel/user)
+- [kernel/panic.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/panic.c) — the `taint_flags[]` table: the authoritative letter-to-meaning mapping behind the `Tainted:` line
+- [scripts/decode_stacktrace.sh](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/decode_stacktrace.sh) — resolves `function+0xNN/0xNN` entries in a captured oops to `function (file.c:line)`
+- [Documentation/networking/netconsole.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/networking/netconsole.rst) — the `netconsole=` module parameter format and the configfs-based dynamic reconfiguration interface (`dev_name`, `local_ip`, `remote_ip`, `remote_mac`, `enabled`, ...)
+
+### Man pages
+
+- [`addr2line(1)`](https://man7.org/linux/man-pages/man1/addr2line.1.html) — converts addresses (or `function+offset`) into file names and line numbers
+- [`objdump(1)`](https://man7.org/linux/man-pages/man1/objdump.1.html) — disassembles object files; used here with `--start-address`/`--stop-address` to inspect the faulting instruction
+
+### Related pages
+
+- [Kernel Panic and Oops](../kernel/panic-oops.md) — the kernel-side code path: `die()`, `oops_begin()`/`oops_end()`, ORC unwinding, and `panic()`
 - [kdump and crash](kdump.md) — automated crash dump collection
 - [KGDB](kgdb.md) — live kernel debugging
 - [Memory Management: KASAN](../mm/kasan.md) — memory error detection
 - [Memory Management: KFENCE](../mm/kfence.md) — lightweight production memory checking
 - [Tracing: kprobes](../tracing/kprobes-tracepoints.md) — probing without crashing
-- `scripts/decode_stacktrace.sh` in the kernel tree
+
+### External
+
+- [Tainted kernels](https://docs.kernel.org/admin-guide/tainted-kernels.html) — full taint flag reference with official descriptions for every letter

--- a/docs/debugging/oops-analysis.md
+++ b/docs/debugging/oops-analysis.md
@@ -260,7 +260,7 @@ echo 1                > /sys/kernel/config/netconsole/target1/enabled
 ### Kernel source
 
 - [arch/x86/include/asm/trap_pf.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/include/asm/trap_pf.h) — the `X86_PF_*` bit definitions behind the page-fault `error_code` breakdown (bit 0 = not-present/protection, bit 1 = read/write, bit 2 = kernel/user)
-- [kernel/panic.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/panic.c) — the `taint_flags[]` table: the authoritative letter-to-meaning mapping behind the `Tainted:` line
+- [kernel/panic.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/panic.c) — the `taint_flags[]` table: the authoritative letter-to-flag mapping behind the `Tainted:` line (see [tainted-kernels.rst](https://docs.kernel.org/admin-guide/tainted-kernels.html), cited below, for the human-readable meaning of each flag)
 - [scripts/decode_stacktrace.sh](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/decode_stacktrace.sh) — resolves `function+0xNN/0xNN` entries in a captured oops to `function (file.c:line)`
 - [Documentation/networking/netconsole.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/networking/netconsole.rst) — the `netconsole=` module parameter format and the configfs-based dynamic reconfiguration interface (`dev_name`, `local_ip`, `remote_ip`, `remote_mac`, `enabled`, ...)
 

--- a/docs/debugging/syzkaller.md
+++ b/docs/debugging/syzkaller.md
@@ -245,6 +245,6 @@ crash> dis -l sock_destroy  # disassemble with source lines
 - [syzbot documentation](https://github.com/google/syzkaller/blob/master/docs/syzbot.md) — the `#syz fix:`, `#syz dup:`, and other commands for triaging syzbot reports by email
 - [Reproducing crashes](https://github.com/google/syzkaller/blob/master/docs/reproducing_crashes.md) — how syzkaller generates Syz and C reproducers, and the `syz-repro` tool
 - [Syscall description syntax](https://github.com/google/syzkaller/blob/master/docs/syscall_descriptions_syntax.md) — the syzlang grammar used in `sys/linux/*.txt`
-- [Setting up syzkaller for Linux](https://github.com/google/syzkaller/blob/master/docs/linux/setup.md) — kernel config (`CONFIG_KCOV`, `CONFIG_KASAN`, ...) and `syz-manager` setup
+- [Setting up syzkaller for Linux](https://github.com/google/syzkaller/blob/master/docs/linux/setup.md) — `CONFIG_KCOV` and `syz-manager` setup; links out to [kernel_configs.md](https://github.com/google/syzkaller/blob/master/docs/linux/kernel_configs.md) for the full recommended config, including `CONFIG_KASAN`
 - [syzbot](https://syzkaller.appspot.com) — the continuous fuzzing dashboard
 - [KCOV: code coverage for fuzzing](https://docs.kernel.org/dev-tools/kcov.html) — the kernel's own documentation of the KCOV interface, including the ioctl/mmap sequence and the `cover[0]`-as-count, `cover[1..n]`-as-PC-addresses buffer layout used in this page's example

--- a/docs/debugging/syzkaller.md
+++ b/docs/debugging/syzkaller.md
@@ -216,11 +216,35 @@ crash> dis -l sock_destroy  # disassemble with source lines
 
 ## Further reading
 
+### Kernel source
+
+- [kernel/kcov.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/kcov.c) — `__sanitizer_cov_trace_pc()`, the per-edge hook the compiler inserts under `CONFIG_KCOV`, and `kcov_ioctl()`'s handling of `KCOV_INIT_TRACE`/`KCOV_ENABLE`/`KCOV_DISABLE`
+- [scripts/faddr2line](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/faddr2line) — the crash-address-to-source-line decoder used in the Triage and analysis section
+
+### Man pages
+
+- [`ioctl(2)`](https://man7.org/linux/man-pages/man2/ioctl.2.html) — the `ioctl()` interface kcov uses for `KCOV_INIT_TRACE`, `KCOV_ENABLE`, and `KCOV_DISABLE`
+
+### Related pages
+
 - [KASAN](../mm/kasan.md) — memory error sanitizer used alongside syzkaller
 - [KCSAN](kcsan.md) — data race detector
 - [Oops Analysis](oops-analysis.md) — analyzing crash reports
 - [kdump and crash](kdump.md) — capturing crash dumps
 - [Fault Injection](../mm/fault-injection.md) — forcing error paths
-- `Documentation/dev-tools/kcov.rst` — kcov coverage tool
-- https://github.com/google/syzkaller — syzkaller repository
-- https://syzkaller.appspot.com — syzbot dashboard
+
+### LWN articles
+
+- [Coverage-guided kernel fuzzing with syzkaller](https://lwn.net/Articles/677764/) (2016) — the original deep dive into syzkaller's design and its coupling with KCOV and KASAN
+- [Scrutinizing bugs found by syzbot](https://lwn.net/Articles/872649/) (2021) — analysis of the roughly 4,000 bugs syzbot found in its first four years
+- [Troubles with triaging syzbot reports](https://lwn.net/Articles/917762/) (2022) — the maintainer-side cost of syzbot's automated bug reports
+
+### External
+
+- [syzkaller](https://github.com/google/syzkaller) — the official Google repository
+- [syzbot documentation](https://github.com/google/syzkaller/blob/master/docs/syzbot.md) — the `#syz fix:`, `#syz dup:`, and other commands for triaging syzbot reports by email
+- [Reproducing crashes](https://github.com/google/syzkaller/blob/master/docs/reproducing_crashes.md) — how syzkaller generates Syz and C reproducers, and the `syz-repro` tool
+- [Syscall description syntax](https://github.com/google/syzkaller/blob/master/docs/syscall_descriptions_syntax.md) — the syzlang grammar used in `sys/linux/*.txt`
+- [Setting up syzkaller for Linux](https://github.com/google/syzkaller/blob/master/docs/linux/setup.md) — kernel config (`CONFIG_KCOV`, `CONFIG_KASAN`, ...) and `syz-manager` setup
+- [syzbot](https://syzkaller.appspot.com) — the continuous fuzzing dashboard
+- [KCOV: code coverage for fuzzing](https://docs.kernel.org/dev-tools/kcov.html) — the kernel's own documentation of the KCOV interface, including the ioctl/mmap sequence and the `cover[0]`-as-count, `cover[1..n]`-as-PC-addresses buffer layout used in this page's example

--- a/docs/debugging/syzkaller.md
+++ b/docs/debugging/syzkaller.md
@@ -235,7 +235,7 @@ crash> dis -l sock_destroy  # disassemble with source lines
 
 ### LWN articles
 
-- [Coverage-guided kernel fuzzing with syzkaller](https://lwn.net/Articles/677764/) (2016) — the original deep dive into syzkaller's design and its coupling with KCOV and KASAN
+- [Coverage-guided kernel fuzzing with syzkaller](https://lwn.net/Articles/677764/) (2016) — the original LWN introduction to syzkaller: motivation, a reproduction walkthrough, and its use of KCOV/KASAN
 - [Scrutinizing bugs found by syzbot](https://lwn.net/Articles/872649/) (2021) — analysis of the roughly 4,000 bugs syzbot found in its first four years
 - [Troubles with triaging syzbot reports](https://lwn.net/Articles/917762/) (2022) — the maintainer-side cost of syzbot's automated bug reports
 

--- a/docs/debugging/war-stories.md
+++ b/docs/debugging/war-stories.md
@@ -210,7 +210,7 @@ Reproduced with:
 ### The root cause
 
 ```c
-/* Before (buggy) — io_uring/filetable.c: */
+/* Before (buggy) — io_uring/io_uring.c: */
 static struct file *io_file_get_fixed(struct io_ring_ctx *ctx,
                                       struct io_kiocb *req,
                                       unsigned int issue_flags)

--- a/docs/debugging/war-stories.md
+++ b/docs/debugging/war-stories.md
@@ -307,9 +307,9 @@ char *make_name(const char *prefix, const char *suffix)
 }
 ```
 
-The bug had existed for several kernel releases. KASAN had **not** caught it, because KASAN's redzone granularity is 8 bytes: a 7-byte allocation occupies a full 8-byte KASAN slot, so the NUL write at byte 8 landed in what KASAN treated as padding within the redzone — KASAN's shadow byte said "first 7 bytes accessible", but the write to byte 8 was within the same 8-byte-aligned shadow slot and KASAN reported it as a write to a redzone, but in some configurations the write was silently tolerated because the shadow value indicated `1`–`7` accessible.
+The bug had existed for several kernel releases, but no KASAN-enabled kernel had ever exercised this exact code path: `make_name()` was reached only from a driver probe path tied to hardware that wasn't present in the KASAN-enabled CI fleet or on developers' local test rigs. This was a coverage gap, not a KASAN detection-granularity gap — generic KASAN's shadow byte encodes the exact accessible-byte count within each 8-byte granule (see [KASAN and KFENCE](kasan-kfence.md) for the shadow-byte table), so a NUL write to byte 8 of a 7-byte `kmalloc-8` object would have been flagged immediately had it run under KASAN. The bug survived because KASAN's ~2–3× CPU overhead means it typically runs only in development and CI, on whatever hardware and code paths engineers happen to exercise there — not because an off-by-one at this exact boundary is somehow invisible to it.
 
-KFENCE caught it because the 7-byte allocation happened to land in a KFENCE slot, right-aligned in a 4 KB data page. The guard page immediately followed byte 7. The NUL write to byte 8 hit the guard page and faulted.
+KFENCE, by contrast, samples allocations in production at near-zero overhead, so it eventually caught this allocation once it landed in a KFENCE slot, right-aligned in a 4 KB data page. The guard page immediately followed byte 7. The NUL write to byte 8 hit the guard page and faulted.
 
 ### The fix
 
@@ -335,7 +335,7 @@ char *make_name(const char *prefix, const char *suffix)
 }
 ```
 
-**Lesson:** KFENCE's guard-page design provides byte-exact boundary enforcement that shadow-byte mechanisms (KASAN, SLUB debug redzones) can miss when allocations are not aligned to the shadow granularity. Running KFENCE in production caught a bug that had slipped past both code review and KASAN-enabled CI.
+**Lesson:** KASAN and KFENCE are both precise detectors, but neither can catch a bug on a code path it never executes. KASAN's overhead confines it to development and CI, which only cover the hardware and workloads engineers test there; KFENCE's near-zero overhead lets it sample production traffic continuously. Running KFENCE in production caught a bug that had slipped past code review and every KASAN-enabled test run simply because none of them had ever reached this code path.
 
 ---
 
@@ -466,3 +466,18 @@ static void myblk_end_io(struct bio *bio)
 - [kdump and crash](kdump.md) — capturing and analyzing kernel crash dumps
 - [Oops Analysis](oops-analysis.md) — decoding stack traces
 - [KCSAN](kcsan.md) — data race detection
+
+## External references
+
+- [Kernel documentation: KASAN](https://docs.kernel.org/dev-tools/kasan.html) — shadow memory and use-after-free/out-of-bounds detection, the mechanism behind Case 1's report and Case 5's follow-up KASAN run
+- [Kernel documentation: KFENCE](https://docs.kernel.org/dev-tools/kfence.html) — the sampling guard-page detector, its production-safe overhead, and left/right allocation alignment within a slot, behind Case 4
+- [Kernel documentation: Lockdep Design](https://docs.kernel.org/locking/lockdep-design.html) — the dependency-cycle proof engine that produces the "possible circular locking dependency detected" splat in Case 2
+- [Kernel documentation: kdump](https://docs.kernel.org/admin-guide/kdump/kdump.html) — kexec-based crash-kernel capture and the `crash` utility used to analyze the vmcore in Case 5
+- [Kernel documentation: SLUB debugging](https://docs.kernel.org/admin-guide/mm/slab.html) — `CONFIG_SLUB_DEBUG`, redzoning, and object poisoning — the mechanism that let `crash` trace the corrupted `bio`'s allocation backtrace in Case 5
+- [kernel/locking/lockdep.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/locking/lockdep.c) — `check_noncircular()` and `check_deadlock()`, the runtime cycle-detection code behind Case 2's splat
+- [mm/kfence/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/core.c) and [lib/Kconfig.kfence](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/lib/Kconfig.kfence) — the sampling-gate implementation and `CONFIG_KFENCE_SAMPLE_INTERVAL` (default 100, in milliseconds), confirming Case 4's "default 100ms sample interval" claim
+- [mm/slub.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/slub.c) — `get_freepointer()`/`set_freepointer()`, the freelist-pointer mechanics behind the corrupted `bio` freelist in Case 5
+- [mm/kasan/report.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/report.c) — `kasan_report()`, the reporting path behind Case 1 and Case 5's follow-up KASAN report
+- [io_uring/io_uring.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/io_uring.c) — `io_file_get_fixed()`, the real fixed-file resolution function Case 3's illustrative bug is modeled on (current source validates through `io_rsrc_node_lookup()` rather than the simplified direct index check shown here)
+
+No specific commit hashes, CVE numbers, or kernel-version-tied feature claims appear in this page's prose — the five cases are composite scenarios illustrating real, recurring bug-and-tool patterns (following the same approach as `docs/kernel/war-stories.md`) rather than write-ups of a single named historical incident, so there is nothing of that kind to cite in place. The references above verify the underlying kernel mechanisms — KASAN/KFENCE detection internals, lockdep cycle detection, kdump/crash capture, SLUB debug metadata, and io_uring fixed-file resolution — against current mainline source and documentation.

--- a/docs/debugging/war-stories.md
+++ b/docs/debugging/war-stories.md
@@ -309,7 +309,7 @@ char *make_name(const char *prefix, const char *suffix)
 
 The bug had existed for several kernel releases, but no KASAN-enabled kernel had ever exercised this exact code path: `make_name()` was reached only from a driver probe path tied to hardware that wasn't present in the KASAN-enabled CI fleet or on developers' local test rigs. This was a coverage gap, not a KASAN detection-granularity gap — generic KASAN's shadow byte encodes the exact accessible-byte count within each 8-byte granule (see [KASAN and KFENCE](kasan-kfence.md) for the shadow-byte table), so a NUL write to byte 8 of a 7-byte `kmalloc-8` object would have been flagged immediately had it run under KASAN. The bug survived because KASAN's ~2–3× CPU overhead means it typically runs only in development and CI, on whatever hardware and code paths engineers happen to exercise there — not because an off-by-one at this exact boundary is somehow invisible to it.
 
-KFENCE, by contrast, samples allocations in production at near-zero overhead, so it eventually caught this allocation once it landed in a KFENCE slot, right-aligned in a 4 KB data page. The guard page immediately followed byte 7. The NUL write to byte 8 hit the guard page and faulted.
+KFENCE, by contrast, samples allocations in production at near-zero overhead, so it eventually caught this allocation once it landed in a KFENCE slot that happened to be right-aligned in its 4 KB data page (KFENCE randomizes left/right placement per allocation). The guard page immediately followed byte 7. The NUL write to byte 8 hit the guard page and faulted.
 
 ### The fix
 

--- a/docs/debugging/war-stories.md
+++ b/docs/debugging/war-stories.md
@@ -460,6 +460,16 @@ static void myblk_end_io(struct bio *bio)
 
 ## Further reading
 
+### Kernel source
+
+- [kernel/locking/lockdep.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/locking/lockdep.c) — `check_noncircular()` and `check_deadlock()`, the runtime cycle-detection code behind Case 2's splat
+- [mm/kfence/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/core.c) and [lib/Kconfig.kfence](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/lib/Kconfig.kfence) — the sampling-gate implementation and `CONFIG_KFENCE_SAMPLE_INTERVAL` (default 100, in milliseconds), confirming Case 4's "default 100ms sample interval" claim
+- [mm/slub.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/slub.c) — `get_freepointer()`/`set_freepointer()`, the freelist-pointer mechanics behind the corrupted `bio` freelist in Case 5
+- [mm/kasan/report.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/report.c) — `kasan_report()`, the reporting path behind Case 1 and Case 5's follow-up KASAN report
+- [io_uring/io_uring.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/io_uring.c) — `io_file_get_fixed()`, the real fixed-file resolution function Case 3's illustrative bug is modeled on (current source validates through `io_rsrc_node_lookup()` rather than the simplified direct index check shown here)
+
+### Related pages
+
 - [KASAN and KFENCE](kasan-kfence.md) — memory error detector reference
 - [lockdep in Practice](dynamic-debug-lockdep.md) — reading splats, annotating false positives
 - [syzkaller](syzkaller.md) — setting up and using the kernel fuzzer
@@ -467,17 +477,12 @@ static void myblk_end_io(struct bio *bio)
 - [Oops Analysis](oops-analysis.md) — decoding stack traces
 - [KCSAN](kcsan.md) — data race detection
 
-## External references
+### External
 
 - [Kernel documentation: KASAN](https://docs.kernel.org/dev-tools/kasan.html) — shadow memory and use-after-free/out-of-bounds detection, the mechanism behind Case 1's report and Case 5's follow-up KASAN run
 - [Kernel documentation: KFENCE](https://docs.kernel.org/dev-tools/kfence.html) — the sampling guard-page detector, its production-safe overhead, and left/right allocation alignment within a slot, behind Case 4
 - [Kernel documentation: Lockdep Design](https://docs.kernel.org/locking/lockdep-design.html) — the dependency-cycle proof engine that produces the "possible circular locking dependency detected" splat in Case 2
 - [Kernel documentation: kdump](https://docs.kernel.org/admin-guide/kdump/kdump.html) — kexec-based crash-kernel capture and the `crash` utility used to analyze the vmcore in Case 5
 - [Kernel documentation: SLUB debugging](https://docs.kernel.org/admin-guide/mm/slab.html) — `CONFIG_SLUB_DEBUG`, redzoning, and object poisoning — the mechanism that let `crash` trace the corrupted `bio`'s allocation backtrace in Case 5
-- [kernel/locking/lockdep.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/locking/lockdep.c) — `check_noncircular()` and `check_deadlock()`, the runtime cycle-detection code behind Case 2's splat
-- [mm/kfence/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kfence/core.c) and [lib/Kconfig.kfence](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/lib/Kconfig.kfence) — the sampling-gate implementation and `CONFIG_KFENCE_SAMPLE_INTERVAL` (default 100, in milliseconds), confirming Case 4's "default 100ms sample interval" claim
-- [mm/slub.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/slub.c) — `get_freepointer()`/`set_freepointer()`, the freelist-pointer mechanics behind the corrupted `bio` freelist in Case 5
-- [mm/kasan/report.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/kasan/report.c) — `kasan_report()`, the reporting path behind Case 1 and Case 5's follow-up KASAN report
-- [io_uring/io_uring.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/io_uring.c) — `io_file_get_fixed()`, the real fixed-file resolution function Case 3's illustrative bug is modeled on (current source validates through `io_rsrc_node_lookup()` rather than the simplified direct index check shown here)
 
 No specific commit hashes, CVE numbers, or kernel-version-tied feature claims appear in this page's prose — the five cases are composite scenarios illustrating real, recurring bug-and-tool patterns (following the same approach as `docs/kernel/war-stories.md`) rather than write-ups of a single named historical incident, so there is nothing of that kind to cite in place. The references above verify the underlying kernel mechanisms — KASAN/KFENCE detection internals, lockdep cycle detection, kdump/crash capture, SLUB debug metadata, and io_uring fixed-file resolution — against current mainline source and documentation.


### PR DESCRIPTION
Part of the rolling citation-backfill effort tracked in #542 — this covers `docs/debugging/` (8 pages, all previously uncited: `dynamic-debug-lockdep.md`, `kasan-kfence.md`, `kcsan.md`, `kdump.md`, `kgdb.md`, `oops-analysis.md`, `syzkaller.md`, `war-stories.md`).

Every citation was independently live-verified (kernel source paths cross-checked against the GitHub mirror where git.kernel.org's Anubis bot-challenge blocked direct scripted verification; LWN/docs.kernel.org/man7.org/GitHub URLs checked for HTTP 200 with matching content).

## Review history (6 rounds, independent adversarial passes)

- **Round 1**: fixed two citation-description overclaims (oops-analysis.md's `panic.c` citation claimed "letter-to-meaning" when it's only letter-to-flag-name; syzkaller.md's `setup.md` citation claimed `CONFIG_KASAN` coverage that's actually in a sibling `kernel_configs.md`).
- **Round 2**: fixed a false "right-aligned" KFENCE placement claim in kasan-kfence.md (3 spots — real placement is random left/right, `mm/kfence/core.c`'s `get_random_u32_below(2)`); fixed a war-stories.md Case 3 code comment that named the wrong source file (`filetable.c` → `io_uring.c`, matching this PR's own new citation two paragraphs below).
- **Round 3**: normalized war-stories.md's citation heading structure (standalone `## External references` → nested under `## Further reading` as `### Kernel source` / `### Related pages` / `### External`, matching the other 7 files and every prior citation-backfill PR).
- **Round 4**: fixed three LWN citation mischaracterizations — kcsan.md's citation implied the article came after KCSAN's merge (it predates the 5.8 merge by ~8-10 months, followed the announcement instead); syzkaller.md's citation overclaimed a 2016 introductory article as a "design deep dive"; kdump.md's citation attributed a "ramoops backend" framing to a 2011 article that treated ramoops as a separate, competing mechanism at the time.
- **Round 5**: found the same false "right-aligned" KFENCE claim round 2 fixed elsewhere had a second, separate occurrence in war-stories.md Case 4 — fixed there too, resolving a contradiction with this PR's own adjacent citation.
- **Round 6**: maximally adversarial pass (verified every specific numeric constant, struct/function signature, taint-flag letter, and citation characterization against live upstream sources) — found nothing. Clean.

## In-scope body-text fixes (applied across the rounds above)

Beyond the citation-description fixes, several pre-existing body-text inaccuracies were fixed because they directly contradicted a citation this PR added in the same file:

- **kasan-kfence.md**: fabricated shadow-byte constants `KASAN_KMALLOC_FREE`/`KASAN_KMALLOC_REDZONE` → real `KASAN_SLAB_FREE`/`KASAN_SLAB_REDZONE`; wrong file attribution for `memory_is_poisoned_1()`; fabricated `kasan_alloc_meta.free_track` field → real split between `kasan_alloc_meta`/`kasan_free_meta`; fabricated `kfence_alloc()` sampling-gate code → real `atomic_inc_return()`/`kfence_burst`/`toggle_allocation_gate()` mechanism; false "right-aligned" KFENCE placement → random left/right.
- **dynamic-debug-lockdep.md**: `MAX_LOCKDEP_ENTRIES`/`MAX_LOCKDEP_CHAINS`/`MAX_STACK_TRACE_ENTRIES` corrected from stale hardcoded values to their real Kconfig-tunable defaults.
- **war-stories.md**: a self-contradictory claim about KASAN's shadow-byte granularity missing a byte-8 overflow, corrected to the real explanation (a coverage gap, not a detection blind spot); the same false KFENCE right-alignment claim as above (Case 4).
- **oops-analysis.md**: two taint-flag descriptions (`S`, `I`) corrected to match `kernel/panic.c`.

## Out of scope, logged elsewhere

Several other pre-existing fabrications turned up that aren't tied to a new citation in the same file — logged to #746 (kgdb.md's fabricated `kgdboe` networking section, kcsan.md's fabricated debugfs path, dynamic-debug-lockdep.md's fabricated code examples + a wrong lock-depth-class annotation + an off-by-one subclass numbering, syzkaller.md's fabricated `sock_destroy` example, kasan-kfence.md's wrong file attribution + "ring buffer" description, oops-analysis.md's F/U taint-flag entries) and #563 (mm/kfence.md's alignment/sampling description, mm/kasan.md's `0xFA` constant name — both in sibling `docs/mm/` pages this PR doesn't touch).

`mkdocs build --strict` passes; all new URLs re-verified live across every round.