### PR TITLE
Add citations to docs/iommu/ (issue #542)

### DIFF
--- a/docs/iommu/dma-api.md
+++ b/docs/iommu/dma-api.md
@@ -163,7 +163,7 @@ dma_addr_t iommu_dma_map_phys(struct device *dev, phys_addr_t phys, size_t size,
     if (!iova)
         return DMA_MAPPING_ERROR;
     if (iommu_map(domain, iova, phys, size, prot, GFP_ATOMIC)) {
-        iommu_dma_free_iova(cookie, iova, size, NULL);
+        iommu_dma_free_iova(domain, iova, size, NULL);
         return DMA_MAPPING_ERROR;
     }
 
@@ -208,7 +208,7 @@ phys_addr_t swiotlb_tbl_map_single(struct device *dev,
 
     /* Find a free slot, in whichever pool has room */
     index = swiotlb_find_slots(dev, orig_addr, size, alloc_align_mask, &pool);
-    tlb_addr = slot_addr(pool->start, index);
+    tlb_addr = slot_addr(pool->start, index) + offset;
 
     /* Copy data to bounce buffer for DMA_TO_DEVICE */
     if (!(attrs & DMA_ATTR_SKIP_CPU_SYNC) &&

--- a/docs/iommu/dma-api.md
+++ b/docs/iommu/dma-api.md
@@ -138,23 +138,30 @@ With an IOMMU, `dma_map_sg` can coalesce adjacent pages into a single IOVA range
 With an IOMMU, each streaming DMA map requires an IOVA allocation:
 
 ```c
-/* drivers/iommu/dma-iommu.c */
-static dma_addr_t iommu_dma_map_page(struct device *dev, struct page *page,
-                                      unsigned long offset, size_t size,
-                                      enum dma_data_direction dir,
-                                      unsigned long attrs)
+/* drivers/iommu/dma-iommu.c — current signature takes a phys_addr_t directly,
+ * not a struct page + offset pair (older kernels used the page+offset form) */
+dma_addr_t iommu_dma_map_phys(struct device *dev, phys_addr_t phys, size_t size,
+                               enum dma_data_direction dir, unsigned long attrs)
 {
+    bool coherent = dev_is_dma_coherent(dev);
+    int prot = dma_info_to_prot(dir, coherent, attrs);
     struct iommu_domain *domain = iommu_get_dma_domain(dev);
     struct iommu_dma_cookie *cookie = domain->iova_cookie;
     struct iova_domain *iovad = &cookie->iovad;
+    dma_addr_t iova, dma_mask = dma_get_mask(dev);
 
-    /* Allocate an IOVA (I/O virtual address range) */
-    dma_addr_t iova = iommu_dma_alloc_iova(domain, size, dma_get_mask(dev), dev);
+    /* If the buffer needs bouncing (unaligned for the device), swiotlb
+     * handles that here before IOVA allocation */
+    if (dev_use_swiotlb(dev, size, dir) && iova_unaligned(iovad, phys, size)) {
+        phys = iommu_dma_map_swiotlb(dev, phys, size, dir, attrs);
+        if (phys == (phys_addr_t)DMA_MAPPING_ERROR)
+            return DMA_MAPPING_ERROR;
+    }
+
+    /* Allocate an IOVA (I/O virtual address range) and map it to phys */
+    iova = iommu_dma_alloc_iova(domain, size, dma_mask, dev);
     if (!iova)
         return DMA_MAPPING_ERROR;
-
-    /* Create IOMMU page table entry: IOVA → physical page */
-    phys_addr_t phys = page_to_phys(page) + offset;
     if (iommu_map(domain, iova, phys, size, prot, GFP_ATOMIC)) {
         iommu_dma_free_iova(cookie, iova, size, NULL);
         return DMA_MAPPING_ERROR;
@@ -182,19 +189,26 @@ Bounce buffer mechanism:
 ```
 
 ```c
-/* kernel/dma/swiotlb.c */
+/* kernel/dma/swiotlb.c — simplified; real function has no separate
+ * alloc_size parameter (it's derived from mapping_size + alignment
+ * padding) and slots are tracked per struct io_tlb_pool, since a
+ * system can have more than one swiotlb pool (CONFIG_SWIOTLB_DYNAMIC) */
 phys_addr_t swiotlb_tbl_map_single(struct device *dev,
                                      phys_addr_t orig_addr,
                                      size_t mapping_size,
-                                     size_t alloc_size,
                                      unsigned int alloc_align_mask,
                                      enum dma_data_direction dir,
                                      unsigned long attrs)
 {
-    struct io_tlb_mem *mem = dev->dma_io_tlb_mem;
-    /* Find a free slot in the swiotlb pool */
-    index = find_slots(dev, mem, orig_addr, alloc_size, alloc_align_mask);
-    tlb_addr = slot_addr(mem->start, index);
+    unsigned int offset = swiotlb_align_offset(dev, alloc_align_mask, orig_addr);
+    size_t size = ALIGN(mapping_size + offset, alloc_align_mask + 1);
+    struct io_tlb_pool *pool;
+    int index;
+    phys_addr_t tlb_addr;
+
+    /* Find a free slot, in whichever pool has room */
+    index = swiotlb_find_slots(dev, orig_addr, size, alloc_align_mask, &pool);
+    tlb_addr = slot_addr(pool->start, index);
 
     /* Copy data to bounce buffer for DMA_TO_DEVICE */
     if (!(attrs & DMA_ATTR_SKIP_CPU_SYNC) &&
@@ -293,9 +307,26 @@ priv->dma_rx = dma_request_chan(dev, "rx");
 
 ## Further reading
 
-- [IOMMU Architecture](iommu-arch.md) — IOMMU hardware and domains
-- [Memory Management: DMA zones](../mm/dma.md) — DMA zone in the buddy allocator
-- [Memory Management: Device Coherency](../mm/device-coherency.md) — cache coherency
-- [Device Drivers: platform driver](../drivers/platform-driver.md) — devm_request_mem_region
-- `include/linux/dma-mapping.h` — DMA API declarations
-- `Documentation/core-api/dma-api.rst` — full DMA API reference
+### Kernel source
+
+- [include/linux/dma-mapping.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/dma-mapping.h) — `dma_map_single()`, `dma_alloc_coherent()`, `dma_mapping_error()`, `dma_set_mask_and_coherent()`: the API declarations used throughout this page
+- [kernel/dma/mapping.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/mapping.c) — `dma_map_sg_attrs()`, `dma_alloc_attrs()`: the core implementation that dispatches to the platform's `dma_map_ops`
+- [kernel/dma/swiotlb.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/swiotlb.c) — `swiotlb_tbl_map_single()`, `swiotlb_find_slots()`: the real bounce-buffer implementation
+- [drivers/iommu/dma-iommu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/dma-iommu.c) — `iommu_dma_map_phys()`: the current IOMMU-backed streaming-DMA mapping function
+- [mm/dmapool.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/dmapool.c) — `dma_pool_create_node()`, `dma_pool_alloc()`, `dma_pool_free()`: the DMA pool allocator behind `dma_pool_create()`
+- [Documentation/core-api/dma-api-howto.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/core-api/dma-api-howto.rst) — the kernel's own practical guide to when to use coherent vs. streaming mappings
+
+### Related pages
+
+- [IOMMU Architecture](iommu-arch.md) — `iommu_domain`, IOTLB, and the hardware DMA remapping this API relies on when an IOMMU is present
+- [IOVA Allocator](iova-allocator.md) — the rbtree/rcache allocator behind every IOMMU-backed `dma_map_single()`/`dma_map_sg()` call
+- [IOMMU War Stories](war-stories.md) — a real incident where per-packet `dma_map_single()` calls became a CPU bottleneck, fixed by batching with `dma_map_sg()`
+- [Memory Management: DMA](../mm/dma.md) — a companion deep-dive on the same API, covering `dma_sync_*`, DMA zones, and swiotlb internals in more depth
+- [Memory Management: Device Coherency](../mm/device-coherency.md) — the cache-coherency rules that govern when `dma_map_single()`/`dma_sync_*` actually need to do anything
+- [Device Drivers: PCI driver](../drivers/pci-driver.md) — `dma_alloc_coherent()`/`dma_map_single()` used in a real PCI network driver
+
+### LWN articles
+
+- [The trouble with 64-bit DMA](https://lwn.net/Articles/904210/) — Jonathan Corbet, August 11, 2022: why the IOMMU layer conservatively picks IOVAs below 4GB even for 64-bit-capable devices, and what went wrong when Robin Murphy tried to relax it — background for the `DMA_BIT_MASK()`/`dma_set_mask_and_coherent()` masks used in this page's setup section
+- [Noncoherent DMA mappings](https://lwn.net/Articles/855328/) — Jonathan Corbet, May 7, 2021: the `dma_alloc_noncontiguous()` API and manual cache synchronization (`dma_sync_sgtable_for_device()`/`_for_cpu()`) for non-cache-coherent architectures — background for this page's coherent-vs-streaming distinction
+- [Restricted DMA](https://lwn.net/Articles/841916/) — Jonathan Corbet, January 7, 2021: Claire Chang's per-device restricted SWIOTLB pools, used to isolate untrusted devices without a full IOMMU — background for the swiotlb bounce-buffer mechanism described on this page

--- a/docs/iommu/iommu-arch.md
+++ b/docs/iommu/iommu-arch.md
@@ -290,4 +290,4 @@ modprobe vfio-pci
 
 ### External
 
-- [x86 IOMMU Support](https://docs.kernel.org/arch/x86/iommu.html) — official kernel documentation on DMAR/IVRS ACPI tables, `intel_iommu=`/`amd_iommu=` boot options, and fault-reporting formats for both vendors
+- [x86 IOMMU Support](https://docs.kernel.org/arch/x86/iommu.html) — official kernel documentation on DMAR/IVRS ACPI tables, the `intel_iommu=igfx_off`/`iommu=pt` boot options, and fault-reporting formats for both vendors

--- a/docs/iommu/iommu-arch.md
+++ b/docs/iommu/iommu-arch.md
@@ -24,7 +24,7 @@ The DMAR unit uses a two-level structure:
 3. Each context entry points to the device's **IOMMU page tables**
 
 ```c
-/* drivers/iommu/intel/iommu.c */
+/* drivers/iommu/intel/iommu.h — the struct definition, not iommu.c */
 struct intel_iommu {
     void __iomem    *reg;        /* MMIO registers */
     u64              cap;        /* capability register */
@@ -32,7 +32,7 @@ struct intel_iommu {
     /* ... */
     struct root_entry *root_entry; /* root table (bus indexed) */
     int              seq_id;
-    struct iommu_device iommu_dev;
+    struct iommu_device iommu;   /* not "iommu_dev" */
 };
 ```
 
@@ -41,18 +41,21 @@ struct intel_iommu {
 AMD uses a single system-wide Device Table (indexed by 16-bit device ID = bus+dev+fn). Each entry points to the device's page table and control flags:
 
 ```c
-/* drivers/iommu/amd/amd_iommu_types.h */
+/* drivers/iommu/amd/amd_iommu_types.h — the real struct is a bare 256-bit
+ * union with no in-source bitfield comment; illustrative bit meanings below */
 struct dev_table_entry {
-    u64 data[4];
-    /*
-     * Bits define:
-     *   [0]    V:  valid
-     *   [1]    TV: translation valid
-     *   [11:9] Mode: page table levels
-     *   [51:12] PTP: page table pointer
-     *   (interrupt remapping fields are in data[2] of the 256-bit entry)
-     */
+    union {
+        u64  data[4];
+        u128 data128[2];
+    };
 };
+/* AMD-Vi hardware bit layout (per the AMD I/O Virtualization spec, not
+ * documented inline in this header):
+ *   [0]    V:  valid
+ *   [1]    TV: translation valid
+ *   [11:9] Mode: page table levels
+ *   [51:12] PTP: page table pointer
+ *   (interrupt remapping fields are in data[2] of the 256-bit entry) */
 ```
 
 ## The IOMMU subsystem
@@ -75,8 +78,11 @@ struct iommu_domain {
 };
 
 struct iommu_domain_ops {
-    int  (*attach_dev)(struct iommu_domain *domain, struct device *dev);
-    void (*detach_dev)(struct iommu_domain *domain, struct device *dev);
+    /* `old` is the domain being replaced. There is no separate detach_dev
+     * callback -- detachment happens by attaching a different domain
+     * (e.g. the blocking domain), not via a dedicated callback. */
+    int  (*attach_dev)(struct iommu_domain *domain, struct device *dev,
+                       struct iommu_domain *old);
 
     int  (*map_pages)(struct iommu_domain *domain, unsigned long iova,
                       phys_addr_t paddr, size_t pgsize, size_t pgcount,
@@ -200,24 +206,34 @@ echo "8086 154c" > /sys/bus/pci/drivers/vfio-pci/new_id
 The IOMMU has its own TLB (IOTLB) that caches IOVA→PA translations. After unmapping, the kernel must flush the IOTLB:
 
 ```c
-/* drivers/iommu/iommu.c */
-void iommu_iotlb_gather_add_page(struct iommu_domain *domain,
-                                  struct iommu_iotlb_gather *gather,
-                                  unsigned long iova, size_t size)
+/* include/linux/iommu.h — these are static inline helpers in the header,
+ * not functions defined in drivers/iommu/iommu.c */
+static inline void iommu_iotlb_gather_add_page(struct iommu_domain *domain,
+                                                struct iommu_iotlb_gather *gather,
+                                                unsigned long iova, size_t size)
 {
-    /* Accumulate unmapped ranges */
+    /* If the new range is disjoint from what's gathered, or uses a
+     * different page size, flush what's gathered first rather than
+     * silently merging non-contiguous ranges into one invalidation */
+    if ((gather->pgsize && gather->pgsize != size) ||
+        iommu_iotlb_gather_is_disjoint(gather, iova, size))
+        iommu_iotlb_sync(domain, gather);
+
+    gather->pgsize = size;
+    /* Accumulate the (now-compatible) range */
     if (gather->start > iova)
         gather->start = iova;
-    if (gather->end < iova + size)
-        gather->end   = iova + size;
-    gather->pgsize = size;
+    if (gather->end < iova + size - 1)
+        gather->end = iova + size - 1;
 }
 
 /* Flush accumulated ranges (batch for efficiency) */
-void iommu_iotlb_sync(struct iommu_domain *domain,
-                       struct iommu_iotlb_gather *iotlb_gather)
+static inline void iommu_iotlb_sync(struct iommu_domain *domain,
+                                     struct iommu_iotlb_gather *iotlb_gather)
 {
-    if (domain->ops->iotlb_sync)
+    /* Only call into the driver if something was actually gathered --
+     * avoids a spurious sync on every call */
+    if (domain->ops->iotlb_sync && iotlb_gather->start < iotlb_gather->end)
         domain->ops->iotlb_sync(domain, iotlb_gather);
     iommu_iotlb_gather_init(iotlb_gather);
 }
@@ -248,9 +264,30 @@ modprobe vfio-pci
 
 ## Further reading
 
-- [DMA API](dma-api.md) — kernel driver DMA programming
-- [Memory Management: DMA](../mm/dma.md) — DMA zones and device coherency
-- [Memory Management: Device Coherency](../mm/device-coherency.md) — cache coherency with devices
-- [Virtualization: KVM Memory](../virtualization/kvm-memory.md) — EPT complements IOMMU for VMs
-- `drivers/iommu/` in the kernel tree — IOMMU subsystem
-- `Documentation/userspace-api/iommu.rst` in the kernel tree
+### Kernel source
+
+- [include/linux/iommu.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/iommu.h) — `struct iommu_domain`, `struct iommu_domain_ops`, the `IOMMU_DOMAIN_*` type constants, and the `iommu_iotlb_gather_add_page()`/`iommu_iotlb_sync()` inline helpers
+- [drivers/iommu/iommu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/iommu.c) — `iommu_group_alloc()` and the rest of IOMMU group/domain management
+- [drivers/iommu/intel/iommu.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/intel/iommu.h) — `struct intel_iommu`: the VT-d per-remapping-unit state (root table, capability registers, queued invalidation)
+- [drivers/iommu/amd/amd_iommu_types.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/amd/amd_iommu_types.h) — `struct dev_table_entry`: the AMD-Vi per-device-ID table entry
+- [Documentation/ABI/testing/sysfs-kernel-iommu_groups](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/ABI/testing/sysfs-kernel-iommu_groups) — the `/sys/kernel/iommu_groups/` ABI referenced in this page's group examples
+
+### Related pages
+
+- [DMA API](dma-api.md) — kernel driver DMA programming built on top of the domain/group model described here
+- [IOVA Allocator](iova-allocator.md) — how `alloc_iova()`/`free_iova()` manage the address space inside an `IOMMU_DOMAIN_DMA` domain
+- [Shared Virtual Addressing](sva.md) — PASID-based translation that shares a process's page tables with a device, built on the same `iommu_domain` infrastructure
+- [VFIO Internals](vfio-internals.md) — the container/group/device hierarchy and type1 IOMMU backend behind the VFIO API shown here
+- [IOMMU War Stories](war-stories.md) — real DMAR fault storms and group-isolation incidents diagnosed with the tools in this page
+- [VFIO: Virtual Function I/O and Device Passthrough](../virtualization/vfio.md) — the VM-passthrough walkthrough this page's VFIO section summarizes
+- [Memory Virtualization](../virtualization/kvm-memory.md) — EPT/NPT, the CPU-side counterpart to IOMMU device translation
+- [Memory Management: DMA](../mm/dma.md) — DMA zones, SWIOTLB, and device coherency
+- [Memory Management: Device Coherency](../mm/device-coherency.md) — cache coherency rules for DMA-capable devices
+
+### LWN articles
+
+- [LWN: Safe device assignment with VFIO](https://lwn.net/Articles/474088/) — Jonathan Corbet's coverage of Alex Williamson's VFIO framework, explaining why "any device can access any memory regions made available to any other devices in the same group" and how groups became the unit of ownership for passthrough (January 3, 2012)
+
+### External
+
+- [x86 IOMMU Support](https://docs.kernel.org/arch/x86/iommu.html) — official kernel documentation on DMAR/IVRS ACPI tables, `intel_iommu=`/`amd_iommu=` boot options, and fault-reporting formats for both vendors

--- a/docs/iommu/iova-allocator.md
+++ b/docs/iommu/iova-allocator.md
@@ -220,8 +220,8 @@ The `dma_32bit_pfn` field in `struct iova_domain` marks the upper boundary of th
  * domain's granule -- it takes no struct device and is not clamped by
  * any device's DMA mask:
  *   iovad->dma_32bit_pfn = 1UL << (32 - iova_shift(iovad));
- * Per-device DMA-mask clamping happens separately, as a local limit_pfn
- * inside iommu_dma_alloc_iova(), not by mutating this field. */
+ * Per-device DMA-mask clamping happens separately, as a local dma_limit
+ * parameter inside iommu_dma_alloc_iova(), not by mutating this field. */
 ```
 
 When a driver calls `dma_set_mask(dev, DMA_BIT_MASK(32))`, subsequent allocations use `limit_pfn = iovad->dma_32bit_pfn`. The allocator satisfies the constraint by searching only the region below 4 GB.

--- a/docs/iommu/iova-allocator.md
+++ b/docs/iommu/iova-allocator.md
@@ -27,6 +27,7 @@ struct iova_domain {
     unsigned long   max32_alloc_size; /* max single alloc below 4GB */
     struct iova      anchor;          /* sentinel node in rbtree */
     struct iova_rcache *rcaches; /* dynamically allocated in iova_domain_init_rcaches() */
+    struct hlist_node cpuhp_dead;     /* CPU-hotplug teardown of rcache state */
 };
 ```
 
@@ -98,7 +99,8 @@ The magazine-style per-CPU cache is the key to keeping IOVA allocation off the r
 ### struct iova_rcache and struct iova_cpu_rcache
 
 ```c
-/* include/linux/iova.h */
+/* drivers/iommu/iova.c — these are all internal to iova.c, not exposed
+ * in include/linux/iova.h, which only forward-declares struct iova_rcache */
 
 /* 127 chosen so sizeof(struct iova_magazine) = exactly 1024 bytes
  * (127 × 8 + 8 = 1024), avoiding kmalloc internal fragmentation. */
@@ -120,11 +122,16 @@ struct iova_cpu_rcache {
 
 struct iova_rcache {
     spinlock_t          lock;       /* protects depot */
-    unsigned long       depot_size;
+    unsigned int         depot_size;
     struct iova_magazine *depot;    /* singly-linked list of depot magazines */
     struct iova_cpu_rcache __percpu *cpu_rcaches;
+    struct iova_domain  *iovad;     /* owning domain, for the depot-trim worker below */
+    struct delayed_work  work;      /* periodically trims the depot back down */
 };
 ```
+
+A delayed-work callback (`iova_depot_work_func()`, period `IOVA_DEPOT_DELAY` = 100ms) periodically
+frees depot magazines down to `num_online_cpus()` — the depot is not an unbounded stash.
 
 `IOVA_RANGE_CACHE_MAX_SIZE` is defined as 6 in recent kernels, giving 6 size classes. Each size class manages IOVAs of a specific power-of-two page count (1, 2, 4, 8, 16, 32 pages), covering the most common DMA buffer sizes for network and NVMe workloads.
 
@@ -158,19 +165,21 @@ The critical property: on the normal alloc/free cycle, no spinlock contention wi
 Introduced in Linux 5.15, flush queues decouple IOVA freeing from IOTLB invalidation. Unmapping a DMA range requires both freeing the IOVA and flushing the IOMMU TLB. IOTLB flushes are expensive — on Intel VT-d they require a write to the DMAR registers and may stall the bus.
 
 ```c
-/* include/linux/iova.h */
+/* drivers/iommu/dma-iommu.c — not include/linux/iova.h, which has no "fq" symbols at all */
 #define IOVA_DEFAULT_FQ_SIZE   256
 
 struct iova_fq_entry {
     unsigned long iova_pfn;
     unsigned long pages;
-    u64 counter;               /* monotonic counter at enqueue time */
+    struct iommu_pages_list freelist; /* IOMMU page-table pages freed with this entry,
+                                        * deferred until the batched flush actually runs */
+    u64 counter;               /* flush counter when this entry was added */
 };
 
 struct iova_fq {
-    unsigned int head;
-    unsigned int tail;
     spinlock_t lock;
+    unsigned int head, tail;
+    unsigned int mod_mask;     /* ring size - 1; entries[] is power-of-two sized */
     struct iova_fq_entry entries[]; /* flexible array member */
 };
 ```
@@ -180,19 +189,23 @@ Instead of calling `iommu_iotlb_sync()` immediately after each unmap, the flush 
 The domain type `IOMMU_DOMAIN_DMA_FQ` enables flush-queue mode:
 
 ```c
-/* drivers/iommu/dma-iommu.c */
-void iommu_dma_free_iova(struct iommu_dma_cookie *cookie,
-                          dma_addr_t iova, size_t size,
-                          struct iommu_iotlb_gather *gather)
+/* drivers/iommu/dma-iommu.c — real signature takes the domain, not the
+ * cookie directly, and handles a separate MSI-cookie teardown case */
+static void iommu_dma_free_iova(struct iommu_domain *domain, dma_addr_t iova,
+                                size_t size, struct iommu_iotlb_gather *gather)
 {
-    struct iova_domain *iovad = &cookie->iovad;
+    struct iova_domain *iovad = &domain->iova_cookie->iovad;
 
-    if (gather && gather->queued)
-        queue_iova(cookie, iova_pfn(iovad, iova),
-                   size >> iova_shift(iovad), gather);
-    else
+    if (domain->cookie_type == IOMMU_COOKIE_DMA_MSI) {
+        /* MSI case: only ever cleaning up the most recent allocation */
+        domain->msi_cookie->msi_iova -= size;
+    } else if (gather && gather->queued) {
+        queue_iova(domain->iova_cookie, iova_pfn(iovad, iova),
+                   size >> iova_shift(iovad), &gather->freelist);
+    } else {
         free_iova_fast(iovad, iova_pfn(iovad, iova),
                        size >> iova_shift(iovad));
+    }
 }
 ```
 
@@ -203,10 +216,12 @@ Many legacy and embedded devices have 32-bit DMA address registers. On a system 
 The `dma_32bit_pfn` field in `struct iova_domain` marks the upper boundary of the 32-bit IOVA region:
 
 ```c
-/* init_iova_domain() sets this based on the device DMA mask.
- * dma_32bit_pfn is the upper PFN limit for 32-bit DMA, derived from:
- *   min(DMA_BIT_MASK(32), dev->bus_dma_limit) >> PAGE_SHIFT
- * It is NOT a sum with IOVA_START_PFN. */
+/* init_iova_domain() sets a fixed 4 GB boundary, derived only from the
+ * domain's granule -- it takes no struct device and is not clamped by
+ * any device's DMA mask:
+ *   iovad->dma_32bit_pfn = 1UL << (32 - iova_shift(iovad));
+ * Per-device DMA-mask clamping happens separately, as a local limit_pfn
+ * inside iommu_dma_alloc_iova(), not by mutating this field. */
 ```
 
 When a driver calls `dma_set_mask(dev, DMA_BIT_MASK(32))`, subsequent allocations use `limit_pfn = iovad->dma_32bit_pfn`. The allocator satisfies the constraint by searching only the region below 4 GB.
@@ -249,7 +264,14 @@ A common tuning mistake for high-throughput drivers: using `dma_map_single()` pe
 
 ## Further reading
 
+### Kernel source
+
+- [drivers/iommu/iova.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/iova.c) — `alloc_iova()`, `free_iova()`, the rbtree allocator, and the per-CPU rcache/magazine implementation
+- [include/linux/iova.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/iova.h) — `struct iova_domain` and `struct iova` definitions
+- [drivers/iommu/dma-iommu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/dma-iommu.c) — `iommu_dma_alloc_iova()` / `iommu_dma_free_iova()`, and the flush-queue (`struct iova_fq`) implementation
+
+### Related pages
+
 - [DMA API](dma-api.md) — `dma_map_single`, `dma_map_sg`, swiotlb
 - [IOMMU Architecture](iommu-arch.md) — IOMMU domains, IOTLB flush mechanics
 - [IOMMU War Stories](war-stories.md) — IOVA allocator as a perf bottleneck (real incident)
-- `Documentation/core-api/dma-api.rst` — DMA API reference

--- a/docs/iommu/sva.md
+++ b/docs/iommu/sva.md
@@ -249,7 +249,6 @@ grep CONFIG_IOMMU_SVA /boot/config-$(uname -r)
 - [drivers/iommu/intel/svm.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/intel/svm.c) — Intel VT-d SVA: `intel_svm_set_dev_pasid()` and first-level PASID table setup
 - [drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3-sva.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3-sva.c) — ARM SMMUv3 SVA: `arm_smmu_sva_set_dev_pasid()` and Context Descriptor programming from `mm->pgd`
 - [include/linux/iommu.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/iommu.h) — `struct iommu_sva` and the `iommu_sva_bind_device()` family of declarations
-- [Documentation/arch/x86/sva.rst](https://docs.kernel.org/arch/x86/sva.html) — the kernel's own SVA/PASID/ENQCMD documentation: PASID life-cycle, the `IA32_PASID` MSR, and the PCIe ATS/PRI background
 
 ### Related pages
 
@@ -261,3 +260,7 @@ grep CONFIG_IOMMU_SVA /boot/config-$(uname -r)
 ### LWN articles
 
 - [5.7 Merge window part 1](https://lwn.net/Articles/816313/) — Jonathan Corbet, April 3, 2020; covers the merge of the "unified user-space access-intended accelerator framework" (uacce), a generic driver framework (used by HiSilicon's accelerators) for exposing SVA-backed devices to user space
+
+### External
+
+- [Documentation/arch/x86/sva.rst](https://docs.kernel.org/arch/x86/sva.html) — the kernel's own SVA/PASID/ENQCMD documentation: PASID life-cycle, the `IA32_PASID` MSR, and the PCIe ATS/PRI background

--- a/docs/iommu/sva.md
+++ b/docs/iommu/sva.md
@@ -100,11 +100,11 @@ struct io_pgtable_ops {
 };
 ```
 
-For SVA, `io_pgtable_ops` maps to the process page tables directly. The ARM SMMU v3 implementation (`drivers/iommu/arm/arm-smmu-v3/`) can configure a stream entry to use the ARM64 page table format. However, the stream table entry does not point directly to the process's `pgd` — ARM SMMUv3 uses a Context Descriptor (CD) table as an indirection layer: the stream table entry points to the CD table, and each CD entry (indexed by PASID) holds the TTBR equivalent that points to the process's `pgd`. Intel's implementation (`drivers/iommu/intel/svm.c`) creates a PASID entry in the DMAR PASID table using first-level page tables (FLPTR in scalable mode); SVA always uses first-level page tables with the process `pgd` — the IOMMU does not use CR3 directly.
+`io_pgtable_ops` is what classic, kernel-managed domains use — it's the abstraction `alloc_io_pgtable_ops()` returns when the IOMMU driver walks and populates its own page tables. **SVA domains never allocate an `io_pgtable_ops` instance at all**: instead of the IOMMU maintaining a separate table, hardware is pointed directly at the process's *existing* CPU page tables. The ARM SMMU v3 implementation (`drivers/iommu/arm/arm-smmu-v3/`) does this via a Context Descriptor (CD) table: the stream table entry points to the CD table, and each CD entry (indexed by PASID) holds the TTBR equivalent that points to the process's `pgd`. Intel's implementation (`drivers/iommu/intel/svm.c`) creates a PASID entry in the DMAR PASID table pointing at first-level page tables (FLPTR in scalable mode) — `intel_pasid_setup_first_level()` programs it with `__pa(mm->pgd)`, the same physical address the CPU's own CR3 register would hold for that process, without the IOMMU reading CR3 itself.
 
-## The Linux SVA API (kernel 5.14+)
+## The Linux SVA API (kernel 5.2+)
 
-The `iommu_sva` API, stabilized in Linux 5.14, provides three operations:
+The `iommu_sva` API, introduced in Linux 5.2 (`iommu_sva_bind_device()`/`iommu_sva_unbind_device()`/`iommu_sva_get_pasid()`), provides three operations:
 
 ```c
 /* include/linux/iommu.h */
@@ -242,8 +242,22 @@ grep CONFIG_IOMMU_SVA /boot/config-$(uname -r)
 
 ## Further reading
 
-- [IOMMU Architecture](iommu-arch.md) — IOMMU domains, IOTLB, hardware overview
-- [VFIO Internals](vfio-internals.md) — device passthrough (different isolation model)
-- [IOMMU War Stories](war-stories.md) — SVA page fault storm incident
-- `Documentation/iommu/iommu-sva.rst` — kernel SVA documentation
-- PCIe Base Specification §10 (ATS), §10.4 (PRI)
+### Kernel source
+
+- [drivers/iommu/iommu-sva.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/iommu-sva.c) — `iommu_sva_bind_device()`, `iommu_sva_unbind_device()`, `iommu_sva_get_pasid()`, and the SVA I/O-page-fault handler
+- [drivers/iommu/iommu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/iommu.c) — `iommu_alloc_global_pasid()` / `iommu_free_global_pasid()`: global PASID allocation, folded in here from the now-removed `ioasid.c`
+- [drivers/iommu/intel/svm.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/intel/svm.c) — Intel VT-d SVA: `intel_svm_set_dev_pasid()` and first-level PASID table setup
+- [drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3-sva.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3-sva.c) — ARM SMMUv3 SVA: `arm_smmu_sva_set_dev_pasid()` and Context Descriptor programming from `mm->pgd`
+- [include/linux/iommu.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/iommu.h) — `struct iommu_sva` and the `iommu_sva_bind_device()` family of declarations
+- [Documentation/arch/x86/sva.rst](https://docs.kernel.org/arch/x86/sva.html) — the kernel's own SVA/PASID/ENQCMD documentation: PASID life-cycle, the `IA32_PASID` MSR, and the PCIe ATS/PRI background
+
+### Related pages
+
+- [IOMMU Architecture](iommu-arch.md) — IOMMU domains, groups, and the VT-d/AMD-Vi hardware SVA builds on
+- [DMA API](dma-api.md) — the pin-and-map path SVA is designed to avoid
+- [VFIO Internals](vfio-internals.md) — device passthrough: pin+map into a container, a different isolation model from SVA's PASID-tagged sharing
+- [IOMMU War Stories](war-stories.md) — Case 4, "SVA page fault storm from an accelerator"
+
+### LWN articles
+
+- [5.7 Merge window part 1](https://lwn.net/Articles/816313/) — Jonathan Corbet, April 3, 2020; covers the merge of the "unified user-space access-intended accelerator framework" (uacce), a generic driver framework (used by HiSilicon's accelerators) for exposing SVA-backed devices to user space

--- a/docs/iommu/vfio-internals.md
+++ b/docs/iommu/vfio-internals.md
@@ -127,6 +127,7 @@ struct vfio_domain {
     struct iommu_domain    *domain;
     struct list_head       next;
     struct list_head       group_list;
+    /* ... */
 };
 
 struct vfio_dma {

--- a/docs/iommu/vfio-internals.md
+++ b/docs/iommu/vfio-internals.md
@@ -36,7 +36,6 @@ VFIO source lives in `drivers/vfio/` with headers in `include/linux/vfio.h`.
 
 ```c
 /* include/linux/vfio.h */
-
 struct vfio_device {
     struct device            *dev;
     const struct vfio_device_ops *ops;
@@ -45,25 +44,31 @@ struct vfio_device {
     /* ... */
 };
 
+/* drivers/vfio/vfio.h -- private to the VFIO core, not the public header above */
 struct vfio_group {
+    struct device             dev;
+    struct cdev                cdev;
+    refcount_t                drivers;
+    unsigned int               container_users;
     struct iommu_group       *iommu_group;
     struct vfio_container    *container;
     struct list_head          device_list;
-    refcount_t                drivers;
     /* ... */
 };
 
+/* drivers/vfio/container.c -- no domain pointer; the container just
+ * dispatches to whichever IOMMU backend (iommu_driver) is set */
 struct vfio_container {
-    struct iommu_domain      *domain;   /* NULL until IOMMU type set */
-    struct vfio_iommu_driver *iommu_driver;
-    void                     *iommu_data; /* driver-private (e.g. vfio_iommu) */
+    struct kref                kref;
     struct list_head          group_list;
     struct rw_semaphore       group_lock;
-    /* ... */
+    struct vfio_iommu_driver *iommu_driver;
+    void                     *iommu_data; /* driver-private (e.g. vfio_iommu) */
+    bool                        noiommu;
 };
 ```
 
-The `vfio_device_ops` structure defines per-device operations (open, release, read, write, ioctl for MMIO/interrupt/reset).
+The `vfio_device_ops` structure defines per-device operations (`open_device`/`close_device`, read, write, ioctl for MMIO/interrupt/reset).
 
 ## IOMMU type1 backend
 
@@ -89,20 +94,22 @@ static int vfio_dma_do_map(struct vfio_iommu *iommu,
     ret = pin_user_pages_remote(current->mm, vaddr,
                                  npage, gup_flags, pages);
 
-    /* Record the mapping in our radix tree */
+    /* Record the mapping in our rb-tree */
     dma = vfio_find_dma(iommu, iova, size);  /* ensure no overlap */
     vfio_link_dma(iommu, new_dma);           /* insert into tree */
 
-    /* Create IOMMU page table entries: IOVA → HPA */
-    iommu_map(iommu->domain, iova, phys, pgsize, prot);
+    /* Create IOMMU page table entries: IOVA → HPA, across every
+     * domain in iommu->domain_list (a container can span more than
+     * one IOMMU domain) -- not a single iommu->domain pointer */
+    vfio_pin_map_dma(iommu, dma, size);
 }
 ```
 
 The `pin_user_pages_remote()` call (introduced in kernel 5.6 to replace `get_user_pages_remote()` for DMA pinning) increments the page refcount and marks pages as pinned, preventing them from being swapped or moved while the device may be accessing them.
 
-### The DMA map radix tree
+### The DMA map rb-tree
 
-All active DMA mappings are tracked in a radix tree (or interval tree in recent kernels) keyed by IOVA. This allows the kernel to:
+All active DMA mappings are tracked in a red-black tree, keyed and searched for overlap by IOVA (`vfio_find_dma()`) — not a radix tree or the kernel's interval-tree API. This allows the kernel to:
 - Detect and reject overlapping `MAP_DMA` requests.
 - Enumerate all mappings for cleanup when a group is removed.
 - Implement `VFIO_IOMMU_UNMAP_DMA` by looking up and removing entries.
@@ -110,10 +117,16 @@ All active DMA mappings are tracked in a radix tree (or interval tree in recent 
 ```c
 /* struct vfio_iommu tracks mappings */
 struct vfio_iommu {
-    struct rb_root        dma_list;    /* interval tree of vfio_dma */
-    struct iommu_domain  *domain;
-    unsigned int          dma_avail;   /* remaining DMA map limit */
+    struct list_head       domain_list; /* one container can span >1 IOMMU domain */
+    struct rb_root          dma_list;   /* rb-tree of vfio_dma, overlap-searched by IOVA */
+    unsigned int            dma_avail;   /* remaining DMA map limit */
     /* ... */
+};
+
+struct vfio_domain {
+    struct iommu_domain    *domain;
+    struct list_head       next;
+    struct list_head       group_list;
 };
 
 struct vfio_dma {
@@ -204,19 +217,22 @@ mdev allows a physical device with internal resources (GPU compute engines, NIC 
 ### Architecture (kernel 5.x)
 
 ```c
-/* include/linux/mdev.h */
-
+/* include/linux/mdev.h — current struct shape; the mdev_parent_ops-based
+ * design this section otherwise describes predates this and was replaced
+ * (see "struct vfio_device_ops" below) */
 struct mdev_parent {
-    struct device           *dev;        /* physical device (PF) */
-    const struct mdev_parent_ops *ops;
-    struct list_head         mdev_list;
+    struct device            *dev;         /* physical device (PF) */
+    struct mdev_driver       *mdev_driver;
+    struct mdev_type        **types;       /* each type is a resource slice */
+    unsigned int              nr_types;
+    atomic_t                  available_instances;
     /* ... */
 };
 
 struct mdev_device {
-    struct device            dev;
-    struct mdev_parent      *parent;
-    guid_t                   uuid;       /* identifies the mdev type */
+    struct device             dev;
+    guid_t                    uuid;        /* identifies the mdev instance */
+    struct mdev_type         *type;        /* reached via type->parent, not a direct field */
     /* ... */
 };
 ```
@@ -234,9 +250,9 @@ ls /sys/bus/mdev/devices/
 # $UUID
 ```
 
-### struct vfio_device_ops (kernel 6.0+)
+### struct vfio_device_ops (kernel 5.19+)
 
-In Linux 6.0, the older `mdev_parent_ops` interface was consolidated into `struct vfio_device_ops`. Physical device drivers that support mdev now implement `vfio_device_ops` directly:
+In Linux 5.19, the older `mdev_parent_ops` interface was consolidated into `struct vfio_device_ops` (commit `6b42f491e17c`, "vfio/mdev: Remove mdev_parent_ops"). Physical device drivers that support mdev now implement `vfio_device_ops` directly:
 
 ```c
 /* include/linux/vfio.h */
@@ -264,7 +280,7 @@ struct vfio_device_ops {
 };
 ```
 
-**Intel GVT-g** (Intel integrated GPU virtualization, deprecated and removed from the Linux kernel around 6.8) and **nvidia vGPU** implement their own `vfio_device_ops`. The mdev device appears to QEMU as a standard VFIO device, so no QEMU changes are needed — QEMU just opens `/dev/vfio/<group>` and operates normally.
+**Intel GVT-g** (Intel integrated GPU virtualization, `drivers/gpu/drm/i915/gvt/`) and **nvidia vGPU** implement their own `vfio_device_ops`. The mdev device appears to QEMU as a standard VFIO device, so no QEMU changes are needed — QEMU just opens `/dev/vfio/<group>` and operates normally.
 
 ### mdev isolation model
 
@@ -375,8 +391,34 @@ grep vfio /proc/interrupts
 
 ## Further reading
 
+### Kernel source
+
+- [drivers/vfio/vfio_main.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/vfio/vfio_main.c) — `vfio_register_group_dev()` and core device/group/container lifecycle
+- [drivers/vfio/vfio.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/vfio/vfio.h) — `struct vfio_group` (private to the VFIO core, not `include/linux/vfio.h`)
+- [drivers/vfio/container.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/vfio/container.c) — `struct vfio_container` and the `VFIO_SET_IOMMU`/group-attach path
+- [drivers/vfio/vfio_iommu_type1.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/vfio/vfio_iommu_type1.c) — `vfio_dma_do_map()`, `struct vfio_iommu`, `struct vfio_dma`: the type1 IOMMU backend
+- [include/linux/vfio.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/vfio.h) — `struct vfio_device` and `struct vfio_device_ops`, the public bus-driver API
+- [drivers/vfio/pci/vfio_pci_intrs.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/vfio/pci/vfio_pci_intrs.c) — `struct vfio_pci_irq_ctx`: MSI/MSI-X/INTx eventfd setup
+- [drivers/vfio/mdev/mdev_core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/vfio/mdev/mdev_core.c) — `mdev_register_parent()` and the mediated-device bus core
+- [virt/kvm/eventfd.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/virt/kvm/eventfd.c) — `irqfd`: a workqueue calls `kvm_set_irq()` when the bound eventfd fires
+
+### Man pages
+
+- [`ioctl(2)`](https://man7.org/linux/man-pages/man2/ioctl.2.html) — every VFIO container/group/device operation (`VFIO_SET_IOMMU`, `VFIO_IOMMU_MAP_DMA`, `VFIO_DEVICE_SET_IRQS`, …) is an ioctl on a `/dev/vfio` file descriptor
+
+### Related pages
+
 - [IOMMU Architecture](iommu-arch.md) — IOMMU domains, groups, SR-IOV
-- [IOVA Allocator](iova-allocator.md) — IOVA allocation used in DMA mappings
+- [IOVA Allocator](iova-allocator.md) — the in-kernel IOVA allocator used by `dma_map_*()`; VFIO's type1 backend bypasses it, since userspace supplies the IOVA directly in `VFIO_IOMMU_MAP_DMA`
 - [IOMMU War Stories](war-stories.md) — group isolation blocking passthrough (real incident)
-- `Documentation/driver-api/vfio.rst` — VFIO userspace API documentation
-- `Documentation/driver-api/vfio-mediated-device.rst` — mdev documentation
+- [VFIO: Virtual Function I/O and Device Passthrough](../virtualization/vfio.md) — the same subsystem from a setup/operations angle: QEMU passthrough, SR-IOV, mdev walkthrough
+- [Getting User Pages (GUP)](../mm/gup.md) — `pin_user_pages_remote()`, the page-pinning primitive behind VFIO's DMA mapping path
+
+### LWN articles
+
+- [Safe device assignment with VFIO](https://lwn.net/Articles/474088/) — Jonathan Corbet's original coverage of the VFIO framework and IOMMU-group-based device assignment (January 3, 2012)
+
+### External
+
+- [VFIO — "Virtual Function I/O"](https://docs.kernel.org/driver-api/vfio.html) — official kernel documentation for the container/group/device model and userspace API
+- [VFIO Mediated devices](https://docs.kernel.org/driver-api/vfio-mediated-device.html) — official documentation for the mdev framework

--- a/docs/iommu/war-stories.md
+++ b/docs/iommu/war-stories.md
@@ -14,9 +14,9 @@ A server running a 10GbE NIC driver starts logging thousands of lines per second
 
 ```
 DMAR: [DMA Write] Request device [02:00.0] fault addr 7fa800000000
-      DMAR:[fault reason 06] Write access is not set
+      DMAR:[fault reason 05] Write access is not set
 DMAR: [DMA Write] Request device [02:00.0] fault addr 7fa800001000
-      DMAR:[fault reason 06] Write access is not set
+      DMAR:[fault reason 05] Write access is not set
 DMAR: [DMA Write] Request device [02:00.0] fault addr 7fa800002000
 ...
 ```
@@ -37,20 +37,22 @@ dmesg | grep "DMAR: IOMMU"
 # DMAR: IOMMU enabled
 
 # DMAR fault registers (Intel VT-d specific)
-# Fault reason 06 = "Write access is not set"
-# (Fault reason 05 = "Read access is not set")
+# Fault reason 05 = "Write access is not set"
+# (Fault reason 06 = "Read access is not set")
 # This means a mapping exists but with wrong permissions (write attempted to read-only mapping)
 
 # Check the IOVA allocator state for the domain
 cat /sys/kernel/debug/iommu/intel/iommu_perf_stats
 ```
 
-Fault reason 06 ("Write access is not set") is the important clue: the mapping exists, but the PTE does not allow writes and the device is trying to write. This points to a driver that incorrectly maps receive buffers as `DMA_TO_DEVICE` (read-only from device perspective) instead of `DMA_FROM_DEVICE`.
+Fault reason 05 ("Write access is not set") is the important clue: the mapping exists, but the PTE does not allow writes and the device is trying to write. This points to a driver that incorrectly maps receive buffers as `DMA_TO_DEVICE` (read-only from device perspective) instead of `DMA_FROM_DEVICE`.
 
 ```bash
-# Enable DMA API debugging to catch mismatched directions at map time
-# (requires CONFIG_DMA_API_DEBUG=y)
-echo 0 > /sys/kernel/debug/dma-api/disabled
+# DMA API debugging catches mismatched directions at map time, but it's a
+# boot-time-only Kconfig option, not something toggled live: rebuild/boot
+# with CONFIG_DMA_API_DEBUG=y first. /sys/kernel/debug/dma-api/disabled is
+# read-only -- it reports whether the framework self-disabled (e.g. after
+# exhausting its tracking pool), not a runtime on/off switch.
 dmesg | grep "DMA-API"
 # DMA-API: device 0000:02:00.0 mapping error: wrong direction
 ```
@@ -121,9 +123,9 @@ perf record -g -p $(pgrep irq/...-eth0) -- sleep 10
 perf report --sort=symbol,dso | head -40
 ```
 
-The perf callgraph shows `alloc_iova` being called from `iommu_dma_map_page` → `dma_map_page` → the NIC driver's descriptor refill function, one call per packet. At 20 Mpps, that is 20 million `alloc_iova` calls per second, each one touching the global rbtree spinlock when the rcache is exhausted.
+The perf callgraph shows `alloc_iova` being called from `iommu_dma_map_phys` → `dma_map_page` → the NIC driver's descriptor refill function, one call per packet. At 20 Mpps, that is 20 million `alloc_iova` calls per second, each one touching the global rbtree spinlock when the rcache is exhausted.
 
-Why is the rcache exhausted? The rcache holds freed IOVAs of matching sizes. With 2 KB receive buffers, the allocator uses the 1-page size class. But if the driver is allocating faster than it frees (in-flight descriptors exceed the rcache magazine size of 128), the rcache runs dry and falls through to the locked rbtree path.
+Why is the rcache exhausted? The rcache holds freed IOVAs of matching sizes. With 2 KB receive buffers, the allocator uses the 1-page size class. But if the driver is allocating faster than it frees (in-flight descriptors exceed the rcache magazine size of 127), the rcache runs dry and falls through to the locked rbtree path.
 
 ### Fix
 
@@ -333,10 +335,10 @@ When the IOMMU is active and a 32-bit device is present, the kernel still uses s
 ```bash
 # Check swiotlb usage
 cat /sys/kernel/debug/swiotlb/io_tlb_nslabs
-# 16384  (64MB / 4KB per slot)
+# 32768  (64MB / 2KB per slot)
 
 cat /sys/kernel/debug/swiotlb/io_tlb_used
-# 16384  ← fully exhausted
+# 32768  ← fully exhausted
 
 # Check IOVA space below 4GB
 # Note: this path does not exist generically — check /sys/kernel/debug/iommu/intel/ or vendor-specific paths
@@ -408,8 +410,42 @@ echo "$USED / $TOTAL"
 
 ## Further reading
 
+### Kernel source
+
+- [drivers/iommu/intel/dmar.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/intel/dmar.c) — `dmar_fault_do_one()` and the `dma_remap_fault_reasons[]` table (reason 5 = "PTE Write access is not set", reason 6 = "PTE Read access is not set") behind Case 1's DMAR fault codes
+- [kernel/dma/debug.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/debug.c) — the `CONFIG_DMA_API_DEBUG` instrumentation framework referenced in Case 1
+- [drivers/iommu/iova.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/iova.c) — `alloc_iova()`, `alloc_iova_fast()`, and the per-CPU IOVA rcache (`IOVA_RANGE_CACHE_MAX_SIZE`, `IOVA_MAG_SIZE`) behind Case 2's allocator bottleneck
+- [drivers/iommu/dma-iommu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/dma-iommu.c) — `iommu_dma_map_phys()` and `iommu_dma_map_sg()`, the streaming-DMA entry points that drive IOVA allocation in Case 2
+- [drivers/iommu/iommu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/iommu.c) — `iommu_map()`, `iommu_unmap_fast()`, and the `IOMMU_DOMAIN_DMA_FQ` flush-queue domain type behind Case 2's fix
+- [drivers/pci/pci.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/pci/pci.c) — `pci_enable_acs()`, the kernel-side PCIe ACS negotiation behind Case 3's IOMMU group isolation
+- [drivers/iommu/iommu-sva.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/iommu-sva.c) — `iommu_sva_handle_mm()`, which calls `handle_mm_fault()` to resolve device page requests, behind Case 4
+- [drivers/iommu/intel/prq.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iommu/intel/prq.c) — the Intel IOMMU Page Request Queue overflow handling underlying Case 4's PRI-queue scenario
+- [mm/madvise.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/madvise.c) — `MADV_POPULATE_WRITE` and `MADV_NOHUGEPAGE`, the mitigations used in Case 4
+- [kernel/dma/swiotlb.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/dma/swiotlb.c) — the swiotlb bounce-buffer pool and its `io_tlb_used`/`io_tlb_nslabs` debugfs counters behind Case 5
+
+### Man pages
+
+- [`madvise(2)`](https://man7.org/linux/man-pages/man2/madvise.2.html) — documents `MADV_POPULATE_WRITE` (since Linux 5.14) and `MADV_NOHUGEPAGE`, used in Case 4
+- [`lspci(8)`](https://man7.org/linux/man-pages/man8/lspci.8.html) — the PCI topology tool used to check ACS capability in Case 3
+
+### Related pages
+
 - [IOMMU Architecture](iommu-arch.md) — IOMMU domains, IOTLB, DMAR fault registers
 - [DMA API](dma-api.md) — `dma_map_single`, scatter-gather, swiotlb internals
 - [IOVA Allocator](iova-allocator.md) — rcache, flush queues, 32-bit limit
 - [SVA](sva.md) — PASID, PRI page fault handling
 - [VFIO Internals](vfio-internals.md) — IOMMU groups, security model
+
+### LWN articles
+
+- [Kernel Summit 2006: DMA and IOMMU issues](https://lwn.net/Articles/191931/) (July 19, 2006) — early discussion of scatter-gather batching (`dma_map_sg()`) to reduce per-mapping overhead, the same principle behind Case 2's fix
+- [Driver API: sleeping poll(), exclusive I/O memory, and DMA API debugging](https://lwn.net/Articles/308426/) (November 24, 2008) — covers the `CONFIG_DMA_API_DEBUG` framework used to catch direction mismatches in Case 1
+- [Safe device assignment with VFIO](https://lwn.net/Articles/474088/) (January 3, 2012) — explains why IOMMU groups exist and why every device in a group must be bound to the same driver, the mechanism behind Case 3
+- [A security fix briefly breaks DMA](https://lwn.net/Articles/889593/) (April 1, 2022) — swiotlb bounce-buffer mechanics and the tension between security assumptions and driver behavior, background for Case 5
+
+### External
+
+- [Kernel documentation: DMA API](https://docs.kernel.org/core-api/dma-api.html) and [DMA API HOWTO](https://docs.kernel.org/core-api/dma-api-howto.html) — `dma_map_single()` and the `DMA_TO_DEVICE`/`DMA_FROM_DEVICE` direction flags at the center of Case 1
+- [Kernel documentation: VFIO](https://docs.kernel.org/driver-api/vfio.html) — the "group is viable" check (every device in the group must be bound to vfio) behind Case 3
+- [Kernel documentation: Shared Virtual Addressing (SVA) with ENQCMD](https://docs.kernel.org/arch/x86/sva.html) — PASID, ATS, and PRI page-fault mechanics behind Case 4
+- [Kernel boot parameters](https://docs.kernel.org/admin-guide/kernel-parameters.html) — `iommu=pt`, `intel_iommu=`, and `swiotlb=`, used across Cases 1, 3, and 5


### PR DESCRIPTION
Part of the rolling citation-backfill effort tracked in #542 — this covers `docs/iommu/` (6 pages, all previously uncited: `dma-api.md`, `iommu-arch.md`, `iova-allocator.md`, `sva.md`, `vfio-internals.md`, `war-stories.md`).

Every citation was independently live-verified (kernel source paths cross-checked against the GitHub mirror where git.kernel.org's Anubis bot-challenge blocked direct scripted verification; LWN/docs.kernel.org/man7.org URLs checked for HTTP 200 with matching content). Two proposed External citations in `sva.md` (an Arm architecture spec and an Intel PDF) were dropped after both came back bot-blocked/403 to independent verification.

## Review history (4 rounds, independent adversarial passes)

- **Round 1**: fixed an invented variable name in a comment (iova-allocator.md); added a missing truncation marker on `struct vfio_domain` (vfio-internals.md).
- **Round 2**: fixed an overclaimed citation in iommu-arch.md (claimed the linked docs.kernel.org page documents `amd_iommu=`; it only covers `intel_iommu=igfx_off`/`iommu=pt`); fixed a heading-categorization inconsistency in sva.md.
- **Round 3**: caught a genuine cross-file bug this PR itself created — `iommu_dma_free_iova()`'s call site in dma-api.md still passed the old cookie-based argument after this same PR's iova-allocator.md rewrite changed the real function's first parameter to a domain pointer; also caught a dropped alignment offset in the rewritten `swiotlb_tbl_map_single()`.
- **Round 4**: a focused confirmation pass — verified both round-3 fixes are internally consistent across the two heavily-rewritten files (dma-api.md, iova-allocator.md), walked every code block end to end checking for undeclared variables/type mismatches, and did a final light check of the other 4 files. Clean.

## In-scope body-text fixes (original pass + rounds above)

- **dma-api.md**: `iommu_dma_map_page()` (doesn't exist) → the real `iommu_dma_map_phys()`; `swiotlb_tbl_map_single()`'s fabricated `alloc_size` parameter and `find_slots()`/`mem->start` calls → the real `swiotlb_find_slots()`/`pool->start` chain, with the alignment offset correctly applied.
- **iommu-arch.md**: `struct intel_iommu`'s real header and field name; `struct dev_table_entry`'s real union layout; `struct iommu_domain_ops`'s real `attach_dev` signature (no separate `detach_dev`); `iommu_iotlb_gather_add_page()`/`iommu_iotlb_sync()` rewritten to the real disjoint-range-flushing logic.
- **iova-allocator.md**: `struct iova_rcache`'s real depot-trim worker fields; `struct iova_fq`/`iova_fq_entry`'s real location and fields; `iommu_dma_free_iova()` rewritten to the real domain-based signature; the `dma_32bit_pfn` comment corrected.
- **sva.md**: the `io_pgtable_ops` section corrected — SVA domains never allocate one; the `iommu_sva` API's real introduction version (5.2, not 5.14); a self-contradictory CR3 description reconciled.
- **vfio-internals.md**: `struct vfio_group`/`vfio_container`/`vfio_iommu`/`vfio_domain`'s real fields; the DMA tracking structure corrected from "radix tree" to the real rb-tree; `struct mdev_parent`/`mdev_device`'s real current fields; the `mdev_parent_ops` removal's real version (5.19, not 6.0); a false claim that Intel GVT-g was removed from mainline.
- **war-stories.md** (largely fixed by the research pass): swapped DMAR fault-reason numbers corrected across 3 places; an `IOVA_MAG_SIZE` off-by-one; a self-contradictory swiotlb slot-count calculation; a nonexistent internal function name; a DMA-API-debug command that would fail.

## Out of scope, logged to #750

A simplified 32-bit-IOVA-fill description, a misattributed dmesg line, minor struct/prose gaps, two pre-existing dma-api.md bugs untouched by this PR, and a stale `docs/virtualization/vfio.md` DMA-mapping description that now disagrees with this PR's corrected `vfio-internals.md`.

`mkdocs build --strict` passes; all ~49 new URLs re-verified live.