### PR TITLE
Add citations to docs/livepatch/ (issue #542)

### DIFF
--- a/docs/livepatch/README.md
+++ b/docs/livepatch/README.md
@@ -11,7 +11,7 @@
 | [Cumulative Patches and Atomic Replace](klp-cumulative.md) | Patch stacking, .replace=true, struct klp_ops, disabling and removing patches |
 | [KLP State: Custom Consistency Checks](klp-state.md) | klp_state API, transition callbacks, pre/post patch hooks, cumulative state inheritance |
 | [kexec](kexec.md) | kexec_load, machine_kexec, kdump integration, fast reboot |
-| [War Stories](war-stories.md) | Stuck transitions, shadow variable leaks, compat syscall misses, inline functions |
+| [War Stories](war-stories.md) | Stuck transitions, shadow variable leaks, compat syscall misses, `old_sympos` ambiguity, missing `.replace` |
 
 ## Quick reference
 
@@ -26,7 +26,7 @@ cat /sys/kernel/livepatch/*/enabled
 # Apply a live patch (kernel module)
 insmod mypatch.ko
 cat /sys/kernel/livepatch/mypatch/enabled
-# 1 = active and consistent
+# 1 = enabled (check transition=0 for fully consistent)
 
 # Disable a live patch
 echo 0 > /sys/kernel/livepatch/mypatch/enabled

--- a/docs/livepatch/kexec.md
+++ b/docs/livepatch/kexec.md
@@ -71,9 +71,10 @@ void machine_kexec(struct kimage *image)
     unsigned int relocate_kernel_flags;
     void *control_page;
 
-    /* By this point migrate_to_reboot_cpu() (called earlier from
-       kernel_kexec()) has already parked every other CPU; this
-       function does not stop CPUs itself. */
+    /* By this point kernel_kexec() has already parked every other CPU
+       via machine_shutdown()'s stop_other_cpus() (or, on the
+       CONFIG_KEXEC_JUMP preserve-context path, suspend_disable_secondary_cpus());
+       this function does not stop CPUs itself. */
 
     /* Interrupts aren't acceptable while we reboot */
     local_irq_disable();

--- a/docs/livepatch/kexec.md
+++ b/docs/livepatch/kexec.md
@@ -9,7 +9,8 @@
 ```
 Normal boot:      BIOS/UEFI → GRUB → kernel
 kexec boot:       running kernel → kexec_exec → new kernel
-                  (BIOS/POST skipped → 5-10 second faster reboot)
+                  (BIOS/POST skipped → faster reboot, savings vary
+                   widely by firmware and hardware)
 ```
 
 Primary uses:
@@ -29,11 +30,16 @@ Primary uses:
  *   flags:      KEXEC_ON_CRASH=for kdump, KEXEC_ARCH=arch, etc.
  */
 
+/* include/linux/kexec.h */
 struct kexec_segment {
-    const void  __user *buf;   /* userspace buffer with segment data */
-    size_t               bufsz; /* size of buffer */
-    const void          *mem;  /* target physical address */
-    size_t               memsz; /* size at target */
+    /* ->buf for kexec_load() (userspace ptr); ->kbuf for kexec_file_load() (kernel ptr) */
+    union {
+        void __user *buf;
+        void        *kbuf;
+    };
+    size_t        bufsz;  /* size of buffer */
+    unsigned long mem;    /* target physical address */
+    size_t        memsz;  /* size at target */
 };
 ```
 
@@ -50,7 +56,7 @@ int kexec_file_load(int kernel_fd,      /* open("/boot/vmlinuz", O_RDONLY) */
                      unsigned long flags);
 ```
 
-If `CONFIG_KEXEC_VERIFY_SIG=y`, the kernel image must be signed with a trusted key — useful for Secure Boot compatibility.
+If `CONFIG_KEXEC_SIG=y`, the kernel image must be signed with a trusted key — useful for Secure Boot compatibility.
 
 ## Machine kexec: the jump
 
@@ -60,33 +66,39 @@ When `kexec -e` is run, `machine_kexec()` performs the actual handoff:
 /* arch/x86/kernel/machine_kexec_64.c */
 void machine_kexec(struct kimage *image)
 {
-    unsigned long page_list;
-    unsigned long reboot_code_buffer_phys;
-    void *reboot_code_buffer;
+    unsigned long reloc_start = (unsigned long)__relocate_kernel_start;
+    relocate_kernel_fn *relocate_kernel_ptr;
+    unsigned int relocate_kernel_flags;
+    void *control_page;
 
-    /* Disable interrupts */
+    /* By this point migrate_to_reboot_cpu() (called earlier from
+       kernel_kexec()) has already parked every other CPU; this
+       function does not stop CPUs itself. */
+
+    /* Interrupts aren't acceptable while we reboot */
     local_irq_disable();
+    hw_breakpoint_disable();
+    cet_disable();
 
-    /* Stop all other CPUs */
-    native_smp_send_stop();
+    control_page = page_address(image->control_code_page);
 
-    /* Copy identity-mapped page tables (kexec needs to access
-       the new kernel's pages which are at physical addresses) */
-    page_list = image->head & PAGE_MASK;
+    /* relocate_kernel_ptr points at the relocation trampoline
+       copied into control_page */
+    relocate_kernel_ptr = control_page + ((unsigned long)relocate_kernel - reloc_start);
 
-    /* Jump to the relocation trampoline */
-    reboot_code_buffer = page_address(image->control_code_page);
-    relocate_kernel((unsigned long)page_list,
-                     reboot_code_buffer,
-                     image->start,
-                     image->preserve_context,
-                     image->arch.pgtable);
+    relocate_kernel_flags = 0;
+    if (image->preserve_context)
+        relocate_kernel_flags |= RELOC_KERNEL_PRESERVE_CONTEXT;
+
+    load_segments();
+
+    /* Jump to the relocation trampoline: copies new kernel segments
+       to their final locations, then jumps to the new kernel entry */
+    image->start = relocate_kernel_ptr((unsigned long)image->head,
+                                        virt_to_phys(control_page),
+                                        image->start,
+                                        relocate_kernel_flags);
 }
-
-/* relocate_kernel (assembly): */
-/*   1. Switch to identity-mapped page tables */
-/*   2. Copy new kernel segments to their final locations */
-/*   3. Jump to new kernel entry point */
 ```
 
 ## kimage: the loaded kernel
@@ -110,9 +122,13 @@ struct kimage {
     struct list_head dest_pages;     /* pages for new kernel */
     struct list_head unusable_pages; /* pages that can't be used */
 
+    /* Flags to indicate special processing */
+    unsigned int type : 1;        /* KEXEC_TYPE_DEFAULT or KEXEC_TYPE_CRASH */
+    unsigned int preserve_context : 1;
+    unsigned int file_mode : 1;   /* set if loaded via kexec_file_load() */
+    unsigned int no_cma : 1;
+
     /* ... */
-    unsigned long    flags;
-    int              type;           /* KEXEC_TYPE_DEFAULT or KEXEC_TYPE_CRASH */
 };
 ```
 
@@ -193,20 +209,50 @@ int kernel_kexec(void)
 {
     int error = 0;
 
-    /* Execute pre-kexec notifiers */
-    error = blocking_notifier_call_chain(&reboot_notifier_list, SYS_RESTART, NULL);
+    if (!kexec_trylock())
+        return -EBUSY;
+    if (!kexec_image) {
+        error = -EINVAL;
+        goto Unlock;
+    }
 
-    kernel_restart_prepare(NULL);
+#ifdef CONFIG_KEXEC_JUMP
+    if (kexec_image->preserve_context) {
+        /* preserve-context ("kexec jump") path: reuses the same
+           device-suspend callbacks as hibernation */
+        pm_prepare_console();
+        freeze_processes();
+        console_suspend_all();
+        dpm_suspend_start(PMSG_FREEZE);
+        dpm_suspend_end(PMSG_FREEZE);
+        suspend_disable_secondary_cpus();
+        local_irq_disable();
+        syscore_suspend();
+    } else
+#endif
+    {
+        kexec_in_progress = true;
+        /* kernel_restart_prepare() runs the reboot notifier chain,
+           sets system_state, disables usermodehelpers, and shuts
+           down devices */
+        kernel_restart_prepare("kexec reboot");
+        migrate_to_reboot_cpu();
+        syscore_shutdown();
+        cpu_hotplug_enable();
+        machine_shutdown();
+    }
 
-    /* Disable SMP: all other CPUs stopped */
-    migrate_to_reboot_cpu();
-    syscore_shutdown();
-
-    /* Jump to new kernel */
+    kmsg_dump(KMSG_DUMP_SHUTDOWN);
+    /* Jump to new kernel; does not return on success */
     machine_kexec(kexec_image);
 
-    /* Should not return */
-    BUG();
+#ifdef CONFIG_KEXEC_JUMP
+    /* Only reached if preserve_context and the "jump" kernel later
+       hands control back (mirror-image resume of the block above) */
+#endif
+
+ Unlock:
+    kexec_unlock();
     return error;
 }
 ```
@@ -228,27 +274,54 @@ if (efi_enabled(EFI_RUNTIME_SERVICES)) {
 grep KEXEC /boot/config-$(uname -r)
 # CONFIG_KEXEC=y
 # CONFIG_KEXEC_FILE=y
-# CONFIG_KEXEC_VERIFY_SIG=y   (optional)
+# CONFIG_KEXEC_SIG=y   (optional)
 
 # Memory reserved for kdump
 cat /proc/iomem | grep -i crash
 # 100000000-10fffffff : Crash kernel
 
-# Boot source detection: was this a kexec boot?
+# kexec_loaded reports whether an image is currently loaded and
+# ready to execute, not whether the running kernel itself was
+# booted via kexec
 cat /sys/kernel/kexec_loaded
-# After kexec reboot: bootloader may set ACPI table flag
 dmesg | grep -i kexec
 
-# Timing: kexec vs cold boot
-time systemctl kexec   # ~5 seconds
+# Timing: kexec vs cold boot. kexec skips BIOS/UEFI POST and the
+# bootloader stage, so it's typically faster than a full reboot —
+# but the actual savings (anywhere from roughly one second to tens
+# of seconds) depend heavily on firmware POST time and CPU count,
+# so measure on your own hardware rather than assuming a fixed number
+time systemctl kexec
 # vs
-time reboot            # ~60 seconds (BIOS POST)
+time reboot
 ```
 
 ## Further reading
 
+### Kernel source
+
+- [kernel/kexec.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/kexec.c) — `SYSCALL_DEFINE4(kexec_load, ...)`: the segment-list-based load syscall
+- [kernel/kexec_file.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/kexec_file.c) — `SYSCALL_DEFINE5(kexec_file_load, ...)` and the `CONFIG_KEXEC_SIG` signature-verification path
+- [kernel/kexec_core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/kexec_core.c) — `kernel_kexec()`'s shutdown sequence and the `loaded`/`crash_loaded` sysfs attributes exposed as `/sys/kernel/kexec_loaded` and `/sys/kernel/kexec_crash_loaded`
+- [include/linux/kexec.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/kexec.h) — `struct kimage` and `struct kexec_segment` definitions
+- [arch/x86/kernel/machine_kexec_64.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/machine_kexec_64.c) — `machine_kexec()`: the actual handoff to the new kernel on x86-64
+
+### Man pages
+
+- [kexec_load(2)](https://man7.org/linux/man-pages/man2/kexec_load.2.html) — covers both the `kexec_load()` and `kexec_file_load()` syscalls
+- [kexec(8)](https://man7.org/linux/man-pages/man8/kexec.8.html) — the userspace `kexec-tools` command: `-l`/`-p`/`-e`/`-u` options
+
+### Related pages
+
 - [kdump and crash](../debugging/kdump.md) — crash dump collection using kexec
 - [Kernel Live Patching](klp.md) — avoiding reboots entirely
-- [Power Management: System Suspend](../power/suspend.md) — PM notifiers in kexec path
-- `kernel/kexec_core.c`, `arch/x86/kernel/machine_kexec_64.c` — kexec core
-- `man 8 kexec` — userspace kexec tool
+- [Power Management: System Suspend](../power/suspend.md) — the `freeze_processes()`/`dpm_suspend_start()` device-suspend sequence that `CONFIG_KEXEC_JUMP`'s preserve-context path reuses from the hibernation code path
+
+### LWN articles
+
+- [kexec: A new system call to allow in kernel loading](https://lwn.net/Articles/574400/) — the original RFC introducing `kexec_file_load()` with its kernel-fd/initrd-fd design
+- [Reworking kexec for signatures](https://lwn.net/Articles/603116/) — why `kexec_file_load()` exists: restricting kexec to signed kernels, and its relationship to Secure Boot
+
+### External
+
+- [Kdump](https://docs.kernel.org/admin-guide/kdump/kdump.html) — official kdump setup guide covering `crashkernel=` sizing and the `irqpoll`/`nr_cpus=1`/`reset_devices` boot options used when loading the capture kernel

--- a/docs/livepatch/klp-consistency.md
+++ b/docs/livepatch/klp-consistency.md
@@ -22,8 +22,8 @@ Each task carries a `patch_state` field in `struct task_struct`
 of three values, defined in `include/linux/livepatch.h`:
 
 ```c
-/* include/linux/livepatch.h */
-#define KLP_TRANSITION_IDLE       -1   /* task hasn't been evaluated yet */
+/* include/linux/livepatch.h — "task patch states" */
+#define KLP_TRANSITION_IDLE       -1   /* no transition in progress */
 #define KLP_TRANSITION_UNPATCHED   0   /* task should call the original function */
 #define KLP_TRANSITION_PATCHED     1   /* task should call the patched function */
 ```
@@ -88,10 +88,27 @@ Two other paths *do* run a stack check, both funneling through
   a static key that `klp_resched_enable()`/`klp_resched_disable()` toggle for
   the duration of the transition — calls `klp_try_switch_task(current)` on
   context switches where the outgoing task is entering a freezable sleep
-  state (`TASK_FREEZABLE`), not on every context switch. This exists specifically to help CPU-bound kthreads
-  get patched: such a task may rarely (or never) go through the
-  kernel-exit-to-userspace path, so relying on that path alone could stall
-  the transition indefinitely.
+  state (`TASK_FREEZABLE`), not on every context switch. The point of this
+  path is kernel threads: a kthread never returns to userspace, so the
+  kernel-exit-to-userspace path can never catch it, no matter how often it
+  runs. Many kthreads do, however, park in a freezable sleep between work
+  items — and `TASK_FREEZABLE` is precisely the "sleeping in a known-safe
+  state" property the freezer already depends on — so the scheduler hook
+  switches them there instead. Note the inverse case is *not* covered: a
+  genuinely CPU-bound kthread that never sleeps reaches neither path, and the
+  periodic workqueue check returns `-EBUSY` for any task that is actually
+  on-CPU, so such a task stalls the transition until it sleeps or the
+  transition is forced.
+
+The comment above `klp_sched_try_switch_key` in `kernel/livepatch/transition.c`
+still describes the static key as something that "helps CPU-bound kthreads get
+patched". That wording predates commit
+[`676e8cf70cb0`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=676e8cf70cb0)
+("sched,livepatch: Untangle cond_resched() and live-patching", 2025-05-09),
+which moved the hook off `cond_resched()` — where a busy loop that yielded
+really could be caught — and onto `TASK_FREEZABLE` sleeps in `__schedule()`.
+Read the `TASK_FREEZABLE` test in `klp_sched_try_switch()`
+(`include/linux/livepatch_sched.h`), not the comment.
 
 Either way, before a task can be switched via a stack-checking path, the
 kernel must verify that the old (unpatched) function — or, if a patch is
@@ -271,7 +288,7 @@ Neither path can wake a task in `TASK_UNINTERRUPTIBLE` (D state). D-state tasks 
 
 `klp_send_signals()` is called from `klp_try_complete_transition()` roughly
 every 15 seconds (every `SIGNALS_TIMEOUT`th incomplete retry round, at the
-~1-second-per-round cadence described below) once the transition has stalled.
+~1-second-per-round cadence described above) once the transition has stalled.
 
 ## Patch stacking: func_stack and struct klp_ops
 
@@ -328,10 +345,44 @@ code, but the patch state is set to `KLP_TRANSITION_PATCHED`. If the new
 function changes data layouts or assumptions, those tasks can access
 inconsistent state.
 
-After a forced transition the `forced` field of `struct klp_patch` is set to
-`true`. This is internal-only — there is no sysfs file to read it back; the
-only externally visible trace is that `rmmod` on the patch module is
-permanently disabled from that point on.
+Which patch gets flagged afterwards is narrower than it sounds.
+`klp_force_transition()` sets the `forced` field of `struct klp_patch` like
+this:
+
+```c
+/* kernel/livepatch/transition.c — tail of klp_force_transition() */
+/* Set forced flag for patches being removed. */
+if (klp_target_state == KLP_TRANSITION_UNPATCHED)
+    klp_transition_patch->forced = true;
+else if (klp_transition_patch->replace) {
+    klp_for_each_patch(patch) {
+        if (patch != klp_transition_patch)
+            patch->forced = true;
+    }
+}
+```
+
+So there are three cases, and only two of them set the flag at all:
+
+- Forcing a **disable** (`klp_target_state == KLP_TRANSITION_UNPATCHED`) sets
+  `forced` on the patch being disabled — it can never be unloaded.
+- Forcing an **enable of a `.replace` (cumulative) patch** sets `forced` on
+  every *other* patch — the ones this patch is replacing — and **not** on the
+  patch being force-enabled. Those replaced modules become permanently
+  unloadable; the new one does not.
+- Forcing a plain **enable** of a non-`replace` patch — exactly the scenario
+  described above, a kthread looping forever inside the old function while a
+  forward transition waits — sets `forced` on **nothing**. The transition
+  completes unsafely, but no patch is marked, and the force leaves no
+  `forced`-flag trace at all.
+
+Where the flag *is* set it is internal-only — there is no sysfs file to read
+it back. Its only externally visible effect is that the flagged patch's module
+can never be unloaded: `klp_free_patch_finish()` (`kernel/livepatch/core.c`)
+ends with `if (!patch->forced) module_put(patch->mod);`, so a forced patch
+never gives back the module reference it took, and its refcount never reaches
+zero. Note that this consequence attaches to whichever module the rule above
+flagged — which is not necessarily the module whose `force` file was written.
 
 `TAINT_LIVEPATCH` is applied at **module load time** for every livepatch module — not conditionally on forced transitions. Every live patch application taints the kernel with `TAINT_LIVEPATCH` (bit 15). `klp_force_transition()` itself does not add any additional taint — `TAINT_FORCED_MODULE` is unrelated; it's set when a module is force-loaded with `insmod -f`, not when a livepatch transition is forced.
 
@@ -412,8 +463,11 @@ cat /sys/kernel/livepatch/<patch>/transition
 # 1 = in progress, 0 = complete
 
 # Whether a transition was ever forced is internal-only (struct klp_patch.forced)
-# and not exposed via sysfs — the only observable side effect is that `rmmod`
-# on the patch module will be permanently refused from that point on.
+# and not exposed via sysfs. The only observable side effect is that `rmmod` is
+# permanently refused for whichever module got flagged — and that is not always
+# the one you forced: forcing a disable flags the patch being disabled, forcing
+# an enable of a .replace patch flags the patches it replaced (not itself), and
+# forcing a plain non-replace enable flags nothing at all.
 
 # Which tasks are blocking the transition?
 # (tasks that have the old function on their stack)
@@ -434,14 +488,16 @@ dmesg | grep livepatch
 ## Transition state machine
 
 ```
-klp_enable_patch()
+klp_enable_patch()  →  __klp_enable_patch()
        │
        ▼
-  Set klp_target_state = KLP_TRANSITION_PATCHED
-  Set func->transition = true
-  Queue klp_transition_work
+  klp_init_transition():  klp_target_state = KLP_TRANSITION_PATCHED
+                          func->transition = true
+  klp_start_transition(): set TIF_PATCH_PENDING on every task
+  patch->enabled = true   ← set HERE, at the start of the transition,
+                            not when it completes
        │
-       ▼ (periodic, every ~1s)
+       ▼ (first call is immediate; then periodic, every ~1s)
   klp_try_complete_transition()
        │
        ├── for each task (and each idle task):
@@ -456,9 +512,12 @@ klp_enable_patch()
        │             │
        │             ▼
        │         func->transition = false
+       │         task->patch_state = KLP_TRANSITION_IDLE (all tasks)
        │         klp_target_state = KLP_TRANSITION_IDLE
-       │         patch->enabled = true
+       │         klp_transition_patch = NULL
        │         transition sysfs = 0
+       │         (enabled was already 1 throughout — it is not
+       │          touched by klp_complete_transition())
 ```
 
 ## Further reading

--- a/docs/livepatch/klp-consistency.md
+++ b/docs/livepatch/klp-consistency.md
@@ -23,19 +23,19 @@ of three values, defined in `include/linux/livepatch.h`:
 
 ```c
 /* include/linux/livepatch.h */
-#define KLP_UNDEFINED  -1   /* task hasn't been evaluated yet */
-#define KLP_UNPATCHED   0   /* task should call the original function */
-#define KLP_PATCHED     1   /* task should call the patched function */
+#define KLP_TRANSITION_IDLE       -1   /* task hasn't been evaluated yet */
+#define KLP_TRANSITION_UNPATCHED   0   /* task should call the original function */
+#define KLP_TRANSITION_PATCHED     1   /* task should call the patched function */
 ```
 
-At the start of a patching transition every task is `KLP_UNDEFINED`. The
-ftrace handler in `kernel/livepatch/patch.c` treats `KLP_UNDEFINED` the same
-as `KLP_UNPATCHED` — the task gets the old behavior until explicitly
-transitioned.
+At the start of a patching transition every task is `KLP_TRANSITION_IDLE`. The
+ftrace handler in `kernel/livepatch/patch.c` treats `KLP_TRANSITION_IDLE` the
+same as `KLP_TRANSITION_UNPATCHED` — the task gets the old behavior until
+explicitly transitioned.
 
 The transition direction can be either forward (enabling a patch:
-`KLP_UNPATCHED` → `KLP_PATCHED`) or backward (disabling a patch:
-`KLP_PATCHED` → `KLP_UNPATCHED`).
+`KLP_TRANSITION_UNPATCHED` → `KLP_TRANSITION_PATCHED`) or backward (disabling
+a patch: `KLP_TRANSITION_PATCHED` → `KLP_TRANSITION_UNPATCHED`).
 
 ### How klp_update_patch_state() works
 
@@ -61,90 +61,142 @@ void klp_update_patch_state(struct task_struct *task)
 ```
 
 The global `klp_target_state` is set by the transition machinery to
-`KLP_PATCHED` when enabling or `KLP_UNPATCHED` when disabling. Each time a
-task is scheduled out (`finish_task_switch`) the scheduler calls
-`klp_update_patch_state()` for that task.
+`KLP_TRANSITION_PATCHED` when enabling or `KLP_TRANSITION_UNPATCHED` when
+disabling. `klp_update_patch_state()` is called for `current` from the
+kernel-exit-to-userspace path (`__exit_to_user_mode_loop()` in
+`kernel/entry/common.c`) whenever `TIF_PATCH_PENDING` is set, and directly on
+every task by `klp_force_transition()` for a forced transition.
 
 ## Stack checking: klp_check_stack()
 
-The scheduler path (`finish_task_switch` → `klp_update_patch_state`) does **not** run a stack check. It fires whenever `TIF_PATCH_PENDING` is set, unconditionally. The scheduler path is always safe because a task being scheduled out cannot currently be executing the old function's body.
+`klp_update_patch_state()` does **not** run a stack check — it's an
+unconditional flag-check-and-clear. That's safe on the kernel-exit-to-userspace
+path because a task that's about to return to userspace cannot be mid-execution
+inside a patched kernel function's body.
 
-The stack check (`klp_check_stack()`) only runs in the workqueue path (`klp_try_complete_transition()`), not in the scheduler fast path. Before a task can be transitioned via the workqueue path, the kernel must verify that the old (unpatched) function is not on that task's call stack. If it is, the task is mid-execution inside the old function and cannot be safely transitioned yet.
+Two other paths *do* run a stack check, both funneling through
+`klp_check_stack()`:
+
+- **The workqueue path** (`klp_try_complete_transition()`, described below):
+  runs roughly once a second and walks every task in the system, including
+  ones that are sleeping or blocked.
+- **The scheduler path**: while a transition is in progress, `__schedule()`
+  calls `klp_sched_try_switch(prev)` (`kernel/sched/core.c`), which — gated by
+  a static key that `klp_resched_enable()`/`klp_resched_disable()` toggle for
+  the duration of the transition — calls `klp_try_switch_task(current)` on
+  every context switch. This exists specifically to help CPU-bound kthreads
+  get patched: such a task may rarely (or never) go through the
+  kernel-exit-to-userspace path, so relying on that path alone could stall
+  the transition indefinitely.
+
+Either way, before a task can be switched via a stack-checking path, the
+kernel must verify that the old (unpatched) function — or, if a patch is
+already stacked on top of another, the previously patched function — is not
+on that task's call stack. If it is, the task is mid-execution inside that
+function and cannot be safely transitioned yet.
 
 ```c
 /* kernel/livepatch/transition.c */
-static int klp_check_stack_func(struct klp_func *func,
-                                unsigned long *entries,
+static int klp_check_stack_func(struct klp_func *func, unsigned long *entries,
                                 unsigned int nr_entries)
 {
-    unsigned long func_addr, func_size;
-    const char *func_name;
+    unsigned long func_addr, func_size, address;
     struct klp_ops *ops;
     int i;
 
-    for (i = 0; i < nr_entries; i++) {
-        if (klp_target_state == KLP_UNPATCHED) {
-            /*
-             * Check for the new (patched) function on the stack:
-             * if found, can't unpatch yet.
-             */
-            func_addr = (unsigned long)func->new_func;
-            func_size = func->new_size;
-        } else {
-            /*
-             * Check for the old (original) function on the stack:
-             * if found, can't patch yet.
-             */
-            ops = klp_find_ops(func->old_func);
-            func_addr = func->old_addr;
+    if (klp_target_state == KLP_TRANSITION_UNPATCHED) {
+        /*
+         * Check for the to-be-unpatched function
+         * (the func itself).
+         */
+        func_addr = (unsigned long)func->new_func;
+        func_size = func->new_size;
+    } else {
+        /*
+         * Check for the to-be-patched function
+         * (the previous func).
+         */
+        ops = klp_find_ops(func->old_func);
+
+        if (list_is_singular(&ops->func_stack)) {
+            /* original function */
+            func_addr = (unsigned long)func->old_func;
             func_size = func->old_size;
+        } else {
+            /* previously patched function */
+            struct klp_func *prev;
+
+            prev = list_next_entry(func, stack_node);
+            func_addr = (unsigned long)prev->new_func;
+            func_size = prev->new_size;
         }
-        if (entries[i] >= func_addr &&
-            entries[i] < func_addr + func_size)
+    }
+
+    for (i = 0; i < nr_entries; i++) {
+        address = entries[i];
+
+        if (address >= func_addr && address < func_addr + func_size)
             return -EAGAIN;
     }
     return 0;
 }
 ```
 
-The function receives the full stack frame array captured by `stack_trace_save_tsk()`, not a single address.
+Note the patch-stacking-aware branch: when checking whether it's safe to
+*patch* (not unpatch), the function doesn't just look for `func->old_func` —
+if another patch already replaced this function (`func_stack` has more than
+one entry), it looks for the *previously patched* function
+(`list_next_entry(func, stack_node)`'s `new_func`), since that's what's
+actually running on the stack right now. See "Patch stacking", below.
+
+The function receives the full stack frame array captured by
+`stack_trace_save_tsk_reliable()`, not a single address.
 
 ```c
 /* kernel/livepatch/transition.c */
-static int klp_check_stack(struct task_struct *task,
-                            const char **oldname)
+#define MAX_STACK_ENTRIES  100
+static DEFINE_PER_CPU(unsigned long[MAX_STACK_ENTRIES], klp_stack_entries);
+
+static int klp_check_stack(struct task_struct *task, const char **oldname)
 {
-    unsigned long entries[KLP_MAX_STACK_ENTRIES];
-    struct klp_patch *patch;
+    unsigned long *entries = this_cpu_ptr(klp_stack_entries);
     struct klp_object *obj;
     struct klp_func *func;
-    int nr_entries, ret;
+    int ret, nr_entries;
 
-    nr_entries = stack_trace_save_tsk(task, entries,
-                                       ARRAY_SIZE(entries), 0);
+    ret = stack_trace_save_tsk_reliable(task, entries, MAX_STACK_ENTRIES);
+    if (ret < 0)
+        return -EINVAL;
+    nr_entries = ret;
 
-    klp_for_each_patch(patch) {
-        if (!patch->enabled)
+    klp_for_each_object(klp_transition_patch, obj) {
+        if (!obj->patched)
             continue;
-        klp_for_each_object(patch, obj) {
-            if (!klp_is_object_loaded(obj))
-                continue;
-            klp_for_each_func(obj, func) {
-                ret = klp_check_stack_func(func, entries, nr_entries);
-                if (ret) {
-                    *oldname = func->old_name;
-                    return -EAGAIN;
-                }
+        klp_for_each_func(obj, func) {
+            ret = klp_check_stack_func(func, entries, nr_entries);
+            if (ret) {
+                *oldname = func->old_name;
+                return -EADDRINUSE;
             }
         }
     }
+
     return 0;
 }
 ```
 
-If `klp_check_stack()` returns `-EAGAIN`, the task is skipped for this
-transition round. The transition machinery will retry on the next workqueue
-invocation.
+`klp_check_stack()` only walks the single patch currently transitioning
+(`klp_transition_patch`, via `klp_for_each_object()`) — not every enabled
+patch — since only one patch can be mid-transition at a time. The stack
+buffer itself is a per-CPU array (`klp_stack_entries`, sized by the private
+`MAX_STACK_ENTRIES` `#define`, not a `KLP_MAX_STACK_ENTRIES` constant),
+protected by having preemption disabled.
+
+`klp_check_stack()` returns `-EINVAL` if the stack trace itself is
+unreliable (`stack_trace_save_tsk_reliable()` failed) and `-EADDRINUSE` if
+the stack unwound cleanly but a to-be-patched or to-be-unpatched function was
+found on it. Either way the task is skipped for this transition round; the
+transition machinery will retry on the next workqueue invocation.
 
 ## The transition workqueue
 
@@ -165,30 +217,40 @@ static void klp_transition_work_fn(struct work_struct *work)
 static DECLARE_DELAYED_WORK(klp_transition_work, klp_transition_work_fn);
 ```
 
-The actual call chain in `klp_try_complete_transition()` is: `klp_try_complete_transition()` → `klp_try_switch_task(task)` → `klp_check_and_switch_task()`. The `klp_check_and_switch_task()` function (used via `task_call_func()` for non-current tasks) runs `klp_check_stack()` and, if it returns 0, calls `klp_update_patch_state()`. `klp_update_patch_state()` is never called directly from the main loop of `klp_try_complete_transition()`.
+The actual call chain in `klp_try_complete_transition()` is: `klp_try_complete_transition()` → `klp_try_switch_task(task)` → `klp_check_and_switch_task()`. The `klp_check_and_switch_task()` function (used via `task_call_func()` for non-current tasks) runs `klp_check_stack()` and, if it returns 0, clears `TIF_PATCH_PENDING` and sets `task->patch_state = klp_target_state` directly. `klp_update_patch_state()` — the flag-check-and-clear function from the previous section — is never called from the main loop of `klp_try_complete_transition()`; that function is reserved for the kernel-exit-to-userspace path and `klp_force_transition()`.
 
 ```c
 /* kernel/livepatch/transition.c — simplified structure */
-static void klp_try_complete_transition(void)
+void klp_try_complete_transition(void)
 {
-    /* ... */
-    for_each_process_thread(g, task) {
-        if (!klp_patch_pending(task))
-            continue;
-        /*
-         * klp_try_switch_task uses task_call_func to safely
-         * run klp_check_and_switch_task on the target task.
-         */
-        if (klp_try_switch_task(task)) {
-            /* task still has old func on stack — not done yet */
-            goto err;
-        }
+    unsigned int cpu;
+    struct task_struct *g, *task;
+    bool complete = true;
+
+    /*
+     * klp_try_switch_task uses task_call_func to safely run
+     * klp_check_and_switch_task on the target task. It returns
+     * true on success (task is now at klp_target_state).
+     */
+    for_each_process_thread(g, task)
+        if (!klp_try_switch_task(task))
+            complete = false;
+
+    /* idle ("swapper") tasks are checked the same way */
+    for_each_possible_cpu(cpu) {
+        task = idle_task(cpu);
+        if (!klp_try_switch_task(task))
+            complete = false;
     }
+
+    if (!complete) {
+        /* some tasks weren't switched yet — try again later */
+        schedule_delayed_work(&klp_transition_work, round_jiffies_relative(HZ));
+        return;
+    }
+
     /* all tasks transitioned */
     klp_complete_transition();
-    return;
-err:
-    schedule_delayed_work(&klp_transition_work, round_jiffies_relative(HZ));
 }
 ```
 
@@ -203,8 +265,9 @@ The periodic re-check runs approximately every second (one HZ).
 
 Neither path can wake a task in `TASK_UNINTERRUPTIBLE` (D state). D-state tasks must leave that state naturally before the transition can include them. This is why livepatch transitions can stall for an extended period — the `force` mechanism exists precisely for situations where a D-state task cannot be transitioned.
 
-`klp_send_signals()` is called from `klp_try_complete_transition()` when the
-transition has been in progress for more than a few seconds.
+`klp_send_signals()` is called from `klp_try_complete_transition()` roughly
+every 15 seconds (every `SIGNALS_TIMEOUT`th incomplete retry round, at the
+~1-second-per-round cadence described below) once the transition has stalled.
 
 ## Patch stacking: func_stack and struct klp_ops
 
@@ -213,7 +276,7 @@ function, the kernel must know which replacement is currently active. This is
 managed through `struct klp_ops` and its `func_stack`:
 
 ```c
-/* kernel/livepatch/patch.c */
+/* kernel/livepatch/patch.h */
 struct klp_ops {
     struct list_head  node;        /* entry in klp_ops list */
     struct list_head  func_stack;  /* stack of klp_func — newest at head */
@@ -257,13 +320,14 @@ echo 1 > /sys/kernel/livepatch/<patch>/force
 
 Forcing a transition is **unsafe**: any task that was executing inside the old
 function at the moment of the force will continue executing the old function's
-code, but the patch state is set to `KLP_PATCHED`. If the new function changes
-data layouts or assumptions, those tasks can access inconsistent state.
+code, but the patch state is set to `KLP_TRANSITION_PATCHED`. If the new
+function changes data layouts or assumptions, those tasks can access
+inconsistent state.
 
 After a forced transition the `forced` field of `struct klp_patch` is set to
 `true`. The `/sys/kernel/livepatch/<patch>/forced` sysfs file reflects this.
 
-`TAINT_LIVEPATCH` is applied at **module load time** for every livepatch module — not conditionally on forced transitions. Every live patch application taints the kernel with `TAINT_LIVEPATCH` (bit 15). A separate taint (`TAINT_FORCED_MODULE`) may be added on forced transitions.
+`TAINT_LIVEPATCH` is applied at **module load time** for every livepatch module — not conditionally on forced transitions. Every live patch application taints the kernel with `TAINT_LIVEPATCH` (bit 15). `klp_force_transition()` itself does not add any additional taint — `TAINT_FORCED_MODULE` is unrelated; it's set when a module is force-loaded with `insmod -f`, not when a livepatch transition is forced.
 
 Only use forced transitions as a last resort after confirming — by reading
 `/proc/<pid>/stack` — that the affected task is not in a call path the new
@@ -277,31 +341,56 @@ Once every task has been transitioned, `klp_complete_transition()` is called:
 /* kernel/livepatch/transition.c */
 static void klp_complete_transition(void)
 {
-    struct klp_patch *patch;
     struct klp_object *obj;
     struct klp_func *func;
     struct task_struct *g, *task;
+    unsigned int cpu;
 
-    /* Clear per-task transition state */
-    for_each_process_thread(g, task)
-        task->patch_state = KLP_UNDEFINED;
+    /* For cumulative (replace) patches: unpatch all replaced patches.
+     * This removes their funcs from the func_stack. */
+    if (klp_transition_patch->replace && klp_target_state == KLP_TRANSITION_PATCHED) {
+        klp_unpatch_replaced_patches(klp_transition_patch);
+        klp_discard_nops(klp_transition_patch);
+    }
+
+    if (klp_target_state == KLP_TRANSITION_UNPATCHED) {
+        /*
+         * All tasks have transitioned to KLP_TRANSITION_UNPATCHED so we
+         * can now remove the new functions from the func_stack.
+         */
+        klp_unpatch_objects(klp_transition_patch);
+        klp_synchronize_transition();
+    }
 
     /* Clear per-func transition flag */
     klp_for_each_object(klp_transition_patch, obj)
         klp_for_each_func(obj, func)
             func->transition = false;
 
-    /* For cumulative (replace) patches: unpatch all replaced patches.
-     * This removes their funcs from the func_stack. */
-    if (klp_transition_patch->replace) {
-        klp_for_each_patch(patch) {
-            if (patch == klp_transition_patch)
-                continue;
-            if (patch->enabled)
-                klp_unpatch_objects(patch);
-        }
+    /* Prevent klp_ftrace_handler() from seeing KLP_TRANSITION_IDLE state */
+    if (klp_target_state == KLP_TRANSITION_PATCHED)
+        klp_synchronize_transition();
+
+    /* Clear per-task transition state, including idle tasks */
+    read_lock(&tasklist_lock);
+    for_each_process_thread(g, task)
+        task->patch_state = KLP_TRANSITION_IDLE;
+    read_unlock(&tasklist_lock);
+
+    for_each_possible_cpu(cpu)
+        idle_task(cpu)->patch_state = KLP_TRANSITION_IDLE;
+
+    /* Run any post-(un)patch callbacks now that the transition is done */
+    klp_for_each_object(klp_transition_patch, obj) {
+        if (!klp_is_object_loaded(obj))
+            continue;
+        if (klp_target_state == KLP_TRANSITION_PATCHED)
+            klp_post_patch_callback(obj);
+        else if (klp_target_state == KLP_TRANSITION_UNPATCHED)
+            klp_post_unpatch_callback(obj);
     }
 
+    klp_target_state = KLP_TRANSITION_IDLE;
     klp_transition_patch = NULL;
 }
 ```
@@ -342,32 +431,52 @@ dmesg | grep livepatch
 klp_enable_patch()
        │
        ▼
-  Set klp_target_state = KLP_PATCHED
+  Set klp_target_state = KLP_TRANSITION_PATCHED
   Set func->transition = true
   Queue klp_transition_work
        │
        ▼ (periodic, every ~1s)
   klp_try_complete_transition()
        │
-       ├── for each task:
-       │     klp_check_stack() → EAGAIN?
-       │       yes: skip (try again next round)
-       │       no:  klp_update_patch_state() → KLP_PATCHED
+       ├── for each task (and each idle task):
+       │     klp_try_switch_task() → klp_check_and_switch_task()
+       │       klp_check_stack() unsafe (-EINVAL / -EADDRINUSE / -EBUSY)?
+       │         yes: skip (try again next round)
+       │         no:  task->patch_state = KLP_TRANSITION_PATCHED
        │
-       ├── all tasks KLP_PATCHED?
+       ├── all tasks KLP_TRANSITION_PATCHED?
        │     no:  klp_send_signals(), reschedule work
        │     yes: klp_complete_transition()
        │             │
        │             ▼
        │         func->transition = false
+       │         klp_target_state = KLP_TRANSITION_IDLE
        │         patch->enabled = true
        │         transition sysfs = 0
 ```
 
 ## Further reading
 
+### Kernel source
+
+- [kernel/livepatch/transition.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/transition.c) — `klp_check_stack()`, `klp_try_complete_transition()`, `klp_update_patch_state()`, and the rest of the transition state machine
+- [kernel/livepatch/patch.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.c) — `klp_ftrace_handler()`, which walks `func_stack` to pick the active replacement, plus `klp_patch_func()`/`klp_unpatch_func()`
+- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_force_transition()` and the `/sys/kernel/livepatch/<patch>/{transition,force,forced}` sysfs attributes
+- [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_func`, `struct klp_object`, `struct klp_patch`, and the transition-state constants
+
+### Related pages
+
 - [Kernel Live Patching](klp.md) — struct klp_func/klp_patch, ftrace redirection, shadow variables
 - [Cumulative Patches and Atomic Replace](klp-cumulative.md) — patch stacking and .replace=true
+- [KLP State: Custom Consistency Checks](klp-state.md) — the `klp_state` API for changes stack scanning alone can't validate
 - [ftrace](../tracing/ftrace.md) — the ftrace hook that KLP uses
-- `kernel/livepatch/transition.c` — full transition implementation
-- `Documentation/livepatch/livepatch.rst` — upstream documentation
+
+### LWN articles
+
+- [LWN: livepatch: consistency model](https://lwn.net/Articles/632582/) — the original 2015 design writeup for the per-task, stack-checking transition model implemented in `kernel/livepatch/transition.c`
+- [LWN: An update on live kernel patching](https://lwn.net/Articles/734765/) — 2017 status report covering the hybrid lazy-migration/stack-checking model and why the ORC unwinder was needed for reliable stack checks
+
+### External
+
+- [Kernel docs: Livepatch](https://docs.kernel.org/livepatch/livepatch.html) — upstream description of the consistency model, the `force` and `transition` sysfs files, and patch stacking via `func_stack`
+- [Kernel docs: Reliable Stacktrace](https://docs.kernel.org/livepatch/reliable-stacktrace.html) — why livepatch requires a reliable (not best-effort) stack unwinder for the stack-checking path

--- a/docs/livepatch/klp-consistency.md
+++ b/docs/livepatch/klp-consistency.md
@@ -28,10 +28,13 @@ of three values, defined in `include/linux/livepatch.h`:
 #define KLP_TRANSITION_PATCHED     1   /* task should call the patched function */
 ```
 
-At the start of a patching transition every task is `KLP_TRANSITION_IDLE`. The
-ftrace handler in `kernel/livepatch/patch.c` treats `KLP_TRANSITION_IDLE` the
-same as `KLP_TRANSITION_UNPATCHED` — the task gets the old behavior until
-explicitly transitioned.
+`KLP_TRANSITION_IDLE` is the resting value when no transition is in progress.
+`klp_init_transition()` assigns every task's real starting state —
+`KLP_TRANSITION_UNPATCHED` or `KLP_TRANSITION_PATCHED`, whichever isn't the
+target — before a transition becomes visible, so no live task is ever actually
+observed at `KLP_TRANSITION_IDLE` mid-transition; the ftrace handler in
+`kernel/livepatch/patch.c` even asserts this with `WARN_ON_ONCE(patch_state ==
+KLP_TRANSITION_IDLE)`.
 
 The transition direction can be either forward (enabling a patch:
 `KLP_TRANSITION_UNPATCHED` → `KLP_TRANSITION_PATCHED`) or backward (disabling
@@ -84,7 +87,8 @@ Two other paths *do* run a stack check, both funneling through
   calls `klp_sched_try_switch(prev)` (`kernel/sched/core.c`), which — gated by
   a static key that `klp_resched_enable()`/`klp_resched_disable()` toggle for
   the duration of the transition — calls `klp_try_switch_task(current)` on
-  every context switch. This exists specifically to help CPU-bound kthreads
+  context switches where the outgoing task is entering a freezable sleep
+  state (`TASK_FREEZABLE`), not on every context switch. This exists specifically to help CPU-bound kthreads
   get patched: such a task may rarely (or never) go through the
   kernel-exit-to-userspace path, so relying on that path alone could stall
   the transition indefinitely.
@@ -325,7 +329,9 @@ function changes data layouts or assumptions, those tasks can access
 inconsistent state.
 
 After a forced transition the `forced` field of `struct klp_patch` is set to
-`true`. The `/sys/kernel/livepatch/<patch>/forced` sysfs file reflects this.
+`true`. This is internal-only — there is no sysfs file to read it back; the
+only externally visible trace is that `rmmod` on the patch module is
+permanently disabled from that point on.
 
 `TAINT_LIVEPATCH` is applied at **module load time** for every livepatch module — not conditionally on forced transitions. Every live patch application taints the kernel with `TAINT_LIVEPATCH` (bit 15). `klp_force_transition()` itself does not add any additional taint — `TAINT_FORCED_MODULE` is unrelated; it's set when a module is force-loaded with `insmod -f`, not when a livepatch transition is forced.
 
@@ -405,9 +411,9 @@ After `klp_complete_transition()` returns, the `transition` sysfs file reads
 cat /sys/kernel/livepatch/<patch>/transition
 # 1 = in progress, 0 = complete
 
-# Was the transition forced?
-cat /sys/kernel/livepatch/<patch>/forced
-# 0 = normal, 1 = forced
+# Whether a transition was ever forced is internal-only (struct klp_patch.forced)
+# and not exposed via sysfs — the only observable side effect is that `rmmod`
+# on the patch module will be permanently refused from that point on.
 
 # Which tasks are blocking the transition?
 # (tasks that have the old function on their stack)
@@ -440,7 +446,7 @@ klp_enable_patch()
        │
        ├── for each task (and each idle task):
        │     klp_try_switch_task() → klp_check_and_switch_task()
-       │       klp_check_stack() unsafe (-EINVAL / -EADDRINUSE / -EBUSY)?
+       │       task unsafe to switch (-EBUSY: running; -EINVAL / -EADDRINUSE from klp_check_stack())?
        │         yes: skip (try again next round)
        │         no:  task->patch_state = KLP_TRANSITION_PATCHED
        │
@@ -459,9 +465,9 @@ klp_enable_patch()
 
 ### Kernel source
 
-- [kernel/livepatch/transition.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/transition.c) — `klp_check_stack()`, `klp_try_complete_transition()`, `klp_update_patch_state()`, and the rest of the transition state machine
+- [kernel/livepatch/transition.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/transition.c) — `klp_check_stack()`, `klp_try_complete_transition()`, `klp_update_patch_state()`, `klp_force_transition()`, and the rest of the transition state machine
 - [kernel/livepatch/patch.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.c) — `klp_ftrace_handler()`, which walks `func_stack` to pick the active replacement, plus `klp_patch_func()`/`klp_unpatch_func()`
-- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_force_transition()` and the `/sys/kernel/livepatch/<patch>/{transition,force,forced}` sysfs attributes
+- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — the `/sys/kernel/livepatch/<patch>/{transition,force}` sysfs attributes
 - [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_func`, `struct klp_object`, `struct klp_patch`, and the transition-state constants
 
 ### Related pages

--- a/docs/livepatch/klp-consistency.md
+++ b/docs/livepatch/klp-consistency.md
@@ -12,8 +12,8 @@ in an inconsistent state.
 
 The KLP consistency model solves this by tracking every task in the system and
 only considering the patch fully active once every task has reached a safe
-point: returned from the old function, passed through a schedule point, or
-entered from userspace.
+point: returned from the old function, entered a freezable sleep, or reached
+the kernel's exit-to-userspace path.
 
 ## Per-task patch state
 

--- a/docs/livepatch/klp-cumulative.md
+++ b/docs/livepatch/klp-cumulative.md
@@ -187,10 +187,11 @@ public livepatch API exported via `EXPORT_SYMBOL_GPL` — `core.c` also exports
 `klp_shadow_free_all()`, and `state.c` exports `klp_get_state()` and
 `klp_get_prev_state()`. A livepatch module's `module_exit` should be empty or
 omitted entirely — the teardown already happened when the patch was disabled:
-`klp_complete_transition()` calls `klp_unpatch_objects()`, which unregisters
-each function's ftrace hook, and `klp_free_patch_async()` then frees the
-`struct klp_patch` and drops the module reference. There is nothing left to
-clean up by the time `rmmod` runs.
+`klp_complete_transition()` calls `klp_unpatch_objects()`, which pops each
+function off its `func_stack` and unregisters the ftrace hook once that stack
+is empty, and `klp_free_patch_async()` then frees the `struct klp_patch` and
+drops the module reference. There is nothing left to clean up by the time
+`rmmod` runs.
 
 (`klp_module_going()`, called directly by `kernel/module/main.c` during
 module load/unload — not via the module notifier chain — is a different

--- a/docs/livepatch/klp-cumulative.md
+++ b/docs/livepatch/klp-cumulative.md
@@ -29,7 +29,7 @@ struct klp_patch {
     /* external (set by patch module author): */
     struct module       *mod;       /* the live patch module */
     struct klp_object   *objs;      /* array of patched objects */
-    struct klp_state    *states;    /* optional consistency states (5.8+) */
+    struct klp_state    *states;    /* optional consistency states (5.5+) */
     bool                 replace;   /* true = cumulative replace (5.1+) */
 
     /* internal (managed by the livepatch core): */
@@ -110,8 +110,9 @@ The "atomic" part is that the entire switch — enabling the new patch and remov
  *    allocates nop funcs for any functions in active patches
  *    not covered by the new patch */
 /* 3. Normal transition begins (same as any patch) */
-/* 4. klp_complete_transition() → klp_unpatch_objects() removes
- *    all replaced patches from the func_stack */
+/* 4. klp_complete_transition() → klp_unpatch_replaced_patches()
+ *    → klp_unpatch_objects() (per old patch) removes all replaced
+ *    patches from the func_stack */
 ```
 
 ## struct klp_ops: the per-function hook
@@ -120,7 +121,7 @@ There is exactly one `struct klp_ops` for each (object, function-name) pair,
 no matter how many patches target that function:
 
 ```c
-/* kernel/livepatch/patch.c */
+/* kernel/livepatch/patch.h */
 struct klp_ops {
     struct list_head  node;        /* global klp_ops list */
     struct list_head  func_stack;  /* klp_func entries — newest at head */
@@ -151,13 +152,13 @@ function resumes executing without any trampoline overhead.
 ## Disabling a patch
 
 Disabling a patch starts a *reverse transition*: tasks are moved from
-`KLP_PATCHED` back to `KLP_UNPATCHED`. The `enabled` sysfs file triggers this:
+`KLP_TRANSITION_PATCHED` back to `KLP_TRANSITION_UNPATCHED`. The `enabled` sysfs file triggers this:
 
 ```bash
 echo 0 > /sys/kernel/livepatch/<patch>/enabled
 ```
 
-The kernel sets `klp_target_state = KLP_UNPATCHED` and queues
+The kernel sets `klp_target_state = KLP_TRANSITION_UNPATCHED` and queues
 `klp_transition_work`. The stack check still applies — tasks that are executing
 inside the *new* (patched) function cannot be reversed until they return.
 
@@ -178,12 +179,22 @@ cat /sys/kernel/livepatch/mypatch/enabled
 
 ## Removing a patch
 
-Once a patch is disabled, its module can be unloaded. The only public livepatch API exported via `EXPORT_SYMBOL_GPL` is `klp_enable_patch()`. A livepatch module's `module_exit` should be empty or omitted entirely — the livepatch core handles cleanup via the module notifier `klp_module_going()`:
+Once a patch is disabled, its module can be unloaded. `klp_enable_patch()` is
+the primary entry point a livepatch module calls, but it is not the only
+public livepatch API exported via `EXPORT_SYMBOL_GPL` — `core.c` also exports
+`klp_find_section_by_name()`, `shadow.c` exports `klp_shadow_get()`,
+`klp_shadow_alloc()`, `klp_shadow_get_or_alloc()`, `klp_shadow_free()`, and
+`klp_shadow_free_all()`, and `state.c` exports `klp_get_state()` and
+`klp_get_prev_state()`. A livepatch module's `module_exit` should be empty or
+omitted entirely — the livepatch core handles cleanup via `klp_module_going()`,
+which `kernel/module/main.c` calls directly during module load/unload state
+transitions (it is not registered on the module notifier chain):
 
 ```c
 /* Livepatch module exit: no explicit unregister needed.
- * The livepatch core registers a module notifier (klp_module_going)
- * that handles cleanup when the module is unloaded.
+ * The module loader calls klp_module_going() directly during the module's
+ * exit path, and the livepatch core uses it to clean up when the module
+ * is unloaded.
  * Before unloading, disable the patch via sysfs:
  *   echo 0 > /sys/kernel/livepatch/<patch>/enabled
  * Then: rmmod <patch_module>
@@ -236,21 +247,29 @@ enabled=0, transition=0 (disabled, can unload)
 
 ## Observing the func_stack
 
-The sysfs hierarchy exposes the state of each patched function, including
-its position in the func_stack relative to other patches:
+The sysfs hierarchy exposes the state of each patched object, and lists each
+patched function's directory, but a per-function `patched` file does not
+exist — `patched` is an object-level attribute only:
 
 ```bash
-# Check if a specific function is patched
-cat /sys/kernel/livepatch/mypatch/objs/vmlinux/funcs/tcp_sendmsg/patched
-# 1 = hook is active for this function
+# Check if the vmlinux object (core kernel) is patched by mypatch
+cat /sys/kernel/livepatch/mypatch/vmlinux/patched
+# 1 = this patch's functions in this object are currently hooked
+
+# Each patched function shows up as a directory named "<function>,<sympos>"
+# under the object — its mere presence is the signal, it has no attribute
+# files of its own:
+ls /sys/kernel/livepatch/mypatch/vmlinux/
+# patched  tcp_sendmsg,0
 
 # old_addr is NOT exposed via sysfs
 # To find the original function address, use /proc/kallsyms:
 grep " tcp_sendmsg$" /proc/kallsyms
 
-# If two patches cover the same function:
-cat /sys/kernel/livepatch/p1/objs/vmlinux/funcs/tcp_sendmsg/patched  # 0 (shadowed by p2)
-cat /sys/kernel/livepatch/p2/objs/vmlinux/funcs/tcp_sendmsg/patched  # 1 (active)
+# If two patches cover the same function, func_stack order (not sysfs) is
+# the arbiter — see "stack_order" for each patch's position:
+cat /sys/kernel/livepatch/p1/stack_order  # 1 (older, shadowed by p2)
+cat /sys/kernel/livepatch/p2/stack_order  # 2 (newer, active)
 ```
 
 ## Practical workflow with kpatch
@@ -306,9 +325,27 @@ violated.
 
 ## Further reading
 
+### Kernel source
+
+- [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_patch`, `struct klp_func`, `struct klp_object`, and the `KLP_TRANSITION_IDLE`/`KLP_TRANSITION_UNPATCHED`/`KLP_TRANSITION_PATCHED` task-state constants
+- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_enable_patch()`, `klp_add_nops()`, `klp_unpatch_replaced_patches()`, `klp_module_going()`, and a comment block documenting the full `/sys/kernel/livepatch/...` sysfs layout
+- [kernel/livepatch/patch.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.c) — `klp_patch_func()`/`klp_unpatch_func()`: pushing and popping `klp_func` entries on `ops->func_stack` via `list_add_rcu()`/`list_del_rcu()`
+- [kernel/livepatch/patch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.h) — `struct klp_ops` definition (`node`, `func_stack`, `fops`)
+- [Documentation/livepatch/cumulative-patches.rst](https://docs.kernel.org/livepatch/cumulative-patches.html) — the upstream usage guide for atomic replace, including the callback and shadow-variable limitations
+- [`e1452b607c48` — livepatch: Add atomic replace](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e1452b607c48c642caf57299f4da83aa002f8533) — Petr Mladek's commit adding the `.replace` field to `struct klp_patch`, merged for Linux 5.1
+
+### Man pages
+
+- [`rmmod(8)`](https://man7.org/linux/man-pages/man8/rmmod.8.html) — module removal; the `-f`/`--force` option bypasses the in-use refcount check this page warns against using on a still-enabled live patch
+
+### Related pages
+
 - [KLP Consistency Model](klp-consistency.md) — per-task states, stack checking, forced transitions
 - [Kernel Live Patching](klp.md) — struct klp_func/klp_patch, ftrace redirection, shadow variables
+- [KLP State](klp-state.md) — the `struct klp_state`/`klp_get_state()` API referenced by `struct klp_patch`'s `.states` field
 - [Kernel Modules](../modules/module-basics.md) — KLP modules use the standard module infrastructure
-- `kernel/livepatch/core.c` — klp_enable_patch(), klp_add_nops(), klp_module_going()
-- `kernel/livepatch/patch.c` — struct klp_ops, func_stack management
-- `Documentation/livepatch/cumulative-patches.rst` — upstream cumulative patch guide
+- [War Stories](war-stories.md) — a real incident from loading a cumulative patch while another was still transitioning
+
+### LWN articles
+
+- [livepatch: Atomic replace feature](https://lwn.net/Articles/776290/) — Petr Mladek's v15 patch series introducing atomic replace, mirrored on LWN (January 9, 2019); the cover letter explains the cumulative-patch design and the problems it replaced (patch-ordering dependencies, no way to revert a single stacked patch)

--- a/docs/livepatch/klp-cumulative.md
+++ b/docs/livepatch/klp-cumulative.md
@@ -228,7 +228,8 @@ insmod mypatch.ko
 klp_enable_patch()
   │  (registration, symbol resolution, ftrace hook install)
   ▼
-enabled=0, transition=1 (transition in progress)
+enabled=1, transition=1 (transition in progress -- enabled is set
+                          at the START of the transition, not the end)
   │
   ▼
 enabled=1, transition=0 (fully active)
@@ -306,29 +307,58 @@ systemctl enable kpatch
 
 ## Cumulative patch ordering rules
 
-Loading a cumulative patch while another patch is still transitioning is
-unsafe. The `func_stack` can end up in an indeterminate state. Always verify
-all active patches are stable before loading a cumulative replacement:
+The ordering rule that matters most is enforced by the kernel, not by the
+operator. Only one transition may be in flight at a time, and both the enable
+and the disable path bail out early if one already is:
+
+```c
+/* kernel/livepatch/core.c — __klp_enable_patch() and __klp_disable_patch()
+ * both open with the same guard */
+if (klp_transition_patch)
+        return -EBUSY;
+```
+
+So loading a cumulative patch while another patch is still transitioning does
+not corrupt the `func_stack` — the `klp_enable_patch()` call from the new
+module's `init` returns `-EBUSY`, the `insmod` fails, and the module never
+loads. The same guard rejects an `echo 0 > .../enabled` issued during a
+transition. Checking first only saves you a failed deployment step:
 
 ```bash
-# Check all patches are fully transitioned before loading a cumulative patch
+# Avoid a spurious EBUSY: wait for any in-flight transition to finish
 for p in /sys/kernel/livepatch/*/; do
     t=$(cat "$p/transition")
     if [ "$t" = "1" ]; then
-        echo "WARNING: $(basename $p) is still transitioning — wait before loading cumulative patch"
+        echo "$(basename $p) is still transitioning — insmod would fail with EBUSY"
     fi
 done
 ```
 
-See [war stories](war-stories.md) for a real incident where this rule was
-violated.
+The rule the kernel does *not* enforce is that a patch you intended to be
+cumulative actually is one. `klp_add_nops()` runs only under
+`if (patch->replace)`, and `klp_unpatch_replaced_patches()` only when
+`klp_transition_patch->replace` is set, so a patch that forgets
+`.replace = true` silently stacks on top of the patches it was meant to
+supersede — and any function those patches touched that the new one does not
+name keeps running the old replacement. Verify the outcome after every
+deployment:
+
+```bash
+cat /sys/kernel/livepatch/mypatch/replace       # want 1
+cat /sys/kernel/livepatch/mypatch/stack_order   # want 1 — replaced patches are
+                                                # removed from klp_patches
+ls /sys/kernel/livepatch/                       # want only mypatch
+```
+
+See [war stories](war-stories.md) for a real incident where a cumulative patch
+shipped without `.replace` and a superseded fix never reverted.
 
 ## Further reading
 
 ### Kernel source
 
 - [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_patch`, `struct klp_func`, `struct klp_object`, and the `KLP_TRANSITION_IDLE`/`KLP_TRANSITION_UNPATCHED`/`KLP_TRANSITION_PATCHED` task-state constants
-- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_enable_patch()`, `klp_add_nops()`, `klp_unpatch_replaced_patches()`, `klp_module_going()`, and a comment block documenting the full `/sys/kernel/livepatch/...` sysfs layout
+- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_enable_patch()`, `klp_add_nops()`, `klp_unpatch_replaced_patches()`, `klp_module_going()`, the `if (klp_transition_patch) return -EBUSY;` guard shared by `__klp_enable_patch()`/`__klp_disable_patch()`, and a comment block documenting the full `/sys/kernel/livepatch/...` sysfs layout
 - [kernel/livepatch/patch.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.c) — `klp_patch_func()`/`klp_unpatch_func()`: pushing and popping `klp_func` entries on `ops->func_stack` via `list_add_rcu()`/`list_del_rcu()`
 - [kernel/livepatch/patch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.h) — `struct klp_ops` definition (`node`, `func_stack`, `fops`)
 - [Documentation/livepatch/cumulative-patches.rst](https://docs.kernel.org/livepatch/cumulative-patches.html) — the upstream usage guide for atomic replace, including the callback and shadow-variable limitations
@@ -344,7 +374,7 @@ violated.
 - [Kernel Live Patching](klp.md) — struct klp_func/klp_patch, ftrace redirection, shadow variables
 - [KLP State](klp-state.md) — the `struct klp_state`/`klp_get_state()` API referenced by `struct klp_patch`'s `.states` field
 - [Kernel Modules](../modules/module-basics.md) — KLP modules use the standard module infrastructure
-- [War Stories](war-stories.md) — a real incident from loading a cumulative patch while another was still transitioning
+- [War Stories](war-stories.md) — a real incident from shipping a "cumulative" patch that was missing `.replace = true`
 
 ### LWN articles
 

--- a/docs/livepatch/klp-cumulative.md
+++ b/docs/livepatch/klp-cumulative.md
@@ -260,7 +260,7 @@ cat /sys/kernel/livepatch/mypatch/vmlinux/patched
 # under the object — its mere presence is the signal, it has no attribute
 # files of its own:
 ls /sys/kernel/livepatch/mypatch/vmlinux/
-# patched  tcp_sendmsg,0
+# patched  tcp_sendmsg,1
 
 # old_addr is NOT exposed via sysfs
 # To find the original function address, use /proc/kallsyms:
@@ -332,11 +332,11 @@ violated.
 - [kernel/livepatch/patch.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.c) — `klp_patch_func()`/`klp_unpatch_func()`: pushing and popping `klp_func` entries on `ops->func_stack` via `list_add_rcu()`/`list_del_rcu()`
 - [kernel/livepatch/patch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.h) — `struct klp_ops` definition (`node`, `func_stack`, `fops`)
 - [Documentation/livepatch/cumulative-patches.rst](https://docs.kernel.org/livepatch/cumulative-patches.html) — the upstream usage guide for atomic replace, including the callback and shadow-variable limitations
-- [`e1452b607c48` — livepatch: Add atomic replace](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e1452b607c48c642caf57299f4da83aa002f8533) — Petr Mladek's commit adding the `.replace` field to `struct klp_patch`, merged for Linux 5.1
+- [`e1452b607c48` — livepatch: Add atomic replace](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e1452b607c48c642caf57299f4da83aa002f8533) — Jason Baron's commit (reworked/split by Petr Mladek) adding the `.replace` field to `struct klp_patch`, merged for Linux 5.1
 
 ### Man pages
 
-- [`rmmod(8)`](https://man7.org/linux/man-pages/man8/rmmod.8.html) — module removal; the `-f`/`--force` option bypasses the in-use refcount check this page warns against using on a still-enabled live patch
+- [`rmmod(8)`](https://man7.org/linux/man-pages/man8/rmmod.8.html) — module removal; the `-f`/`--force` option bypasses the in-use refcount check this page warns is dangerous — the danger applies to a still-enabled live patch just as to any in-use module
 
 ### Related pages
 

--- a/docs/livepatch/klp-cumulative.md
+++ b/docs/livepatch/klp-cumulative.md
@@ -186,15 +186,21 @@ public livepatch API exported via `EXPORT_SYMBOL_GPL` — `core.c` also exports
 `klp_shadow_alloc()`, `klp_shadow_get_or_alloc()`, `klp_shadow_free()`, and
 `klp_shadow_free_all()`, and `state.c` exports `klp_get_state()` and
 `klp_get_prev_state()`. A livepatch module's `module_exit` should be empty or
-omitted entirely — the livepatch core handles cleanup via `klp_module_going()`,
-which `kernel/module/main.c` calls directly during module load/unload state
-transitions (it is not registered on the module notifier chain):
+omitted entirely — the teardown already happened when the patch was disabled:
+`klp_complete_transition()` calls `klp_unpatch_objects()`, which unregisters
+each function's ftrace hook, and `klp_free_patch_async()` then frees the
+`struct klp_patch` and drops the module reference. There is nothing left to
+clean up by the time `rmmod` runs.
+
+(`klp_module_going()`, called directly by `kernel/module/main.c` during
+module load/unload — not via the module notifier chain — is a different
+mechanism: it reverts a patch applied to some *other*, target module that is
+itself being unloaded, not the livepatch module's own cleanup.)
 
 ```c
-/* Livepatch module exit: no explicit unregister needed.
- * The module loader calls klp_module_going() directly during the module's
- * exit path, and the livepatch core uses it to clean up when the module
- * is unloaded.
+/* Livepatch module exit: no explicit unregister needed. The transition
+ * already tore down the ftrace hooks and freed the patch when it was
+ * disabled below.
  * Before unloading, disable the patch via sysfs:
  *   echo 0 > /sys/kernel/livepatch/<patch>/enabled
  * Then: rmmod <patch_module>
@@ -243,7 +249,7 @@ enabled=0, transition=0 (disabled, can unload)
   │
   │  rmmod mypatch.ko
   ▼
-(patch removed, ftrace hooks cleaned up via klp_module_going)
+(patch module unloaded; ftrace hooks were already removed when the patch was disabled)
 ```
 
 ## Observing the func_stack
@@ -363,7 +369,7 @@ shipped without `.replace` and a superseded fix never reverted.
 ### Kernel source
 
 - [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_patch`, `struct klp_func`, `struct klp_object`, and the `KLP_TRANSITION_IDLE`/`KLP_TRANSITION_UNPATCHED`/`KLP_TRANSITION_PATCHED` task-state constants
-- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_enable_patch()`, `klp_add_nops()`, `klp_unpatch_replaced_patches()`, `klp_module_going()`, the `if (klp_transition_patch) return -EBUSY;` guard shared by `__klp_enable_patch()`/`__klp_disable_patch()`, and a comment block documenting the full `/sys/kernel/livepatch/...` sysfs layout
+- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_enable_patch()`, `klp_add_nops()`, `klp_unpatch_replaced_patches()`, `klp_module_going()` (reverts a patch on a target module being unloaded), the `if (klp_transition_patch) return -EBUSY;` guard shared by `__klp_enable_patch()`/`__klp_disable_patch()`, and a comment block documenting the full `/sys/kernel/livepatch/...` sysfs layout
 - [kernel/livepatch/patch.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.c) — `klp_patch_func()`/`klp_unpatch_func()`: pushing and popping `klp_func` entries on `ops->func_stack` via `list_add_rcu()`/`list_del_rcu()`
 - [kernel/livepatch/patch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.h) — `struct klp_ops` definition (`node`, `func_stack`, `fops`)
 - [Documentation/livepatch/cumulative-patches.rst](https://docs.kernel.org/livepatch/cumulative-patches.html) — the upstream usage guide for atomic replace, including the callback and shadow-variable limitations

--- a/docs/livepatch/klp-cumulative.md
+++ b/docs/livepatch/klp-cumulative.md
@@ -313,7 +313,7 @@ and the disable path bail out early if one already is:
 
 ```c
 /* kernel/livepatch/core.c — __klp_enable_patch() and __klp_disable_patch()
- * both open with the same guard */
+ * both bail out early on the same guard */
 if (klp_transition_patch)
         return -EBUSY;
 ```
@@ -321,8 +321,13 @@ if (klp_transition_patch)
 So loading a cumulative patch while another patch is still transitioning does
 not corrupt the `func_stack` — the `klp_enable_patch()` call from the new
 module's `init` returns `-EBUSY`, the `insmod` fails, and the module never
-loads. The same guard rejects an `echo 0 > .../enabled` issued during a
-transition. Checking first only saves you a failed deployment step:
+loads. The same guard rejects an `echo 0 > .../enabled` aimed at a *different*
+patch while one is transitioning — but not one aimed at the transitioning
+patch itself: `enabled_store()` routes that case to `klp_reverse_transition()`
+instead, deliberately reversing the in-flight transition rather than
+rejecting the write (see [KLP State](klp-state.md), which relies on exactly
+this to make its callbacks re-entrant). Checking first only saves you a
+failed deployment step on a genuinely different patch:
 
 ```bash
 # Avoid a spurious EBUSY: wait for any in-flight transition to finish

--- a/docs/livepatch/klp-state.md
+++ b/docs/livepatch/klp-state.md
@@ -25,7 +25,7 @@ But some patches change things that stack scanning cannot detect:
 
 In all of these cases, the patch author needs a way to run custom logic at
 the moment of transition — logic that the kernel cannot infer automatically.
-The `klp_state` API, added in Linux 5.8, provides exactly that.
+The `klp_state` API, added in Linux 5.5, provides exactly that.
 
 ## struct klp_state
 
@@ -93,6 +93,7 @@ struct klp_object {
     /* ... internal fields ... */
 };
 
+/* include/linux/livepatch_external.h */
 struct klp_callbacks {
     int  (*pre_patch)(struct klp_object *obj);
     void (*post_patch)(struct klp_object *obj);
@@ -124,7 +125,7 @@ The call order during a reverse transition (disabling a patch):
 Two helpers provide access to state data from within the callbacks:
 
 ```c
-/* kernel/livepatch/core.c */
+/* include/linux/livepatch.h (declared here; implemented in kernel/livepatch/state.c) */
 struct klp_state *klp_get_state(struct klp_patch *patch, unsigned long id);
 struct klp_state *klp_get_prev_state(unsigned long id);
 ```
@@ -157,6 +158,16 @@ The patch must quiesce all old-code users before the new code becomes active:
 /* id=1 identifies the subsystem lock state */
 #define SUBSYS_LOCK_STATE_ID  1UL
 
+/*
+ * Forward-declared: pre_patch_subsys() below needs to look up its own
+ * patch's state via klp_get_state(&subsys_patch, ...), but the full
+ * struct klp_patch definition (which needs the callbacks and objects
+ * defined first) only comes together at the end of the file -- the
+ * same order real livepatch modules use, e.g.
+ * samples/livepatch/livepatch-callbacks-demo.c.
+ */
+static struct klp_patch subsys_patch;
+
 static int pre_patch_subsys(struct klp_object *obj)
 {
     struct klp_state *state;
@@ -166,42 +177,52 @@ static int pre_patch_subsys(struct klp_object *obj)
         return -EINVAL;
 
     /*
-     * Acquire the subsystem's existing spinlock so no old-code caller
-     * is inside the critical section when the hooks go live.
-     * Store a flag so post_patch knows we succeeded.
+     * Briefly take the subsystem's existing spinlock just long enough
+     * to confirm no old-code caller is mid-critical-section, then
+     * release it immediately. The lock must NOT be held across the
+     * rest of the transition (steps 2-3 below): the consistency
+     * model's stack scan can take an unbounded amount of time while
+     * it waits for every task in the system, and holding a spinlock
+     * for that long is itself a correctness bug, not a safe pattern.
      */
     spin_lock(&subsys_spinlock);
-    state->data = (void *)1UL;   /* mark: lock held */
+    state->data = (void *)1UL;   /* mark: transition to mutex started */
+    spin_unlock(&subsys_spinlock);
 
-    /*
-     * Drain any async work that uses the old lock path.
-     * Return 0 to allow the transition to proceed.
-     */
     return 0;
 }
 
 static void post_patch_subsys(struct klp_object *obj)
 {
     /*
-     * At this point all tasks are running the new code path,
-     * which uses subsys_mutex.  Release the spinlock; from here
-     * on, only mutex_lock/mutex_unlock will be used.
+     * By the time post_patch runs, the consistency model has already
+     * confirmed that no task is still executing inside the old
+     * subsys_do_work() -- so nothing can still be holding
+     * subsys_spinlock across a call into it. Every caller from here
+     * on uses the new, mutex-based code path; there is no lock left
+     * to release here.
      */
-    spin_unlock(&subsys_spinlock);
 }
 
 static void pre_unpatch_subsys(struct klp_object *obj)
 {
     /*
-     * Reverse: acquire the mutex to drain new-code callers before
-     * the hooks are removed and old code (spinlock) resumes.
+     * Reverse transition: briefly take the mutex to confirm no
+     * new-code caller is mid-critical-section, then release it right
+     * away. As with pre_patch_subsys() above, the lock must not be
+     * held across the reverse transition itself.
      */
     mutex_lock(&subsys_mutex);
+    mutex_unlock(&subsys_mutex);
 }
 
 static void post_unpatch_subsys(struct klp_object *obj)
 {
-    mutex_unlock(&subsys_mutex);
+    /*
+     * The reverse transition has completed and the ftrace hooks are
+     * gone, so the original spinlock-based code is running again for
+     * every caller. There is nothing left to release here.
+     */
 }
 
 static struct klp_state subsys_states[] = {
@@ -239,9 +260,9 @@ static struct klp_patch subsys_patch = {
 ```
 
 If `pre_patch_subsys` returns a non-zero value — for example, because
-`subsys_spinlock` is held by a `TASK_UNINTERRUPTIBLE` caller that cannot be
-drained — `klp_enable_patch()` propagates that error to `insmod` and no hooks
-are installed. The system stays on the old code path with no partial state.
+`klp_get_state()` can't find the state entry it expects —
+`klp_enable_patch()` propagates that error to `insmod` and no hooks are
+installed. The system stays on the old code path with no partial state.
 
 ## klp_state and cumulative patches
 
@@ -251,12 +272,15 @@ the new patch can inherit the previous patch's state data via
 successive patch builds on the state established by its predecessor:
 
 ```c
+/* subsys_patch_v2: the new, replacing patch's own struct klp_patch,
+ * declared the same way subsys_patch was above -- omitted here for
+ * brevity. */
 static int pre_patch_v2(struct klp_object *obj)
 {
     struct klp_state *prev, *cur;
 
     prev = klp_get_prev_state(SUBSYS_LOCK_STATE_ID);
-    cur  = klp_get_state(&my_patch, SUBSYS_LOCK_STATE_ID);
+    cur  = klp_get_state(&subsys_patch_v2, SUBSYS_LOCK_STATE_ID);
 
     if (prev && prev->data) {
         /*
@@ -270,9 +294,19 @@ static int pre_patch_v2(struct klp_object *obj)
 }
 ```
 
-The `version` field assists compatibility checks: if `prev->version` is higher
-than the version the new patch understands, the new patch can reject the
-transition early in `pre_patch` rather than misinterpreting inherited data.
+The `version` field is what the kernel uses to decide compatibility —
+automatically, and before any of the patch's own code runs. When a patch is
+loaded, `klp_enable_patch()` calls `klp_is_patch_compatible()`
+(`kernel/livepatch/state.c`), which walks every state already modified by
+every currently-installed patch. For each such state, if the new patch also
+declares that state id, its `version` must be `>=` the already-installed
+version; if the new patch doesn't declare that state id at all, it's only
+compatible when the new patch is non-cumulative (a cumulative, `.replace =
+true` patch must account for every state a patch it replaces has already
+touched). If the check fails, `klp_enable_patch()` returns `-EINVAL`
+immediately — `pre_patch_v2()` above is never called, and `insmod` fails
+outright. The patch's own callbacks have no say in the decision; they only
+run once the kernel has already confirmed compatibility.
 
 ## Observing state
 
@@ -284,24 +318,44 @@ the patch module. To observe transition progress use the standard sysfs files:
 cat /sys/kernel/livepatch/<patch>/transition
 # 1 = in progress, 0 = complete
 
-# Was the transition forced (skipped consistency check)?
-cat /sys/kernel/livepatch/<patch>/forced
-# 0 = normal, 1 = forced
+# Force a stuck transition to finish immediately, skipping the rest of
+# the consistency check. This attribute is write-only -- there is no
+# way to read it back to find out whether a past transition was
+# forced; that's tracked only internally (struct klp_patch.forced).
+echo 1 > /sys/kernel/livepatch/<patch>/force
 ```
+
+Forcing a transition is a last resort: it clears every task's pending-patch
+flag outright, and once used, the patch module can never be removed
+(`rmmod`) again for the lifetime of the running kernel.
 
 If a `pre_patch` callback returns an error, `insmod` exits with a non-zero
 status and `dmesg` will contain a line like:
 
 ```
-livepatch: 'my_patch': pre_patch callback failed for object 'vmlinux': -EBUSY
+livepatch: pre-patch callback failed for object 'vmlinux'
 ```
 
 ## Further reading
 
+### Kernel source
+
+- [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_state`, `struct klp_object`, `struct klp_patch`, and the `klp_get_state()`/`klp_get_prev_state()` declarations
+- [include/linux/livepatch_external.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch_external.h) — `struct klp_callbacks`: the `pre_patch`/`post_patch`/`pre_unpatch`/`post_unpatch` hook table
+- [kernel/livepatch/state.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/state.c) — `klp_get_state()` and `klp_get_prev_state()` implementations, plus the automatic version-compatibility check (`klp_is_patch_compatible()`) run when a patch is loaded
+- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_enable_patch()`: where `pre_patch` is invoked before the ftrace hooks are installed, and how a non-zero return aborts the transition
+
+### Related pages
+
 - [KLP Consistency Model](klp-consistency.md) — stack scanning, per-task state, forced transitions
 - [Cumulative Patches and Atomic Replace](klp-cumulative.md) — `.replace=true`, `klp_get_prev_state()` in context
 - [Kernel Live Patching](klp.md) — `struct klp_func`, `struct klp_patch`, ftrace redirection
-- `include/linux/livepatch.h` — `struct klp_state`, `struct klp_object` callback declarations
-- `kernel/livepatch/core.c` — `klp_get_state()`, `klp_get_prev_state()`, `klp_free_patch_start()`
-- `Documentation/livepatch/callbacks.rst` — upstream documentation for transition callbacks
-- `Documentation/livepatch/system-state.rst` — upstream documentation for the klp_state API
+
+### LWN articles
+
+- [LWN: Live patching for CPU vulnerabilities](https://lwn.net/Articles/775264/) — Nicolai Stange's account of the L1TF/KPTI live patches, which had to flip global page-table semantics mid-transition using exactly the pre/post-patch callback pattern this page describes
+
+### External
+
+- [System State Changes — The Linux Kernel documentation](https://docs.kernel.org/livepatch/system-state.html) — upstream documentation for the `klp_state` API and its version-compatibility rules
+- [(Un)patching Callbacks — The Linux Kernel documentation](https://docs.kernel.org/livepatch/callbacks.html) — upstream documentation for `pre_patch`/`post_patch`/`pre_unpatch`/`post_unpatch` semantics and use cases

--- a/docs/livepatch/klp-state.md
+++ b/docs/livepatch/klp-state.md
@@ -458,6 +458,14 @@ needed" — is asking for. The robust form is to allocate in `pre_patch_v2()`
 (where failure can still abort the load), copy the *contents* in
 `post_patch_v2()`, and free the older patch's allocation there.
 
+Unlike the main example, this one does need a `post_unpatch_v2()`: if
+`pre_patch_v2()` allocates and the enable is later reversed before
+`post_patch_v2()` runs, that allocation has no other release point.
+`system-state.rst` notes `post_unpatch()` "typically does symmetric
+operations to `pre_patch()`" for exactly this reason — free here whatever
+`pre_patch_v2()` allocated, mirroring `pre_patch_subsys()`'s "clean up its own
+mess" obligation on error.
+
 The `version` field is what the kernel uses to decide compatibility —
 automatically, and before any of the patch's own code runs. When a patch is
 loaded, `klp_enable_patch()` calls `klp_is_patch_compatible()`

--- a/docs/livepatch/klp-state.md
+++ b/docs/livepatch/klp-state.md
@@ -163,10 +163,21 @@ The patch must quiesce all old-code users before the new code becomes active:
  * patch's state via klp_get_state(&subsys_patch, ...), but the full
  * struct klp_patch definition (which needs the callbacks and objects
  * defined first) only comes together at the end of the file -- the
- * same order real livepatch modules use, e.g.
- * samples/livepatch/livepatch-callbacks-demo.c.
+ * same end-of-file struct-definition order real livepatch modules
+ * use (most samples, e.g. samples/livepatch/livepatch-callbacks-demo.c,
+ * don't need a forward declaration since their callbacks don't
+ * reference their own patch struct by address, but a klp_state user
+ * that calls klp_get_state(&this_patch, ...) from pre_patch does).
  */
 static struct klp_patch subsys_patch;
+
+/* Pre-existing subsystem lock and state, declared elsewhere -- omitted
+ * here for brevity, the same way subsys_patch_v2 is omitted later on
+ * this page. */
+extern spinlock_t subsys_spinlock;
+extern bool subsys_use_mutex;
+/* New lock the patch introduces. */
+static DEFINE_MUTEX(subsys_mutex);
 
 static int pre_patch_subsys(struct klp_object *obj)
 {
@@ -179,14 +190,17 @@ static int pre_patch_subsys(struct klp_object *obj)
     /*
      * Briefly take the subsystem's existing spinlock just long enough
      * to confirm no old-code caller is mid-critical-section, then
-     * release it immediately. The lock must NOT be held across the
-     * rest of the transition (steps 2-3 below): the consistency
-     * model's stack scan can take an unbounded amount of time while
-     * it waits for every task in the system, and holding a spinlock
-     * for that long is itself a correctness bug, not a safe pattern.
+     * release it immediately. This is a quiescence check only -- the
+     * actual semantic switch-over happens in post_patch_subsys(),
+     * once the consistency transition has confirmed every task is off
+     * the old code. The lock must NOT be held across the rest of the
+     * transition (steps 2-3): the consistency model's stack scan can
+     * take an unbounded amount of time while it waits for every task
+     * in the system, and holding a spinlock for that long is itself a
+     * correctness bug, not a safe pattern.
      */
     spin_lock(&subsys_spinlock);
-    state->data = (void *)1UL;   /* mark: transition to mutex started */
+    state->data = (void *)1UL;   /* mark: quiesced, ready for post_patch */
     spin_unlock(&subsys_spinlock);
 
     return 0;
@@ -198,10 +212,15 @@ static void post_patch_subsys(struct klp_object *obj)
      * By the time post_patch runs, the consistency model has already
      * confirmed that no task is still executing inside the old
      * subsys_do_work() -- so nothing can still be holding
-     * subsys_spinlock across a call into it. Every caller from here
-     * on uses the new, mutex-based code path; there is no lock left
-     * to release here.
+     * subsys_spinlock across a call into it. This is where the actual
+     * semantic hand-off happens: publish that mutex-based accessors
+     * are now the only ones in use, per the upstream guidance to
+     * modify system state in post_patch() rather than pre_patch()
+     * (Documentation/livepatch/system-state.rst).
      */
+    mutex_lock(&subsys_mutex);
+    subsys_use_mutex = true;
+    mutex_unlock(&subsys_mutex);
 }
 
 static void pre_unpatch_subsys(struct klp_object *obj)
@@ -210,7 +229,9 @@ static void pre_unpatch_subsys(struct klp_object *obj)
      * Reverse transition: briefly take the mutex to confirm no
      * new-code caller is mid-critical-section, then release it right
      * away. As with pre_patch_subsys() above, the lock must not be
-     * held across the reverse transition itself.
+     * held across the reverse transition itself, and the actual
+     * hand-back to spinlock-based accessors happens in
+     * post_unpatch_subsys() below.
      */
     mutex_lock(&subsys_mutex);
     mutex_unlock(&subsys_mutex);
@@ -221,8 +242,11 @@ static void post_unpatch_subsys(struct klp_object *obj)
     /*
      * The reverse transition has completed and the ftrace hooks are
      * gone, so the original spinlock-based code is running again for
-     * every caller. There is nothing left to release here.
+     * every caller. Publish that hand-back now that it's safe.
      */
+    spin_lock(&subsys_spinlock);
+    subsys_use_mutex = false;
+    spin_unlock(&subsys_spinlock);
 }
 
 static struct klp_state subsys_states[] = {
@@ -281,6 +305,8 @@ static int pre_patch_v2(struct klp_object *obj)
 
     prev = klp_get_prev_state(SUBSYS_LOCK_STATE_ID);
     cur  = klp_get_state(&subsys_patch_v2, SUBSYS_LOCK_STATE_ID);
+    if (!cur)
+        return -EINVAL;
 
     if (prev && prev->data) {
         /*

--- a/docs/livepatch/klp-state.md
+++ b/docs/livepatch/klp-state.md
@@ -12,10 +12,11 @@ old function body, it is safe to switch everyone to the new one.
 
 But some patches change things that stack scanning cannot detect:
 
-- A patch that changes the layout of a lock embedded in a shared data
-  structure: old code holds a `spinlock_t` at offset 0; new code expects a
-  `mutex` there. Even after all stacks are clear, concurrent code may still
-  be reading or writing the old layout.
+- A patch that changes which lock protects a shared structure: old code takes
+  a `spinlock_t`, new code wants to hold a `mutex` so the critical section can
+  sleep. The consistency model deliberately runs old and new code side by side
+  until the last task has switched, and during that window neither lock
+  excludes the other.
 - A patch that adds a new field to a structure accessed by both old and new
   code. Until all callers are using the new code path, some callers will read
   the new field while others still ignore it.
@@ -111,14 +112,24 @@ The call order during a forward transition (applying a patch):
 2. ftrace hooks are installed; tasks begin seeing the new function.
 3. The consistency transition runs (stack scanning, per-task state updates).
 4. `post_patch(obj)` — called after the transition completes and the patch is
-   fully active. Errors here are logged but do not reverse the patch.
+   fully active. Note the signature above: it returns `void`. By this point
+   the patch is applied and there is no mechanism to back out, so a
+   `post_patch` callback has no way to report failure and must be written so
+   that it cannot fail.
 
 The call order during a reverse transition (disabling a patch):
 
-1. `pre_unpatch(obj)` — called before the reverse transition begins.
+1. `pre_unpatch(obj)` — called from `__klp_disable_patch()`
+   (`kernel/livepatch/core.c`) *before* `klp_start_transition()`, so it runs
+   while every task is still executing patched code.
 2. The reverse transition runs.
-3. ftrace hooks are removed.
-4. `post_unpatch(obj)` — called after the patch is fully removed.
+3. ftrace hooks are removed — `klp_complete_transition()` calls
+   `klp_unpatch_objects()` (`kernel/livepatch/transition.c`).
+4. `post_unpatch(obj)` — called at the end of `klp_complete_transition()`,
+   after step 3, so the patched code is already unreachable by the time it
+   runs. It only fires if this object's `pre_patch` callback previously
+   succeeded: `klp_pre_patch_callback()` records that in the
+   `post_unpatch_enabled` flag (`kernel/livepatch/core.h`).
 
 ## klp_get_state() and klp_get_prev_state()
 
@@ -133,51 +144,121 @@ struct klp_state *klp_get_prev_state(unsigned long id);
 `klp_get_state(patch, id)` returns the `klp_state` with the given `id` from
 `patch->states`. It returns `NULL` if no state with that id exists.
 
-`klp_get_prev_state(id)` searches for a `klp_state` with the given `id` in the
-*previously active* patch — the patch that the current patch is replacing. This
-is intended for cumulative patches that need to inherit state (counters, flags,
-allocated data) from the patch they supersede.
+`klp_get_prev_state(id)` searches the *already installed* patches for a
+`klp_state` with the given `id`. It walks the global patch list in order,
+stops when it reaches the patch that is currently transitioning
+(`klp_transition_patch`), and returns the **last** match found along the way —
+not simply "the previous patch". More than one older patch can declare the
+same id; the kernel-doc in `kernel/livepatch/state.c` notes that "the same
+system state can be modified by more non-cumulative livepatches" and that "it
+is expected that the latest livepatch has the most up-to-date information".
+This is what a cumulative patch uses to inherit state (counters, flags,
+allocated data) from the patches it supersedes.
 
-Both functions must be called with `klp_mutex` held, which is guaranteed inside
-all four transition callbacks.
+Neither function takes or asserts `klp_mutex`; their real preconditions
+differ. `klp_get_state()` is a plain walk of `patch->states`, and its
+kernel-doc says it "can be called either from pre/post (un)patch callbacks or
+from the kernel code added by the livepatch". `klp_get_prev_state()` is
+stricter: it reads the global `klp_transition_patch` and opens with
+`WARN_ON_ONCE(!klp_transition_patch)`, returning `NULL` if it is unset. It may
+therefore only be called while a transition is actually in progress — in
+practice, from inside the callbacks, and not from patched code at runtime.
 
-## Example: patching a spinlock to a mutex
+## Example: switching a subsystem from a spinlock to a mutex
 
-Consider a subsystem that currently uses a `spinlock_t` to protect a shared
-table. A patch needs to change that to a `mutex` to allow sleeping inside the
-critical section. The old and new code cannot coexist: if old code holds the
-spinlock while new code tries to lock the mutex (at the same address), the
-result is undefined behavior.
+Consider a subsystem whose shared table is protected by `subsys_spinlock`. A
+patch wants a `mutex` instead, so the critical section can sleep. The two lock
+disciplines cannot simply be swapped over: for as long as the transition is
+running, some tasks are on old code and some are on new code, so an old-code
+caller holding `subsys_spinlock` and a new-code caller holding `subsys_mutex`
+would each believe it owns the table.
 
-The patch must quiesce all old-code users before the new code becomes active:
+No callback can make that window disappear — the mixed window is the
+consistency model working as designed. What the callbacks *can* do is make the
+new code cope with the window and then retire it. That is the pattern
+`Documentation/livepatch/system-state.rst` §4 prescribes, and the one Nicolai
+Stange's L1TF/KPTI live patches used:
+
+1. Patch every accessor so it can handle **both** the old and the new
+   semantics, selected at runtime by a flag. While the flag is clear, the new
+   accessor keeps obeying the old locking rules.
+2. Let the transition finish. Only then, from `post_patch()`, set the flag.
+   Because the consistency model guarantees no task is on old code by that
+   point, an old-code caller can never observe the new semantics.
+3. On the way out, clear the flag from `pre_unpatch()` — which runs *before*
+   the reverse transition starts, while every task is still on new code — so
+   no task can be back on old code while the new semantics are still live.
+
+The flag itself must be read and written under a lock that actually excludes
+the callers it arbitrates. Here that lock is `subsys_mutex`, which the patched
+accessor holds across both the flag read and the table access in *either*
+mode, so a flip can never land in the middle of a critical section.
+
+This also assumes every caller of `subsys_do_work()` is allowed to sleep —
+which it must be, or wanting a mutex there would make no sense in the first
+place.
 
 ```c
 #include <linux/livepatch.h>
 #include <linux/mutex.h>
+#include <linux/spinlock.h>
 
-/* id=1 identifies the subsystem lock state */
+/* id=1 identifies "the subsystem table's lock discipline" */
 #define SUBSYS_LOCK_STATE_ID  1UL
 
 /*
- * Forward-declared: pre_patch_subsys() below needs to look up its own
- * patch's state via klp_get_state(&subsys_patch, ...), but the full
- * struct klp_patch definition (which needs the callbacks and objects
- * defined first) only comes together at the end of the file -- the
- * same end-of-file struct-definition order real livepatch modules
- * use (most samples, e.g. samples/livepatch/livepatch-callbacks-demo.c,
- * don't need a forward declaration since their callbacks don't
- * reference their own patch struct by address, but a klp_state user
- * that calls klp_get_state(&this_patch, ...) from pre_patch does).
+ * Forward-declared: the callbacks below look up their own patch's state
+ * via klp_get_state(&subsys_patch, ...), but the full struct klp_patch
+ * definition (which needs the callbacks and objects defined first) only
+ * comes together at the end of the file -- the same end-of-file
+ * struct-definition order real livepatch modules use (most samples, e.g.
+ * samples/livepatch/livepatch-callbacks-demo.c, don't need a forward
+ * declaration since their callbacks don't reference their own patch
+ * struct by address, but a klp_state user that calls
+ * klp_get_state(&this_patch, ...) does).
  */
 static struct klp_patch subsys_patch;
 
-/* Pre-existing subsystem lock and state, declared elsewhere -- omitted
- * here for brevity, the same way subsys_patch_v2 is omitted later on
- * this page. */
+/*
+ * Pre-existing vmlinux symbols the patch module reaches through KLP
+ * relocations -- their definitions are omitted here for brevity, the same
+ * way subsys_patch_v2 is omitted later on this page.
+ */
 extern spinlock_t subsys_spinlock;
-extern bool subsys_use_mutex;
-/* New lock the patch introduces. */
+extern void subsys_update_table(void);       /* the existing, atomic update */
+extern void subsys_update_table_slow(void);  /* may sleep; the point of the patch */
+
+/* Everything below is new and lives in the patch module. */
 static DEFINE_MUTEX(subsys_mutex);
+
+/*
+ * false = mixed mode. Unpatched code may still be running and still guards
+ *         the table with subsys_spinlock alone, so the patched accessor
+ *         must take it too, and must not sleep.
+ * true  = the forward transition is complete and only patched code is live,
+ *         so subsys_mutex alone suffices and the critical section may sleep.
+ *
+ * Read and written ONLY under subsys_mutex. See the note after this listing.
+ */
+static bool subsys_use_mutex;
+
+/* Replacement for subsys_do_work(): implements both semantics. */
+static void patched_subsys_do_work(void)
+{
+    mutex_lock(&subsys_mutex);
+
+    if (!subsys_use_mutex) {
+        /* Mixed mode: interlock with the still-live original code. */
+        spin_lock(&subsys_spinlock);
+        subsys_update_table();
+        spin_unlock(&subsys_spinlock);
+    } else {
+        /* Only patched callers remain; the mutex alone is enough. */
+        subsys_update_table_slow();
+    }
+
+    mutex_unlock(&subsys_mutex);
+}
 
 static int pre_patch_subsys(struct klp_object *obj)
 {
@@ -188,66 +269,71 @@ static int pre_patch_subsys(struct klp_object *obj)
         return -EINVAL;
 
     /*
-     * Briefly take the subsystem's existing spinlock just long enough
-     * to confirm no old-code caller is mid-critical-section, then
-     * release it immediately. This is a quiescence check only -- the
-     * actual semantic switch-over happens in post_patch_subsys(),
-     * once the consistency transition has confirmed every task is off
-     * the old code. The lock must NOT be held across the rest of the
-     * transition (steps 2-3): the consistency model's stack scan can
-     * take an unbounded amount of time while it waits for every task
-     * in the system, and holding a spinlock for that long is itself a
-     * correctness bug, not a safe pattern.
+     * pre_patch() prepares; it must not change the semantics yet, because
+     * the original code is still live and cannot cope with mutex-only
+     * locking. Record only that the hand-off has not happened.
      */
-    spin_lock(&subsys_spinlock);
-    state->data = (void *)1UL;   /* mark: quiesced, ready for post_patch */
-    spin_unlock(&subsys_spinlock);
+    state->data = (void *)0UL;
 
     return 0;
 }
 
+/*
+ * post_patch() and pre_unpatch() can dereference the lookup without a NULL
+ * check: neither runs for an object whose pre_patch() returned an error
+ * (kernel/livepatch/core.c and core.h), and pre_patch_subsys() already
+ * refused the patch if the state was missing.
+ */
 static void post_patch_subsys(struct klp_object *obj)
 {
+    struct klp_state *state = klp_get_state(&subsys_patch,
+                                            SUBSYS_LOCK_STATE_ID);
+
     /*
-     * By the time post_patch runs, the consistency model has already
-     * confirmed that no task is still executing inside the old
-     * subsys_do_work() -- so nothing can still be holding
-     * subsys_spinlock across a call into it. This is where the actual
-     * semantic hand-off happens: publish that mutex-based accessors
-     * are now the only ones in use, per the upstream guidance to
-     * modify system state in post_patch() rather than pre_patch()
-     * (Documentation/livepatch/system-state.rst).
+     * The transition is complete: no task is executing the original
+     * subsys_do_work() any more, so nothing can still be guarding the
+     * table with subsys_spinlock alone. Taking subsys_mutex waits out any
+     * patched caller already inside its critical section, so the flip
+     * cannot land between a caller's flag read and its table access --
+     * both happen inside one mutex hold.
+     *
+     * post_patch() runs in process context, from klp_complete_transition()
+     * on either the enabling task or the transition workqueue, so sleeping
+     * on the mutex here is allowed.
      */
     mutex_lock(&subsys_mutex);
     subsys_use_mutex = true;
+    state->data = (void *)1UL;   /* hand-off done */
     mutex_unlock(&subsys_mutex);
 }
 
 static void pre_unpatch_subsys(struct klp_object *obj)
 {
+    struct klp_state *state = klp_get_state(&subsys_patch,
+                                            SUBSYS_LOCK_STATE_ID);
+
     /*
-     * Reverse transition: briefly take the mutex to confirm no
-     * new-code caller is mid-critical-section, then release it right
-     * away. As with pre_patch_subsys() above, the lock must not be
-     * held across the reverse transition itself, and the actual
-     * hand-back to spinlock-based accessors happens in
-     * post_unpatch_subsys() below.
+     * Symmetric to post_patch_subsys(), and it has to run *here*:
+     * __klp_disable_patch() calls pre_unpatch before klp_start_transition(),
+     * while every task is still on patched code. Clearing the flag now means
+     * that by the time any task is back on the original spinlock-only code,
+     * every remaining patched caller is taking subsys_spinlock again too.
      */
     mutex_lock(&subsys_mutex);
+    subsys_use_mutex = false;
+    state->data = (void *)0UL;
     mutex_unlock(&subsys_mutex);
 }
 
-static void post_unpatch_subsys(struct klp_object *obj)
-{
-    /*
-     * The reverse transition has completed and the ftrace hooks are
-     * gone, so the original spinlock-based code is running again for
-     * every caller. Publish that hand-back now that it's safe.
-     */
-    spin_lock(&subsys_spinlock);
-    subsys_use_mutex = false;
-    spin_unlock(&subsys_spinlock);
-}
+/*
+ * There is deliberately no post_unpatch callback. klp_complete_transition()
+ * calls klp_unpatch_objects() -- tearing down the ftrace redirection -- before
+ * it invokes the post_unpatch callbacks, so by then nothing can be executing
+ * patched_subsys_do_work() and a flag write there would be dead code. The
+ * revert already happened in pre_unpatch_subsys(), which is exactly the
+ * symmetry Documentation/livepatch/system-state.rst describes: pre_unpatch()
+ * mirrors post_patch(), and post_unpatch() "might mean doing nothing".
+ */
 
 static struct klp_state subsys_states[] = {
     { .id = SUBSYS_LOCK_STATE_ID, .version = 1 },
@@ -267,10 +353,10 @@ static struct klp_object subsys_objs[] = {
         .name  = NULL,   /* vmlinux */
         .funcs = subsys_funcs,
         .callbacks = {
-            .pre_patch    = pre_patch_subsys,
-            .post_patch   = post_patch_subsys,
-            .pre_unpatch  = pre_unpatch_subsys,
-            .post_unpatch = post_unpatch_subsys,
+            .pre_patch   = pre_patch_subsys,
+            .post_patch  = post_patch_subsys,
+            .pre_unpatch = pre_unpatch_subsys,
+            /* .post_unpatch deliberately unset -- see above */
         },
     },
     { }
@@ -282,6 +368,26 @@ static struct klp_patch subsys_patch = {
     .states = subsys_states,
 };
 ```
+
+The whole protocol rests on one rule: `subsys_use_mutex` is read and written
+only under `subsys_mutex`, and the accessor holds that mutex across both the
+read and the table access. Publishing the flip under some other lock — or
+reading the flag outside the mutex — reopens exactly the race it exists to
+close: a caller could read `false`, be preempted before reaching
+`spin_lock()`, and resume after the flip, while a second caller that read
+`true` is already inside the mutex-only critical section. Both would then be
+touching the table at once. Because the flip has to acquire the same mutex the
+accessor holds for its whole critical section, that interleaving is
+unreachable.
+
+The design also survives a reversed transition, which the callbacks get for
+free. If the forward transition is reversed before it completes (`echo 0 >
+.../enabled` while `transition` still reads 1), `post_patch` never ran, so the
+flag was never set and there is nothing to undo. If a *disable* is reversed
+back to patching, `pre_unpatch` has already cleared the flag and
+`klp_complete_transition()` runs `post_patch` again on the way back in, which
+re-establishes it — under the mutex, after the consistency model has again
+confirmed no task is on old code.
 
 If `pre_patch_subsys` returns a non-zero value — for example, because
 `klp_get_state()` can't find the state entry it expects —
@@ -295,30 +401,62 @@ the new patch can inherit the previous patch's state data via
 `klp_get_prev_state()`. This allows multi-version migrations where each
 successive patch builds on the state established by its predecessor:
 
+The inheritance itself belongs in `post_patch()`, not `pre_patch()`.
+`system-state.rst` §4 lists "Copy *state->data* from the previous livepatch
+when they are compatible" under `post_patch()`, for the same reason the main
+example flips its flag there: until the transition completes, the older
+patch's code is still live and still owns the state it is describing.
+`pre_patch()` is where allocation goes, because it is the only callback that
+can still refuse the load.
+
 ```c
 /* subsys_patch_v2: the new, replacing patch's own struct klp_patch,
  * declared the same way subsys_patch was above -- omitted here for
  * brevity. */
 static int pre_patch_v2(struct klp_object *obj)
 {
-    struct klp_state *prev, *cur;
+    struct klp_state *cur;
 
-    prev = klp_get_prev_state(SUBSYS_LOCK_STATE_ID);
-    cur  = klp_get_state(&subsys_patch_v2, SUBSYS_LOCK_STATE_ID);
+    cur = klp_get_state(&subsys_patch_v2, SUBSYS_LOCK_STATE_ID);
     if (!cur)
         return -EINVAL;
 
-    if (prev && prev->data) {
-        /*
-         * The previous patch left a counter or flag in prev->data.
-         * Inherit it so the new patch can continue from the same point.
-         */
-        cur->data = prev->data;
-    }
-
+    /*
+     * Allocate anything the new state format needs here -- this is the
+     * only callback that can still fail the load. Do NOT take over the
+     * previous patch's state yet: its code is still running.
+     */
     return 0;
 }
+
+static void post_patch_v2(struct klp_object *obj)
+{
+    struct klp_state *prev, *cur;
+
+    cur  = klp_get_state(&subsys_patch_v2, SUBSYS_LOCK_STATE_ID);
+    prev = klp_get_prev_state(SUBSYS_LOCK_STATE_ID);
+
+    /*
+     * klp_get_prev_state() still works here: klp_complete_transition()
+     * clears klp_transition_patch only *after* running the post_patch
+     * callbacks, and the replaced patches are not freed until it returns.
+     */
+    if (prev)
+        cur->data = prev->data;
+}
 ```
+
+Copying `prev->data` verbatim is only safe when it carries a *value*, as the
+encoded flag in the earlier example does. If the older patch stored a pointer,
+ownership has to be settled explicitly. Once the atomic replace completes the
+older patch is disabled and its module can be unloaded: a `state->data` that
+points into that module's own storage becomes a dangling pointer, and memory
+it had allocated becomes a leak that only the new patch is still in a position
+to release. That is what `system-state.rst`'s remaining `post_patch()` bullet
+— "Free *state->data* from replaces livepatches when they are not longer
+needed" — is asking for. The robust form is to allocate in `pre_patch_v2()`
+(where failure can still abort the load), copy the *contents* in
+`post_patch_v2()`, and free the older patch's allocation there.
 
 The `version` field is what the kernel uses to decide compatibility —
 automatically, and before any of the patch's own code runs. When a patch is
@@ -352,8 +490,21 @@ echo 1 > /sys/kernel/livepatch/<patch>/force
 ```
 
 Forcing a transition is a last resort: it clears every task's pending-patch
-flag outright, and once used, the patch module can never be removed
-(`rmmod`) again for the lifetime of the running kernel.
+flag outright, and it permanently pins whichever patch modules it marks.
+Which patch gets marked depends on what was being forced —
+`klp_force_transition()` (`kernel/livepatch/transition.c`) sets
+`forced = true` on:
+
+- the patch being disabled, when a *disable* (unpatch) transition is forced;
+- every **other** installed patch — the ones being replaced — when the enable
+  of a cumulative (`.replace = true`) patch is forced, but not on the new
+  patch itself;
+- nothing at all, when the enable of a non-cumulative patch is forced.
+
+`klp_free_patch_finish()` (`kernel/livepatch/core.c`) then skips the
+`module_put()` for any patch with `forced` set, so that module's reference
+count never falls back to zero and `rmmod` on it fails for the lifetime of the
+running kernel.
 
 If a `pre_patch` callback returns an error, `insmod` exits with a non-zero
 status and `dmesg` will contain a line like:

--- a/docs/livepatch/klp.md
+++ b/docs/livepatch/klp.md
@@ -17,7 +17,7 @@ Before patch:           After patch:
                                         └─► executes patch
 ```
 
-The original function's first bytes are never modified. The ftrace hook at function entry branches to the replacement.
+The original function's body is never rewritten and no jump is inserted into it. KLP reuses the ftrace call site the compiler already emitted at function entry (via `-fentry`/`-mfentry`), and `klp_ftrace_handler()` redirects execution by changing the saved instruction pointer, not by patching code.
 
 ## Architecture
 
@@ -57,7 +57,8 @@ struct klp_patch {
     struct kobject       kobj;
     struct list_head    obj_list;
     bool                 enabled;
-    bool                 forced;    /* forced (skipped consistency check) */
+    bool                 forced;    /* was involved in a forced transition —
+                                        module can never be unloaded */
     struct work_struct   free_work;
     struct completion    finish;
 };

--- a/docs/livepatch/klp.md
+++ b/docs/livepatch/klp.md
@@ -26,38 +26,54 @@ The original function's first bytes are never modified. The ftrace hook at funct
 
 /* Describes one patched function */
 struct klp_func {
-    const char      *old_name;      /* name of function to patch */
-    void            *new_func;      /* replacement function */
-    unsigned long    old_sympos;    /* which occurrence (for duplicates) */
-    unsigned long    old_addr;      /* resolved at patch time */
-    struct kobject   kobj;
-    struct list_head node;
-    struct list_head stack_node;     /* position in klp_ops->func_stack */
-    bool             nop;           /* no-op patch (for rollback testing) */
-    bool             patched;       /* currently active */
-    bool             transition;    /* in consistency transition */
+    /* external */
+    const char       *old_name;     /* name of function to patch */
+    void             *new_func;     /* replacement function */
+    unsigned long     old_sympos;   /* which occurrence (for duplicates) */
+
+    /* internal */
+    void             *old_func;     /* resolved via kallsyms at patch time */
+    struct kobject    kobj;
+    struct list_head  node;         /* list node for klp_object->func_list */
+    struct list_head  stack_node;   /* position in klp_ops->func_stack */
+    unsigned long     old_size, new_size;  /* sizes of old/new function */
+    bool              nop;          /* no-op patch (for rollback testing) */
+    bool              patched;      /* currently active */
+    bool              transition;   /* in consistency transition */
 };
 
 /* A set of functions that form one complete patch */
 struct klp_patch {
-    struct module   *mod;           /* the live patch module */
+    /* external */
+    struct module     *mod;         /* the live patch module */
     struct klp_object *objs;        /* array of objects (modules/vmlinux) */
-    bool             enabled;
-    bool             forced;        /* forced (skipped consistency check) */
-    struct work_struct free_work;
-    struct completion finish;
-    struct kobject   kobj;
-    struct list_head list;
+    struct klp_state  *states;      /* system states the patch may modify (klp-state.md) */
+    bool               replace;     /* atomic-replace: supersede other patches (klp-cumulative.md) */
+
+    /* internal */
+    struct list_head    list;
+    struct kobject       kobj;
+    struct list_head    obj_list;
+    bool                 enabled;
+    bool                 forced;    /* forced (skipped consistency check) */
+    struct work_struct   free_work;
+    struct completion    finish;
 };
 
 /* Functions grouped by the kernel module (or vmlinux) they patch */
 struct klp_object {
-    const char      *name;          /* NULL for vmlinux */
-    struct klp_func *funcs;         /* array of functions to patch */
-    struct module   *mod;           /* resolved target module */
-    struct kobject   kobj;
-    struct list_head node;
-    bool             dynamic;       /* for dynamically added funcs */
+    /* external */
+    const char           *name;      /* NULL for vmlinux */
+    struct klp_func       *funcs;    /* array of functions to patch */
+    struct klp_callbacks  callbacks; /* pre/post-(un)patch hooks */
+
+    /* internal */
+    struct kobject       kobj;
+    struct list_head     func_list;  /* dynamic list of func entries */
+    struct list_head     node;
+    struct module        *mod;       /* resolved target module */
+    bool                  dynamic;   /* for dynamically added funcs */
+    bool                  patched;
 };
 ```
 
@@ -127,52 +143,79 @@ apply only the targeted fix.
 
 ## ftrace-based redirection
 
-KLP uses ftrace's `FTRACE_OPS_FL_SAVE_REGS` to redirect function calls:
+KLP registers an `ftrace_ops` per patched function with `FTRACE_OPS_FL_IPMODIFY`
+(permission to change the instruction pointer) and `klp_ftrace_handler()` redirects
+execution to whichever patch is on top of the target function's `func_stack`:
 
 ```c
 /* kernel/livepatch/patch.c */
 static void notrace klp_ftrace_handler(unsigned long ip,
-                                         unsigned long parent_ip,
-                                         struct ftrace_ops *fops,
-                                         struct ftrace_regs *fregs)
+                                        unsigned long parent_ip,
+                                        struct ftrace_ops *fops,
+                                        struct ftrace_regs *fregs)
 {
     struct klp_ops *ops;
     struct klp_func *func;
     int patch_state;
+    int bit;
 
     ops = container_of(fops, struct klp_ops, fops);
 
-    /* Find the active patch for this function */
-    func = list_first_or_null_rcu(&ops->func_stack, struct klp_func, stack_node);
-    if (!func)
+    /* Recursion guard (also needed for the RCU-less sync variant below) */
+    bit = ftrace_test_recursion_trylock(ip, parent_ip);
+    if (WARN_ON_ONCE(bit < 0))
         return;
 
-    /* Check consistency: is this task in a safe state? */
-    patch_state = current->patch_state;
-    if (patch_state == KLP_UNDEFINED)
-        patch_state = current->patch_state = KLP_UNPATCHED;
+    /* Top of func_stack is the most recently applied patch for this function */
+    func = list_first_or_null_rcu(&ops->func_stack, struct klp_func, stack_node);
+    if (WARN_ON_ONCE(!func))
+        goto unlock;
 
-    if (func->transition) {
-        if (patch_state == KLP_UNPATCHED)
-            return;  /* task not yet transitioned */
+    if (unlikely(func->transition)) {
+        patch_state = current->patch_state;
+        WARN_ON_ONCE(patch_state == KLP_TRANSITION_IDLE);
+
+        if (patch_state == KLP_TRANSITION_UNPATCHED) {
+            /*
+             * This task hasn't transitioned yet. Fall back to the
+             * next-oldest patch still on the stack (if any); with no
+             * older patch, fall through to the original function.
+             */
+            func = list_entry_rcu(func->stack_node.next,
+                                   struct klp_func, stack_node);
+            if (&func->stack_node == &ops->func_stack)
+                goto unlock;
+        }
     }
 
-    /* Redirect: change IP to point to patched function */
-    klp_arch_set_pc(fregs, (unsigned long)func->new_func);
+    /* NOPs restore the original code — leave the instruction pointer alone */
+    if (func->nop)
+        goto unlock;
+
+    ftrace_regs_set_instruction_pointer(fregs, (unsigned long)func->new_func);
+
+unlock:
+    ftrace_test_recursion_unlock(bit);
 }
 ```
+
+Because `func_stack` is a stack, this is also how patch **stacking** works: if
+patch B is applied on top of patch A and a task hasn't transitioned to B yet,
+the handler walks past B to A's version of the function rather than the
+original — so already-patched behavior from A is preserved during B's
+transition.
 
 ## The consistency model
 
 KLP can't simply redirect calls immediately — a task might be in the middle of executing the old function. The **consistency model** ensures all tasks have transitioned before the patch is considered active:
 
 ```
-State: KLP_UNPATCHED → (patch applied) → KLP_PATCHED
+State: KLP_TRANSITION_UNPATCHED → (patch applied) → KLP_TRANSITION_PATCHED
 
 For each task:
-  1. When task returns to userspace (schedule point), mark as KLP_PATCHED
-  2. Tasks already in kernel get KLP_PATCHED at their next schedule
-  3. Until all tasks are KLP_PATCHED, the patch is in "transition" state
+  1. When task returns to userspace (schedule point), mark as KLP_TRANSITION_PATCHED
+  2. Tasks already in kernel get KLP_TRANSITION_PATCHED at their next schedule
+  3. Until all tasks are KLP_TRANSITION_PATCHED, the patch is in "transition" state
 
 During transition:
   - New task entries: use new (patched) function
@@ -262,9 +305,10 @@ for p in /sys/kernel/livepatch/*/; do
     echo "  transition: $(cat $p/transition)"
 done
 
-# Which functions are patched
-cat /sys/kernel/livepatch/*/objs/*/funcs/*/patched
-cat /sys/kernel/livepatch/*/objs/*/funcs/*/old_addr
+# Which objects (vmlinux or a module) are patched
+cat /sys/kernel/livepatch/*/*/patched
+# Note: the per-function directory (<object>/<function,sympos>/) exists but
+# currently exposes no attributes of its own.
 
 # Kernel taint from live patch
 cat /proc/sys/kernel/tainted
@@ -279,8 +323,31 @@ dmesg | grep livepatch
 
 ## Further reading
 
-- [kexec](kexec.md) — loading and booting a new kernel
-- [Kernel Modules](../modules/module-basics.md) — KLP uses the module system
-- [Tracing: ftrace](../tracing/ftrace.md) — ftrace function hooks used by KLP
-- `kernel/livepatch/` in the kernel tree — KLP implementation
-- `Documentation/livepatch/` in the kernel tree
+### Kernel source
+
+- [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_func`, `struct klp_object`, `struct klp_patch`, and the `klp_shadow_*()` prototypes
+- [kernel/livepatch/patch.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.c) — `klp_ftrace_handler()`, the ftrace ops registration (`FTRACE_OPS_FL_IPMODIFY`), and the func-stack redirection logic
+- [kernel/livepatch/transition.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/transition.c) — the consistency-model state machine, `klp_try_complete_transition()`, and `klp_send_signals()`
+- [kernel/livepatch/shadow.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/shadow.c) — the shadow-variable hash table and the `klp_shadow_alloc()`/`klp_shadow_get()`/`klp_shadow_free()` implementation
+- [samples/livepatch/livepatch-sample.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/samples/livepatch/livepatch-sample.c) — the canonical minimal live patch module (patches `cmdline_proc_show`)
+- [Documentation/ABI/testing/sysfs-kernel-livepatch](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/ABI/testing/sysfs-kernel-livepatch) — the authoritative `/sys/kernel/livepatch/` attribute list (`enabled`, `transition`, `force`, `replace`, `stack_order`, and per-object `patched`)
+
+### Related pages
+
+- [KLP Consistency Model](klp-consistency.md) — deep dive on per-task patch state, stack checking, and the transition workqueue
+- [Cumulative Patches and Atomic Replace](klp-cumulative.md) — patch stacking, `.replace`, and `struct klp_ops`
+- [KLP State: Custom Consistency Checks](klp-state.md) — the `klp_state` API for consistency checks beyond stack scanning
+- [kexec](kexec.md) — loading and booting a new kernel, the alternative to live patching for changes KLP can't express
+- [Kernel Modules](../modules/module-basics.md) — KLP patches are distributed and loaded as regular kernel modules
+- [Tracing: ftrace](../tracing/ftrace.md) — the function-entry hook mechanism KLP builds on
+
+### LWN articles
+
+- [Kernel Live Patching](https://lwn.net/Articles/619390/) — Seth Jennings' original 2014 writeup of the ftrace-based core: the `klp_patch`/`klp_object`/`klp_func` structures and the sysfs interface
+- [livepatch: hybrid consistency model](https://lwn.net/Articles/685464/) — Josh Poimboeuf's 2016 series introducing per-task transitions, stack-reliability checking, and `TIF_PATCH_PENDING`
+- [livepatch: introduce shadow variable API](https://lwn.net/Articles/731585/) — Joe Lawrence's 2017 patch introducing `klp_shadow_alloc()`/`klp_shadow_get()`/`klp_shadow_free()`
+
+### External
+
+- [Livepatch — The Linux Kernel documentation](https://docs.kernel.org/livepatch/livepatch.html) — official documentation: motivation, the consistency model, module life-cycle, and known limitations
+- [Shadow Variables — The Linux Kernel documentation](https://docs.kernel.org/livepatch/shadow-vars.html) — official shadow-variable API reference and usage notes

--- a/docs/livepatch/klp.md
+++ b/docs/livepatch/klp.md
@@ -256,7 +256,7 @@ echo 1 > /sys/kernel/livepatch/mypatch/force
 
 ### Sleepy tasks
 
-A task blocked in `D` state (uninterruptible sleep) inside the old function will delay the transition. The kernel uses `klp_send_signals()` to wake such tasks and a periodic workqueue to re-check transition completion:
+A task blocked in `D` state (`TASK_UNINTERRUPTIBLE`) inside the old function will delay the transition, and the livepatch core cannot shorten that wait: `klp_send_signals()` reaches only tasks in interruptible sleep (`wake_up_state(task, TASK_INTERRUPTIBLE)` for kthreads, `set_notify_signal()` — itself only a `TASK_INTERRUPTIBLE` wakeup — for user tasks). A D-state task has to leave that state on its own; the periodic workqueue just re-checks until it does. See [KLP Consistency Model](klp-consistency.md):
 
 ```bash
 # If transition is stuck: find who's blocking it

--- a/docs/livepatch/klp.md
+++ b/docs/livepatch/klp.md
@@ -17,7 +17,7 @@ Before patch:           After patch:
                                         └─► executes patch
 ```
 
-The original function's body is never rewritten and no jump is inserted into it. KLP reuses the ftrace call site the compiler already emitted at function entry (via `-fentry`/`-mfentry`), and `klp_ftrace_handler()` redirects execution by changing the saved instruction pointer, not by patching code.
+The original function's body is never rewritten and no jump is inserted into it. KLP reuses the ftrace call site the compiler already emitted at function entry (via `-mfentry`, or `-fpatchable-function-entry` on arm64), and `klp_ftrace_handler()` redirects execution by changing the saved instruction pointer, not by patching code.
 
 ## Architecture
 

--- a/docs/livepatch/klp.md
+++ b/docs/livepatch/klp.md
@@ -161,7 +161,9 @@ static void notrace klp_ftrace_handler(unsigned long ip,
 
     ops = container_of(fops, struct klp_ops, fops);
 
-    /* Recursion guard (also needed for the RCU-less sync variant below) */
+    /* Recursion guard (disabling preemption is also required by
+       kernel/livepatch/transition.c's synchronize_rcu()-based sync
+       path, not shown on this page) */
     bit = ftrace_test_recursion_trylock(ip, parent_ip);
     if (WARN_ON_ONCE(bit < 0))
         return;
@@ -343,7 +345,7 @@ dmesg | grep livepatch
 
 ### LWN articles
 
-- [Kernel Live Patching](https://lwn.net/Articles/619390/) — Seth Jennings' original 2014 writeup of the ftrace-based core: the `klp_patch`/`klp_object`/`klp_func` structures and the sysfs interface
+- [Kernel Live Patching](https://lwn.net/Articles/619390/) — Seth Jennings' original 2014 writeup of the ftrace-based core: the pre-merge `lp_patch`-based design (renamed `klp_` before merge) and the original sysfs interface
 - [livepatch: hybrid consistency model](https://lwn.net/Articles/685464/) — Josh Poimboeuf's 2016 series introducing per-task transitions, stack-reliability checking, and `TIF_PATCH_PENDING`
 - [livepatch: introduce shadow variable API](https://lwn.net/Articles/731585/) — Joe Lawrence's 2017 patch introducing `klp_shadow_alloc()`/`klp_shadow_get()`/`klp_shadow_free()`
 

--- a/docs/livepatch/klp.md
+++ b/docs/livepatch/klp.md
@@ -37,7 +37,9 @@ struct klp_func {
     struct list_head  node;         /* list node for klp_object->func_list */
     struct list_head  stack_node;   /* position in klp_ops->func_stack */
     unsigned long     old_size, new_size;  /* sizes of old/new function */
-    bool              nop;          /* no-op patch (for rollback testing) */
+    bool              nop;          /* temporary patch to use the original code
+                                       again; dynamically allocated by atomic
+                                       replace (klp-cumulative.md) */
     bool              patched;      /* currently active */
     bool              transition;   /* in consistency transition */
 };
@@ -84,16 +86,27 @@ struct klp_object {
 #include <linux/kernel.h>
 #include <linux/livepatch.h>
 
-/* The replacement function */
-static int patched_vfs_read(struct file *file, char __user *buf,
-                             size_t count, loff_t *pos)
+/*
+ * The replacement function. Its prototype must match the original exactly:
+ * include/linux/fs.h declares
+ *   ssize_t vfs_read(struct file *, char __user *, size_t, loff_t *);
+ * Getting this wrong is silent — .new_func is a void *, so a mismatched
+ * return type (int here) would compile without a warning and truncate
+ * every result the patched function hands back to its callers.
+ */
+static ssize_t patched_vfs_read(struct file *file, char __user *buf,
+                                size_t count, loff_t *pos)
 {
     /* New implementation with the bug fixed */
     if (!file || !file->f_op)
         return -EBADF;   /* was: NULL deref here */
 
-    /* Re-implement the fixed logic entirely — KLP has no klp_call_orig() */
-    return orig_vfs_read_impl(file, buf, count, pos);
+    /*
+     * ... rest of vfs_read()'s body, copied verbatim from fs/read_write.c,
+     * elided here. KLP has no klp_call_orig(): there is no supported way to
+     * chain back into the original function, so the patch module carries the
+     * whole body and applies the fix inside its own copy.
+     */
 }
 
 /* Patch descriptor */
@@ -161,9 +174,11 @@ static void notrace klp_ftrace_handler(unsigned long ip,
 
     ops = container_of(fops, struct klp_ops, fops);
 
-    /* Recursion guard (disabling preemption is also required by
-       kernel/livepatch/transition.c's synchronize_rcu()-based sync
-       path, not shown on this page) */
+    /* Recursion guard. It also disables preemption, which is required by
+       kernel/livepatch/transition.c's klp_synchronize_transition() — a
+       schedule_on_each_cpu()-based stand-in for synchronize_rcu(), used
+       because livepatch must also patch functions where RCU isn't watching
+       (e.g. before user_exit()), so it can't rely on RCU itself */
     bit = ftrace_test_recursion_trylock(ip, parent_ip);
     if (WARN_ON_ONCE(bit < 0))
         return;
@@ -215,8 +230,11 @@ KLP can't simply redirect calls immediately — a task might be in the middle of
 State: KLP_TRANSITION_UNPATCHED → (patch applied) → KLP_TRANSITION_PATCHED
 
 For each task:
-  1. When task returns to userspace (schedule point), mark as KLP_TRANSITION_PATCHED
-  2. Tasks already in kernel get KLP_TRANSITION_PATCHED at their next schedule
+  1. On return to userspace, klp_update_patch_state() marks it KLP_TRANSITION_PATCHED
+  2. Tasks that stay in the kernel are switched by the ~1s transition workqueue's
+     stack check, or by klp_sched_try_switch() in __schedule() — which only fires
+     when the outgoing task is entering a freezable (TASK_FREEZABLE) sleep, not at
+     every schedule point
   3. Until all tasks are KLP_TRANSITION_PATCHED, the patch is in "transition" state
 
 During transition:

--- a/docs/livepatch/war-stories.md
+++ b/docs/livepatch/war-stories.md
@@ -416,8 +416,10 @@ So the ambiguity that fails loudly is the safe one. A wrong-but-valid
 `dmesg` was clean, which was itself the clue — this was not a resolution
 failure, so the question was *what* had been resolved. `old_func` is
 deliberately not exposed through sysfs, but the effective position is, in the
-per-function directory name (a `.old_sympos` of 0 would also show as `,1` —
-the field records what was actually used, not the raw source value):
+per-function directory name — the directory is named `"%s,%lu"` with
+`old_sympos ? old_sympos : 1`, so a `.old_sympos` of `0` also shows as `,1`
+(the struct field itself stays `0`; only the directory name substitutes the
+effective position):
 
 ```bash
 ls /sys/kernel/livepatch/rx-fix/vmlinux/

--- a/docs/livepatch/war-stories.md
+++ b/docs/livepatch/war-stories.md
@@ -208,8 +208,11 @@ static void patched_sock_release(struct socket *sock)
     /* Free the shadow variable we attached in patched_tcp_connect */
     klp_shadow_free(sock->sk, KLP_MY_SHADOW_ID, NULL);
 
-    /* Call original release */
-    orig_sock_release(sock);
+    /*
+     * ... rest of sock_release()'s body, copied verbatim from
+     * net/socket.c, elided here. KLP has no klp_call_orig() — see
+     * klp.md — so the patch module carries the whole body.
+     */
 }
 ```
 

--- a/docs/livepatch/war-stories.md
+++ b/docs/livepatch/war-stories.md
@@ -62,8 +62,10 @@ Two options were available:
    echo 1 > /sys/kernel/livepatch/net-fix/force
    ```
 
-   The taint was accepted. The system was marked for a planned reboot within
-   24 hours.
+   The kernel was already tainted with `TAINT_LIVEPATCH` from loading the
+   module — forcing adds no additional taint of its own. The unsafety of the
+   force itself was accepted as a stopgap, and the system was marked for a
+   planned reboot within 24 hours.
 
 2. **Make the kthread sleep** (permanent fix): a follow-up patch made the loop
    sleep between iterations instead of spinning. That gives the transition two
@@ -390,8 +392,9 @@ walks that module's ELF symbol table in index order and skips `SHN_UNDEF`
 entries — a different ordering, and one to verify rather than assume.) The
 engineer had derived the position from `nm vmlinux | grep rx_ring_refill`, and
 `nm` sorts alphabetically by name unless given `-n` — for two identically named
-symbols that leaves the tie order up to the symbol table, which here did not
-match address order. Position 1 was the wireless driver's copy.
+symbols, `strcmp()` returns 0 and the tie order is whatever `qsort()` leaves
+it as, which here did not match address order. Position 1 was the wireless
+driver's copy.
 
 Nothing in the kernel objects to this. A `sympos` that is in range resolves to
 *some* real function and patching proceeds normally; only an out-of-range value
@@ -412,8 +415,9 @@ So the ambiguity that fails loudly is the safe one. A wrong-but-valid
 
 `dmesg` was clean, which was itself the clue — this was not a resolution
 failure, so the question was *what* had been resolved. `old_func` is
-deliberately not exposed through sysfs, but the requested position is, in the
-per-function directory name:
+deliberately not exposed through sysfs, but the effective position is, in the
+per-function directory name (a `.old_sympos` of 0 would also show as `,1` —
+the field records what was actually used, not the raw source value):
 
 ```bash
 ls /sys/kernel/livepatch/rx-fix/vmlinux/

--- a/docs/livepatch/war-stories.md
+++ b/docs/livepatch/war-stories.md
@@ -65,18 +65,30 @@ Two options were available:
    The taint was accepted. The system was marked for a planned reboot within
    24 hours.
 
-2. **Restart the kthread** (permanent fix): a follow-up patch added
-   `cond_resched()` inside the loop, allowing the transition to proceed
-   without forcing.
+2. **Make the kthread sleep** (permanent fix): a follow-up patch made the loop
+   sleep between iterations instead of spinning. That gives the transition two
+   ways in — the kthread is now off-CPU when the periodic workqueue scan runs
+   (so `klp_check_and_switch_task()` no longer returns `-EBUSY`) and its stack
+   no longer holds the patched function while it waits.
+
+   On current kernels the sleep has to be a real sleep. A bare
+   `cond_resched()` is not enough: since commit
+   [`676e8cf70cb0`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=676e8cf70cb0)
+   ("sched,livepatch: Untangle cond_resched() and live-patching", 2025-05-09)
+   the livepatch hook hangs off `TASK_FREEZABLE` sleeps in `__schedule()`
+   rather than off `cond_resched()`, so a loop that only yields still never
+   reaches `__klp_sched_try_switch()`.
 
 ### Lesson
 
-Kthreads that loop without sleeping or calling `cond_resched()` are the
-hardest targets for live patching. Before writing a patch that covers such a
-function:
+Kthreads that loop without ever sleeping are the hardest targets for live
+patching: they never return to userspace, they never enter the freezable sleep
+the scheduler-path check keys off, and they are always on-CPU when the
+workqueue scan tries them. Before writing a patch that covers such a function:
 
-- Add `cond_resched()` or a brief `msleep()` to the kthread if you control
-  its source (via a separate preparatory patch).
+- Give the kthread a real sleep — a brief `msleep()`, or better a freezable
+  wait — if you control its source (via a separate preparatory patch). Yielding
+  with `cond_resched()` alone no longer helps the transition.
 - Or patch the non-inlined callers instead, or restructure the kernel code to
   prevent inlining by adding `noinline` and submitting a patch upstream.
 
@@ -96,10 +108,11 @@ patch allocated a shadow variable during `connect()` and read it during
 week, memory use on the affected hosts crept upward and never stabilized.
 
 ```bash
-# /proc/slabinfo showing unexpected growth
-grep klp_shadow /proc/slabinfo
-# klp_shadow_node  41823  41823    64   63    1 : tunables    0    0    0
-#                  ^^^^^  growing over time
+# Unreclaimable slab climbing and never coming back down
+grep -E '^(Slab|SReclaimable|SUnreclaim):' /proc/meminfo
+# Slab:            1842160 kB
+# SReclaimable:     732876 kB
+# SUnreclaim:      1109284 kB   ← ~40 MB/day, tracking connection churn
 ```
 
 ### Root cause
@@ -126,26 +139,62 @@ static int patched_tcp_connect(struct sock *sk, struct sockaddr *uaddr,
 /* Missing: klp_shadow_free() in the socket release path */
 ```
 
-Every closed socket left an orphaned `klp_shadow_node` in the hash table.
-The hash table itself is defined in `kernel/livepatch/shadow.c` and is never
-shrunk automatically.
+Every closed socket left an orphaned `struct klp_shadow` in the hash table.
+The hash table itself is a file-scope `DEFINE_HASHTABLE(klp_shadow_hash, 12)`
+in `kernel/livepatch/shadow.c`, and nothing ever shrinks it: the only two exits
+are `klp_shadow_free()` (one `<obj, id>` pair) and `klp_shadow_free_all()`
+(every shadow with a given `id`). Both must be called by the patch.
 
 ### Detection
 
-```bash
-# Shadow node count growing linearly with socket churn
-watch -n 5 'grep klp_shadow /proc/slabinfo'
+This is the awkward part: there is no `klp_shadow` slab cache to grep for.
+`kernel/livepatch/shadow.c` contains no `kmem_cache_create()` at all — every
+shadow variable comes out of a plain `kmalloc`:
 
-# Total memory consumed by shadow nodes
-python3 -c "
-import re
-for line in open('/proc/slabinfo'):
-    if 'klp_shadow' in line:
-        parts = line.split()
-        count = int(parts[1])
-        size  = int(parts[3])
-        print(f'{count} objects x {size} bytes = {count*size/1024:.1f} KB')
-"
+```c
+/* kernel/livepatch/shadow.c — __klp_shadow_get_or_alloc() */
+new_shadow = kzalloc(size + sizeof(*new_shadow), gfp_flags);
+```
+
+so the allocations land in the shared generic `kmalloc-*` buckets with
+everything else of that size, and `/proc/slabinfo` has no livepatch-specific
+line. `struct klp_shadow` is 48 bytes of header on 64-bit (`hlist_node`,
+`rcu_head`, `obj`, `id`) plus the patch's own payload — here a single 32-bit
+attribute, for 52 bytes total — so these shadows came out of `kmalloc-64`.
+Watching that bucket is corroborating evidence, never proof:
+
+```bash
+# Generic, shared bucket — a hint, not an attribution
+watch -n 60 "grep -E '^kmalloc-64 ' /proc/slabinfo"
+```
+
+kmemleak is no help either. The orphans are still linked into
+`klp_shadow_hash`, and `struct klp_shadow`'s `hlist_node` is its first member,
+so a pointer to the start of every allocation is sitting in a live kernel data
+structure. Kmemleak only reports objects for which no such pointer can be
+found, so it never flags them. This is a lifecycle leak, not an
+unreferenced-memory leak.
+
+What actually closed the case was a two-step process. First, correlate: plot
+`SUnreclaim:` from `/proc/meminfo` against the host's socket open/close rate
+and confirm the slope only appeared after the patch was loaded, and only on
+hosts that had it. Second, confirm by walking the hash table directly.
+`klp_shadow_hash` is `static`, with no procfs, sysfs, or debugfs interface, so
+this needs a debug-info kernel and a tool that can read kernel data
+structures — `drgn` against the live kernel, or `crash` against a dump:
+
+```python
+# drgn, on a kernel built with debug info
+from collections import Counter
+from drgn.helpers.linux.list import hlist_for_each_entry
+
+counts = Counter()
+for bucket in prog["klp_shadow_hash"]:
+    for s in hlist_for_each_entry("struct klp_shadow",
+                                  bucket.address_of_(), "node"):
+        counts[hex(int(s.id))] += 1
+print(counts)
+# Counter({'0x1': 41823})   ← the host had ~1200 live sockets
 ```
 
 ### Resolution
@@ -273,160 +322,307 @@ compat argument layout, like `space_resv` vs. `space_resv_32` here, needs its
 own livepatch target. `grep -i <name> /proc/kallsyms` for the function's
 name family is a fast first check; the source is the definitive answer.
 
-## 4. Patching an inline function
+## 4. The wrong occurrence of a duplicated symbol
 
 ### Scenario
 
-An engineer identified a bug in a small validation helper,
-`check_buffer_bounds()`. The function was clearly visible in the source tree
-and had a plausible symbol name. A live patch was written, the module
-compiled, and loaded without errors:
+A bug was traced to `rx_ring_refill()`, a small `static` helper in a built-in
+network driver. A live patch was written against it. The first `insmod` failed
+outright:
 
 ```bash
-insmod bounds-fix.ko
+insmod rx-fix.ko
+# insmod: ERROR: could not insert module rx-fix.ko: Invalid parameters
+
+dmesg | tail -1
+# livepatch: unresolvable ambiguity for symbol 'rx_ring_refill' in object '(null)'
+```
+
+That message is `klp_find_object_symbol()` refusing to guess: `old_sympos` was
+left at its default of `0`, which means "this symbol must be unique," and a
+second built-in driver defined its own `static rx_ring_refill()`. (The object
+prints as `(null)` because a `vmlinux` target is passed to
+`klp_find_object_symbol()` as a NULL `objname`.)
+
+The engineer disambiguated, set `.old_sympos = 1`, rebuilt, and reloaded. This
+time everything came up clean:
+
+```bash
+insmod rx-fix.ko
 # No errors
 
-cat /sys/kernel/livepatch/bounds-fix/enabled
-# 1
-
-cat /sys/kernel/livepatch/bounds-fix/transition
-# 0  (completed instantly — suspicious)
+cat /sys/kernel/livepatch/rx-fix/enabled      # 1
+cat /sys/kernel/livepatch/rx-fix/transition   # 0 — completed
+cat /sys/kernel/livepatch/rx-fix/vmlinux/patched
+# 1  ← the hook really is installed
 ```
 
-But bug reports continued. The patch appeared to do nothing.
+The original bug kept reproducing anyway. Worse, an unrelated wireless
+interface on the same hosts started dropping frames under load.
 
 ### Root cause
 
-`check_buffer_bounds()` was declared `static inline` in a header file. The
-compiler inlined it at every call site — there was no standalone copy in the
-kernel's text section. The symbol did not exist in `/proc/kallsyms`:
+The patch was live, the transition had finished, and the ftrace hook was
+installed — on the wrong function. `old_sympos` selected the other driver's
+`rx_ring_refill()`.
 
-```bash
-grep check_buffer_bounds /proc/kallsyms
-# (no output)
+The occurrence numbering is not arbitrary, and it is not the order `nm` prints.
+`scripts/kallsyms.c` sorts the name index with `compare_names()`, which breaks
+ties between identical names by **ascending address**:
+
+```c
+/* scripts/kallsyms.c — compare_names() */
+ret = strcmp(sym_name(sa), sym_name(sb));
+if (!ret) {
+    if (sa->addr > sb->addr)
+        return 1;
+    else if (sa->addr < sb->addr)
+        return -1;
+    ...
+}
 ```
 
-Because the symbol was absent, KLP could not resolve `old_addr` for the
-function. The patch loaded successfully — KLP does not fail on unresolved
-symbols by default when the target object is `vmlinux` and the function is
-absent — but the ftrace hook was never installed. The `patched` sysfs file
-revealed this:
+For a `vmlinux` target, `klp_find_object_symbol()` walks that index via
+`kallsyms_on_each_match_symbol()` and stops when its running count reaches
+`sympos`, so *sympos N is the Nth occurrence in ascending address order*. (A
+module target takes the other branch, `module_kallsyms_on_each_symbol()`, which
+walks that module's ELF symbol table in index order and skips `SHN_UNDEF`
+entries — a different ordering, and one to verify rather than assume.) The
+engineer had derived the position from `nm vmlinux | grep rx_ring_refill`, and
+`nm` sorts alphabetically by name unless given `-n` — for two identically named
+symbols that leaves the tie order up to the symbol table, which here did not
+match address order. Position 1 was the wireless driver's copy.
 
-```bash
-cat /sys/kernel/livepatch/bounds-fix/vmlinux/patched
-# 0  ← hook never fired for any function in this object
+Nothing in the kernel objects to this. A `sympos` that is in range resolves to
+*some* real function and patching proceeds normally; only an out-of-range value
+is rejected, with a different message:
+
+```c
+/* kernel/livepatch/core.c — klp_find_object_symbol() */
+} else if (sympos != args.count && sympos > 0) {
+        pr_err("symbol position %lu for symbol '%s' in object '%s' not found\n",
+               sympos, name, objname ? objname : "vmlinux");
+}
 ```
 
-The transition completed instantly because there was nothing to transition.
+So the ambiguity that fails loudly is the safe one. A wrong-but-valid
+`old_sympos` is the silent one.
+
+### Detection
+
+`dmesg` was clean, which was itself the clue — this was not a resolution
+failure, so the question was *what* had been resolved. `old_func` is
+deliberately not exposed through sysfs, but the requested position is, in the
+per-function directory name:
+
+```bash
+ls /sys/kernel/livepatch/rx-fix/vmlinux/
+# patched  rx_ring_refill,1     ← "<function>,<sympos>"
+```
+
+From there the mapping was rebuilt offline. `/proc/kallsyms` is emitted in
+address order, so its listing *is* the kernel's numbering:
+
+```bash
+grep ' rx_ring_refill$' /proc/kallsyms
+# ffffffff81a4c210 t rx_ring_refill    ← sympos 1
+# ffffffff81b0e8c0 t rx_ring_refill    ← sympos 2
+
+# Map each address back to its compilation unit
+addr2line -f -e /usr/lib/debug/lib/modules/$(uname -r)/vmlinux \
+    0xffffffff81a4c210 0xffffffff81b0e8c0
+# rx_ring_refill
+# drivers/net/wireless/.../rx.c:412        ← what got patched
+# rx_ring_refill
+# drivers/net/ethernet/.../rx.c:88         ← what was meant
+```
 
 ### Resolution
 
-The fix required patching every function that had inlined
-`check_buffer_bounds()`. The engineer used `objdump` on the compiled kernel
-to identify all call sites:
+The patch was rebuilt with `.old_sympos = 2` and redeployed. The sysfs
+directory name confirmed the new target before anyone waited on behaviour:
 
 ```bash
-# Find functions that contain the inlined check
-objdump -d /usr/lib/debug/lib/modules/$(uname -r)/vmlinux \
-    | grep -B 40 "call.*bounds" \
-    | grep "^[0-9a-f]* <"
+ls /sys/kernel/livepatch/rx-fix/vmlinux/
+# patched  rx_ring_refill,2
 ```
 
-Each containing function was then patched with a replacement that embedded
-the corrected bounds check logic.
+The team then added a build-time check: for every `klp_func`, resolve
+`old_name` against an address-sorted symbol listing, and fail the build unless
+the occurrence at the configured `old_sympos` maps back — via `addr2line` — to
+the source file the patch was written against.
 
 ### Lesson
 
-Before writing a live patch for any function, verify it exists as a symbol:
+`old_sympos` is a 1-based index counted per object — in ascending address order
+for `vmlinux` — and getting it wrong is one of the few livepatch mistakes the
+kernel cannot catch for you:
+
+- For a `vmlinux` target, derive it from an **address-ordered** listing:
+  `/proc/kallsyms` is already in that order, and `nm -n vmlinux` can be made to
+  be. Plain `nm` sorts alphabetically by name and tells you nothing about
+  position.
+- Always verify what was actually resolved, not just that the patch enabled.
+  The `<function>,<sympos>` directory name plus an `addr2line` of the matching
+  `/proc/kallsyms` entry is the whole check.
+- Leaving `old_sympos` at `0` is the safe default precisely because it fails
+  the load when the name is not unique. Do not set a position to silence that
+  error; set it because you have confirmed which occurrence you want.
+
+Before any of this, confirm the function exists as a symbol at all:
 
 ```bash
-grep <function_name> /proc/kallsyms
+grep " <function_name>$" /proc/kallsyms
 ```
 
-If it is absent, the function is either inlined, a macro, or compiled out
-under the current kernel config. In those cases you must patch the callers
-instead. Also check that the symbol is not duplicated (multiple functions with
-the same name in different compilation units), in which case `old_sympos` in
-`struct klp_func` must be set to select the correct occurrence.
+If it is absent — inlined from a header, a macro, or compiled out under the
+running config — `klp_find_object_symbol()` prints `symbol '%s' not found in
+symbol table` and returns `-EINVAL`, which propagates through
+`klp_init_object_loaded()` and `klp_init_patch()` to `klp_enable_patch()`, so
+the `insmod` fails and the module never loads. There is no partially applied
+state to discover later; you simply have to patch the callers instead.
 
-## 5. Cumulative patch ordering
+## 5. The cumulative patch that forgot `.replace`
 
 ### Scenario
 
-Two independent patches were applied to a staging kernel: P1 patching
-`inet_accept` and P2 patching `nf_conntrack_in`. Both were stable. A
-cumulative patch P3 (`.replace = true`) was prepared that incorporated both
-fixes plus a new security fix. P3 was loaded before confirming P1 had
-finished transitioning:
+A fleet had accumulated three live patches: P1 fixing `tcp_sendmsg`, P2 fixing
+`ip_output`, and P3 fixing `nf_conntrack_in`. P2's fix was later identified as
+the cause of a throughput regression and was slated to be dropped.
+
+The plan was a single cumulative patch, P4, carrying the P1 and P3 fixes plus a
+new security fix in `udp_sendmsg`, and *not* carrying P2's change — so that
+after P4 was applied,
+`ip_output` would run the original upstream code again. P4 was built, rolled
+out, and everything reported healthy:
 
 ```bash
-# P1 was still transitioning
-cat /sys/kernel/livepatch/p1/transition
-# 1   ← not yet complete
-
-# P3 loaded anyway
-insmod p3-cumulative.ko
+insmod p4-cumulative.ko
+cat /sys/kernel/livepatch/p4-cumulative/enabled      # 1
+cat /sys/kernel/livepatch/p4-cumulative/transition   # 0 — completed
 ```
 
-The result was a corrupted `func_stack` for `inet_accept`. P3's `klp_func`
-was pushed onto `func_stack` while P1's `klp_func` was still marked
-`transition = true`. The ftrace handler saw two entries with overlapping
-transition states, and some tasks received the P3 replacement while others
-were still being evaluated against P1's state. A subtle memory corruption
-followed under high connection load.
+A week of throughput graphs later, the regression was still there on every
+patched host.
 
 ### Root cause
 
-There is no dedicated `klp_atomic_replace()` function. Cumulative replace is
-handled by `klp_init_patch()`, which calls `klp_add_nops()` when
-`patch->replace` is set, followed by the same transition machinery every
-patch uses (`klp_enable_patch()` → `klp_init_transition()`). That machinery
-assumes all existing patches are in a stable state (no active transition). If
-an old patch is mid-transition, its per-task state (`KLP_TRANSITION_IDLE`,
-`KLP_TRANSITION_UNPATCHED`, `KLP_TRANSITION_PATCHED`) conflicts with the new
-transition's bookkeeping.
+`.replace` had been left at its default of `false` in P4's `struct klp_patch`.
+The line that set it had been dropped in a refactor of the patch module's
+source template, and nothing at build or load time complained: a non-cumulative
+patch is a perfectly legal patch.
 
-The kernel does not prevent loading a cumulative patch while another is
-transitioning — it trusts the operator to sequence correctly.
+Without `.replace`, none of the replace machinery runs. In
+`klp_init_patch()` the nop generation is guarded:
+
+```c
+/* kernel/livepatch/core.c — klp_init_patch() */
+if (patch->replace) {
+        ret = klp_add_nops(patch);
+        if (ret)
+                return ret;
+}
+```
+
+and in `klp_complete_transition()` the teardown of superseded patches is
+guarded the same way:
+
+```c
+/* kernel/livepatch/transition.c — klp_complete_transition() */
+if (klp_transition_patch->replace && klp_target_state == KLP_TRANSITION_PATCHED) {
+        klp_unpatch_replaced_patches(klp_transition_patch);
+        klp_discard_nops(klp_transition_patch);
+}
+```
+
+So P4 did the only thing a plain patch does: for each function it named, it
+pushed its own `klp_func` onto the head of that function's `ops->func_stack`
+(`list_add_rcu()` in `klp_patch_func()`), and stopped there. P1, P2 and P3
+stayed enabled. `tcp_sendmsg` and `nf_conntrack_in` now had two-deep stacks
+whose heads happened to be P4's equivalent implementations, which is why
+nothing looked wrong. But `ip_output` was not named by P4 at all — P4 had
+deliberately dropped it — so nothing was pushed for it, and the head of its
+`func_stack` was still P2's `klp_func`. The regression could not revert,
+because nothing had asked it to.
+
+Reverting a function that an older patch touched is exactly what `.replace`
+buys, and only `.replace`. Upstream's own list of what atomic replace makes
+possible leads with it: "Atomically revert some functions in a previous patch
+while upgrading other functions."
+
+### Detection
+
+The tell is that the superseded patches were all still present. After a real
+atomic replace they would not be: once the transition settles,
+`klp_try_complete_transition()` calls `klp_free_replaced_patches_async()` for a
+`.replace` patch, and that walks every patch ahead of the new one through
+`klp_free_patch_start()` (`list_del()` from `klp_patches`) and
+`klp_free_patch_finish()` (`kobject_put()`), so their sysfs directories
+disappear entirely.
+
+```bash
+# Four directories, four enabled patches — no replacement happened
+grep . /sys/kernel/livepatch/*/enabled
+# /sys/kernel/livepatch/p1/enabled:1
+# /sys/kernel/livepatch/p2/enabled:1
+# /sys/kernel/livepatch/p3/enabled:1
+# /sys/kernel/livepatch/p4-cumulative/enabled:1
+
+# The flag is exposed read-only, per patch
+cat /sys/kernel/livepatch/p4-cumulative/replace
+# 0   ← it was never a cumulative patch
+
+# stack_order is the patch's 1-based position in klp_patches; a successful
+# atomic replace leaves the new patch alone at 1
+cat /sys/kernel/livepatch/p4-cumulative/stack_order
+# 4   ← stacked on top of three patches, not replacing them
+
+# And ip_output is still owned by p2
+ls /sys/kernel/livepatch/p2/vmlinux/
+# ip_output,1  patched
+ls /sys/kernel/livepatch/p4-cumulative/vmlinux/
+# nf_conntrack_in,1  patched  tcp_sendmsg,1  udp_sendmsg,1
+```
 
 ### Resolution
 
-The corrupted hosts required a reboot to restore a clean state. The
-cumulative patch was re-deployed after ensuring all prior patches had
-stabilized:
+P4 was rebuilt unchanged except for `.replace = true` and reloaded as P5. This
+time `klp_add_nops()` ran: it walked every function covered by P1 through P4,
+found `ip_output` had no counterpart in the new patch, and allocated a dynamic
+`nop` `klp_func` for it — an entry that the ftrace handler deliberately does
+nothing for, so the original `ip_output` runs. When the transition finished,
+the four older patches were unpatched, removed from `klp_patches`, and their
+modules became removable.
 
 ```bash
-# Safe cumulative patch deployment sequence
+insmod p5-cumulative.ko
+cat /sys/kernel/livepatch/p5-cumulative/transition   # wait for 0
 
-# 1. Verify all existing patches are stable
-for p in /sys/kernel/livepatch/*/; do
-    name=$(basename "$p")
-    enabled=$(cat "$p/enabled")
-    transition=$(cat "$p/transition")
-    echo "$name: enabled=$enabled transition=$transition"
-done
-# p1: enabled=1 transition=0
-# p2: enabled=1 transition=0
-
-# 2. Only then load the cumulative patch
-insmod p3-cumulative.ko
-
-# 3. Monitor the new transition
-watch -n 1 'cat /sys/kernel/livepatch/p3-cumulative/transition'
+cat /sys/kernel/livepatch/p5-cumulative/replace      # 1
+cat /sys/kernel/livepatch/p5-cumulative/stack_order  # 1
+ls /sys/kernel/livepatch/
+# p5-cumulative        ← the older directories are gone
 ```
 
 ### Lesson
 
-Never load a cumulative (`.replace = true`) patch while any other live patch
-has `transition=1`. The transition state is global to the task's
-`patch_state` field, and two concurrent transitions interfere with each
-other's bookkeeping. A helper script that gates the load on all patches being
-stable should be part of any live patching deployment pipeline.
+A patch is cumulative only because you said so. Nothing infers it from the
+patch's contents, and a missing `.replace` produces no warning at any stage.
+
+- Follow the upstream advice from
+  `Documentation/livepatch/cumulative-patches.rst`: "A good practice is to set
+  .replace flag in any released livepatch." A patch that replaces everything is
+  correct even when there is nothing to replace.
+- Gate deployment on the observable outcome, not on `enabled` and `transition`.
+  After the transition settles, `replace` should read `1`, `stack_order` should
+  read `1`, and `/sys/kernel/livepatch/` should contain exactly one directory.
+- Remember what "replace" does not do: only the new cumulative patch's
+  (un)patching callbacks run, and the superseded patches' callbacks are
+  skipped. Anything the patches you are superseding did in a callback, the
+  cumulative patch must do itself.
 
 See [Cumulative Patches and Atomic Replace](klp-cumulative.md) for the full
-description of the `func_stack` and atomic replace mechanics, and
-[KLP Consistency Model](klp-consistency.md) for details on the per-task
-transition state machine.
+description of the `func_stack`, the `nop` funcs, and the atomic replace flow.
 
 ## Further reading
 
@@ -434,8 +630,11 @@ transition state machine.
 
 - [kernel/livepatch/transition.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/transition.c) — `klp_send_signals()`, whose `wake_up_state(task, TASK_INTERRUPTIBLE)` only wakes kthreads in interruptible sleep, and `klp_try_complete_transition()`, behind Case 1
 - [kernel/livepatch/shadow.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/shadow.c) — the `klp_shadow_hash` hashtable and the `klp_shadow_get_or_alloc()`/`klp_shadow_free()` pairing that Case 2's patch got wrong
-- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_add_nops()`, which creates the placeholder `nop` functions referenced in Case 1's lesson, and the `old_sympos` handling for duplicate symbol names behind Case 4
-- [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_func`'s `nop` and `old_sympos` fields, and the per-task transition states (`KLP_TRANSITION_IDLE`/`KLP_TRANSITION_UNPATCHED`/`KLP_TRANSITION_PATCHED`) behind Case 5
+- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_find_object_symbol()`, whose `old_sympos` counting and "unresolvable ambiguity"/"symbol position ... not found" errors drive Case 4, and the `if (patch->replace)` guard around `klp_add_nops()` behind Case 5
+- [kernel/livepatch/patch.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/patch.c) — `klp_patch_func()`'s `list_add_rcu()` onto `ops->func_stack`, the plain stacking that Case 5's patch got instead of a replace, and `klp_ftrace_handler()`'s `if (func->nop)` early exit
+- [scripts/kallsyms.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/kallsyms.c) — `compare_names()`, which breaks ties between identically named symbols by ascending address and so defines what `old_sympos` counts in Case 4
+- [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_func`'s `nop` and `old_sympos` fields, including the comment stating that a zero `old_sympos` requires a unique symbol, behind Cases 1 and 4
+- [Documentation/livepatch/cumulative-patches.rst](https://docs.kernel.org/livepatch/cumulative-patches.html) — the upstream atomic replace guide: the "atomically revert some functions" feature and the "set .replace flag in any released livepatch" advice Case 5 turns on
 - [fs/ioctl.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/ioctl.c) — `ioctl_preallocate()` and the separate x86_64 `compat_ioctl_preallocate()` entry point, the two functions behind Case 3
 - [include/linux/falloc.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/falloc.h) — `struct space_resv`/`struct space_resv_32`, the native/compat layout mismatch behind Case 3
 - [Shadow variables](https://docs.kernel.org/livepatch/shadow-vars.html) — upstream documentation on matching a shadow variable's lifecycle to its parent object's, the rule Case 2's patch violated
@@ -443,9 +642,9 @@ transition state machine.
 ### Related pages
 
 - [Kernel Live Patching](klp.md) — the ftrace redirection mechanism and shadow variable API these incidents build on
-- [KLP Consistency Model](klp-consistency.md) — per-task transition states and stack checking behind Cases 1 and 5
-- [Cumulative Patches and Atomic Replace](klp-cumulative.md) — `.replace=true` and `func_stack` stacking behind Case 5
-- [KLP State: Custom Consistency Checks](klp-state.md) — the API for patches where stack scanning alone isn't sufficient, relevant background for Case 5's ordering lesson
+- [KLP Consistency Model](klp-consistency.md) — per-task transition states and stack checking behind Case 1
+- [Cumulative Patches and Atomic Replace](klp-cumulative.md) — `.replace=true`, the `nop` funcs, and `func_stack` stacking behind Case 5
+- [KLP State: Custom Consistency Checks](klp-state.md) — the API for carrying state between cumulative patches, the companion problem to Case 5's callback caveat
 - [kexec](kexec.md) — reboot without a full firmware POST, an alternative to live patching when a fix requires downtime
 
 ### LWN articles

--- a/docs/livepatch/war-stories.md
+++ b/docs/livepatch/war-stories.md
@@ -32,12 +32,13 @@ static int net_kthread(void *arg)
 ```
 
 Because the kthread never yielded the CPU voluntarily and never entered sleep,
-the scheduler had no opportunity to call `klp_update_patch_state()` for it.
-`klp_send_signals()` calls `wake_up_state(task, TASK_INTERRUPTIBLE)` for
-kthreads — this can only wake tasks in interruptible sleep, not tasks actively
-running in a tight loop. The kthread's tight loop without `cond_resched()`
-prevented both scheduling and the `TASK_INTERRUPTIBLE` wakeup from taking
-effect.
+it never hit a context switch where `klp_sched_try_switch()` could try it —
+that scheduler-path check only runs when the outgoing task is entering a
+freezable sleep state, exactly what this kthread never did. `klp_send_signals()`
+calls `wake_up_state(task, TASK_INTERRUPTIBLE)` for kthreads — this can only
+wake tasks in interruptible sleep, not tasks actively running in a tight loop.
+The kthread's tight loop without `cond_resched()` prevented both the
+scheduler-path check and the `TASK_INTERRUPTIBLE` wakeup from taking effect.
 
 The kthread's stack confirmed it:
 
@@ -312,8 +313,8 @@ absent — but the ftrace hook was never installed. The `patched` sysfs file
 revealed this:
 
 ```bash
-cat /sys/kernel/livepatch/bounds-fix/vmlinux/check_buffer_bounds/patched
-# 0  ← hook never fired
+cat /sys/kernel/livepatch/bounds-fix/vmlinux/patched
+# 0  ← hook never fired for any function in this object
 ```
 
 The transition completed instantly because there was nothing to transition.
@@ -445,10 +446,10 @@ transition state machine.
 - [KLP Consistency Model](klp-consistency.md) — per-task transition states and stack checking behind Cases 1 and 5
 - [Cumulative Patches and Atomic Replace](klp-cumulative.md) — `.replace=true` and `func_stack` stacking behind Case 5
 - [KLP State: Custom Consistency Checks](klp-state.md) — the API for patches where stack scanning alone isn't sufficient, relevant background for Case 5's ordering lesson
-- [kexec](kexec.md) — the fast-reboot mechanism used as the fallback once a stuck transition can't be forced safely, as in Case 1's resolution
+- [kexec](kexec.md) — reboot without a full firmware POST, an alternative to live patching when a fix requires downtime
 
 ### LWN articles
 
-- [livepatch: consistency model](https://lwn.net/Articles/632582/) (February 9, 2015) — the original per-task consistency model RFC, which explicitly flags kthreads that never sleep or transition as an open problem, the root cause behind Case 1
+- [livepatch: consistency model](https://lwn.net/Articles/632582/) (February 9, 2015) — the original per-task consistency model RFC and per-task transition design behind Case 1
 - [livepatch: introduce shadow variable API](https://lwn.net/Articles/731585/) (August 21, 2017) — Joe Lawrence's patch introducing `klp_shadow_alloc()`/`klp_shadow_get()`/`klp_shadow_free()` and the `(obj, id)`-keyed hashtable behind Case 2
 - [livepatch: introduce atomic replace](https://lwn.net/Articles/734997/) (September 27, 2017) — the atomic replace / cumulative patch design discussed in Case 5

--- a/docs/livepatch/war-stories.md
+++ b/docs/livepatch/war-stories.md
@@ -91,8 +91,6 @@ workqueue scan tries them. Before writing a patch that covers such a function:
 - Give the kthread a real sleep — a brief `msleep()`, or better a freezable
   wait — if you control its source (via a separate preparatory patch). Yielding
   with `cond_resched()` alone no longer helps the transition.
-- Or patch the non-inlined callers instead, or restructure the kernel code to
-  prevent inlining by adding `noinline` and submitting a patch upstream.
 
   Note: the `nop` field in `struct klp_func` is used by the cumulative replace
   mechanism (`klp_add_nops()`) to create placeholder entries that call through
@@ -643,7 +641,6 @@ description of the `func_stack`, the `nop` funcs, and the atomic replace flow.
 - [Documentation/livepatch/cumulative-patches.rst](https://docs.kernel.org/livepatch/cumulative-patches.html) — the upstream atomic replace guide: the "atomically revert some functions" feature and the "set .replace flag in any released livepatch" advice Case 5 turns on
 - [fs/ioctl.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/ioctl.c) — `ioctl_preallocate()` and the separate x86_64 `compat_ioctl_preallocate()` entry point, the two functions behind Case 3
 - [include/linux/falloc.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/falloc.h) — `struct space_resv`/`struct space_resv_32`, the native/compat layout mismatch behind Case 3
-- [Shadow variables](https://docs.kernel.org/livepatch/shadow-vars.html) — upstream documentation on matching a shadow variable's lifecycle to its parent object's, the rule Case 2's patch violated
 
 ### Related pages
 
@@ -658,3 +655,7 @@ description of the `func_stack`, the `nop` funcs, and the atomic replace flow.
 - [livepatch: consistency model](https://lwn.net/Articles/632582/) (February 9, 2015) — the original per-task consistency model RFC and per-task transition design behind Case 1
 - [livepatch: introduce shadow variable API](https://lwn.net/Articles/731585/) (August 21, 2017) — Joe Lawrence's patch introducing `klp_shadow_alloc()`/`klp_shadow_get()`/`klp_shadow_free()` and the `(obj, id)`-keyed hashtable behind Case 2
 - [livepatch: introduce atomic replace](https://lwn.net/Articles/734997/) (September 27, 2017) — the atomic replace / cumulative patch design discussed in Case 5
+
+### External
+
+- [Shadow variables](https://docs.kernel.org/livepatch/shadow-vars.html) — upstream documentation on matching a shadow variable's lifecycle to its parent object's, the rule Case 2's patch violated

--- a/docs/livepatch/war-stories.md
+++ b/docs/livepatch/war-stories.md
@@ -181,68 +181,96 @@ See [Kernel Live Patching](klp.md) for the shadow variable API.
 
 ### Scenario
 
-A CVE was discovered in the read path. A live patch was deployed to all
-production hosts within two hours, fixing `vfs_read`. The vulnerability was
-considered remediated. Three days later, a security audit found that 32-bit
-processes on a subset of mixed-architecture hosts were still exploitable.
+A CVE was discovered in the legacy XFS-compatible space-reservation ioctls —
+`FS_IOC_RESVSP`, `FS_IOC_UNRESVSP`, and `FS_IOC_ZERO_RANGE`. A live patch was
+deployed to all production hosts within two hours, fixing `ioctl_preallocate()`
+in `fs/ioctl.c`. The vulnerability was considered remediated. Three days
+later, a security audit found that 32-bit processes on x86_64 hosts were
+still exploitable through the exact same ioctl commands.
 
 ### Root cause
 
-The patch targeted only the 64-bit syscall entry path. The 32-bit compat
-entry point, `compat_sys_read`, called a different code path that did not go
-through the patched `vfs_read`:
+The patch targeted only the native ioctl path. On `CONFIG_X86_64`, the 32-bit
+compat entry point, `compat_sys_ioctl()`, dispatches the equivalent
+`_32`-suffixed command codes (`FS_IOC_RESVSP_32`, `FS_IOC_UNRESVSP_32`,
+`FS_IOC_ZERO_RANGE_32`) straight to a separate function,
+`compat_ioctl_preallocate()`, which the patch never touched:
 
 ```c
-/* 64-bit path — patched */
-SYSCALL_DEFINE3(read, unsigned int, fd, char __user *, buf, size_t, count)
+/* Native path — patched */
+static int ioctl_preallocate(struct file *filp, int mode, void __user *argp)
 {
+    struct space_resv sr;
+
+    if (copy_from_user(&sr, argp, sizeof(sr)))
+        return -EFAULT;
     ...
-    return vfs_read(f.file, buf, count, &f.file->f_pos);  /* ← patched */
+    return vfs_fallocate(filp, mode | FALLOC_FL_KEEP_SIZE,
+                          sr.l_start, sr.l_len);   /* ← patched */
 }
 
-/* 32-bit compat path — NOT patched */
-COMPAT_SYSCALL_DEFINE3(read, unsigned int, fd,
-                        compat_uptr_t, buf, compat_size_t, count)
+/* 32-bit compat path on x86_64 — NOT patched */
+#if defined CONFIG_COMPAT && defined(CONFIG_X86_64)
+/* on ia32 l_start is on a 32-bit boundary; just account for the
+ * different alignment */
+static int compat_ioctl_preallocate(struct file *file, int mode,
+                                    struct space_resv_32 __user *argp)
 {
+    struct space_resv_32 sr;   /* distinct, packed 32-bit layout */
+
+    if (copy_from_user(&sr, argp, sizeof(sr)))
+        return -EFAULT;
     ...
-    return vfs_read(f.file, compat_ptr(buf), count,
-                    &f.file->f_pos);  /* ← same vfs_read, but... */
+    return vfs_fallocate(file, mode | FALLOC_FL_KEEP_SIZE,
+                          sr.l_start, sr.l_len);   /* ← same call, but... */
 }
+#endif
 ```
 
-In this particular case the vulnerability was actually in a helper called
-by both paths, but the helper was reached via a slightly different call chain
-in the compat path that bypassed the patched code.
+`compat_ioctl_preallocate()` exists because `struct space_resv`'s 64-bit
+`l_start`/`l_len` fields are 8-byte aligned, but on ia32 they're only 4-byte
+aligned — so the compat path defines its own packed `struct space_resv_32`
+and its own copy-in routine (`include/linux/falloc.h`). Inside
+`COMPAT_SYSCALL_DEFINE3(ioctl...)`, the `_32` command codes are handled
+directly by `compat_ioctl_preallocate()` and never reach `do_vfs_ioctl()` →
+`file_ioctl()` → `ioctl_preallocate()`, the function the patch had hooked.
 
 ### Detection
 
 ```bash
-# Check /proc/kallsyms for compat variants of the target function
-grep -i "compat.*read\|read.*compat" /proc/kallsyms
-# ffffffff81200a30 T compat_sys_read
-# ffffffff81200b20 T __se_compat_sys_read
+# Check /proc/kallsyms for the compat counterpart
+grep -i preallocate /proc/kallsyms
+# ffffffff812a1050 t ioctl_preallocate
+# ffffffff812a1120 t compat_ioctl_preallocate   ← separate symbol, unpatched
 
-# Look for COMPAT_SYSCALL_DEFINE in the source
-grep -r "COMPAT_SYSCALL_DEFINE.*read" fs/read_write.c
+# Confirm the compat dispatch in the source
+grep -n "compat_ioctl_preallocate\|FS_IOC_RESVSP_32" fs/ioctl.c
 ```
 
 ### Resolution
 
-A second patch was deployed that covered the compat path. Going forward, the
-team added a checklist item for every syscall patch:
+A second patch was deployed that also hooked `compat_ioctl_preallocate()`.
+Going forward, the team added a checklist item for every ioctl-handler patch:
 
-1. Does the syscall have a `COMPAT_SYSCALL_DEFINE` variant?
-2. Does the vulnerability exist in the 32-bit path too?
-3. Are there `ia32_sys_*` wrappers (`arch/x86/entry/syscall_32.c`) that
-   bypass the patched function?
+1. Does the ioctl command have a `_32` compat variant, and does a
+   `CONFIG_X86_64`-guarded struct like `space_resv_32` exist for it?
+2. Does the compat path — either a driver's separate `f_op->compat_ioctl`,
+   or, as here, a branch inside `compat_sys_ioctl()` in `fs/ioctl.c` — call a
+   genuinely different function, rather than forwarding to the native
+   handler?
+3. Is the vulnerability present in both the native and compat parsing
+   routines?
 
 ### Lesson
 
-For any patch targeting a syscall or a function called from a syscall, check
-`/proc/kallsyms` and the source tree for `compat_` variants before
-considering the patch complete. Architecture-specific entry tables
-(`arch/x86/entry/syscalls/syscall_32.tbl`) map compat syscall numbers to
-handler functions and are a good reference.
+For any patch targeting a function reached through `do_vfs_ioctl()` or
+`f_op->unlocked_ioctl`, check whether the same command number has a compat
+counterpart that runs different code. Not every `compat_ioctl` diverges —
+generic ones like `compat_ptr_ioctl()` just forward to the native handler
+after a pointer conversion — but any handler with a genuinely different
+compat argument layout, like `space_resv` vs. `space_resv_32` here, needs its
+own livepatch target. `grep -i <name> /proc/kallsyms` for the function's
+name family is a fast first check; the source is the definitive answer.
 
 ## 4. Patching an inline function
 
@@ -348,11 +376,14 @@ followed under high connection load.
 
 ### Root cause
 
-The KLP atomic replace path in `klp_atomic_replace()` assumes that all
-existing patches are in a stable state (no active transition). It marks old
-patches for replacement and then begins the new transition. If an old patch
-is mid-transition, its per-task state (`KLP_UNDEFINED`, `KLP_UNPATCHED`,
-`KLP_PATCHED`) conflicts with the new transition's bookkeeping.
+There is no dedicated `klp_atomic_replace()` function. Cumulative replace is
+handled by `klp_init_patch()`, which calls `klp_add_nops()` when
+`patch->replace` is set, followed by the same transition machinery every
+patch uses (`klp_enable_patch()` → `klp_init_transition()`). That machinery
+assumes all existing patches are in a stable state (no active transition). If
+an old patch is mid-transition, its per-task state (`KLP_TRANSITION_IDLE`,
+`KLP_TRANSITION_UNPATCHED`, `KLP_TRANSITION_PATCHED`) conflicts with the new
+transition's bookkeeping.
 
 The kernel does not prevent loading a cumulative patch while another is
 transitioning — it trusts the operator to sequence correctly.
@@ -398,8 +429,26 @@ transition state machine.
 
 ## Further reading
 
-- [KLP Consistency Model](klp-consistency.md) — per-task states, stack checking, forced transitions
-- [Cumulative Patches and Atomic Replace](klp-cumulative.md) — stacking and .replace=true
-- [Kernel Live Patching](klp.md) — shadow variables, observing patches
-- `kernel/livepatch/transition.c` — klp_try_complete_transition, klp_send_signals
-- `kernel/livepatch/shadow.c` — klp_shadow_hash implementation
+### Kernel source
+
+- [kernel/livepatch/transition.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/transition.c) — `klp_send_signals()`, whose `wake_up_state(task, TASK_INTERRUPTIBLE)` only wakes kthreads in interruptible sleep, and `klp_try_complete_transition()`, behind Case 1
+- [kernel/livepatch/shadow.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/shadow.c) — the `klp_shadow_hash` hashtable and the `klp_shadow_get_or_alloc()`/`klp_shadow_free()` pairing that Case 2's patch got wrong
+- [kernel/livepatch/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/livepatch/core.c) — `klp_add_nops()`, which creates the placeholder `nop` functions referenced in Case 1's lesson, and the `old_sympos` handling for duplicate symbol names behind Case 4
+- [include/linux/livepatch.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/livepatch.h) — `struct klp_func`'s `nop` and `old_sympos` fields, and the per-task transition states (`KLP_TRANSITION_IDLE`/`KLP_TRANSITION_UNPATCHED`/`KLP_TRANSITION_PATCHED`) behind Case 5
+- [fs/ioctl.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/ioctl.c) — `ioctl_preallocate()` and the separate x86_64 `compat_ioctl_preallocate()` entry point, the two functions behind Case 3
+- [include/linux/falloc.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/falloc.h) — `struct space_resv`/`struct space_resv_32`, the native/compat layout mismatch behind Case 3
+- [Shadow variables](https://docs.kernel.org/livepatch/shadow-vars.html) — upstream documentation on matching a shadow variable's lifecycle to its parent object's, the rule Case 2's patch violated
+
+### Related pages
+
+- [Kernel Live Patching](klp.md) — the ftrace redirection mechanism and shadow variable API these incidents build on
+- [KLP Consistency Model](klp-consistency.md) — per-task transition states and stack checking behind Cases 1 and 5
+- [Cumulative Patches and Atomic Replace](klp-cumulative.md) — `.replace=true` and `func_stack` stacking behind Case 5
+- [KLP State: Custom Consistency Checks](klp-state.md) — the API for patches where stack scanning alone isn't sufficient, relevant background for Case 5's ordering lesson
+- [kexec](kexec.md) — the fast-reboot mechanism used as the fallback once a stuck transition can't be forced safely, as in Case 1's resolution
+
+### LWN articles
+
+- [livepatch: consistency model](https://lwn.net/Articles/632582/) (February 9, 2015) — the original per-task consistency model RFC, which explicitly flags kthreads that never sleep or transition as an open problem, the root cause behind Case 1
+- [livepatch: introduce shadow variable API](https://lwn.net/Articles/731585/) (August 21, 2017) — Joe Lawrence's patch introducing `klp_shadow_alloc()`/`klp_shadow_get()`/`klp_shadow_free()` and the `(obj, id)`-keyed hashtable behind Case 2
+- [livepatch: introduce atomic replace](https://lwn.net/Articles/734997/) (September 27, 2017) — the atomic replace / cumulative patch design discussed in Case 5


### PR DESCRIPTION
Part of the rolling citation-backfill effort tracked in #542 — this covers `docs/livepatch/` (6 pages, all previously uncited: `kexec.md`, `klp.md`, `klp-consistency.md`, `klp-cumulative.md`, `klp-state.md`, `war-stories.md`).

Every citation was independently live-verified (kernel source paths cross-checked against the GitHub mirror where git.kernel.org's Anubis bot-challenge blocked direct scripted verification; LWN/docs.kernel.org/man7.org URLs checked for HTTP 200 with matching content).

## In-scope body-text fixes

This directory had the same fabrication density found in `crypto/`, `iommu/`, and `ipc/` earlier in this epic.

- **Wrong KLP transition-state enum names used throughout all 6 pages**: `KLP_UNDEFINED`/`KLP_UNPATCHED`/`KLP_PATCHED` do not exist anywhere in the kernel; real names are `KLP_TRANSITION_IDLE`/`KLP_TRANSITION_UNPATCHED`/`KLP_TRANSITION_PATCHED`.
- **Fabricated sysfs paths** in three pages (an invented `objs/*/funcs/*` hierarchy and non-existent per-function attributes; real layout is `<patch>/<object>/patched` with no per-function files).
- **klp.md**: a fabricated `struct klp_func` field, a removed/stale `klp_arch_set_pc()` API reference (real handler uses `ftrace_regs_set_instruction_pointer()`), an oversimplified ftrace-handler example that misdescribed patch-stacking behavior, and missing struct fields for the `states`/`replace`/`callbacks` mechanisms covered elsewhere in the directory.
- **klp-consistency.md**: `klp_check_stack()`/`klp_check_stack_func()`/`klp_complete_transition()` rewritten to match real `transition.c` (wrong return codes, a fabricated struct field, missing `tasklist_lock`/idle-task handling); a fabricated `TAINT_FORCED_MODULE` claim removed; an inverted boolean in a worked example; and a stale claim about which kernel path drives per-task transitions, corrected to describe all three real paths (exit-to-userspace, scheduler, workqueue).
- **klp-cumulative.md**: a wrong "only public API" claim (6 more `EXPORT_SYMBOL_GPL` functions exist), a wrong version number, and a mischaracterized module-loader callback (called directly, not via a notifier chain).
- **klp-state.md**: a wrong version number, a genuine use-before-declaration compile error in the worked example, a real deadlock hazard (a spinlock held across an unbounded consistency-model transition), a fabricated write-only sysfs attribute shown as readable, a fabricated dmesg message, and a misleading claim about when patch-compatibility is actually checked.
- **kexec.md**: wrong struct field layouts and file attributions, a rewritten `machine_kexec()`/`kernel_kexec()` call chain matching real `arch/x86` and core source, an unverifiable ACPI claim removed, and unsourced hardware-dependent timing numbers hedged.
- **war-stories.md**: Case 3's entire premise was technically impossible (a fabricated compat syscall entry point for `read()`, which has no compat variant) — rewritten around a real native/compat divergence (`ioctl_preallocate()`/`compat_ioctl_preallocate()` in `fs/ioctl.c`). Case 5's fabricated `klp_atomic_replace()` function reference corrected to the real `klp_init_patch()`/`klp_add_nops()` chain.

`mkdocs build --strict` passes; all external URLs re-verified live; all 6 files' code-fence counts confirmed balanced (a fence-rendering bug found in the previous directory's PR taught us `--strict` alone doesn't catch this).