### PR TITLE
Add citations to docs/crypto/ (issue #542)

### DIFF
--- a/docs/crypto/crypto-api.md
+++ b/docs/crypto/crypto-api.md
@@ -20,9 +20,10 @@ struct crypto_alg {
     unsigned int        cra_blocksize;  /* cipher block size */
     unsigned int        cra_ctxsize;    /* size of transform context */
     unsigned int        cra_alignmask; /* required alignment */
+    unsigned int        cra_reqsize;   /* extra per-request context size */
 
     int                 cra_priority;  /* higher = preferred (e.g., AES-NI > software) */
-    atomic_t            cra_refcnt;
+    refcount_t          cra_refcnt;
 
     char                cra_name[CRYPTO_MAX_ALG_NAME];    /* "aes", "sha256", ... */
     char                cra_driver_name[CRYPTO_MAX_ALG_NAME]; /* "aes-aesni", ... */
@@ -31,10 +32,10 @@ struct crypto_alg {
 
     union {
         struct cipher_alg      cipher;
-        struct compress_alg    compress;
     } cra_u;
     /* Note: ablkcipher_alg and blkcipher_alg were removed in kernel 5.5;
-     * all symmetric ciphers now use skcipher_alg */
+     * all symmetric ciphers now use skcipher_alg. Compression is a
+     * separate transform type today, not a member of this union. */
 
     int (*cra_init)(struct crypto_tfm *tfm);
     void (*cra_exit)(struct crypto_tfm *tfm);
@@ -208,19 +209,19 @@ The crypto subsystem automatically uses hardware accelerators when available. Th
 | Priority | Implementation |
 |----------|---------------|
 | 4001 | Intel QAT hardware |
-| 800  | Intel AES-NI + PCLMULQDQ |
+| 400–800  | Intel AES-GCM, by instruction set: base AES-NI (400), AVX (500), VAES+AVX2 (600), VAES+AVX512 (800) — the highest available on the running CPU wins |
 | 300  | Generic C implementation |
 
 ```bash
 # See which implementation is selected
 cat /proc/crypto | grep -A 10 "name.*gcm"
 # name         : gcm(aes)
-# driver       : gcm_base(ctr(aes-aesni),ghash-clmulni-intel)
+# driver       : generic-gcm-aesni
 # module       : kernel
-# priority     : 800     ← AES-NI selected
+# priority     : 400     ← base AES-NI selected (higher-priority AVX/VAES variants need newer CPU support)
 
-# Force software implementation (for testing)
-modprobe tcrypt mode=1  # run crypto test suite
+# Run the full crypto test suite (requires CONFIG_CRYPTO_TEST)
+modprobe tcrypt mode=0
 ```
 
 ### Intel AES-NI
@@ -228,29 +229,42 @@ modprobe tcrypt mode=1  # run crypto test suite
 AES-NI adds hardware instructions for AES rounds. The kernel implementation uses them via SIMD (SSE/AVX) register operations:
 
 ```c
-/* arch/x86/crypto/aesni-intel_glue.c */
-static int aesni_skcipher_encrypt(struct skcipher_request *req)
+/* arch/x86/crypto/aesni-intel_glue.c — real cbc_encrypt() */
+static int cbc_encrypt(struct skcipher_request *req)
 {
     struct crypto_skcipher *tfm = crypto_skcipher_reqtfm(req);
     struct crypto_aes_ctx *ctx = aes_ctx(crypto_skcipher_ctx(tfm));
+    struct skcipher_walk walk;
+    unsigned int nbytes;
+    int err;
 
     /* Kernel must save/restore SIMD registers around these calls */
-    if (!crypto_simd_usable())
-        /* software fallback: use a separate fallback tfm stored in private ctx */
-        return crypto_skcipher_encrypt(fallback_req); /* fallback_req set up from ctx->fallback */
-
-    kernel_fpu_begin();   /* save FPU state */
-    aesni_cbc_enc(ctx, dst, src, len, iv);  /* AESENC instruction */
-    kernel_fpu_end();     /* restore FPU state */
-    return 0;
+    err = skcipher_walk_virt(&walk, req, false);
+    while ((nbytes = walk.nbytes)) {
+        kernel_fpu_begin();   /* save FPU state */
+        aesni_cbc_enc(ctx, walk.dst.virt.addr, walk.src.virt.addr,
+                      nbytes & AES_BLOCK_MASK, walk.iv);  /* AESENC instruction */
+        kernel_fpu_end();     /* restore FPU state */
+        nbytes &= AES_BLOCK_SIZE - 1;
+        err = skcipher_walk_done(&walk, nbytes);
+    }
+    return err;
 }
 ```
+
+The `crypto_simd_usable()`/fallback branch used when SIMD isn't available (e.g. in some interrupt contexts) lives one layer up, in key setup (`aes_set_key_common()`), not inline in each per-block encrypt function like `cbc_encrypt()`.
 
 `kernel_fpu_begin()` is relatively expensive (saves ~512 bytes of SIMD state), so AES-NI is most beneficial for large buffers.
 
 ## AF_ALG: userspace access to kernel crypto
 
-AF_ALG sockets expose kernel crypto to userspace without copying data to/from kernel buffers:
+AF_ALG sockets expose kernel crypto to userspace. The kernel's own documentation
+([`userspace-if.rst`](https://docs.kernel.org/crypto/userspace-if.html), cited below) is blunt
+about it: AF_ALG is deprecated, "most kernel developers now consider it to be a mistake," its
+original purpose (giving userspace access to hardware accelerators) has been removed, it is
+always slower than an optimized userspace implementation, and it has a history of CVEs. New
+code should use a userspace crypto library instead; this section documents the interface as it
+exists, not as a recommended approach.
 
 ```c
 /* Userspace: use kernel AES-GCM via AF_ALG socket */
@@ -284,7 +298,7 @@ recvmsg(opfd, &msg_out, 0);
 cat /proc/crypto
 
 # Crypto test suite (requires CONFIG_CRYPTO_TEST)
-modprobe tcrypt mode=1   # test all algorithms
+modprobe tcrypt mode=0   # test all algorithms (mode=1 tests MD5 only)
 modprobe tcrypt mode=200 # benchmark AES
 # testing AES-128-ECB encryption
 #  128 bit key:  1234.5 MB/s
@@ -298,8 +312,29 @@ perf stat -e instructions,cycles cryptsetup benchmark
 
 ## Further reading
 
-- [dm-crypt and fscrypt](encryption.md) — using kernel crypto for storage
-- [BPF: verifier](../bpf/bpf-verifier.md) — BPF crypto helpers
-- [Security: seccomp](../security/seccomp.md) — restricting crypto syscalls
-- `crypto/` in the kernel tree — algorithm implementations
-- `Documentation/crypto/` in the kernel tree
+### Kernel source
+
+- [include/linux/crypto.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/crypto.h) — `struct crypto_alg`, `CRYPTO_ALG_TYPE_*`, and the `cra_*` flag bits
+- [include/crypto/skcipher.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/crypto/skcipher.h) — `crypto_alloc_skcipher()`, `skcipher_request_set_crypt()`, and the full SKCIPHER API surface
+- [include/crypto/aead.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/crypto/aead.h) — `crypto_alloc_aead()`, `aead_request_set_ad()`, `crypto_aead_setauthsize()`
+- [include/crypto/hash.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/crypto/hash.h) — `crypto_alloc_shash()`/`crypto_alloc_ahash()`, `SHASH_DESC_ON_STACK`, `ahash_request_set_crypt()`
+- [arch/x86/crypto/aesni-intel_glue.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/crypto/aesni-intel_glue.c) — the real AES-NI SKCIPHER implementations (`cbc_encrypt()`, `ecb_encrypt()`, the `DEFINE_GCM_ALGS()` AEAD family) and their registered `cra_priority` values
+- [Documentation/crypto/userspace-if.rst](https://docs.kernel.org/crypto/userspace-if.html) — the AF_ALG user-space interface; as of this kernel it opens with an explicit deprecation notice (see note below)
+
+### Related pages
+
+- [dm-crypt and fscrypt](encryption.md) — the main consumer of SKCIPHER/AEAD for storage encryption
+- [crypto_engine: Hardware Offload Framework](crypto-engine.md) — how DMA-based hardware accelerators plug into the `cra_priority` selection this page describes
+- [Kernel Keyring](keyring.md) — where key material handed to `crypto_*_setkey()` is usually stored
+- [Random Number Generation](rng.md) — `crypto_alloc_rng()` and the DRBG algorithms exposed through this same API
+- [Crypto War Stories](war-stories.md) — IV reuse, timing side channels, and a hardware accelerator that silently corrupted AES-GCM output
+
+### LWN articles
+
+- [A netlink-based user-space crypto API](https://lwn.net/Articles/410763/) — Jake Edge, October 20, 2010: Herbert Xu's original proposal for the `AF_ALG` address family covered in this page
+- [WireGuard and the crypto API](https://lwn.net/Articles/802376/) — Jake Edge, October 16, 2019: Jason Donenfeld's and Linus Torvalds's criticism of the abstract AEAD/SKCIPHER interfaces for performance-critical, compile-time-known transforms
+- [Progress in modernizing kernel cryptography](https://lwn.net/Articles/1077427/) — Joe Brockmeier, July 8, 2026: Eric Biggers on the overhead of the `struct crypto_alg`/SKCIPHER/AEAD model described on this page, and the ongoing move toward simpler `lib/crypto` library functions
+
+### External
+
+- [NIST SP 800-38D: Recommendation for Block Cipher Modes of Operation — GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final) — the specification behind `"gcm(aes)"`, including the 96-bit IV recommendation used in the AEAD example above

--- a/docs/crypto/crypto-api.md
+++ b/docs/crypto/crypto-api.md
@@ -220,7 +220,7 @@ cat /proc/crypto | grep -A 10 "name.*gcm"
 # module       : kernel
 # priority     : 400     ← base AES-NI selected (higher-priority AVX/VAES variants need newer CPU support)
 
-# Run the full crypto test suite (requires CONFIG_CRYPTO_TEST)
+# Run the full crypto test suite (requires CONFIG_CRYPTO_BENCHMARK)
 modprobe tcrypt mode=0
 ```
 

--- a/docs/crypto/crypto-engine.md
+++ b/docs/crypto/crypto-engine.md
@@ -93,11 +93,12 @@ struct crypto_engine_op {
 |---|---|---|
 | `do_one_request` | Hardware is idle, request at head of queue | Start DMA, return `-EINPROGRESS` |
 
-`do_one_request` is required and is the only callback in modern kernels (5.13+).
+`do_one_request` is required and is the only callback in current kernels.
 
-> **Note**: Before kernel ~5.13, the equivalent per-request-type structs also contained
-> `prepare_cipher_request`/`unprepare_cipher_request` (and the `hash`-suffixed equivalents),
-> removed in the engine refactor.
+> **Note**: Through kernel 6.5, `struct crypto_engine_op` was a single generic struct (not
+> split by request type) with three callbacks: `prepare_request`, `unprepare_request`, and
+> `do_one_request`. The refactor to today's model — `do_one_request` only, wrapped in
+> per-type structs like `skcipher_engine_alg` — landed between 6.5 and 6.6.
 
 ## Algorithm registration: skcipher_engine_alg
 

--- a/docs/crypto/crypto-engine.md
+++ b/docs/crypto/crypto-engine.md
@@ -46,36 +46,36 @@ Caller (IPsec, dm-crypt, TLS)
 
 ## struct crypto_engine
 
-Defined in `include/crypto/engine.h`:
+Defined in the driver-internal header `include/crypto/internal/engine.h` (not the public
+`include/crypto/engine.h`):
 
 ```c
-/* simplified — see include/crypto/engine.h for authoritative layout */
+/* include/crypto/internal/engine.h */
 struct crypto_engine {
     char                    name[ENGINE_NAME_LEN];
-    bool                    idling;
-    bool                    retry_support;
-
-    struct crypto_async_request *cur_req;
-
+    bool                    busy;         /* request pump is busy */
     bool                    running;
-    int                     cur_req_prepared;
+
+    bool                    retry_support;
+    bool                    rt;           /* run the pump as a realtime task */
 
     struct list_head        list;
     spinlock_t              queue_lock;
     struct crypto_queue     queue;              /* pending requests */
+    struct device           *dev;
 
-    struct work_struct      pump_requests;      /* work item pumping the queue */
-    struct workqueue_struct *wq;
+    struct kthread_worker   *kworker;
+    struct kthread_work     pump_requests;      /* work item pumping the queue */
 
-    int (*prepare_crypt_hardware)(struct crypto_engine *engine);
-    int (*unprepare_crypt_hardware)(struct crypto_engine *engine);
-    int (*do_batch_requests)(struct crypto_engine *engine);
+    void                    *priv_data;
+    struct crypto_async_request *cur_req;
 };
 ```
 
-The `wq` workqueue runs `pump_requests` to dequeue and dispatch requests to hardware. Most
-drivers allocate one engine per hardware channel, or one per device if the hardware is
-single-channel.
+A dedicated kthread worker (`kworker`) runs `pump_requests` to dequeue and dispatch requests
+to hardware — not a generic workqueue. Most drivers allocate one engine per hardware channel,
+or one per device if the hardware is single-channel. There is no batching callback on this
+struct; see "Batching" below.
 
 ## Driver callbacks: crypto_engine_op
 
@@ -95,8 +95,9 @@ struct crypto_engine_op {
 
 `do_one_request` is required and is the only callback in modern kernels (5.13+).
 
-> **Note**: Before kernel ~5.13, this struct also contained `prepare_request` and
-> `unprepare_request` callbacks, which were removed in the engine refactor.
+> **Note**: Before kernel ~5.13, the equivalent per-request-type structs also contained
+> `prepare_cipher_request`/`unprepare_cipher_request` (and the `hash`-suffixed equivalents),
+> removed in the engine refactor.
 
 ## Algorithm registration: skcipher_engine_alg
 
@@ -375,30 +376,28 @@ ahash, and akcipher.
 
 ## Retry support
 
-When `engine->retry_support = true`, the re-queuing behavior depends on the error returned
-by `do_one_request()`:
+When `engine->retry_support = true`, `crypto_pump_requests()` in `crypto/crypto_engine.c`
+handles a `do_one_request()` failure differently depending on the error:
 
-- **`-ENOSPC`**: ALL pending requests in the engine queue are re-queued and retried after a
-  delay. This handles drivers whose hardware command FIFOs can fill up under sustained load
-  (e.g., Marvell CESA, Allwinner CE).
-- **Any other error**: only requests that have the `CRYPTO_TFM_REQ_MAY_BACKLOG` flag set are
-  re-queued; requests without that flag fail immediately with the error.
+- **`-ENOSPC`**: only the single request that just failed is re-queued, at the *head* of the
+  engine queue (`crypto_enqueue_request_head()`) to preserve ordering, and the pump is
+  rescheduled to retry it on the next cycle. This handles drivers whose hardware command
+  FIFOs can fill up under sustained load (e.g., Marvell CESA, Allwinner CE).
+- **Any other error**: the request fails immediately (`crypto_request_complete()`) regardless
+  of retry support. The `CRYPTO_TFM_REQ_MAY_BACKLOG` flag is unrelated to this retry path —
+  it governs backlog behavior when a request is first submitted to an already-full queue, not
+  what happens after `do_one_request()` fails.
 
-Without retry support, any error from the hardware causes the request to fail immediately
-with an error back to the caller.
+Without retry support (or on any non-`-ENOSPC` error), a hardware failure causes the request
+to fail immediately with an error back to the caller.
 
-## Batching: do_batch_requests
+## Batching
 
-Some hardware (like QAT) can process a batch of requests in one DMA pass. The engine
-supports this via the optional `do_batch_requests` callback on the engine itself:
-
-```c
-dd->engine->do_batch_requests = mydrv_do_batch;
-```
-
-When set, the engine calls `do_batch_requests` instead of `do_one_request` for each pump
-cycle. The driver can then dequeue multiple requests from `engine->queue` and program them
-all in a single hardware submission.
+There is no batching callback in `crypto_engine` — `struct crypto_engine` has no
+`do_batch_requests`-style hook, and `crypto_pump_requests()` always dispatches exactly one
+request per `do_one_request()` call. Hardware capable of submitting several requests in a
+single DMA pass (e.g., QAT) implements its own batching outside of `crypto_engine`, or
+processes requests one at a time through it regardless.
 
 ## crypto_engine vs. writing directly to the crypto API
 
@@ -406,7 +405,7 @@ all in a single hardware submission.
 |---|---|---|
 | Hardware is DMA-based, async completion via IRQ | Yes | — |
 | Hardware can only do one operation at a time | Yes | — |
-| Hardware has a deep command queue (e.g., 64 slots) | Use do_batch_requests | — |
+| Hardware has a deep command queue (e.g., 64 slots) | Optional | Driver can manage its own queue instead |
 | Pure software algorithm (no DMA) | No | Yes (`crypto_register_skcipher`) |
 | SIMD-accelerated (AES-NI, ARM CE) | No | Yes (use kernel_fpu_begin) |
 | PCIe offload card with its own scheduler | Optional | Sometimes better |
@@ -416,9 +415,9 @@ all in a single hardware submission.
 | Driver | Source | Notable pattern |
 |---|---|---|
 | stm32-cryp | `drivers/crypto/stm32/stm32-cryp.c` | Single-channel, full fallback, rotate IV in CBC |
-| sun8i-ce | `drivers/crypto/allwinner/sun8i-ce/` | Multi-algorithm, retry support, scatter-gather |
-| marvell/cesa | `drivers/crypto/marvell/cesa/` | Batching via chain descriptors |
-| bcm2835 | `drivers/crypto/bcm/cipher.c` | Broadcom scatter-gather DMA engine |
+| sun8i-ce | `drivers/crypto/allwinner/sun8i-ce/` | Multi-algorithm crypto_engine user, scatter-gather |
+| marvell/cesa | `drivers/crypto/marvell/cesa/` | Does *not* use `crypto_engine` — its own TDMA-chain-based queueing |
+| bcm2835 | `drivers/crypto/bcm/cipher.c` | Does *not* use `crypto_engine` — its own kthread-based queue |
 
 ## Observing crypto_engine
 
@@ -440,15 +439,22 @@ modprobe tcrypt mode=0
 # This exercises all registered algorithms including hardware ones
 ```
 
-## Relevant source
-
-- `crypto/engine.c` — the engine implementation
-- `include/crypto/engine.h` — structs and prototypes
-- `drivers/crypto/` — all upstream hardware crypto drivers
-- `Documentation/crypto/crypto_engine.rst` — kernel documentation
-
 ## Further reading
 
-- [Kernel Crypto API](crypto-api.md) — SKCIPHER, AEAD, ahash interfaces
+### Kernel source
+
+- [crypto/crypto_engine.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/crypto/crypto_engine.c) — the engine implementation: `crypto_pump_requests()`, the retry/backlog logic, and the `crypto_engine_register_*()` helpers
+- [include/crypto/engine.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/crypto/engine.h) — the public API: `struct crypto_engine_op`, the `*_engine_alg` wrapper structs, `crypto_transfer_*_request_to_engine()`, `crypto_finalize_*_request()`
+- [include/crypto/internal/engine.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/crypto/internal/engine.h) — the actual `struct crypto_engine` definition (driver-internal header)
+- [Documentation/crypto/crypto_engine.rst](https://docs.kernel.org/crypto/crypto_engine.html) — kernel documentation; note it still describes the older `enginectx`/`prepare_cipher_request` design and has not been updated for the `crypto_engine_op`/`do_one_request` model in current code
+
+### Related pages
+
+- [Kernel Crypto API](crypto-api.md) — SKCIPHER, AEAD, ahash interfaces that `crypto_engine` sits underneath
 - [dm-crypt and fscrypt](encryption.md) — consumers of hardware crypto
-- [Memory Management: DMA](../mm/dma.md) — scatter-gather and DMA mapping
+- [Crypto War Stories](war-stories.md) — incident 5 covers a hardware accelerator silently corrupting ciphertext and the fallback pattern used to work around it
+- [Memory Management: DMA](../mm/dma.md) — scatter-gather and DMA mapping used by `do_one_request()` implementations
+
+### LWN articles
+
+- [LWN: Asynchronous crypto](https://lwn.net/Articles/109475/) (November 3, 2004) — the original design discussion for queueing crypto requests to hardware accelerators with async completion callbacks; the conceptual ancestor of the `-EINPROGRESS` / completion-callback model `crypto_engine` implements

--- a/docs/crypto/crypto-engine.md
+++ b/docs/crypto/crypto-engine.md
@@ -417,7 +417,7 @@ processes requests one at a time through it regardless.
 | stm32-cryp | `drivers/crypto/stm32/stm32-cryp.c` | Single-channel, full fallback, rotate IV in CBC |
 | sun8i-ce | `drivers/crypto/allwinner/sun8i-ce/` | Multi-algorithm crypto_engine user, scatter-gather |
 | marvell/cesa | `drivers/crypto/marvell/cesa/` | Does *not* use `crypto_engine` — its own TDMA-chain-based queueing |
-| bcm2835 | `drivers/crypto/bcm/cipher.c` | Does *not* use `crypto_engine` — its own kthread-based queue |
+| bcm2835 | `drivers/crypto/bcm/cipher.c` | Does *not* use `crypto_engine` — submits via the mailbox (mbox) framework to the SPU coprocessor |
 
 ## Observing crypto_engine
 

--- a/docs/crypto/encryption.md
+++ b/docs/crypto/encryption.md
@@ -61,19 +61,25 @@ struct crypt_config {
     struct workqueue_struct *crypt_queue;
 
     /* Crypto transform */
-    struct crypto_skcipher **tfms;      /* one per CPU for parallelism */
+    union {
+        struct crypto_skcipher **tfms;  /* one per CPU for parallelism */
+        struct crypto_aead    **tfms_aead;
+    } cipher_tfm;
     unsigned int          tfms_count;
 
     /* IV generator */
-    struct iv_operations  *iv_gen_ops;  /* ESSIV, plain64, benbi, ... */
-    char                  iv_mode[CRYPTO_MAX_ALG_NAME];
+    const struct crypt_iv_operations *iv_gen_ops;  /* ESSIV, plain64, benbi, ... */
+    union {
+        struct iv_benbi_private    benbi;
+        struct iv_lmk_private      lmk;
+        struct iv_tcw_private      tcw;
+        struct iv_elephant_private elephant;
+    } iv_gen_private;                   /* per-IV-mode private state */
 
-    unsigned long long    iv_offset;    /* sector number offset for IV */
-    unsigned int          iv_size;
+    u64                    iv_offset;   /* sector number offset for IV */
+    unsigned int           iv_size;
 
-    char                  cipher_string[CRYPTO_MAX_ALG_NAME];
-
-    struct crypt_iv_operations *iv_gen_private;
+    char                  *cipher_string;  /* allocated, not embedded */
 };
 
 /* Each I/O is processed in a crypt_io */
@@ -221,18 +227,22 @@ int fscrypt_decrypt_pagecache_blocks(struct folio *folio, size_t len,
                                       size_t offs)
 {
     const struct inode *inode = folio->mapping->host;
-    const unsigned int du_bits = inode->i_crypt_info->ci_data_unit_bits;
+    const struct fscrypt_inode_info *ci = fscrypt_get_inode_info_raw(inode);
+    const unsigned int du_bits = ci->ci_data_unit_bits;
     const unsigned int du_size = 1U << du_bits;
     u64 index = ((u64)folio->index << (PAGE_SHIFT - du_bits)) + (offs >> du_bits);
-    unsigned int i;
+    size_t i;
+    int err;
 
     for (i = offs; i < offs + len; i += du_size, index++) {
-        /* Derive IV from file offset (sector number equivalent) */
-        u64 lblk_num = index;  /* logical block number */
+        struct page *page = folio_page(folio, i >> PAGE_SHIFT);
 
-        /* Decrypt using per-file key */
-        fscrypt_crypt_block(inode, FS_DECRYPT, lblk_num,
-                            folio_page(folio, i >> PAGE_SHIFT), ...);
+        /* Decrypt one data unit using the per-file key; index doubles
+         * as the IV input (logical data-unit number) */
+        err = fscrypt_crypt_data_unit(ci, FS_DECRYPT, index, page,
+                                      page, du_size, i & ~PAGE_MASK);
+        if (err)
+            return err;
     }
     return 0;
 }
@@ -302,10 +312,33 @@ cat /sys/block/dm-0/stat
 
 ## Further reading
 
-- [Kernel Crypto API](crypto-api.md) — AES-XTS and AEAD internals
-- [Memory Management: DMA](../mm/dma.md) — DMA for hardware crypto engines
-- [Security: Capabilities](../security/capabilities.md) — `CAP_SYS_ADMIN` for dm setup
-- [Block Layer: bio and request](../block/bio-request.md) — bio processing through dm-crypt
-- `drivers/md/dm-crypt.c` — dm-crypt implementation
-- `fs/crypto/` — fscrypt implementation
-- `man 8 cryptsetup` — LUKS management
+### Kernel source
+
+- [drivers/md/dm-crypt.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/md/dm-crypt.c) — `struct crypt_config`, `crypt_map()`, and the per-CPU cipher/IV setup
+- [fs/crypto/crypto.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/crypto/crypto.c) — `fscrypt_decrypt_pagecache_blocks()`
+- [include/uapi/linux/fscrypt.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/fscrypt.h) — `struct fscrypt_policy_v2` and the `FSCRYPT_MODE_*` constants
+
+### Man pages
+
+- [`cryptsetup(8)`](https://man.archlinux.org/man/cryptsetup.8.en) — LUKS/dm-crypt volume management
+- [`keyctl(1)`](https://man7.org/linux/man-pages/man1/keyctl.1.html) — keyring command-line tool (`add`, `show`, `new_session`, ...)
+- [`keyrings(7)`](https://man7.org/linux/man-pages/man7/keyrings.7.html) — the in-kernel key management facility
+
+### Related pages
+
+- [dm-crypt: Block-Level Encryption](../security/dm-crypt.md) — deeper dive into LUKS2's on-disk format, key derivation, and the kernel-side `crypt_map()` I/O path
+- [fscrypt: Per-File Encryption](../security/fscrypt.md) — deeper dive into the key hierarchy, the `FS_IOC_*` ioctl API, and inline encryption hardware
+- [Kernel Keyring](keyring.md) — the `logon` key type both dm-crypt and fscrypt use to store key material
+- [Kernel Crypto API](crypto-api.md) — the `skcipher` and AEAD transforms (`xts(aes)`, `gcm(aes)`) that dm-crypt and fscrypt call into
+- [crypto_engine: Hardware Offload Framework](crypto-engine.md) — how hardware crypto accelerators plug in beneath callers like dm-crypt
+- [Random Number Generation](rng.md) — where key material (`/dev/urandom`, `get_random_bytes()`) comes from
+
+### LWN articles
+
+- [Ext4 encryption](https://lwn.net/Articles/639427/) — Jonathan Corbet, April 8, 2015 — the original per-file encryption design that became fscrypt
+- [Adiantum: encryption for the low end](https://lwn.net/Articles/776721/) — Jake Edge, January 16, 2019 — the `FSCRYPT_MODE_ADIANTUM` cipher for devices without AES-NI
+
+### External
+
+- [Documentation/filesystems/fscrypt.rst](https://docs.kernel.org/filesystems/fscrypt.html) — the kernel's own fscrypt design and threat-model documentation
+- [Documentation/admin-guide/device-mapper/dm-crypt.rst](https://docs.kernel.org/admin-guide/device-mapper/dm-crypt.html) — the kernel's own dm-crypt target documentation

--- a/docs/crypto/keyring.md
+++ b/docs/crypto/keyring.md
@@ -23,10 +23,11 @@ struct key {
     key_serial_t            serial;         /* unique key ID (keyctl show prints these) */
     union {
         struct list_head    graveyard_link;
-        /* internal linkage — varies by kernel version */
+        struct rb_node      serial_node;
     };
     struct rw_semaphore     sem;            /* protects key contents */
     struct key_user         *user;          /* owner accounting */
+    void                    *security;      /* LSM security blob */
     union {
         time64_t            expiry;         /* 0 = no expiry */
         time64_t            revoked_at;
@@ -39,23 +40,35 @@ struct key {
 
     unsigned short          quotalen;       /* bytes charged against quota */
     unsigned short          datalen;        /* payload length */
+    short                   state;          /* key state (+) or rejection error (-);
+                                              * KEY_IS_UNINSTANTIATED / KEY_IS_POSITIVE */
 
     unsigned long           flags;
-    /* KEY_FLAG_INSTANTIATED, KEY_FLAG_DEAD, KEY_FLAG_REVOKED, ... */
+    /* KEY_FLAG_DEAD, KEY_FLAG_REVOKED, KEY_FLAG_IN_QUOTA, KEY_FLAG_INVALIDATED, ...
+     * (instantiation is tracked by `state` above, not a flag bit) */
 
-    char                    *description;  /* human-readable name */
-
-    const struct key_type   *type;         /* "user", "logon", "keyring", ... */
-
-    struct keyring_index_key index_key; /* holds type and description */
+    /* type + description: overlaid two ways depending on how they're accessed */
+    union {
+        struct keyring_index_key index_key;
+        struct {
+            unsigned long    hash;
+            unsigned long    len_desc;
+            struct key_type  *type;         /* "user", "logon", "keyring", ... */
+            struct key_tag   *domain_tag;   /* domain of operation */
+            char             *description;  /* human-readable name */
+        };
+    };
 
     union {
         union key_payload   payload;        /* the actual key material */
         struct {
             /* For keyrings: */
+            struct list_head name_link;
             struct assoc_array      keys;
         };
     };
+
+    struct key_restriction  *restrict_link; /* keyring only: gates what can be linked in */
 };
 ```
 
@@ -114,13 +127,15 @@ plaintext never leaves kernel space:
 /* security/keys/encrypted-keys/encrypted.c */
 struct encrypted_key_payload {
     struct rcu_head     rcu;
+    char               *format;         /* datablob: format */
     char               *master_desc;    /* description of the encrypting key */
     char               *datalen;
     u8                 *iv;
     u8                 *encrypted_data;
+    unsigned short      datablob_len;         /* length of datablob */
     unsigned short      decrypted_datalen;
     unsigned short      payload_datalen;
-    unsigned short      format;
+    unsigned short      encrypted_key_format; /* encrypted key format */
     u8                 *decrypted_data;         /* AES-CBC decrypted in kernel */
     u8                  payload_data[];
 };
@@ -151,7 +166,7 @@ key material is never exposed to userspace — it only exists inside the TPM or 
 memory while unsealed:
 
 ```c
-/* security/keys/trusted-keys/trusted_tpm1.c and trusted_tpm2.c */
+/* include/keys/trusted-type.h (used by security/keys/trusted-keys/trusted_tpm1.c and trusted_tpm2.c) */
 struct trusted_key_payload {
     struct rcu_head     rcu;
     unsigned int        key_len;            /* key size in bytes */
@@ -514,7 +529,30 @@ keyctl search @u logon fscrypt:0123456789abcdef
 
 ## Further reading
 
+### Kernel source
+
+- [include/linux/key.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/key.h) — `struct key`, `struct key_type`, and the `KEY_POS_*`/`KEY_USR_*` permission bit definitions
+- [security/keys/](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/security/keys) — core keyring implementation: `keyctl()` syscall dispatch (`keyctl.c`), `request_key()` (`request_key.c`), permission checks (`permission.c`)
+- [include/keys/trusted-type.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/keys/trusted-type.h) — `struct trusted_key_payload`, the TPM-sealed key payload
+- [include/keys/encrypted-type.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/keys/encrypted-type.h) — `struct encrypted_key_payload`, the AES-CBC + HMAC-SHA256 datablob format
+- [include/uapi/linux/keyctl.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/keyctl.h) — `KEYCTL_*` operation codes and `KEY_SPEC_*` special-keyring constants
+- [Documentation/security/keys/core.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/security/keys/core.rst) — the kernel's own Key Retention Service documentation
+
+### Man pages
+
+- [`add_key(2)`](https://man7.org/linux/man-pages/man2/add_key.2.html) — add a key to the kernel's key management facility
+- [`request_key(2)`](https://man7.org/linux/man-pages/man2/request_key.2.html) — search for a key, invoking a userspace upcall if it isn't found
+- [`keyctl(2)`](https://man7.org/linux/man-pages/man2/keyctl.2.html) — the syscall behind every `KEYCTL_*` operation
+- [`keyrings(7)`](https://man7.org/linux/man-pages/man7/keyrings.7.html) — overview of the in-kernel key management and retention facility
+- [`keyctl(1)`](https://man7.org/linux/man-pages/man1/keyctl.1.html) — the keyutils command-line tool used throughout this page
+
+### Related pages
+
 - [dm-crypt and fscrypt](encryption.md) — how logon keys integrate with fscrypt and dm-crypt
-- [Kernel Crypto API](crypto-api.md) — the crypto primitives that process key material
-- `man 7 keyrings` — userspace keyring overview
-- `man 1 keyctl` — shell commands for key management
+- [Kernel Crypto API](crypto-api.md) — the AES-CBC and HMAC-SHA256 primitives that encrypted and trusted keys build on
+- [fscrypt: Per-File Encryption](../security/fscrypt.md) — detailed walkthrough of `FS_IOC_ADD_ENCRYPTION_KEY` and how fscrypt stores its master key as a logon key
+- [User Namespaces and Credential Mapping](../security/user-namespaces.md) — the uid/gid mapping model behind the container-isolation behavior described above
+
+### LWN articles
+
+- [Trusted and encrypted keys](https://lwn.net/Articles/408439/) — Jake Edge, October 2010: the introduction of the "trusted" and "encrypted" key types for EVM, including TPM sealing and the AES + HMAC datablob format

--- a/docs/crypto/rng.md
+++ b/docs/crypto/rng.md
@@ -43,10 +43,12 @@ The new pool:
 
 /* The primary pool is 256 bits mixed through BLAKE2s (input pool, not CRNG output) */
 static struct {
-    struct blake2s_state    hash;
+    struct blake2s_ctx      hash;
     spinlock_t              lock;
     unsigned int            init_bits;  /* accumulated so far */
 } input_pool = {
+    .hash.h = { /* BLAKE2s IV, pre-mixed with the output length */ ... },
+    .hash.outlen = BLAKE2S_HASH_SIZE,
     .lock = __SPIN_LOCK_UNLOCKED(input_pool.lock),
 };
 ```
@@ -57,7 +59,8 @@ is 0 → 1 → 2. After `crng_init` reaches 2, the pool is periodically reseeded
 entropy, but the CRNG output is already cryptographically indistinguishable from random.
 
 The CRNG (Cryptographically Secure Random Number Generator) uses ChaCha20 as its stream
-cipher. Per-CPU CRNGs (added in 5.14) allow fast, lock-free generation:
+cipher. Per-CPU CRNGs (added in 5.18, replacing an earlier per-NUMA-node design) allow fast,
+lock-free generation:
 
 ```c
 /* struct crng — internal type, wraps ChaCha20 state; not a public kernel API */
@@ -72,7 +75,7 @@ The kernel feeds entropy into the pool from multiple sources:
 |---|---|---|
 | Interrupt timing | `add_interrupt_randomness()` — called from interrupt handlers | Jitter between interrupts carries entropy |
 | Hardware RNG | `add_hwgenerator_randomness()` — from `/dev/hwrng` | RDRAND, TPM, virtio-rng |
-| Disk I/O | Block layer timing via `add_disk_randomness()` | Removed in 5.18 as negligible |
+| Disk I/O | Block layer timing via `add_disk_randomness()` | Still present and exported (`EXPORT_SYMBOL_GPL`) |
 | Boot-time | Seed file from previous boot via rng-tools/systemd-random-seed | Critical for VMs |
 | CPU RDRAND | `arch_get_random_long()` — used during CRNG initialization | See note on RDRAND below |
 
@@ -84,9 +87,9 @@ not as the sole source:
 
 ```c
 /* arch/x86/kernel/cpu/rdrand.c */
-static void __init x86_init_rdrand(struct cpuinfo_x86 *c)
+void x86_init_rdrand(struct cpuinfo_x86 *c)
 {
-    /* Test: generate 8 values; if any fail, disable RDRAND usage */
+    /* Test: generate 8 values; if any fail or don't change enough, disable RDRAND usage */
     ...
 }
 ```
@@ -172,8 +175,8 @@ The kernel implements NIST SP 800-90A Deterministic Random Bit Generators via th
 ```c
 #include <crypto/rng.h>
 
-/* Allocate an HMAC-SHA256 based DRBG (no prediction resistance) */
-struct crypto_rng *rng = crypto_alloc_rng("drbg_nopr_hmac_sha256", 0, 0);
+/* Allocate the kernel's registered DRBG (exposed under the generic "stdrng" name) */
+struct crypto_rng *rng = crypto_alloc_rng("stdrng", 0, 0);
 if (IS_ERR(rng))
     return PTR_ERR(rng);
 
@@ -189,17 +192,13 @@ ret = crypto_rng_get_bytes(rng, output, sizeof(output));
 crypto_free_rng(rng);
 ```
 
-DRBG algorithm names follow the pattern `drbg_{pr,nopr}_{hmac,hash,ctr}_{hash_alg}`:
-
-```
-drbg_pr_hmac_sha256    HMAC-DRBG SHA-256, with prediction resistance
-drbg_nopr_hmac_sha256  HMAC-DRBG SHA-256, no prediction resistance (faster)
-drbg_pr_sha256         Hash-DRBG SHA-256, with prediction resistance
-drbg_nopr_ctr_aes256   CTR-DRBG AES-256, no prediction resistance
-```
-
-Prediction resistance means the DRBG is reseeded from the entropy pool before each generate
-call, providing forward secrecy. `nopr` variants reseed only periodically or on request.
+As of this kernel, `crypto/drbg.c` registers a single algorithm: `cra_name = "stdrng"`,
+`cra_driver_name = "drbg_nopr_hmac_sha512"` — an HMAC-DRBG built on SHA-512, without
+prediction resistance. The older design registered a family of names following the pattern
+`drbg_{pr,nopr}_{hmac,hash,ctr}_{hash_alg}` (letting callers pick a specific mode/hash and
+choose prediction resistance); that family, and support for prediction resistance itself,
+were removed in a later simplification, leaving `crypto_alloc_rng("stdrng", 0, 0)` as the way
+to reach it.
 
 ## Kernel internal interfaces
 
@@ -209,17 +208,15 @@ For kernel code that needs random data:
 /* General: block until CRNG is initialized, then return bytes */
 void get_random_bytes(void *buf, size_t len);
 
-/* Fast per-CPU versions (lock-free, 5.14+) */
+/* Fast per-CPU versions (lock-free, 5.18+) */
 u32 get_random_u32(void);
 u64 get_random_u64(void);
 u32 get_random_u32_below(u32 ceil);  /* uniform in [0, ceil) — added 6.2 */
-
-/* For filling structures with random data */
-void get_random_bytes_arch(void *buf, size_t len);  /* prefers RDRAND */
-
-/* For non-cryptographic random numbers (fast, no entropy guarantee) */
-u32 prandom_u32(void);   /* deprecated; use get_random_u32() */
 ```
+
+`get_random_bytes_arch()` and the zero-argument `prandom_u32()` — both older APIs sometimes
+referenced in outdated documentation — no longer exist in the current tree; `get_random_u32()`
+is the current replacement for both use cases.
 
 ```c
 /* Example: generate a random nonce for a network protocol */
@@ -249,7 +246,7 @@ Power on
     │  crng_init_done()              ← wake_up_all() for getrandom() waiters
     │  pr_notice("random: crng init done")
     │
-    └─ Periodic reseed               ← every ~5 minutes from fresh entropy
+    └─ Periodic reseed               ← every CRNG_RESEED_INTERVAL (60 seconds) from fresh entropy
 ```
 
 In a typical boot on bare metal, `crng_init_done` happens within the first few seconds.
@@ -306,14 +303,29 @@ machine generation ID (VMGENID) ACPI device. When the hypervisor changes the gen
 
 ```c
 /* drivers/virt/vmgenid.c */
-/* ACPI device publishes a 128-bit generation counter in ACPI table */
-/* On generation ID change, kernel calls add_vmfork_randomness() */
-static void vmgenid_notify(struct acpi_device *device, u32 event)
+/* ACPI/DT device publishes a 128-bit generation counter */
+struct vmgenid_state {
+    u8 *next_id;              /* pointer to the live counter in device memory */
+    u8 this_id[VMGENID_SIZE]; /* last-seen copy */
+};
+
+static void vmgenid_notify(struct device *device)
 {
-    ...
-    add_vmfork_randomness(new_id, sizeof(new_id));
+    struct vmgenid_state *state = device->driver_data;
+    u8 old_id[VMGENID_SIZE];
+
+    memcpy(old_id, state->this_id, sizeof(old_id));
+    memcpy(state->this_id, state->next_id, sizeof(state->this_id));
+    if (!memcmp(old_id, state->this_id, sizeof(old_id)))
+        return;  /* unchanged: not a fork/resume event */
+
+    add_vmfork_randomness(state->this_id, sizeof(state->this_id));
 }
 ```
+
+The ACPI notify handler is a thin wrapper that just calls `vmgenid_notify(dev)` when the
+platform signals a generation-ID change; the diff-and-reseed logic above is what actually
+detects the change and reseeds.
 
 ## getrandom() in containers
 
@@ -333,9 +345,9 @@ cat /proc/sys/kernel/random/entropy_avail
 
 # Pool parameters
 cat /proc/sys/kernel/random/poolsize      # 256
-# Note: read_wakeup_threshold and write_wakeup_threshold were removed in Linux 5.17.
-# They do not exist on modern kernels. Use entropy_avail, poolsize, and
-# urandom_min_reseed_secs instead.
+# Note: read_wakeup_threshold was removed in Linux 5.17. write_wakeup_threshold is
+# still a live sysctl node but is now vestigial (reads return a value; writes are
+# silently ignored). Use entropy_avail, poolsize, and urandom_min_reseed_secs instead.
 
 # UUID generated from /dev/urandom (convenient test)
 cat /proc/sys/kernel/random/uuid
@@ -377,8 +389,32 @@ rngd -f -r /dev/hwrng
 
 ## Further reading
 
-- [Kernel Crypto API](crypto-api.md) — DRBG via crypto_alloc_rng()
-- [Kernel Keyring](keyring.md) — key generation uses get_random_bytes()
-- `man 2 getrandom` — syscall documentation
-- `man 4 random` — /dev/random and /dev/urandom
-- Donenfeld, "A New Random Number Generator" (LWN, 2022) — design rationale for the 5.17 rewrite
+### Kernel source
+
+- [drivers/char/random.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/char/random.c) — the BLAKE2s input pool, ChaCha20 CRNG, and the `getrandom()`/`/dev/random`/`/dev/urandom` implementation
+- [crypto/drbg.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/crypto/drbg.c) — the NIST SP 800-90A DRBG exposed through `crypto_alloc_rng()`
+- [include/linux/random.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/random.h) — `get_random_bytes()`, `get_random_u32()`/`get_random_u64()`, `get_random_u32_below()`, and the `add_*_randomness()` entropy-feeding API
+- [drivers/virt/vmgenid.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/virt/vmgenid.c) — VM fork detection via the VMGENID ACPI/DT device
+- [arch/x86/kernel/cpu/rdrand.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/rdrand.c) — `x86_init_rdrand()`, the boot-time RDRAND self-test
+
+### Man pages
+
+- [`getrandom(2)`](https://man7.org/linux/man-pages/man2/getrandom.2.html) — syscall flags (`GRND_NONBLOCK`, `GRND_RANDOM`), signal behavior, and the 256-byte no-short-read guarantee
+- [`random(4)`](https://man7.org/linux/man-pages/man4/random.4.html) — `/dev/random` and `/dev/urandom` device semantics, including the Linux 5.6 non-blocking change
+
+### Related pages
+
+- [Kernel Crypto API](crypto-api.md) — `crypto_alloc_rng()` and the DRBG interface built on top of this page's entropy pool
+- [dm-crypt and fscrypt](encryption.md) — where `get_random_bytes()`/`/dev/urandom` output is consumed for volume keys and IVs
+- [Kernel Keyring](keyring.md) — where generated key material is stored once created
+- [Crypto War Stories](war-stories.md) — incident 3, "`getrandom()` blocking at boot," a real entropy-starvation case built on the material in this page
+
+### LWN articles
+
+- [The search for truly random numbers in the kernel](https://lwn.net/Articles/567055/) — Jonathan Corbet, September 18, 2013 — why the kernel mixes RDRAND into the pool instead of trusting it alone
+- [A system call for random numbers: getrandom()](https://lwn.net/Articles/606141/) — Jake Edge, July 23, 2014 — the original design discussion for the syscall this page documents
+- [Uniting the Linux random-number devices](https://lwn.net/Articles/884875/) — Jake Edge, February 16, 2022 — Jason Donenfeld's push, from the era of the pool rewrite, to make `/dev/random` and `/dev/urandom` behave identically
+
+### External
+
+- [NIST SP 800-90A Rev. 1](https://csrc.nist.gov/pubs/sp/800/90/a/r1/final) — "Recommendation for Random Number Generation Using Deterministic Random Bit Generators," the standard implemented by `crypto/drbg.c`

--- a/docs/crypto/war-stories.md
+++ b/docs/crypto/war-stories.md
@@ -139,8 +139,10 @@ static inline int crypto_memneq(const void *a, const void *b, size_t size)
 }
 
 /* lib/crypto/memneq.c — simplified generic path; the real implementation
- * also has a loop-free 16-byte fast path and an unaligned-access variant */
-noinline unsigned long __crypto_memneq_generic(const void *a, const void *b, size_t size)
+ * also has a loop-free 16-byte fast path and an unaligned-access variant.
+ * This helper is static inline; noinline is on the exported dispatcher,
+ * __crypto_memneq(), which switches on size and calls this or the fast path. */
+static inline unsigned long __crypto_memneq_generic(const void *a, const void *b, size_t size)
 {
     unsigned long neq = 0;
 
@@ -166,9 +168,9 @@ noinline unsigned long __crypto_memneq_generic(const void *a, const void *b, siz
 
 `OPTIMIZER_HIDE_VAR(neq)` after every accumulation step (not a `-Os` compiler flag — there is
 no such override for this file) hides the running accumulator from the optimizer, preventing
-it from proving the loop could exit early. Combined with `noinline` (which prevents the
-surrounding code's optimization context from affecting it), the function maintains its
-constant-time property.
+it from proving the loop could exit early. Combined with the exported dispatcher
+`__crypto_memneq()` being `noinline` (preventing the caller's optimization context from
+affecting the comparison), the function maintains its constant-time property.
 
 ### Fix
 

--- a/docs/crypto/war-stories.md
+++ b/docs/crypto/war-stories.md
@@ -132,14 +132,15 @@ in ways that create timing variation.
 Linux added `crypto_memneq()` in kernel 3.14 (commit b839da0f) specifically to address this:
 
 ```c
-/* include/crypto/algapi.h */
+/* include/crypto/utils.h */
 static inline int crypto_memneq(const void *a, const void *b, size_t size)
 {
-    return __crypto_memneq(a, b, size);
+    return __crypto_memneq(a, b, size) != 0UL ? 1 : 0;
 }
 
-/* crypto/memneq.c */
-noinline int __crypto_memneq(const void *a, const void *b, size_t size)
+/* lib/crypto/memneq.c — simplified generic path; the real implementation
+ * also has a loop-free 16-byte fast path and an unaligned-access variant */
+noinline unsigned long __crypto_memneq_generic(const void *a, const void *b, size_t size)
 {
     unsigned long neq = 0;
 
@@ -147,32 +148,27 @@ noinline int __crypto_memneq(const void *a, const void *b, size_t size)
      * Every byte is always read; no early exit. */
     while (size >= sizeof(unsigned long)) {
         neq |= *(unsigned long *)a ^ *(unsigned long *)b;
+        OPTIMIZER_HIDE_VAR(neq);
         a   += sizeof(unsigned long);
         b   += sizeof(unsigned long);
         size -= sizeof(unsigned long);
     }
     while (size > 0) {
         neq |= *(unsigned char *)a ^ *(unsigned char *)b;
+        OPTIMIZER_HIDE_VAR(neq);
         a++;
         b++;
         size--;
     }
-    return (neq != 0) ? 1 : 0;
+    return neq;
 }
 ```
 
-The function is compiled with special care:
-
-```makefile
-# crypto/Makefile
-CFLAGS_memneq.o := -Os
-```
-
-The `-Os` (optimize for size) flag prevents loop unrolling and early-exit optimizations that
-could introduce timing variation. Combined with the `noinline` attribute (which prevents
-inlining that could allow the surrounding code's optimization context to affect it) and
-`OPTIMIZER_HIDE_VAR()` (which hides the accumulator from the optimizer), the function
-maintains its constant-time property.
+`OPTIMIZER_HIDE_VAR(neq)` after every accumulation step (not a `-Os` compiler flag — there is
+no such override for this file) hides the running accumulator from the optimizer, preventing
+it from proving the loop could exit early. Combined with `noinline` (which prevents the
+surrounding code's optimization context from affecting it), the function maintains its
+constant-time property.
 
 ### Fix
 
@@ -180,7 +176,7 @@ Replace all `memcmp()` calls in authentication paths with `crypto_memneq()`:
 
 ```c
 /* Correct: constant-time comparison */
-#include <crypto/algapi.h>
+#include <crypto/utils.h>
 
 if (crypto_memneq(received_tag, expected_tag, TAG_LEN)) {
     return -EBADMSG;
@@ -533,17 +529,46 @@ validate hardware with workload-realistic test patterns before relying on new ac
 | Incident | Core mistake | Correct approach |
 |---|---|---|
 | IV reuse (dm-crypt) | Legacy `aes-cbc-plain` cipher string | Use `aes-xts-plain64` (LUKS2 default) |
-| Timing attack (memcmp) | `memcmp()` for secret comparison | `crypto_memneq()` from `<crypto/algapi.h>` |
+| Timing attack (memcmp) | `memcmp()` for secret comparison | `crypto_memneq()` from `<crypto/utils.h>` |
 | Boot entropy starvation | No hardware RNG in VM | virtio-rng device + saved seed |
 | Keyring description leak | Sensitive data in key description | Opaque descriptions + logon key type |
 | Hardware silent corruption | Trusted self-tests as sufficient validation | DMA boundary checks + fallback |
 
 ## Further reading
 
+### Kernel source
+
+- [drivers/md/dm-crypt.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/md/dm-crypt.c) — `crypt_iv_plain_gen()` and `crypt_iv_essiv_gen()`, the IV generators behind Case 1's plain-IV watermarking issue
+- [include/crypto/utils.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/crypto/utils.h) and [lib/crypto/memneq.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/lib/crypto/memneq.c) — `crypto_memneq()`/`__crypto_memneq()`, the constant-time comparison behind Case 2
+- [drivers/char/random.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/char/random.c) — `add_hwgenerator_randomness()` and the `pr_notice("crng init done\n")` log line behind Case 3
+- [drivers/char/hw_random/virtio-rng.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/char/hw_random/virtio-rng.c) — the virtio-rng guest driver's `hwrng.read` callback that Case 3's fix relies on to feed host entropy into the guest pool
+- [security/keys/proc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/security/keys/proc.c) — `proc_keys_show()` and its `key_task_permission(..., KEY_NEED_VIEW)` check, the `/proc/keys` view-permission filtering behind Case 4
+- [include/linux/crypto.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/crypto.h) — `CRYPTO_ALG_TESTED` (`0x00000400`), the self-test gate behind Case 5
+- [crypto/testmgr.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/crypto/testmgr.c) and [crypto/tcrypt.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/crypto/tcrypt.c) — the mandatory self-test framework and the standalone stress-test module referenced in Case 5's fix
+
+### Man pages
+
+- [`cryptsetup(8)`](https://man7.org/linux/man-pages/man8/cryptsetup.8.html) — the LUKS/dm-crypt command-line tool used throughout Case 1
+- [`getrandom(2)`](https://man7.org/linux/man-pages/man2/getrandom.2.html) — documents the blocking-until-seeded behavior behind Case 3
+- [`random(4)`](https://man7.org/linux/man-pages/man4/random.4.html) — `/dev/random` vs `/dev/urandom`, entropy pool initialization, and why `getrandom(2)` is recommended during early boot
+- [`keyctl(1)`](https://man7.org/linux/man-pages/man1/keyctl.1.html) — `setperm`, `print`, and the view/read/write/search/link/setattr permission bits used in Case 4
+
+### Related pages
+
 - [Kernel Crypto API](crypto-api.md) — AEAD, SKCIPHER, the algorithm registration model
 - [dm-crypt and fscrypt](encryption.md) — IV modes and cipher choices
 - [Kernel Keyring](keyring.md) — key types and permission model
 - [crypto_engine](crypto-engine.md) — the fallback pattern for hardware drivers
 - [Random Number Generation](rng.md) — entropy at boot
-- `crypto/testmgr.c` — the kernel self-test framework
-- `crypto/memneq.c` — constant-time comparison
+
+### LWN articles
+
+- [Constant-time instructions and processor optimizations](https://lwn.net/Articles/921511/) (February 2023) — timing side channels and the tension between constant-time code and CPU-level optimizations, directly behind Case 2
+- [FIPS-compliant random numbers for the kernel](https://lwn.net/Articles/877607/) (December 2021) — the debate over faster boot-time entropy collection, the broader context behind Case 3
+
+### External
+
+- [Kernel documentation: dm-crypt](https://docs.kernel.org/admin-guide/device-mapper/dm-crypt.html) — the `cipher-chainmode-ivmode[:ivopts]` specification format, including `aes-cbc-essiv:sha256` and `aes-xts-plain64`, behind Case 1
+- [Kernel documentation: hw_random](https://docs.kernel.org/admin-guide/hw_random.html) — the `/dev/hwrng` framework that hardware RNG drivers (including virtio-rng) feed, behind Case 3's fix
+- [Kernel documentation: Key Service (core)](https://docs.kernel.org/security/keys/core.html) — `/proc/keys` semantics, the view/read/write/search/link/setattr permission bits, and the `logon` key type, behind Case 4
+- [Kernel documentation: Kernel Crypto API Architecture](https://docs.kernel.org/crypto/architecture.html) — the `priority` and `selftest` fields shown in `/proc/crypto` and the priority-based implementation selection behind Case 5


### PR DESCRIPTION
Part of the rolling citation-backfill effort tracked in #542 — this covers `docs/crypto/` (6 pages, all previously uncited: `crypto-api.md`, `crypto-engine.md`, `encryption.md`, `keyring.md`, `rng.md`, `war-stories.md`).

Every citation was independently live-verified (kernel source paths cross-checked against the GitHub mirror where git.kernel.org's Anubis bot-challenge blocked direct scripted verification; LWN/docs.kernel.org/man7.org/NIST URLs checked for HTTP 200 with matching content).

## Review history (4 rounds, independent adversarial passes)

This directory's research pass surfaced an unusually high volume of pre-existing fabricated structs, functions, and tables compared to prior citation-backfill PRs — the review process caught several cases where a fix itself swapped one wrong claim for a different, subtly wrong one:

- **Round 1**: fixed a wrong Kconfig symbol (`CONFIG_CRYPTO_TEST` → `CONFIG_CRYPTO_BENCHMARK`) in a comment I'd added; fixed a `noinline` misattribution in the rewritten `crypto_memneq()` code block (attached to `__crypto_memneq_generic()`, which is actually `static inline` — the real `noinline` dispatcher, `__crypto_memneq()`, isn't shown in the simplified snippet).
- **Round 2**: caught that my own bcm2835 driver-table fix (correctly removing a false "uses crypto_engine batching" claim) had replaced it with a *new* fabrication ("its own kthread-based queue") — fixed to the real mechanism (mailbox/mbox framework to the SPU coprocessor).
- **Round 3**: caught that my own "pre-refactor crypto_engine_op callbacks" note had invented field names (`prepare_cipher_request`/`unprepare_cipher_request`) that never existed in the real struct — fixed to the real pre-refactor generic struct (`prepare_request`/`unprepare_request`/`do_one_request`), and corrected an adjacent wrong version claim ("5.13+" → "between 6.5 and 6.6", confirmed by tag diffing).
- **Round 4**: the deepest pass — tag-diffed every version number in the diff against real release tags, verified every LWN/docs.kernel.org citation's specific technical characterization word-for-word against the source article, and re-read every file end to end. Found nothing. Clean.

## In-scope body-text fixes (original pass + rounds above)

- **crypto-api.md**: `struct crypto_alg` missing `cra_reqsize`, wrong `cra_refcnt` type (`atomic_t` → `refcount_t`), a fabricated `compress_alg` union member; a fabricated `aesni_skcipher_encrypt()` replaced with the real `cbc_encrypt()`; wrong AES-NI/AVX/VAES priority values (was flat 800, real range is 400–800 by instruction set); an unqualified AF_ALG section given the kernel's own documented deprecation notice; `mode=1` corrected to `mode=0` for the full tcrypt suite.
- **crypto-engine.md**: `struct crypto_engine`'s real location and fields (`kthread_worker`, not a generic workqueue; no `prepare`/`unprepare`/batch hooks); a fabricated `do_batch_requests` batching feature removed entirely; retry-on-`-ENOSPC` semantics corrected; the driver-examples table corrected across 3 rounds (`marvell/cesa` and `bcm2835` don't use `crypto_engine`; `bcm2835` uses mbox, not a kthread); the pre-refactor callback note corrected to real field names and version.
- **encryption.md**: `struct crypt_config`'s real `cipher_tfm`/`iv_gen_private` unions; `fscrypt_decrypt_pagecache_blocks()` rewritten to the real call chain.
- **keyring.md**: `struct key`'s real field layout; `struct encrypted_key_payload`'s missing fields and wrong names; `struct trusted_key_payload`'s real header location.
- **rng.md**: `input_pool`'s real `blake2s_ctx` type; per-CPU CRNGs dated to 5.18; `add_disk_randomness()` is not removed; the DRBG section rewritten for the current single `"stdrng"` registration; `get_random_bytes_arch()`/`prandom_u32()` no longer exist; `x86_init_rdrand()`'s real signature; `vmgenid_notify()`'s real logic; reseed interval corrected to 60s; a still-live `write_wakeup_threshold` sysctl.
- **war-stories.md**: `crypto_memneq()`'s real location and `noinline` attribution.

## Out of scope, logged to #748

Several pre-existing issues not tied to a new citation in the same file: a wrong AES key size and a fabricated `key_namespace` struct in keyring.md; a fabricated dmesg line and a minor misattribution in war-stories.md; two untouched `CONFIG_CRYPTO_TEST` references; a QAT AES-GCM priority/driver-name claim; a false "full fallback" claim on crypto-engine.md's stm32-cryp table row.

`mkdocs build --strict` passes; all ~58 new URLs re-verified live across rounds.