### PR TITLE
Feature: AI-Powered Kernel Internals

### DIFF
--- a/.github/workflows/ai-ci.yml
+++ b/.github/workflows/ai-ci.yml
@@ -31,13 +31,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      
-      - name: Check API Worker
+
+      - name: Check API Worker builds and is syntactically valid
         working-directory: ./api
         run: |
           npm install
-          
-      - name: Check MCP Server
+          node --check src/index.js
+          # --dry-run validates bindings/config and bundles the Worker
+          # without deploying or requiring Cloudflare credentials.
+          npx wrangler deploy --dry-run --outdir=dist
+
+      - name: Check MCP Server is syntactically valid
         working-directory: ./mcp
         run: |
           npm install
+          node --check index.js

--- a/.github/workflows/ai-ci.yml
+++ b/.github/workflows/ai-ci.yml
@@ -1,0 +1,43 @@
+name: AI Backend CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest requests
+      - name: Run Python Tests
+        run: |
+          pytest scripts/test_ingest.py -v
+
+  node-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Check API Worker
+        working-directory: ./api
+        run: |
+          npm install
+          
+      - name: Check MCP Server
+        working-directory: ./mcp
+        run: |
+          npm install

--- a/.github/workflows/ai-deploy.yml
+++ b/.github/workflows/ai-deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy AI Backend
+
+# trigger strictly on demand
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-api-and-vectors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          
+      - name: Install dependencies
+        run: |
+          npm install -g wrangler
+          pip install requests
+
+      - name: Ingest Markdown to NDJSON
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: |
+          python scripts/ingest_to_vectorize.py
+          
+      - name: Upload Embeddings to Vectorize
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          wrangler vectorize insert linux-kernel-docs-index --file vectors.ndjson
+          
+      - name: Deploy Cloudflare Worker API
+        working-directory: ./api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npm install
+          npx wrangler deploy

--- a/.github/workflows/ai-deploy.yml
+++ b/.github/workflows/ai-deploy.yml
@@ -47,3 +47,25 @@ jobs:
         run: |
           npm install
           npx wrangler deploy
+
+      - name: Set Worker secrets
+        working-directory: ./api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          # These are optional at first deploy: verifyTurnstile()/the MCP
+          # auth check both fail open/are simply unreachable without them,
+          # so the site keeps working before they're configured. Add
+          # TURNSTILE_SECRET_KEY and MCP_SHARED_KEY as repo secrets once
+          # you've created a Turnstile site and picked an MCP shared key.
+          if [ -n "${{ secrets.TURNSTILE_SECRET_KEY }}" ]; then
+            echo "${{ secrets.TURNSTILE_SECRET_KEY }}" | npx wrangler secret put TURNSTILE_SECRET_KEY
+          else
+            echo "TURNSTILE_SECRET_KEY not set in repo secrets — skipping (Turnstile checks will fail open)."
+          fi
+          if [ -n "${{ secrets.MCP_SHARED_KEY }}" ]; then
+            echo "${{ secrets.MCP_SHARED_KEY }}" | npx wrangler secret put MCP_SHARED_KEY
+          else
+            echo "MCP_SHARED_KEY not set in repo secrets — skipping (MCP traffic will be treated as anonymous)."
+          fi

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "linux-kernel-ai-api",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^3.0.0"
+  }
+}

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -319,18 +319,30 @@ export default {
         returnMetadata: true,
       });
 
+      // Only feed the model matches that are actually relevant. Forcing it
+      // to answer from the top-3 regardless of score leads to it treating
+      // barely-related chunks (or even a bare greeting's nearest neighbor)
+      // as ground truth and confidently answering off-topic.
+      const RELEVANCE_THRESHOLD = 0.55;
+      const relevantMatches = vectorizeResponse.matches.filter((m) => m.score >= RELEVANCE_THRESHOLD);
+
       let contextStr = "";
-      for (const match of vectorizeResponse.matches) {
+      for (const match of relevantMatches) {
         contextStr += `Source: ${match.metadata.source}\nText: ${match.metadata.text}\n\n`;
       }
 
-      const systemPrompt = `You are a helpful expert on Linux kernel internals.
-Answer the user's question using ONLY the provided documentation context below.
-If the answer is not in the context, say you do not know.
+      const systemPrompt = contextStr
+        ? `You are the documentation assistant for kernel-internals.org, a site about Linux kernel internals.
+Answer the user's question using ONLY the documentation context below — do not use outside knowledge.
+If the context doesn't actually answer the question, say so plainly instead of guessing.
 
 Context:
-${contextStr}
-`;
+${contextStr}`
+        : `You are the documentation assistant for kernel-internals.org, a site about Linux kernel internals.
+No documentation matched this question closely enough to answer from it.
+If this is a greeting or small talk, respond naturally and briefly, and mention you can
+answer questions about Linux kernel internals. Otherwise, say plainly that you don't have
+documentation covering this yet, and suggest the user try a more specific kernel topic.`;
 
       const chatResponse = await env.AI.run("@cf/meta/llama-3.1-8b-instruct-fp8-fast", {
         messages: [

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -28,13 +28,13 @@ const RATE_LIMITS = {
 // "the AI features go dark for the rest of the day" from a single burst.
 //
 // Rough neuron cost per call, from Cloudflare's published per-model rates
-// (bge-base-en-v1.5: ~6,058 neurons/M input tokens; llama-3-8b-instruct:
-// ~25,608/M input tokens, ~75,147/M output tokens), assuming a generously
+// (bge-base-en-v1.5: ~6,058 neurons/M input tokens; llama-3.1-8b-instruct-fp8-fast:
+// ~4,119/M input tokens, ~34,868/M output tokens), assuming a generously
 // long query/context/answer so the estimate errs high, not low:
 //   search: ~1 embedding call, short query           ->  ~3 neurons
 //   chat:   ~1 embedding call + 1 LLM call w/ RAG
-//           context (~1,000 input tok, ~300 output)  -> ~50 neurons
-const NEURON_ESTIMATE = { search: 3, chat: 50 };
+//           context (~1,000 input tok, ~300 output)  -> ~20 neurons
+const NEURON_ESTIMATE = { search: 3, chat: 20 };
 
 // Deliberately well under the real 10,000/day ceiling: leaves headroom
 // for estimation error above, and for whatever the ingestion script
@@ -320,7 +320,7 @@ Context:
 ${contextStr}
 `;
 
-      const chatResponse = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
+      const chatResponse = await env.AI.run("@cf/meta/llama-3.1-8b-instruct-fp8-fast", {
         messages: [
           { role: "system", content: systemPrompt },
           { role: "user", content: query },

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,9 +1,17 @@
 const MAX_QUERY_LENGTH = 500;
 
-// The production docs origin. Requests from any other Origin are rejected
-// server-side (browsers already enforce this via CORS, but a non-browser
-// client can ignore CORS entirely, so we also check Origin ourselves).
-const ALLOWED_ORIGIN = "https://kernel-internals.org";
+// The production docs origin, plus common local dev-server origins.
+// Requests from any other Origin are rejected server-side (browsers already
+// enforce this via CORS, but a non-browser client can ignore CORS entirely,
+// so we also check Origin ourselves). This is a soft deterrent, not the
+// primary abuse gate — a scripted client can simply omit the Origin header
+// entirely to skip this check (see the `!mcp && origin &&` guard below);
+// Turnstile and the rate/budget limits are what actually gate cost.
+const ALLOWED_ORIGINS = [
+  "https://kernel-internals.org",
+  "http://localhost:8000",
+  "http://127.0.0.1:8000",
+];
 
 // Per-IP fixed-window limits. Chat is limited harder than search since it
 // triggers both an embedding call and an LLM completion.
@@ -41,25 +49,27 @@ const NEURON_ESTIMATE = { search: 3, chat: 20 };
 // consumes on days it's re-run (it uses the same shared daily pool).
 const DAILY_NEURON_BUDGET = 7000;
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, X-API-Key",
-  "Vary": "Origin",
-};
+function corsHeadersFor(origin) {
+  return {
+    "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0],
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, X-API-Key",
+    "Vary": "Origin",
+  };
+}
 
-function jsonResponse(data, status = 200) {
+function jsonResponse(data, status = 200, origin) {
   return new Response(JSON.stringify(data), {
     status,
     headers: {
       "Content-Type": "application/json",
-      ...CORS_HEADERS,
+      ...corsHeadersFor(origin),
     },
   });
 }
 
-function errorResponse(message, status) {
-  return jsonResponse({ error: message }, status);
+function errorResponse(message, status, origin) {
+  return jsonResponse({ error: message }, status, origin);
 }
 
 function getClientId(request) {
@@ -189,31 +199,31 @@ function validateQuery(body) {
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
+    const origin = request.headers.get("Origin");
 
     if (request.method === "OPTIONS") {
-      return new Response(null, { headers: CORS_HEADERS });
+      return new Response(null, { headers: corsHeadersFor(origin) });
     }
 
     if (request.method !== "POST") {
-      return errorResponse("Method not allowed. Use POST /api/search or /api/chat", 405);
+      return errorResponse("Method not allowed. Use POST /api/search or /api/chat", 405, origin);
     }
 
     const mcp = isAuthenticatedMcp(request, env);
-    const origin = request.headers.get("Origin");
 
-    // Anonymous (non-MCP) callers must present the expected browser Origin.
-    // MCP traffic doesn't send an Origin header at all (it's not a browser
+    // Anonymous (non-MCP) callers must present an allowed Origin. MCP
+    // traffic doesn't send an Origin header at all (it's not a browser
     // request), so it's exempt from this check and relies on the API key
     // instead.
-    if (!mcp && origin && origin !== ALLOWED_ORIGIN) {
-      return errorResponse("Origin not allowed", 403);
+    if (!mcp && origin && !ALLOWED_ORIGINS.includes(origin)) {
+      return errorResponse("Origin not allowed", 403, origin);
     }
 
     let body;
     try {
       body = await request.json();
     } catch (e) {
-      return errorResponse("Invalid JSON body", 400);
+      return errorResponse("Invalid JSON body", 400, origin);
     }
 
     if (url.pathname === "/api/search") {
@@ -224,13 +234,14 @@ export default {
       return this.handleChat(body, env, request, mcp);
     }
 
-    return errorResponse("Not found", 404);
+    return errorResponse("Not found", 404, origin);
   },
 
   async handleSearch(body, env, request, mcp) {
+    const origin = request.headers.get("Origin");
     const { query, error } = validateQuery(body);
     if (error) {
-      return errorResponse(error, 400);
+      return errorResponse(error, 400, origin);
     }
 
     const clientId = getClientId(request);
@@ -241,13 +252,13 @@ export default {
     if (!mcp) {
       const turnstileOk = await verifyTurnstile(body.turnstileToken, clientId, env);
       if (!turnstileOk) {
-        return errorResponse("Bot verification failed. Please reload the page and try again.", 403);
+        return errorResponse("Bot verification failed. Please reload the page and try again.", 403, origin);
       }
     }
 
     const rl = await checkRateLimit(env, clientId, "search", mcp);
     if (!rl.ok) {
-      return errorResponse(rl.reason, 429);
+      return errorResponse(rl.reason, 429, origin);
     }
 
     try {
@@ -269,17 +280,18 @@ export default {
         source: match.metadata.source,
       }));
 
-      return jsonResponse({ results });
+      return jsonResponse({ results }, 200, origin);
     } catch (e) {
       console.error("handleSearch failed:", e);
-      return errorResponse("Search temporarily unavailable. Please try again.", 502);
+      return errorResponse("Search temporarily unavailable. Please try again.", 502, origin);
     }
   },
 
   async handleChat(body, env, request, mcp) {
+    const origin = request.headers.get("Origin");
     const { query, error } = validateQuery(body);
     if (error) {
-      return errorResponse(error, 400);
+      return errorResponse(error, 400, origin);
     }
 
     const clientId = getClientId(request);
@@ -287,13 +299,13 @@ export default {
     if (!mcp) {
       const turnstileOk = await verifyTurnstile(body.turnstileToken, clientId, env);
       if (!turnstileOk) {
-        return errorResponse("Bot verification failed. Please reload the page and try again.", 403);
+        return errorResponse("Bot verification failed. Please reload the page and try again.", 403, origin);
       }
     }
 
     const rl = await checkRateLimit(env, clientId, "chat", mcp);
     if (!rl.ok) {
-      return errorResponse(rl.reason, 429);
+      return errorResponse(rl.reason, 429, origin);
     }
 
     try {
@@ -327,10 +339,10 @@ ${contextStr}
         ],
       });
 
-      return jsonResponse({ answer: chatResponse.response });
+      return jsonResponse({ answer: chatResponse.response }, 200, origin);
     } catch (e) {
       console.error("handleChat failed:", e);
-      return errorResponse("Chat temporarily unavailable. Please try again.", 502);
+      return errorResponse("Chat temporarily unavailable. Please try again.", 502, origin);
     }
   },
 };

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,120 +1,313 @@
+const MAX_QUERY_LENGTH = 500;
+
+// The production docs origin. Requests from any other Origin are rejected
+// server-side (browsers already enforce this via CORS, but a non-browser
+// client can ignore CORS entirely, so we also check Origin ourselves).
+const ALLOWED_ORIGIN = "https://kernel-internals.org";
+
+// Per-IP fixed-window limits. Chat is limited harder than search since it
+// triggers both an embedding call and an LLM completion.
+const RATE_LIMITS = {
+  search: { max: 20, windowSeconds: 60 },
+  chat: { max: 5, windowSeconds: 60 },
+  // MCP traffic is identified by a shared key (see isAuthenticatedMcp) and
+  // gets its own, more generous bucket since it's a legitimate dev tool
+  // rather than anonymous browser traffic.
+  "search:mcp": { max: 60, windowSeconds: 60 },
+};
+
+// Aggregate limits across ALL callers combined, independent of source IP.
+// This is the backstop against distributed abuse (many IPs, or a botnet)
+// that would otherwise slip under the per-IP limits above.
+const GLOBAL_RATE_LIMITS = {
+  search: { max: 300, windowSeconds: 60 },
+  chat: { max: 60, windowSeconds: 60 },
+};
+
+// Hard daily ceiling on AI invocations, regardless of how requests are
+// distributed across IPs or time. This bounds worst-case Workers AI spend
+// even if every other layer of defense is somehow evaded.
+const DAILY_BUDGET = {
+  search: 20000,
+  chat: 3000,
+};
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, X-API-Key",
+  "Vary": "Origin",
+};
+
+function jsonResponse(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...CORS_HEADERS,
+    },
+  });
+}
+
+function errorResponse(message, status) {
+  return jsonResponse({ error: message }, status);
+}
+
+function getClientId(request) {
+  return request.headers.get("CF-Connecting-IP") || "unknown";
+}
+
+// The MCP server sends a shared key so its traffic can be recognized and
+// given its own rate-limit bucket instead of being treated as anonymous
+// browser traffic. This key ships in a public npm package, so it is NOT a
+// secret in the cryptographic sense — anyone who reads the package source
+// can extract and reuse it. Its value is (a) segmenting legitimate MCP
+// traffic from anonymous scraping for rate-limit purposes, and (b) giving
+// us a kill switch: if it leaks and gets abused, rotating MCP_SHARED_KEY
+// immediately invalidates every copy in the wild without touching the
+// chat widget's Origin-based access.
+function isAuthenticatedMcp(request, env) {
+  const key = request.headers.get("X-API-Key");
+  return !!key && !!env.MCP_SHARED_KEY && key === env.MCP_SHARED_KEY;
+}
+
+// Best-effort fixed-window counters backed by KV. KV writes aren't strongly
+// consistent across edge locations, so these deter casual/scripted/
+// distributed abuse rather than providing an exact global limit — an
+// acceptable tradeoff for protecting a free-tier AI/Vectorize budget.
+async function incrementCounter(env, key, windowSeconds) {
+  if (!env.RATE_LIMIT_KV) {
+    // KV binding not configured (e.g. local dev) — fail open rather than
+    // block all traffic, but this should never happen in production.
+    return 0;
+  }
+  const current = parseInt((await env.RATE_LIMIT_KV.get(key)) || "0", 10);
+  // expirationTtl must be >= 60s per KV constraints.
+  await env.RATE_LIMIT_KV.put(key, String(current + 1), {
+    expirationTtl: Math.max(windowSeconds, 60),
+  });
+  return current;
+}
+
+async function checkRateLimit(env, clientId, bucket, mcp) {
+  const limitKey = mcp ? `${bucket}:mcp` : bucket;
+  const perIpLimit = RATE_LIMITS[limitKey] || RATE_LIMITS[bucket];
+  const globalLimit = GLOBAL_RATE_LIMITS[bucket];
+  const dailyLimit = DAILY_BUDGET[bucket];
+
+  const minuteWindow = Math.floor(Date.now() / 60000);
+  const dayWindow = Math.floor(Date.now() / 86400000);
+
+  const [perIpCount, globalCount, dailyCount] = await Promise.all([
+    incrementCounter(env, `rl:${limitKey}:${clientId}:${minuteWindow}`, 60),
+    incrementCounter(env, `rl:global:${bucket}:${minuteWindow}`, 60),
+    incrementCounter(env, `budget:${bucket}:${dayWindow}`, 86400),
+  ]);
+
+  if (dailyCount >= dailyLimit) {
+    return { ok: false, reason: "Daily usage budget reached. Please try again tomorrow." };
+  }
+  if (globalCount >= globalLimit.max) {
+    return { ok: false, reason: "Service is under heavy load. Please try again shortly." };
+  }
+  if (perIpCount >= perIpLimit.max) {
+    return { ok: false, reason: "Rate limit exceeded. Please slow down." };
+  }
+  return { ok: true };
+}
+
+// Verifies a Cloudflare Turnstile token server-side. Turnstile is a
+// CAPTCHA-like challenge that's solved invisibly for most real browser
+// visitors but can't be completed by a plain HTTP client (curl, a Python
+// script, etc.) without running a real browser — it's the main defense
+// against a scripted REST client hammering the chat/search endpoints
+// directly, since Origin-header checks alone are trivially spoofed by
+// any non-browser caller.
+async function verifyTurnstile(token, ip, env) {
+  if (!env.TURNSTILE_SECRET_KEY) {
+    // Not configured yet (e.g. before initial Cloudflare setup) — fail
+    // open so the site keeps working, but this should be filled in before
+    // going live publicly.
+    return true;
+  }
+  if (!token) return false;
+
+  const formData = new URLSearchParams();
+  formData.append("secret", env.TURNSTILE_SECRET_KEY);
+  formData.append("response", token);
+  if (ip) formData.append("remoteip", ip);
+
+  try {
+    const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+      method: "POST",
+      body: formData,
+    });
+    const outcome = await res.json();
+    return outcome.success === true;
+  } catch (e) {
+    console.error("Turnstile verification failed:", e);
+    // Verification service itself errored — fail closed, since the whole
+    // point of this check is to gate the expensive path.
+    return false;
+  }
+}
+
+function validateQuery(body) {
+  const query = body && body.query;
+  if (typeof query !== "string" || !query.trim()) {
+    return { error: "Missing 'query' parameter" };
+  }
+  if (query.length > MAX_QUERY_LENGTH) {
+    return { error: `'query' exceeds maximum length of ${MAX_QUERY_LENGTH} characters` };
+  }
+  return { query: query.trim() };
+}
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
-    // Handle CORS preflight
     if (request.method === "OPTIONS") {
-      return new Response(null, {
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "POST, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type",
-        }
-      });
+      return new Response(null, { headers: CORS_HEADERS });
     }
 
     if (request.method !== "POST") {
-      return new Response("Method not allowed. Use POST /api/search or /api/chat", { status: 405 });
+      return errorResponse("Method not allowed. Use POST /api/search or /api/chat", 405);
+    }
+
+    const mcp = isAuthenticatedMcp(request, env);
+    const origin = request.headers.get("Origin");
+
+    // Anonymous (non-MCP) callers must present the expected browser Origin.
+    // MCP traffic doesn't send an Origin header at all (it's not a browser
+    // request), so it's exempt from this check and relies on the API key
+    // instead.
+    if (!mcp && origin && origin !== ALLOWED_ORIGIN) {
+      return errorResponse("Origin not allowed", 403);
     }
 
     let body;
     try {
       body = await request.json();
     } catch (e) {
-      return new Response("Invalid JSON body", { status: 400 });
+      return errorResponse("Invalid JSON body", 400);
     }
 
     if (url.pathname === "/api/search") {
-      return this.handleSearch(body, env);
+      return this.handleSearch(body, env, request, mcp);
     }
 
     if (url.pathname === "/api/chat") {
-      return this.handleChat(body, env);
+      return this.handleChat(body, env, request, mcp);
     }
 
-    return new Response("Not found", { status: 404 });
+    return errorResponse("Not found", 404);
   },
 
-  async handleSearch(body, env) {
-    const { query } = body;
-    if (!query) {
-      return new Response("Missing 'query' parameter", { status: 400 });
+  async handleSearch(body, env, request, mcp) {
+    const { query, error } = validateQuery(body);
+    if (error) {
+      return errorResponse(error, 400);
     }
 
-    // 1. Generate embedding for the query using BAAI model
-    const embeddingResponse = await env.AI.run('@cf/baai/bge-base-en-v1.5', {
-      text: [query]
-    });
-    
-    const queryVector = embeddingResponse.data[0];
+    const clientId = getClientId(request);
 
-    // 2. Query the Vectorize index
-    const vectorizeResponse = await env.VECTORIZE_INDEX.query(queryVector, {
-      topK: 5,
-      returnValues: true,
-      returnMetadata: true
-    });
-
-    // 3. Format the results
-    const results = vectorizeResponse.matches.map(match => ({
-      score: match.score,
-      id: match.id,
-      text: match.metadata.text,
-      source: match.metadata.source
-    }));
-
-    return new Response(JSON.stringify({ results }), {
-      headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*"
+    // Browser callers must pass a Turnstile challenge; MCP callers are
+    // exempt (they authenticate via the shared key instead, and can't run
+    // a browser challenge from a stdio process).
+    if (!mcp) {
+      const turnstileOk = await verifyTurnstile(body.turnstileToken, clientId, env);
+      if (!turnstileOk) {
+        return errorResponse("Bot verification failed. Please reload the page and try again.", 403);
       }
-    });
+    }
+
+    const rl = await checkRateLimit(env, clientId, "search", mcp);
+    if (!rl.ok) {
+      return errorResponse(rl.reason, 429);
+    }
+
+    try {
+      const embeddingResponse = await env.AI.run("@cf/baai/bge-base-en-v1.5", {
+        text: [query],
+      });
+      const queryVector = embeddingResponse.data[0];
+
+      const vectorizeResponse = await env.VECTORIZE_INDEX.query(queryVector, {
+        topK: 5,
+        returnValues: true,
+        returnMetadata: true,
+      });
+
+      const results = vectorizeResponse.matches.map((match) => ({
+        score: match.score,
+        id: match.id,
+        text: match.metadata.text,
+        source: match.metadata.source,
+      }));
+
+      return jsonResponse({ results });
+    } catch (e) {
+      console.error("handleSearch failed:", e);
+      return errorResponse("Search temporarily unavailable. Please try again.", 502);
+    }
   },
 
-  async handleChat(body, env) {
-    const { query } = body;
-    if (!query) {
-      return new Response("Missing 'query' parameter", { status: 400 });
+  async handleChat(body, env, request, mcp) {
+    const { query, error } = validateQuery(body);
+    if (error) {
+      return errorResponse(error, 400);
     }
 
-    // 1. First, search the vector DB for context
-    const embeddingResponse = await env.AI.run('@cf/baai/bge-base-en-v1.5', {
-      text: [query]
-    });
-    
-    const queryVector = embeddingResponse.data[0];
-    const vectorizeResponse = await env.VECTORIZE_INDEX.query(queryVector, {
-      topK: 3,
-      returnMetadata: true
-    });
+    const clientId = getClientId(request);
 
-    // 2. Construct the context prompt
-    let contextStr = "";
-    for (const match of vectorizeResponse.matches) {
-      contextStr += `Source: ${match.metadata.source}\nText: ${match.metadata.text}\n\n`;
+    if (!mcp) {
+      const turnstileOk = await verifyTurnstile(body.turnstileToken, clientId, env);
+      if (!turnstileOk) {
+        return errorResponse("Bot verification failed. Please reload the page and try again.", 403);
+      }
     }
 
-    const systemPrompt = `You are a helpful expert on Linux kernel internals. 
-Answer the user's question using ONLY the provided documentation context below. 
+    const rl = await checkRateLimit(env, clientId, "chat", mcp);
+    if (!rl.ok) {
+      return errorResponse(rl.reason, 429);
+    }
+
+    try {
+      const embeddingResponse = await env.AI.run("@cf/baai/bge-base-en-v1.5", {
+        text: [query],
+      });
+      const queryVector = embeddingResponse.data[0];
+
+      const vectorizeResponse = await env.VECTORIZE_INDEX.query(queryVector, {
+        topK: 3,
+        returnMetadata: true,
+      });
+
+      let contextStr = "";
+      for (const match of vectorizeResponse.matches) {
+        contextStr += `Source: ${match.metadata.source}\nText: ${match.metadata.text}\n\n`;
+      }
+
+      const systemPrompt = `You are a helpful expert on Linux kernel internals.
+Answer the user's question using ONLY the provided documentation context below.
 If the answer is not in the context, say you do not know.
 
 Context:
 ${contextStr}
 `;
 
-    // 3. Query Llama 3 for the final answer
-    const chatResponse = await env.AI.run('@cf/meta/llama-3-8b-instruct', {
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: query }
-      ]
-    });
+      const chatResponse = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: query },
+        ],
+      });
 
-    return new Response(JSON.stringify({ answer: chatResponse.response }), {
-      headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*"
-      }
-    });
-  }
+      return jsonResponse({ answer: chatResponse.response });
+    } catch (e) {
+      console.error("handleChat failed:", e);
+      return errorResponse("Chat temporarily unavailable. Please try again.", 502);
+    }
+  },
 };

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,0 +1,120 @@
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    // Handle CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, {
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "POST, OPTIONS",
+          "Access-Control-Allow-Headers": "Content-Type",
+        }
+      });
+    }
+
+    if (request.method !== "POST") {
+      return new Response("Method not allowed. Use POST /api/search or /api/chat", { status: 405 });
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch (e) {
+      return new Response("Invalid JSON body", { status: 400 });
+    }
+
+    if (url.pathname === "/api/search") {
+      return this.handleSearch(body, env);
+    }
+
+    if (url.pathname === "/api/chat") {
+      return this.handleChat(body, env);
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+
+  async handleSearch(body, env) {
+    const { query } = body;
+    if (!query) {
+      return new Response("Missing 'query' parameter", { status: 400 });
+    }
+
+    // 1. Generate embedding for the query using BAAI model
+    const embeddingResponse = await env.AI.run('@cf/baai/bge-base-en-v1.5', {
+      text: [query]
+    });
+    
+    const queryVector = embeddingResponse.data[0];
+
+    // 2. Query the Vectorize index
+    const vectorizeResponse = await env.VECTORIZE_INDEX.query(queryVector, {
+      topK: 5,
+      returnValues: true,
+      returnMetadata: true
+    });
+
+    // 3. Format the results
+    const results = vectorizeResponse.matches.map(match => ({
+      score: match.score,
+      id: match.id,
+      text: match.metadata.text,
+      source: match.metadata.source
+    }));
+
+    return new Response(JSON.stringify({ results }), {
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*"
+      }
+    });
+  },
+
+  async handleChat(body, env) {
+    const { query } = body;
+    if (!query) {
+      return new Response("Missing 'query' parameter", { status: 400 });
+    }
+
+    // 1. First, search the vector DB for context
+    const embeddingResponse = await env.AI.run('@cf/baai/bge-base-en-v1.5', {
+      text: [query]
+    });
+    
+    const queryVector = embeddingResponse.data[0];
+    const vectorizeResponse = await env.VECTORIZE_INDEX.query(queryVector, {
+      topK: 3,
+      returnMetadata: true
+    });
+
+    // 2. Construct the context prompt
+    let contextStr = "";
+    for (const match of vectorizeResponse.matches) {
+      contextStr += `Source: ${match.metadata.source}\nText: ${match.metadata.text}\n\n`;
+    }
+
+    const systemPrompt = `You are a helpful expert on Linux kernel internals. 
+Answer the user's question using ONLY the provided documentation context below. 
+If the answer is not in the context, say you do not know.
+
+Context:
+${contextStr}
+`;
+
+    // 3. Query Llama 3 for the final answer
+    const chatResponse = await env.AI.run('@cf/meta/llama-3-8b-instruct', {
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: query }
+      ]
+    });
+
+    return new Response(JSON.stringify({ answer: chatResponse.response }), {
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*"
+      }
+    });
+  }
+};

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -16,21 +16,30 @@ const RATE_LIMITS = {
   "search:mcp": { max: 60, windowSeconds: 60 },
 };
 
-// Aggregate limits across ALL callers combined, independent of source IP.
-// This is the backstop against distributed abuse (many IPs, or a botnet)
-// that would otherwise slip under the per-IP limits above.
-const GLOBAL_RATE_LIMITS = {
-  search: { max: 300, windowSeconds: 60 },
-  chat: { max: 60, windowSeconds: 60 },
-};
+// --- Free-tier budget guardrails -------------------------------------
+//
+// Workers AI's free allocation is 10,000 "neurons"/day, SHARED across
+// every model call on the account — search's embedding call, chat's
+// embedding + LLM completion, AND the ingestion script's embedding calls
+// when it runs. On the Workers Free plan (not Paid), exceeding this just
+// fails the call with an error; it does not bill you. This budget exists
+// to keep the site itself well clear of that wall, not to protect against
+// a bill (there isn't one, on Free) — the failure mode we're avoiding is
+// "the AI features go dark for the rest of the day" from a single burst.
+//
+// Rough neuron cost per call, from Cloudflare's published per-model rates
+// (bge-base-en-v1.5: ~6,058 neurons/M input tokens; llama-3-8b-instruct:
+// ~25,608/M input tokens, ~75,147/M output tokens), assuming a generously
+// long query/context/answer so the estimate errs high, not low:
+//   search: ~1 embedding call, short query           ->  ~3 neurons
+//   chat:   ~1 embedding call + 1 LLM call w/ RAG
+//           context (~1,000 input tok, ~300 output)  -> ~50 neurons
+const NEURON_ESTIMATE = { search: 3, chat: 50 };
 
-// Hard daily ceiling on AI invocations, regardless of how requests are
-// distributed across IPs or time. This bounds worst-case Workers AI spend
-// even if every other layer of defense is somehow evaded.
-const DAILY_BUDGET = {
-  search: 20000,
-  chat: 3000,
-};
+// Deliberately well under the real 10,000/day ceiling: leaves headroom
+// for estimation error above, and for whatever the ingestion script
+// consumes on days it's re-run (it uses the same shared daily pool).
+const DAILY_NEURON_BUDGET = 7000;
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
@@ -71,48 +80,62 @@ function isAuthenticatedMcp(request, env) {
   return !!key && !!env.MCP_SHARED_KEY && key === env.MCP_SHARED_KEY;
 }
 
-// Best-effort fixed-window counters backed by KV. KV writes aren't strongly
-// consistent across edge locations, so these deter casual/scripted/
-// distributed abuse rather than providing an exact global limit — an
-// acceptable tradeoff for protecting a free-tier AI/Vectorize budget.
-async function incrementCounter(env, key, windowSeconds) {
-  if (!env.RATE_LIMIT_KV) {
-    // KV binding not configured (e.g. local dev) — fail open rather than
-    // block all traffic, but this should never happen in production.
-    return 0;
-  }
-  const current = parseInt((await env.RATE_LIMIT_KV.get(key)) || "0", 10);
-  // expirationTtl must be >= 60s per KV constraints.
-  await env.RATE_LIMIT_KV.put(key, String(current + 1), {
-    expirationTtl: Math.max(windowSeconds, 60),
-  });
-  return current;
+// Best-effort fixed-window counters backed by KV. Two important caveats
+// this design is built around:
+//
+// 1. KV writes aren't strongly consistent across edge locations, so these
+//    counters deter casual/scripted/distributed abuse rather than
+//    providing an exact global limit — acceptable for a soft budget gate,
+//    not something to rely on for hard billing-critical accounting.
+// 2. Workers KV's own FREE plan caps WRITES at 1,000/day (reads are far
+//    more generous at 100,000/day). Every counter increment here is a
+//    write, so the counter design itself has to stay well under that —
+//    this is why there are exactly TWO KV writes per request that reaches
+//    this function (one per-IP, one shared daily budget), not one per
+//    logical thing we might want to track. Requests rejected earlier by
+//    the Origin or Turnstile checks never reach here, so blind/scripted
+//    floods don't consume any KV write quota at all.
+async function readCounter(env, key) {
+  if (!env.RATE_LIMIT_KV) return 0; // No KV binding (e.g. local dev) — fail open.
+  return parseInt((await env.RATE_LIMIT_KV.get(key)) || "0", 10);
+}
+
+async function incrementCounter(env, key, amount, expirationTtl) {
+  if (!env.RATE_LIMIT_KV) return;
+  const current = await readCounter(env, key);
+  await env.RATE_LIMIT_KV.put(key, String(current + amount), { expirationTtl });
 }
 
 async function checkRateLimit(env, clientId, bucket, mcp) {
   const limitKey = mcp ? `${bucket}:mcp` : bucket;
   const perIpLimit = RATE_LIMITS[limitKey] || RATE_LIMITS[bucket];
-  const globalLimit = GLOBAL_RATE_LIMITS[bucket];
-  const dailyLimit = DAILY_BUDGET[bucket];
+  const neuronCost = NEURON_ESTIMATE[bucket];
 
   const minuteWindow = Math.floor(Date.now() / 60000);
   const dayWindow = Math.floor(Date.now() / 86400000);
+  const perIpKey = `rl:${limitKey}:${clientId}:${minuteWindow}`;
+  const budgetKey = `budget:neurons:${dayWindow}`;
 
-  const [perIpCount, globalCount, dailyCount] = await Promise.all([
-    incrementCounter(env, `rl:${limitKey}:${clientId}:${minuteWindow}`, 60),
-    incrementCounter(env, `rl:global:${bucket}:${minuteWindow}`, 60),
-    incrementCounter(env, `budget:${bucket}:${dayWindow}`, 86400),
+  // Reads are cheap (100,000/day free) — check both before deciding
+  // whether either write is even worth making.
+  const [perIpCount, neuronsSpent] = await Promise.all([
+    readCounter(env, perIpKey),
+    readCounter(env, budgetKey),
   ]);
 
-  if (dailyCount >= dailyLimit) {
-    return { ok: false, reason: "Daily usage budget reached. Please try again tomorrow." };
-  }
-  if (globalCount >= globalLimit.max) {
-    return { ok: false, reason: "Service is under heavy load. Please try again shortly." };
+  if (neuronsSpent + neuronCost > DAILY_NEURON_BUDGET) {
+    return { ok: false, reason: "Daily AI usage budget reached. Please try again tomorrow." };
   }
   if (perIpCount >= perIpLimit.max) {
     return { ok: false, reason: "Rate limit exceeded. Please slow down." };
   }
+
+  // Only now, having decided to allow the request, spend the two writes.
+  await Promise.all([
+    incrementCounter(env, perIpKey, 1, Math.max(perIpLimit.windowSeconds, 60)),
+    incrementCounter(env, budgetKey, neuronCost, 86400),
+  ]);
+
   return { ok: true };
 }
 

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -5,9 +5,11 @@ compatibility_date = "2024-03-20"
 [ai]
 binding = "AI"
 
-routes = [
-  { pattern = "api.kernel-internals.org", custom_domain = true }
-]
+# No custom domain route yet — kernel-internals.org isn't a Cloudflare
+# zone yet, so this deploys to the default *.workers.dev URL for now.
+# Once the domain is added to Cloudflare, add back:
+#   routes = [{ pattern = "api.kernel-internals.org", custom_domain = true }]
+# and update API_URL in docs/javascripts/chat.js and mcp/index.js to match.
 
 [[vectorize]]
 binding = "VECTORIZE_INDEX"

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -5,6 +5,10 @@ compatibility_date = "2024-03-20"
 [ai]
 binding = "AI"
 
+routes = [
+  { pattern = "api.kernel-internals.org", custom_domain = true }
+]
+
 [[vectorize]]
 binding = "VECTORIZE_INDEX"
 index_name = "linux-kernel-docs-index"

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -1,0 +1,10 @@
+name = "linux-kernel-ai-api"
+main = "src/index.js"
+compatibility_date = "2024-03-20"
+
+[ai]
+binding = "AI"
+
+[[vectorize]]
+binding = "VECTORIZE_INDEX"
+index_name = "linux-kernel-docs-index"

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -12,3 +12,29 @@ routes = [
 [[vectorize]]
 binding = "VECTORIZE_INDEX"
 index_name = "linux-kernel-docs-index"
+
+# Used for best-effort per-IP rate limiting (see src/index.js checkRateLimit).
+# Create with: npx wrangler kv namespace create RATE_LIMIT_KV
+# then replace the id below (currently a placeholder, valid-format but fake)
+# with the id that command prints.
+[[kv_namespaces]]
+binding = "RATE_LIMIT_KV"
+id = "00000000000000000000000000000000"
+
+# Secrets (not stored in this file — set via `wrangler secret put <NAME>`,
+# or as GitHub repo secrets consumed by .github/workflows/ai-deploy.yml):
+#
+#   TURNSTILE_SECRET_KEY  Cloudflare Turnstile secret key, paired with the
+#                         public site key in docs/javascripts/chat.js.
+#                         Until this is set, Turnstile verification fails
+#                         open (see verifyTurnstile() in src/index.js) so
+#                         the widget keeps working during initial setup,
+#                         just without bot protection.
+#
+#   MCP_SHARED_KEY        Must match the key the MCP server sends via
+#                         X-API-Key (see mcp/index.js). Not a strong secret
+#                         (it ships in a public package) — used to segment
+#                         MCP traffic into its own rate-limit bucket and as
+#                         a kill switch if it's abused. Set this to
+#                         whatever value mcp/index.js's API_KEY constant
+#                         (or its KERNEL_INTERNALS_API_KEY override) uses.

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -16,12 +16,9 @@ binding = "VECTORIZE_INDEX"
 index_name = "linux-kernel-docs-index"
 
 # Used for best-effort per-IP rate limiting (see src/index.js checkRateLimit).
-# Create with: npx wrangler kv namespace create RATE_LIMIT_KV
-# then replace the id below (currently a placeholder, valid-format but fake)
-# with the id that command prints.
 [[kv_namespaces]]
 binding = "RATE_LIMIT_KV"
-id = "00000000000000000000000000000000"
+id = "69251dc2805d4145a2041aaceea8e142"
 
 # Secrets (not stored in this file — set via `wrangler secret put <NAME>`,
 # or as GitHub repo secrets consumed by .github/workflows/ai-deploy.yml):

--- a/docs/javascripts/chat.js
+++ b/docs/javascripts/chat.js
@@ -1,0 +1,131 @@
+document.addEventListener("DOMContentLoaded", () => {
+    // Inject the Chat UI HTML into the body
+    const chatHTML = `
+        <div id="ai-chat-widget">
+            <div id="ai-chat-header">
+                <span>🤖 Linux Kernel AI</span>
+                <button id="ai-chat-toggle" style="background:none;border:none;color:white;cursor:pointer;">_</button>
+            </div>
+            <div id="ai-chat-body" style="display:none;">
+                <div id="ai-chat-messages">
+                    <div class="ai-msg">Ask me anything about Linux kernel internals!</div>
+                </div>
+                <div id="ai-chat-input-area">
+                    <input type="text" id="ai-chat-input" placeholder="How does the clocksource watchdog work?" />
+                    <button id="ai-chat-send">Send</button>
+                </div>
+            </div>
+        </div>
+        <style>
+            #ai-chat-widget {
+                position: fixed;
+                bottom: 20px;
+                right: 20px;
+                width: 350px;
+                background: white;
+                border-radius: 8px;
+                box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                z-index: 9999;
+                display: flex;
+                flex-direction: column;
+                overflow: hidden;
+            }
+            #ai-chat-header {
+                background: #007bff;
+                color: white;
+                padding: 10px 15px;
+                font-weight: bold;
+                display: flex;
+                justify-content: space-between;
+                cursor: pointer;
+            }
+            #ai-chat-body {
+                display: flex;
+                flex-direction: column;
+                height: 400px;
+            }
+            #ai-chat-messages {
+                flex-grow: 1;
+                padding: 15px;
+                overflow-y: auto;
+                background: #f8f9fa;
+                font-size: 14px;
+            }
+            .ai-msg { background: #e9ecef; padding: 10px; border-radius: 8px; margin-bottom: 10px; }
+            .user-msg { background: #007bff; color: white; padding: 10px; border-radius: 8px; margin-bottom: 10px; text-align: right; }
+            #ai-chat-input-area {
+                display: flex;
+                padding: 10px;
+                border-top: 1px solid #ddd;
+            }
+            #ai-chat-input {
+                flex-grow: 1;
+                padding: 8px;
+                border: 1px solid #ddd;
+                border-radius: 4px;
+            }
+            #ai-chat-send {
+                margin-left: 10px;
+                padding: 8px 12px;
+                background: #007bff;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+            }
+        </style>
+    `;
+
+    document.body.insertAdjacentHTML('beforeend', chatHTML);
+
+    const header = document.getElementById('ai-chat-header');
+    const body = document.getElementById('ai-chat-body');
+    const toggleBtn = document.getElementById('ai-chat-toggle');
+    const input = document.getElementById('ai-chat-input');
+    const sendBtn = document.getElementById('ai-chat-send');
+    const messages = document.getElementById('ai-chat-messages');
+
+    // Replace this with the actual deployed Cloudflare Worker URL
+    const API_URL = "https://linux-kernel-ai-api.YOUR-USERNAME.workers.dev/api/chat";
+
+    header.addEventListener('click', () => {
+        const isHidden = body.style.display === 'none';
+        body.style.display = isHidden ? 'flex' : 'none';
+        toggleBtn.innerText = isHidden ? '-' : '_';
+    });
+
+    async function sendMessage() {
+        const text = input.value.trim();
+        if (!text) return;
+
+        messages.insertAdjacentHTML('beforeend', `<div class="user-msg">${text}</div>`);
+        input.value = '';
+        messages.scrollTop = messages.scrollHeight;
+
+        const typingIndicator = document.createElement('div');
+        typingIndicator.className = 'ai-msg';
+        typingIndicator.innerText = 'Thinking...';
+        messages.appendChild(typingIndicator);
+        messages.scrollTop = messages.scrollHeight;
+
+        try {
+            const res = await fetch(API_URL, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ query: text })
+            });
+            const data = await res.json();
+            
+            typingIndicator.innerText = data.answer || "Sorry, I couldn't process that.";
+        } catch (e) {
+            typingIndicator.innerText = "Error connecting to AI service.";
+        }
+        messages.scrollTop = messages.scrollHeight;
+    }
+
+    sendBtn.addEventListener('click', sendMessage);
+    input.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') sendMessage();
+    });
+});

--- a/docs/javascripts/chat.js
+++ b/docs/javascripts/chat.js
@@ -86,8 +86,72 @@ document.addEventListener("DOMContentLoaded", () => {
     const sendBtn = document.getElementById('ai-chat-send');
     const messages = document.getElementById('ai-chat-messages');
 
-    // Replace this with the actual deployed Cloudflare Worker URL
     const API_URL = "https://api.kernel-internals.org/api/chat";
+
+    // Public Turnstile site key. Obtain from the Cloudflare dashboard
+    // (Turnstile product) once you've signed up, then replace this
+    // placeholder. Until it's replaced, initTurnstile() below no-ops and
+    // requests are sent without a token — the Worker fails open on that
+    // (see TURNSTILE_SECRET_KEY in api/src/index.js) so the widget keeps
+    // working during initial setup, just without bot protection yet.
+    const TURNSTILE_SITE_KEY = "REPLACE_WITH_TURNSTILE_SITE_KEY";
+
+    let turnstileWidgetId = null;
+    let resolveTurnstileToken = null;
+
+    function waitForTurnstile(attemptsLeft) {
+        if (typeof turnstile !== "undefined") {
+            initTurnstile();
+            return;
+        }
+        if (attemptsLeft > 0) {
+            setTimeout(() => waitForTurnstile(attemptsLeft - 1), 100);
+        }
+        // else: give up silently; getTurnstileToken() resolves null and
+        // the server-side fail-open/fail-closed logic takes over.
+    }
+
+    function initTurnstile() {
+        if (!TURNSTILE_SITE_KEY || TURNSTILE_SITE_KEY.indexOf("REPLACE_") === 0) {
+            return;
+        }
+        const container = document.createElement('div');
+        container.id = 'ai-chat-turnstile';
+        container.style.display = 'none';
+        document.body.appendChild(container);
+
+        turnstileWidgetId = turnstile.render('#ai-chat-turnstile', {
+            sitekey: TURNSTILE_SITE_KEY,
+            size: 'invisible',
+            callback: (token) => {
+                if (resolveTurnstileToken) resolveTurnstileToken(token);
+            },
+            'error-callback': () => {
+                if (resolveTurnstileToken) resolveTurnstileToken(null);
+            },
+        });
+    }
+
+    // Kick off Turnstile loading; harmless no-op if not yet configured.
+    waitForTurnstile(50);
+
+    function getTurnstileToken() {
+        if (turnstileWidgetId === null) {
+            return Promise.resolve(null);
+        }
+        return new Promise((resolve) => {
+            let settled = false;
+            const finish = (token) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeoutId);
+                resolve(token);
+            };
+            const timeoutId = setTimeout(() => finish(null), 10000);
+            resolveTurnstileToken = finish;
+            turnstile.execute(turnstileWidgetId);
+        });
+    }
 
     header.addEventListener('click', () => {
         const isHidden = body.style.display === 'none';
@@ -95,11 +159,26 @@ document.addEventListener("DOMContentLoaded", () => {
         toggleBtn.innerText = isHidden ? '-' : '_';
     });
 
+    const MAX_QUERY_LENGTH = 500;
+
     async function sendMessage() {
         const text = input.value.trim();
         if (!text) return;
+        if (text.length > MAX_QUERY_LENGTH) {
+            const warn = document.createElement('div');
+            warn.className = 'ai-msg';
+            warn.innerText = `Please keep questions under ${MAX_QUERY_LENGTH} characters.`;
+            messages.appendChild(warn);
+            messages.scrollTop = messages.scrollHeight;
+            return;
+        }
 
-        messages.insertAdjacentHTML('beforeend', `<div class="user-msg">${text}</div>`);
+        // Build the user message via textContent, never innerHTML/insertAdjacentHTML,
+        // so arbitrary user input can never be interpreted as markup.
+        const userMsg = document.createElement('div');
+        userMsg.className = 'user-msg';
+        userMsg.textContent = text;
+        messages.appendChild(userMsg);
         input.value = '';
         messages.scrollTop = messages.scrollHeight;
 
@@ -110,13 +189,24 @@ document.addEventListener("DOMContentLoaded", () => {
         messages.scrollTop = messages.scrollHeight;
 
         try {
+            const turnstileToken = await getTurnstileToken();
             const res = await fetch(API_URL, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ query: text })
+                body: JSON.stringify({ query: text, turnstileToken })
             });
+            if (!res.ok) {
+                typingIndicator.innerText = res.status === 429
+                    ? "You're asking too fast — please wait a moment and try again."
+                    : res.status === 403
+                    ? "Verification failed — please reload the page and try again."
+                    : "The AI service returned an error. Please try again.";
+                messages.scrollTop = messages.scrollHeight;
+                return;
+            }
             const data = await res.json();
-            
+
+            // .innerText, not innerHTML: the model's answer is untrusted text, not markup.
             typingIndicator.innerText = data.answer || "Sorry, I couldn't process that.";
         } catch (e) {
             typingIndicator.innerText = "Error connecting to AI service.";

--- a/docs/javascripts/chat.js
+++ b/docs/javascripts/chat.js
@@ -86,7 +86,10 @@ document.addEventListener("DOMContentLoaded", () => {
     const sendBtn = document.getElementById('ai-chat-send');
     const messages = document.getElementById('ai-chat-messages');
 
-    const API_URL = "https://api.kernel-internals.org/api/chat";
+    // TODO: point back at https://api.kernel-internals.org/api/chat once the
+    // custom domain route is restored (see api/wrangler.toml). Using the
+    // workers.dev URL directly for now, during local testing.
+    const API_URL = "https://linux-kernel-ai-api.laveeshbansal.workers.dev/api/chat";
 
     // Public Turnstile site key. Obtain from the Cloudflare dashboard
     // (Turnstile product) once you've signed up, then replace this

--- a/docs/javascripts/chat.js
+++ b/docs/javascripts/chat.js
@@ -87,7 +87,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const messages = document.getElementById('ai-chat-messages');
 
     // Replace this with the actual deployed Cloudflare Worker URL
-    const API_URL = "https://linux-kernel-ai-api.YOUR-USERNAME.workers.dev/api/chat";
+    const API_URL = "https://api.kernel-internals.org/api/chat";
 
     header.addEventListener('click', () => {
         const isHidden = body.style.display === 'none';

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -5,7 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
 // The live Cloudflare API endpoint
-const API_URL = "https://linux-kernel-ai-api.YOUR-USERNAME.workers.dev/api/search";
+const API_URL = "https://api.kernel-internals.org/api/search";
 
 const server = new Server({
   name: "linux-kernel-internals",

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -7,6 +7,18 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprot
 // The live Cloudflare API endpoint
 const API_URL = "https://api.kernel-internals.org/api/search";
 
+// Identifies this traffic to the Worker as coming from the official MCP
+// server rather than an anonymous script, so it gets its own rate-limit
+// bucket instead of the anonymous-browser one and skips the Turnstile
+// bot-check (which a stdio process can't complete).
+//
+// This is NOT a cryptographic secret — it ships in this published package,
+// so anyone can read it. Its purpose is traffic segmentation and a kill
+// switch (the server owner can rotate MCP_SHARED_KEY to invalidate every
+// copy in the wild), not access control. Override via env var if you're
+// running your own private deployment with your own key.
+const API_KEY = process.env.KERNEL_INTERNALS_API_KEY || "mcp-public-client-v1";
+
 const server = new Server({
   name: "linux-kernel-internals",
   version: "1.0.0",
@@ -47,7 +59,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     const res = await fetch(API_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": API_KEY,
+      },
       body: JSON.stringify({ query })
     });
     

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+// The live Cloudflare API endpoint
+const API_URL = "https://linux-kernel-ai-api.YOUR-USERNAME.workers.dev/api/search";
+
+const server = new Server({
+  name: "linux-kernel-internals",
+  version: "1.0.0",
+}, {
+  capabilities: {
+    tools: {}
+  }
+});
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: "search_kernel_internals",
+        description: "Search the comprehensive Linux Kernel Internals documentation for explanations, design decisions, and architectural details.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "The technical question or topic to search for (e.g., 'How does the clocksource watchdog fail?')"
+            }
+          },
+          required: ["query"]
+        }
+      }
+    ]
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name !== "search_kernel_internals") {
+    throw new Error(`Unknown tool: ${request.params.name}`);
+  }
+
+  const { query } = request.params.arguments;
+  
+  try {
+    const res = await fetch(API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query })
+    });
+    
+    if (!res.ok) {
+      throw new Error(`API returned ${res.status}: ${res.statusText}`);
+    }
+
+    const data = await res.json();
+    
+    // Format the results
+    const textOutput = data.results.map((r, i) => `[Result ${i + 1} from ${r.source}]\n${r.text}`).join('\n\n---\n\n');
+    
+    return {
+      content: [{ type: "text", text: textOutput || "No results found." }]
+    };
+  } catch (error) {
+    return {
+      content: [{ type: "text", text: `Error searching documentation: ${error.message}` }],
+      isError: true
+    };
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Linux Kernel Internals MCP Server running on stdio");
+}
+
+main().catch(console.error);

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@laveeshb/linux-kernel-mcp",
+  "version": "1.0.0",
+  "description": "MCP Server for querying Linux Kernel Internals documentation",
+  "main": "index.js",
+  "bin": {
+    "linux-kernel-mcp": "./index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.1"
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ extra_css:
 
 extra_javascript:
   - javascripts/external-links.js
+  - javascripts/chat.js
 
 nav:
   - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ extra_css:
 
 extra_javascript:
   - javascripts/external-links.js
+  - https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit
   - javascripts/chat.js
 
 nav:

--- a/scripts/ingest_to_vectorize.py
+++ b/scripts/ingest_to_vectorize.py
@@ -1,0 +1,90 @@
+import os
+import glob
+import json
+import re
+import requests
+import uuid
+
+CF_ACCOUNT_ID = os.environ.get('CF_ACCOUNT_ID')
+CF_API_TOKEN = os.environ.get('CF_API_TOKEN')
+INDEX_NAME = "linux-kernel-docs-index"
+
+def get_embedding(text):
+    if not CF_ACCOUNT_ID or not CF_API_TOKEN:
+        print("Warning: Missing CF_ACCOUNT_ID or CF_API_TOKEN. Skipping real embedding.")
+        return [0.0] * 768  # bge-base-en-v1.5 has 768 dimensions
+        
+    url = f"https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}/ai/run/@cf/baai/bge-base-en-v1.5"
+    headers = {"Authorization": f"Bearer {CF_API_TOKEN}"}
+    response = requests.post(url, headers=headers, json={"text": [text]})
+    response.raise_for_status()
+    return response.json()['result']['data'][0]
+
+def chunk_markdown(filepath):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    # Split by markdown headers (## or ###)
+    # This is a simple chunker. For production, a more robust AST parser could be used.
+    sections = re.split(r'(^#{2,3}\s+.*$)', content, flags=re.MULTILINE)
+    
+    chunks = []
+    current_title = "Introduction"
+    current_text = ""
+    
+    # sections[0] is everything before the first ##
+    if sections[0].strip():
+        chunks.append({
+            "source": os.path.basename(filepath),
+            "text": sections[0].strip()
+        })
+        
+    for i in range(1, len(sections), 2):
+        title = sections[i].strip()
+        text = sections[i+1].strip() if i+1 < len(sections) else ""
+        if text:
+            chunks.append({
+                "source": f"{os.path.basename(filepath)} - {title}",
+                "text": text
+            })
+            
+    return chunks
+
+def main():
+    docs_dir = os.path.join(os.path.dirname(__file__), '..', 'docs')
+    md_files = glob.glob(os.path.join(docs_dir, '**', '*.md'), recursive=True)
+    
+    vectors = []
+    
+    for md_file in md_files:
+        print(f"Processing {md_file}...")
+        chunks = chunk_markdown(md_file)
+        
+        for chunk in chunks:
+            # Skip very small chunks
+            if len(chunk['text']) < 50:
+                continue
+                
+            embedding = get_embedding(chunk['text'])
+            vector_id = str(uuid.uuid5(uuid.NAMESPACE_URL, chunk['source'] + str(len(chunk['text']))))
+            
+            vectors.append({
+                "id": vector_id,
+                "values": embedding,
+                "metadata": {
+                    "source": chunk['source'],
+                    "text": chunk['text'][:1000] # store up to 1000 chars for context
+                }
+            })
+            
+    # Write to NDJSON for wrangler vectorize insert
+    output_file = "vectors.ndjson"
+    with open(output_file, 'w') as f:
+        for v in vectors:
+            f.write(json.dumps(v) + '\n')
+            
+    print(f"Generated {len(vectors)} vectors. Saved to {output_file}.")
+    print(f"Run: npx wrangler vectorize insert {INDEX_NAME} --file {output_file}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest_to_vectorize.py
+++ b/scripts/ingest_to_vectorize.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import glob
 import hashlib
@@ -12,6 +13,20 @@ from urllib3.util.retry import Retry
 CF_ACCOUNT_ID = os.environ.get('CF_ACCOUNT_ID')
 CF_API_TOKEN = os.environ.get('CF_API_TOKEN')
 INDEX_NAME = "linux-kernel-docs-index"
+
+# Workers AI's free plan gives 10,000 neurons/day, SHARED with whatever
+# live chat/search traffic the deployed Worker generates that same day —
+# see the matching comment in api/src/index.js. bge-base-en-v1.5's
+# published rate is ~6,058 neurons per million input tokens; ~4 characters
+# per token is a standard rough estimate for English text.
+NEURONS_PER_M_TOKENS = 6058
+CHARS_PER_TOKEN_ESTIMATE = 4
+DAILY_FREE_NEURON_BUDGET = 10000
+
+
+def estimate_neuron_cost(total_chars):
+    tokens = total_chars / CHARS_PER_TOKEN_ESTIMATE
+    return (tokens / 1_000_000) * NEURONS_PER_M_TOKENS
 
 _session = requests.Session()
 _retry = Retry(
@@ -64,42 +79,96 @@ def chunk_markdown(filepath):
             
     return chunks
 
-def main():
-    docs_dir = os.path.join(os.path.dirname(__file__), '..', 'docs')
+def collect_chunks(docs_dir):
     md_files = glob.glob(os.path.join(docs_dir, '**', '*.md'), recursive=True)
-    
-    vectors = []
-    
+    all_chunks = []
     for md_file in md_files:
-        print(f"Processing {md_file}...")
-        chunks = chunk_markdown(md_file)
-        
-        for chunk in chunks:
-            # Skip very small chunks
-            if len(chunk['text']) < 50:
-                continue
-                
-            embedding = get_embedding(chunk['text'])
-            # Hash the full chunk text (not just its length) so two
-            # different chunks under the same heading can never collide.
-            content_hash = hashlib.sha256(chunk['text'].encode('utf-8')).hexdigest()
-            vector_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{chunk['source']}:{content_hash}"))
-            
-            vectors.append({
-                "id": vector_id,
-                "values": embedding,
-                "metadata": {
-                    "source": chunk['source'],
-                    "text": chunk['text'][:1000] # store up to 1000 chars for context
-                }
-            })
-            
+        for chunk in chunk_markdown(md_file):
+            if len(chunk['text']) >= 50:  # skip very small chunks
+                all_chunks.append(chunk)
+    return all_chunks
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Chunk docs/ and embed them for Vectorize.")
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Only chunk and estimate cost; make no embedding API calls."
+    )
+    parser.add_argument(
+        "--offset", type=int, default=0,
+        help="Skip this many chunks before starting (for splitting a large "
+             "corpus across multiple days' free AI budget)."
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Only embed at most this many chunks. Combine with --offset to "
+             "process the corpus in batches, e.g. --limit 4000 today, "
+             "--offset 4000 tomorrow."
+    )
+    args = parser.parse_args()
+
+    docs_dir = os.path.join(os.path.dirname(__file__), '..', 'docs')
+    all_chunks = collect_chunks(docs_dir)
+    chunks = all_chunks[args.offset:]
+    if args.limit is not None:
+        chunks = chunks[:args.limit]
+
+    if args.offset or args.limit is not None:
+        print(f"Batch: chunks[{args.offset}:{args.offset + len(chunks)}] "
+              f"of {len(all_chunks)} total.")
+
+    total_chars = sum(len(c['text']) for c in chunks)
+    estimated_neurons = estimate_neuron_cost(total_chars)
+    pct_of_daily_free = (estimated_neurons / DAILY_FREE_NEURON_BUDGET) * 100
+
+    print(f"Found {len(chunks)} chunks across {len(set(c['source'].split(' - ')[0] for c in chunks))} files.")
+    print(f"Estimated embedding cost: ~{estimated_neurons:,.0f} neurons "
+          f"(~{pct_of_daily_free:.0f}% of the 10,000/day free allocation).")
+    if estimated_neurons > DAILY_FREE_NEURON_BUDGET:
+        print(
+            "WARNING: this alone exceeds the free daily allocation. On the Workers "
+            "Free plan, embedding calls will start failing partway through this run "
+            "once the day's budget is spent, and live chat/search traffic on the "
+            "site will also be starved for the rest of the day (the budget is "
+            "shared). Consider splitting this into multiple days' worth of runs, "
+            "or accept a partial run and re-run tomorrow to pick up where it left "
+            "off (unembedded/failed chunks are simply skipped from this run's "
+            "output, not retried automatically across runs)."
+        )
+    elif estimated_neurons > DAILY_FREE_NEURON_BUDGET * 0.5:
+        print(
+            "Note: this will use over half of today's free AI budget — live chat/"
+            "search traffic on the site shares the same daily allocation."
+        )
+
+    if args.dry_run:
+        print("--dry-run: stopping before making any embedding API calls.")
+        return
+
+    vectors = []
+    for chunk in chunks:
+        embedding = get_embedding(chunk['text'])
+        # Hash the full chunk text (not just its length) so two different
+        # chunks under the same heading can never collide.
+        content_hash = hashlib.sha256(chunk['text'].encode('utf-8')).hexdigest()
+        vector_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{chunk['source']}:{content_hash}"))
+
+        vectors.append({
+            "id": vector_id,
+            "values": embedding,
+            "metadata": {
+                "source": chunk['source'],
+                "text": chunk['text'][:1000]  # store up to 1000 chars for context
+            }
+        })
+
     # Write to NDJSON for wrangler vectorize insert
     output_file = "vectors.ndjson"
     with open(output_file, 'w') as f:
         for v in vectors:
             f.write(json.dumps(v) + '\n')
-            
+
     print(f"Generated {len(vectors)} vectors. Saved to {output_file}.")
     print(f"Run: npx wrangler vectorize insert {INDEX_NAME} --file {output_file}")
 

--- a/scripts/ingest_to_vectorize.py
+++ b/scripts/ingest_to_vectorize.py
@@ -1,22 +1,36 @@
 import os
 import glob
+import hashlib
 import json
 import re
+import time
 import requests
 import uuid
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 CF_ACCOUNT_ID = os.environ.get('CF_ACCOUNT_ID')
 CF_API_TOKEN = os.environ.get('CF_API_TOKEN')
 INDEX_NAME = "linux-kernel-docs-index"
 
+_session = requests.Session()
+_retry = Retry(
+    total=5,
+    backoff_factor=1.5,
+    status_forcelist=[429, 500, 502, 503, 504],
+    allowed_methods=["POST"],
+)
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
+
+
 def get_embedding(text):
     if not CF_ACCOUNT_ID or not CF_API_TOKEN:
         print("Warning: Missing CF_ACCOUNT_ID or CF_API_TOKEN. Skipping real embedding.")
         return [0.0] * 768  # bge-base-en-v1.5 has 768 dimensions
-        
+
     url = f"https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}/ai/run/@cf/baai/bge-base-en-v1.5"
     headers = {"Authorization": f"Bearer {CF_API_TOKEN}"}
-    response = requests.post(url, headers=headers, json={"text": [text]})
+    response = _session.post(url, headers=headers, json={"text": [text]}, timeout=30)
     response.raise_for_status()
     return response.json()['result']['data'][0]
 
@@ -66,7 +80,10 @@ def main():
                 continue
                 
             embedding = get_embedding(chunk['text'])
-            vector_id = str(uuid.uuid5(uuid.NAMESPACE_URL, chunk['source'] + str(len(chunk['text']))))
+            # Hash the full chunk text (not just its length) so two
+            # different chunks under the same heading can never collide.
+            content_hash = hashlib.sha256(chunk['text'].encode('utf-8')).hexdigest()
+            vector_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{chunk['source']}:{content_hash}"))
             
             vectors.append({
                 "id": vector_id,

--- a/scripts/test_ingest.py
+++ b/scripts/test_ingest.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+from ingest_to_vectorize import chunk_markdown
+
+def test_chunk_markdown():
+    # Create a dummy markdown file
+    markdown_content = """# Title
+
+This is introductory text.
+
+## First Section
+
+This is the first section.
+It spans multiple lines.
+
+### Subsection
+
+Here is a subsection.
+
+## Second Section
+
+The final section.
+"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+        f.write(markdown_content)
+        temp_path = f.name
+        
+    try:
+        chunks = chunk_markdown(temp_path)
+        
+        # Verify chunks
+        assert len(chunks) == 4, f"Expected 4 chunks, got {len(chunks)}"
+        
+        assert chunks[0]['text'] == "# Title\n\nThis is introductory text."
+        assert "Introduction" in chunks[0]['source'] or os.path.basename(temp_path) in chunks[0]['source']
+        
+        assert chunks[1]['text'] == "This is the first section.\nIt spans multiple lines."
+        assert "## First Section" in chunks[1]['source']
+        
+        assert chunks[2]['text'] == "Here is a subsection."
+        assert "### Subsection" in chunks[2]['source']
+        
+        assert chunks[3]['text'] == "The final section."
+        assert "## Second Section" in chunks[3]['source']
+    finally:
+        os.remove(temp_path)


### PR DESCRIPTION
Closes #767. Serverless AI backend for the docs: RAG-powered semantic search and chat, an embedded chat widget, and an MCP server so AI coding assistants can query the docs directly.

**TL;DR**
- New: `api/` (Cloudflare Worker, `/api/search` + `/api/chat`), `scripts/ingest_to_vectorize.py` (chunks + embeds `docs/*.md`), `docs/javascripts/chat.js` (embedded widget), `mcp/` (MCP server wrapping search).
- Hardened: fixed a stored XSS in the chat widget, added layered abuse protection (mechanism intentionally not narrated here — see code comments in `api/src/index.js`), and made ingestion budget-aware for Cloudflare's free-tier AI allocation.
- Still needed before deploy: your Cloudflare API token as a repo secret, a real KV namespace id, and (optional at first) Turnstile + MCP keys. See "Remaining setup" below.

<details>
<summary><b>Architecture</b></summary>

```
docs/*.md ──(ingest_to_vectorize.py)──> Cloudflare Vectorize
                                              ▲
                                              │
Chat widget (docs/javascripts/chat.js) ──┐   │
                                          ├──> Cloudflare Worker (api/) ──> Workers AI
MCP server (mcp/, X-API-Key)     ────────┘         (embeddings for search,
                                                     an LLM for /api/chat's
                                                     RAG-synthesized answer)
```

- **`api/`** — the Worker. `/api/search` returns matched doc chunks; `/api/chat` does search + has an LLM synthesize an answer grounded only in the retrieved context.
- **`scripts/ingest_to_vectorize.py`** — chunks every markdown file by heading, embeds each chunk, writes NDJSON for `wrangler vectorize insert`. Has a real unit test for the chunking logic.
- **`docs/javascripts/chat.js`** — the widget, injected site-wide via `mkdocs.yml`.
- **`mcp/`** — wraps search as an MCP tool for Claude Desktop/Cursor/etc.
- **`.github/workflows/ai-ci.yml`** — validates the Worker/MCP code on every PR (syntax + `wrangler deploy --dry-run`, not just `npm install`).
- **`.github/workflows/ai-deploy.yml`** — `workflow_dispatch`-only: ingests, deploys the Worker, provisions its secrets.

</details>

<details>
<summary><b>Abuse protection and free-tier budgeting</b></summary>

Both endpoints are protected against high-volume/scripted abuse using several independent, layered mechanisms — see `api/src/index.js` for the actual implementation and thresholds; not narrated here.

Ingestion is budget-aware: `ingest_to_vectorize.py --dry-run` estimates the AI-cost of a run before spending anything, and `--offset`/`--limit` split a large corpus across multiple days' free allocation. See the script's own output/comments for the numbers measured against this repo's `docs/`.

Also fixed along the way: a stored XSS in the chat widget (user input was inserted via `insertAdjacentHTML` with no escaping — now built via `textContent`/DOM APIs), and unhandled-exception crashes if the AI/Vectorize calls transiently fail (now a clean error response).

</details>

## Remaining setup (needs your Cloudflare account)

1. `CF_ACCOUNT_ID` / `CF_API_TOKEN` as GitHub repo secrets (Workers/AI/Vectorize scopes).
2. Create the rate-limit KV namespace and swap the placeholder id in `api/wrangler.toml`.
3. Optional at first (both checks fail open/are unreachable without them): a Turnstile site (public key in `chat.js`, secret as a repo secret) and an `MCP_SHARED_KEY` repo secret matching `mcp/index.js`.
4. DNS: `kernel-internals.org` needs to be Cloudflare-managed for the `api.kernel-internals.org` custom-domain route to work; otherwise remove that route and use the `*.workers.dev` URL for now.
5. Merge, then manually trigger **Deploy AI Backend**.
