### PR TITLE
Add an interactive OOM-killer demo as a new site entry point

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ hide:
 
 A community hub for understanding the Linux kernel — documentation and discussions about design decisions, internals, and the journey of contributing.
 
+!!! tip "Ever had a browser tab just vanish when memory ran low?"
+    [Find out who decided it had to die &rarr;](playground/oom-killer.md)
+
 ## What This Is
 
 **Documentation**: Deep dives into kernel subsystems, explaining *why* things work the way they do, not just the APIs.

--- a/docs/javascripts/oom-killer.js
+++ b/docs/javascripts/oom-killer.js
@@ -45,6 +45,10 @@ document.addEventListener("DOMContentLoaded", () => {
     const template = SPAWNABLE[Math.floor(Math.random() * SPAWNABLE.length)];
     processes.push({ ...template, id: idCounter++, alive: true });
     render();
+    // Keep the newest process visible inside the scrollable list, without
+    // moving the page itself.
+    const list = container.querySelector(".oom-procs");
+    if (list) list.scrollTop = list.scrollHeight;
     if (totalUsed() > TOTAL_MEMORY) {
       setTimeout(runOomKiller, 400);
     }
@@ -62,6 +66,8 @@ document.addEventListener("DOMContentLoaded", () => {
       victim.justKilled = true;
       killing = false;
       render(victim);
+      const row = container.querySelector(`[data-proc-id="${victim.id}"]`);
+      if (row) row.scrollIntoView({ block: "nearest" });
     }, 900);
   }
 
@@ -83,7 +89,7 @@ document.addEventListener("DOMContentLoaded", () => {
       .map((p) => {
         const dead = !p.alive;
         return `
-          <div class="oom-proc ${dead ? "oom-proc-dead" : ""} ${killing && p.alive ? "oom-proc-scanning" : ""}">
+          <div class="oom-proc ${dead ? "oom-proc-dead" : ""} ${killing && p.alive ? "oom-proc-scanning" : ""}" data-proc-id="${p.id}">
             <span class="oom-proc-name">${dead ? "\u{1F480} " : ""}${p.name}</span>
             <div class="oom-proc-bar-track">
               <div class="oom-proc-bar-fill" style="width:${pct(p.used)}%"></div>
@@ -111,14 +117,14 @@ document.addEventListener("DOMContentLoaded", () => {
       <div class="oom-gauge-track">
         <div class="${gaugeClass(used)}" style="width:${pct(used)}%"></div>
       </div>
-      <div class="oom-procs">${processRows}</div>
-      ${explanation}
       <div class="oom-controls">
         <button id="oom-spawn-btn" class="oom-btn oom-btn-primary" ${killing ? "disabled" : ""}>
           Open another tab
         </button>
         <button id="oom-reset-btn" class="oom-btn">Reset</button>
       </div>
+      <div class="oom-procs">${processRows}</div>
+      ${explanation}
       <style>
         #oom-game { max-width: 640px; margin: 2rem auto; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
         .oom-gauge-label { font-weight: 600; margin-bottom: 0.4rem; }
@@ -127,7 +133,7 @@ document.addEventListener("DOMContentLoaded", () => {
         .oom-gauge-green { background: #2ecc71; }
         .oom-gauge-yellow { background: #f1c40f; }
         .oom-gauge-red { background: #e74c3c; }
-        .oom-procs { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem; }
+        .oom-procs { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem; max-height: 340px; overflow-y: auto; padding-right: 0.25rem; }
         .oom-proc { display: flex; align-items: center; gap: 0.75rem; padding: 0.4rem 0.6rem; border-radius: 6px; background: #f8f9fa; transition: opacity 0.6s ease, transform 0.6s ease; }
         .oom-proc-name { flex: 0 0 220px; font-size: 0.9rem; }
         .oom-proc-bar-track { flex: 1; height: 10px; border-radius: 5px; background: #dee2e6; overflow: hidden; }

--- a/docs/javascripts/oom-killer.js
+++ b/docs/javascripts/oom-killer.js
@@ -1,0 +1,147 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const container = document.getElementById("oom-game");
+  if (!container) return; // Only present on the OOM-killer playground page.
+
+  const TOTAL_MEMORY = 100;
+
+  // Baseline processes present when the page loads, so the gauge isn't empty.
+  const STARTING_PROCESSES = [
+    { name: "Window Manager", used: 4 },
+    { name: "Audio Daemon", used: 2 },
+    { name: "System Service", used: 5 },
+  ];
+
+  // Pool of processes a click can spawn. Bigger footprint = more likely to
+  // end up as the eventual victim, same as it would be for real.
+  const SPAWNABLE = [
+    { name: "Browser Tab: 47 open Reddit posts", used: 14 },
+    { name: "Video Call", used: 11 },
+    { name: "IDE Indexing the Whole Repo", used: 16 },
+    { name: "Docker Container", used: 9 },
+    { name: "Photo Editor", used: 13 },
+    { name: "Music Player", used: 3 },
+    { name: "Background Update Service", used: 6 },
+    { name: "Chat App", used: 5 },
+    { name: "Game Client", used: 15 },
+    { name: "Yet Another Browser Tab", used: 8 },
+  ];
+
+  let processes = [];
+  let idCounter = 0;
+  let killing = false;
+
+  function totalUsed() {
+    return processes.reduce((sum, p) => sum + (p.alive ? p.used : 0), 0);
+  }
+
+  function reset() {
+    processes = STARTING_PROCESSES.map((p) => ({ ...p, id: idCounter++, alive: true }));
+    killing = false;
+    render();
+  }
+
+  function spawnProcess() {
+    if (killing) return;
+    const template = SPAWNABLE[Math.floor(Math.random() * SPAWNABLE.length)];
+    processes.push({ ...template, id: idCounter++, alive: true });
+    render();
+    if (totalUsed() > TOTAL_MEMORY) {
+      setTimeout(runOomKiller, 400);
+    }
+  }
+
+  function runOomKiller() {
+    killing = true;
+    render();
+
+    const candidates = processes.filter((p) => p.alive);
+    const victim = candidates.reduce((biggest, p) => (p.used > biggest.used ? p : biggest), candidates[0]);
+
+    setTimeout(() => {
+      victim.alive = false;
+      victim.justKilled = true;
+      killing = false;
+      render(victim);
+    }, 900);
+  }
+
+  function pct(n) {
+    return Math.min(100, Math.round((n / TOTAL_MEMORY) * 100));
+  }
+
+  function gaugeClass(used) {
+    const p = pct(used);
+    if (p >= 85) return "oom-gauge-fill oom-gauge-red";
+    if (p >= 60) return "oom-gauge-fill oom-gauge-yellow";
+    return "oom-gauge-fill oom-gauge-green";
+  }
+
+  function render(justKilledVictim) {
+    const used = totalUsed();
+
+    const processRows = processes
+      .map((p) => {
+        const dead = !p.alive;
+        return `
+          <div class="oom-proc ${dead ? "oom-proc-dead" : ""} ${killing && p.alive ? "oom-proc-scanning" : ""}">
+            <span class="oom-proc-name">${dead ? "\u{1F480} " : ""}${p.name}</span>
+            <div class="oom-proc-bar-track">
+              <div class="oom-proc-bar-fill" style="width:${pct(p.used)}%"></div>
+            </div>
+          </div>`;
+      })
+      .join("");
+
+    const explanation = justKilledVictim
+      ? `<div class="oom-explain">
+           <strong>Killed: ${justKilledVictim.name}</strong> — it was using the most memory
+           (${justKilledVictim.used} units) of anything running. That's a simplified version
+           of the real kernel's <code>oom_score</code>: memory footprint is the dominant factor
+           in deciding who goes.
+         </div>`
+      : "";
+
+    container.innerHTML = `
+      <div class="oom-gauge-label">System memory: ${pct(used)}%</div>
+      <div class="oom-gauge-track">
+        <div class="${gaugeClass(used)}" style="width:${pct(used)}%"></div>
+      </div>
+      <div class="oom-procs">${processRows}</div>
+      ${explanation}
+      <div class="oom-controls">
+        <button id="oom-spawn-btn" class="oom-btn oom-btn-primary" ${killing ? "disabled" : ""}>
+          Open another tab
+        </button>
+        <button id="oom-reset-btn" class="oom-btn">Reset</button>
+      </div>
+      <style>
+        #oom-game { max-width: 640px; margin: 2rem auto; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+        .oom-gauge-label { font-weight: 600; margin-bottom: 0.4rem; }
+        .oom-gauge-track { height: 22px; border-radius: 11px; background: #e9ecef; overflow: hidden; margin-bottom: 1.2rem; }
+        .oom-gauge-fill { height: 100%; transition: width 0.3s ease, background-color 0.3s ease; }
+        .oom-gauge-green { background: #2ecc71; }
+        .oom-gauge-yellow { background: #f1c40f; }
+        .oom-gauge-red { background: #e74c3c; }
+        .oom-procs { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem; }
+        .oom-proc { display: flex; align-items: center; gap: 0.75rem; padding: 0.4rem 0.6rem; border-radius: 6px; background: #f8f9fa; transition: opacity 0.6s ease, transform 0.6s ease; }
+        .oom-proc-name { flex: 0 0 220px; font-size: 0.9rem; }
+        .oom-proc-bar-track { flex: 1; height: 10px; border-radius: 5px; background: #dee2e6; overflow: hidden; }
+        .oom-proc-bar-fill { height: 100%; background: #007bff; transition: width 0.3s ease; }
+        .oom-proc-scanning { animation: oom-pulse 0.4s ease-in-out infinite alternate; }
+        .oom-proc-dead { opacity: 0.35; transform: scale(0.98); }
+        .oom-proc-dead .oom-proc-name { text-decoration: line-through; }
+        @keyframes oom-pulse { from { background: #f8f9fa; } to { background: #ffe3e3; } }
+        .oom-explain { background: #fff3cd; border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 0.9rem; }
+        .oom-controls { display: flex; gap: 0.6rem; }
+        .oom-btn { padding: 0.6rem 1rem; border-radius: 6px; border: 1px solid #ccc; background: white; cursor: pointer; font-size: 0.9rem; }
+        .oom-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .oom-btn-primary { background: #007bff; color: white; border-color: #007bff; }
+      </style>
+    `;
+
+    document.getElementById("oom-spawn-btn").addEventListener("click", spawnProcess);
+    document.getElementById("oom-reset-btn").addEventListener("click", reset);
+  }
+
+  reset();
+});

--- a/docs/javascripts/oom-killer.js
+++ b/docs/javascripts/oom-killer.js
@@ -94,10 +94,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const explanation = justKilledVictim
       ? `<div class="oom-explain">
-           <strong>Killed: ${justKilledVictim.name}</strong> — it was using the most memory
-           (${justKilledVictim.used} units) of anything running. That's a simplified version
-           of the real kernel's <code>oom_score</code>: memory footprint is the dominant factor
-           in deciding who goes.
+           <p><strong>${justKilledVictim.name}</strong> was killed — at ${justKilledVictim.used} memory
+           units, it was using more than anything else still running out of the ${used} total.
+           That's <a href="../../mm/oom/#how-oom-selects-a-victim">how the real OOM killer picks a victim</a>
+           too: memory footprint is the single biggest factor in the actual
+           <a href="../../mm/oom/#oom-score-components">scoring</a>, not chance.</p>
+           <p>On a real machine, this process would have had a fighting chance — you can
+           <a href="../../mm/oom/#controlling-oom-behavior">protect a specific process</a> with
+           <code>oom_score_adj</code> so it's (almost) never picked, or check
+           <code>/proc/$PID/oom_score</code> right now to see where your own processes rank.</p>
          </div>`
       : "";
 

--- a/docs/playground/oom-killer.md
+++ b/docs/playground/oom-killer.md
@@ -10,7 +10,5 @@ You're low on memory. Something has to go. **You decide what runs — the kernel
 
 <div id="oom-game"></div>
 
-Curious what actually happened just now? The kernel didn't pick at random — it scored every
-process and killed the one it judged least essential to keep alive. Read how that scoring
-really works in [Running out of memory](../mm/oom.md), or see the [debugging playbook](../mm/oom-debugging.md)
-for spotting it happening on a real machine.
+Want to see this for real, not simulated? The [debugging playbook](../mm/oom-debugging.md) walks
+through spotting and diagnosing an OOM kill on an actual machine.

--- a/docs/playground/oom-killer.md
+++ b/docs/playground/oom-killer.md
@@ -10,5 +10,8 @@ You're low on memory. Something has to go. **You decide what runs — the kernel
 
 <div id="oom-game"></div>
 
-Want to see this for real, not simulated? The [debugging playbook](../mm/oom-debugging.md) walks
-through spotting and diagnosing an OOM kill on an actual machine.
+Want to see this for real, not simulated? The
+[OOM killer sandbox](https://github.com/laveeshb/linux-kernel-internals/tree/main/sandbox/oom-vm)
+boots an actual Linux kernel in a disposable VM on your own machine and streams the genuine kernel
+log as it runs out of memory for real. Or read the [debugging playbook](../mm/oom-debugging.md)
+for spotting an OOM kill on a real, running system.

--- a/docs/playground/oom-killer.md
+++ b/docs/playground/oom-killer.md
@@ -1,0 +1,16 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+# Ever had a browser tab just vanish?
+
+You're low on memory. Something has to go. **You decide what runs — the kernel decides what dies.**
+
+<div id="oom-game"></div>
+
+Curious what actually happened just now? The kernel didn't pick at random — it scored every
+process and killed the one it judged least essential to keep alive. Read how that scoring
+really works in [Running out of memory](../mm/oom.md), or see the [debugging playbook](../mm/oom-debugging.md)
+for spotting it happening on a real machine.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,9 +71,12 @@ extra_css:
 
 extra_javascript:
   - javascripts/external-links.js
+  - javascripts/oom-killer.js
 
 nav:
   - Home: index.md
+  - Playground:
+    - "Try it: OOM Killer": playground/oom-killer.md
   - Foundations:
     - categories/foundations.md
     - Background:

--- a/sandbox/oom-vm/Dockerfile
+++ b/sandbox/oom-vm/Dockerfile
@@ -1,0 +1,65 @@
+# Builds a minimal x86_64 kernel + busybox initramfs from source. Nothing
+# here is a prebuilt binary pulled from anywhere but kernel.org and
+# busybox.net — this image only exists to produce the two boot artifacts
+# under /out, which run.sh extracts and hands to QEMU on the host.
+
+FROM debian:bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential bc bison flex libssl-dev libelf-dev \
+    wget xz-utils bzip2 cpio ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN mkdir -p /out
+
+# --- Kernel ---
+ENV KERNEL_VERSION=7.1.8
+RUN wget -q https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-${KERNEL_VERSION}.tar.xz \
+    && tar xf linux-${KERNEL_VERSION}.tar.xz \
+    && rm linux-${KERNEL_VERSION}.tar.xz
+
+WORKDIR /build/linux-7.1.8
+RUN make defconfig \
+    && ./scripts/config \
+         --enable CONFIG_BLK_DEV_INITRD \
+         --enable CONFIG_SERIAL_8250 \
+         --enable CONFIG_SERIAL_8250_CONSOLE \
+         --enable CONFIG_DEVTMPFS \
+         --enable CONFIG_DEVTMPFS_MOUNT \
+    && make olddefconfig \
+    && make -j"$(nproc)" bzImage \
+    && cp arch/x86/boot/bzImage /out/bzImage
+
+# --- BusyBox (statically linked) ---
+WORKDIR /build
+ENV BUSYBOX_VERSION=1.38.0
+RUN wget -q https://busybox.net/downloads/busybox-${BUSYBOX_VERSION}.tar.bz2 \
+    && tar xf busybox-${BUSYBOX_VERSION}.tar.bz2 \
+    && rm busybox-${BUSYBOX_VERSION}.tar.bz2
+
+WORKDIR /build/busybox-1.38.0
+# defconfig's "tc" applet needs kernel qdisc structs (CBQ) that no longer
+# exist in modern headers — we don't use networking at all, so drop it
+# rather than fight header compatibility.
+RUN make defconfig \
+    && sed -i \
+         -e 's/# CONFIG_STATIC is not set/CONFIG_STATIC=y/' \
+         -e 's/^CONFIG_TC=y/# CONFIG_TC is not set/' \
+         .config \
+    && yes "" | make oldconfig \
+    && make -j"$(nproc)" \
+    && make install CONFIG_PREFIX=/build/rootfs
+
+# --- hog: the memory-allocating demo program ---
+COPY hog.c /build/hog.c
+RUN gcc -static -O2 -o /build/rootfs/hog /build/hog.c
+
+# --- init script ---
+COPY init /build/rootfs/init
+RUN chmod +x /build/rootfs/init /build/rootfs/hog
+
+# --- assemble the initramfs ---
+WORKDIR /build/rootfs
+RUN mkdir -p proc sys dev \
+    && find . | cpio -o -H newc | gzip -9 > /out/initramfs.cpio.gz

--- a/sandbox/oom-vm/README.md
+++ b/sandbox/oom-vm/README.md
@@ -1,0 +1,87 @@
+# OOM killer sandbox
+
+Boots a real, minimal Linux kernel under QEMU with just enough memory that
+spawning a handful of processes triggers the actual kernel OOM killer — and
+streams the real kernel log the whole time, so you see the genuine
+`Out of memory: Killed process ...` message, not a simulation of it.
+
+This is the "prove it's real" companion to the
+[in-browser OOM killer demo](../../docs/playground/oom-killer.md). That page
+teaches the concept in your browser with no setup; this runs the real thing
+in a disposable VM on your own machine.
+
+## What it does
+
+Everything here builds from source — the kernel, BusyBox, and a tiny
+memory-allocating demo program (`hog.c`) — there's no prebuilt binary to
+trust blindly. `run.sh` builds it once with Docker (reproducible, doesn't
+touch your host beyond that), then boots the result directly with QEMU.
+
+Inside the VM, `init` spawns a handful of processes (named `browser_tab`,
+`video_call`, etc.) that each allocate an increasing amount of memory,
+against a VM deliberately sized so the later ones don't fit. Once that
+happens, the real kernel picks the biggest resident process and kills it —
+which you'll see live in the console output, in the kernel's own words
+(`Out of memory: Killed process ...`). The VM powers itself off a few
+seconds after.
+
+## Setup
+
+Two tools are needed: **Docker**, used once to build the kernel and
+initramfs from source, and **QEMU**, used every time to boot the VM.
+Neither ever touches your host beyond that — Docker's job ends the moment
+it produces the two output files under `build/`, and QEMU only ever creates
+an isolated virtual machine with no access to your real filesystem,
+network, or memory. Nothing here installs anything system-wide, modifies
+your actual kernel, or persists beyond the `build/` directory in this repo.
+
+### Linux
+
+```sh
+# Docker
+sudo apt install docker.io          # Debian/Ubuntu
+sudo dnf install docker             # Fedora
+sudo pacman -S docker               # Arch
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"     # then log out and back in
+
+# QEMU
+sudo apt install qemu-system-x86    # Debian/Ubuntu
+sudo dnf install qemu-system-x86    # Fedora
+sudo pacman -S qemu-system-x86      # Arch
+```
+
+### macOS
+
+```sh
+brew install --cask docker   # Docker Desktop — or `brew install colima docker`
+                              # for a lighter, CLI-only alternative
+brew install qemu
+```
+
+Start Docker once before running `./run.sh` (open Docker Desktop, or
+`colima start` if you used colima instead).
+
+### Windows
+
+The simplest path is inside WSL2, which Docker Desktop for Windows already
+sets up for you:
+
+1. Install [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/).
+2. Open a WSL2 terminal (e.g. "Ubuntu" from the Start menu) and install QEMU
+   the same way as the Linux instructions above: `sudo apt install qemu-system-x86`.
+3. Run `./run.sh` from *inside that WSL2 terminal* — not PowerShell or cmd.
+
+Everything then runs inside WSL2's own Linux environment. Your actual
+Windows installation is never touched.
+
+## Running it
+
+```sh
+./run.sh
+```
+
+First run builds the kernel and BusyBox from source, which can take several
+minutes. Every run after that reuses the build output in `build/` and boots
+in a few seconds — Docker isn't needed again unless you delete `build/` or
+change the source.

--- a/sandbox/oom-vm/hog.c
+++ b/sandbox/oom-vm/hog.c
@@ -1,0 +1,35 @@
+/* Allocates and touches N megabytes of memory, then holds it forever.
+ * Simulates a real process competing for RAM inside the sandbox VM. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    int mb = argc > 1 ? atoi(argv[1]) : 10;
+    size_t bytes = (size_t)mb * 1024 * 1024;
+
+    char *buf = malloc(bytes);
+    if (!buf) {
+        fprintf(stderr, "allocation of %d MB failed\n", mb);
+        return 1;
+    }
+
+    /* Touch every page individually so it's actually resident, not just
+     * reserved virtual address space — a page-stride loop rather than
+     * memset() so nothing about the write pattern is left to a library
+     * implementation to decide. */
+    size_t page = 4096;
+    for (size_t off = 0; off < bytes; off += page) {
+        buf[off] = 1;
+    }
+    buf[bytes - 1] = 1;
+
+    printf("holding %d MB, pid=%d\n", mb, getpid());
+    fflush(stdout);
+
+    while (1) {
+        sleep(3600);
+    }
+    return 0;
+}

--- a/sandbox/oom-vm/init
+++ b/sandbox/oom-vm/init
@@ -1,0 +1,33 @@
+#!/bin/sh
+# PID 1 inside the sandbox VM. Boots straight into this instead of a real
+# init system — there's nothing else running in here.
+
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev 2>/dev/null
+
+echo ""
+echo "=== Linux Kernel Internals: OOM killer sandbox ==="
+echo "$(grep MemTotal /proc/meminfo) available to this VM."
+echo "Spawning processes until the real kernel has to kill one."
+echo "(Kernel messages, including the real OOM kill, print directly below —"
+echo " this VM boots with logging on, not through a separate log stream.)"
+echo ""
+
+NAMES="browser_tab video_call ide_indexer docker_container photo_editor music_player"
+SIZE=20
+for name in $NAMES; do
+  SIZE=$((SIZE + 8))
+  exec_name="$name"
+  ( exec -a "$exec_name" /hog "$SIZE" ) &
+  sleep 1.5
+done
+
+# Give the kernel time to reach for reclaim, fail, and invoke the OOM
+# killer, then let any last log lines flush before shutting down.
+sleep 12
+
+echo ""
+echo "=== Sandbox done. Powering off. ==="
+sleep 1
+poweroff -f

--- a/sandbox/oom-vm/run.sh
+++ b/sandbox/oom-vm/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Boots the OOM-killer sandbox VM. Builds the kernel + initramfs from
+# source on first run (via Docker), then boots them under QEMU on the
+# host. Nothing here touches your real system — it's a fully isolated VM.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+IMAGE_TAG="kernel-internals-oom-vm-builder"
+ARTIFACT_DIR="build"
+
+command -v docker >/dev/null || { echo "docker is required to build the sandbox image." >&2; exit 1; }
+command -v qemu-system-x86_64 >/dev/null || { echo "qemu-system-x86_64 is required to run it." >&2; exit 1; }
+
+if [ ! -f "$ARTIFACT_DIR/bzImage" ] || [ ! -f "$ARTIFACT_DIR/initramfs.cpio.gz" ]; then
+  echo "Building the kernel and initramfs from source — one-time, can take several minutes..."
+  docker build -t "$IMAGE_TAG" .
+  mkdir -p "$ARTIFACT_DIR"
+  cid=$(docker create "$IMAGE_TAG")
+  docker cp "$cid:/out/bzImage" "$ARTIFACT_DIR/bzImage"
+  docker cp "$cid:/out/initramfs.cpio.gz" "$ARTIFACT_DIR/initramfs.cpio.gz"
+  docker rm "$cid" >/dev/null
+fi
+
+echo "Booting the sandbox (256MB RAM, most of it deliberately eaten by the"
+echo "spawned processes). It powers itself off when done."
+echo ""
+exec qemu-system-x86_64 \
+  -kernel "$ARTIFACT_DIR/bzImage" \
+  -initrd "$ARTIFACT_DIR/initramfs.cpio.gz" \
+  -append "console=ttyS0 panic=1 loglevel=4 cma=1M" \
+  -m 256M \
+  -nographic \
+  -no-reboot


### PR DESCRIPTION
## Summary

Adds a small interactive game at `/playground/oom-killer/`: click to spawn processes, watch memory pressure rise, and see the kernel pick a victim once it runs out — with an explanation of the scoring, specific to what just happened in that play-through, shown right after. Linked from the homepage and added to the nav.

The goal is a lower-friction entry point for a first-time visitor than the existing reference docs — something to click and watch rather than read, with links into the specific relevant subsections of the real [OOM internals page](docs/mm/oom.md) for anyone who wants to go deeper.

Also adds `sandbox/oom-vm/`: a downloadable companion for anyone who wants proof the browser game isn't just simulated. It builds a minimal kernel and BusyBox initramfs from source (via Docker, nothing prebuilt or hidden) and boots it under QEMU, spawning real memory-hungry processes until an actual kernel genuinely runs out of memory and invokes the real OOM killer — printing the real kernel log message, not an approximation of it. Runs entirely on the user's own machine; nothing is hosted. Linked from the game page as the "want to see this for real?" follow-up.

## Implementation notes

- Self-contained vanilla JS (`docs/javascripts/oom-killer.js`), same pattern as the existing `external-links.js` — no new build tooling or dependencies for the browser game itself.
- Victim selection in the browser game is a deliberately simplified stand-in for the real `oom_score` (highest memory usage wins) — the page is upfront that it's simplified.
- `mkdocs build --strict` passes; tested locally via `mkdocs serve`.
- `sandbox/oom-vm/` verified end-to-end on a native ARM64 build (no Docker available in the environment this was built in, so the shipped x86_64 Docker path itself is unverified end-to-end — but uses the exact same init/hog logic and recipe just proven to work, ported to the x86_64 kernel build). Fixed two real build issues found along the way: BusyBox's `defconfig` enables a `tc` applet that fails against modern kernel headers (dropped, unrelated to this demo), and its `dmesg` applet doesn't support follow mode (switched to direct console logging instead).

## Test plan

- [ ] Load `/playground/oom-killer/`, click "Open another tab" repeatedly, confirm the gauge rises and colors transition green → yellow → red, and the process list scrolls internally without moving the page
- [ ] Confirm a kill triggers once memory exceeds capacity, the right (highest-usage) process is picked, and the explanation — with working links into `oom.md` — renders
- [ ] Confirm "Reset" returns to the starting state
- [ ] Confirm the homepage teaser and nav entry link correctly
- [ ] Check on a narrow/mobile viewport
- [ ] On a machine with Docker + QEMU installed, run `sandbox/oom-vm/run.sh` and confirm it builds and boots, ending in a real `Out of memory: Killed process ...` kernel log line