### PR TITLE
virtualization: fix fabricated technical details in kvm-arch.md

### DIFF
--- a/docs/virtualization/kvm-arch.md
+++ b/docs/virtualization/kvm-arch.md
@@ -144,7 +144,8 @@ struct kvm {
 
 struct kvm_vcpu {
     struct kvm          *kvm;
-    int                  cpu;         /* physical CPU this vCPU ran on last */
+    int                  cpu;         /* physical CPU currently loaded on;
+                                          -1 if not loaded (see vcpu_load()/vcpu_put()) */
     int                  vcpu_id;     /* id given by userspace at creation */
     int                  vcpu_idx;    /* index into kvm->vcpu_array */
 

--- a/docs/virtualization/kvm-arch.md
+++ b/docs/virtualization/kvm-arch.md
@@ -113,55 +113,54 @@ Frequency matters: frequent exits (like timer ticks, MMIO) are costly because th
 ## struct kvm and struct kvm_vcpu
 
 ```c
-/* virt/kvm/kvm_main.c */
+/* Simplified — real struct kvm is defined in include/linux/kvm_host.h;
+ * arch-specific state (including the page-track notifier head) lives in
+ * the embedded struct kvm_arch, defined per-arch (e.g.
+ * arch/x86/include/asm/kvm_host.h), not here. */
 struct kvm {
-    spinlock_t          mmu_lock;
-    struct mutex        slots_lock;
-    struct mutex        slots_arch_lock;
+    spinlock_t           mmu_lock;      /* rwlock_t instead, on archs with
+                                            KVM_HAVE_MMU_RWLOCK */
+    struct mutex         slots_lock;
+    struct mutex         slots_arch_lock;
 
-    struct mm_struct   *mm;          /* userspace VM process mm */
-    unsigned long       nr_memslot_pages;
-    struct kvm_memslots *memslots[KVM_ADDRESS_SPACE_NUM];
+    struct mm_struct     *mm;            /* userspace tied to this vm */
+    unsigned long        nr_memslot_pages;
+    struct kvm_memslots  *memslots[KVM_MAX_NR_ADDRESS_SPACES];
 
-    struct kvm_vcpu    *vcpus[KVM_MAX_VCPUS];
-    atomic_t            online_vcpus;
-    int                 max_vcpus;
-    int                 created_vcpus;
+    struct xarray        vcpu_array;     /* indexed by vcpu_idx, not a flat
+                                             array — see vcpu_idx below */
+    atomic_t             online_vcpus;
+    int                  max_vcpus;
+    int                  created_vcpus;
 
-    struct list_head    vm_list;     /* link in kvm_list */
-    struct mutex        lock;
-    struct kvm_io_bus   *buses[KVM_NR_BUSES];
+    struct list_head     vm_list;
+    struct mutex         lock;
+    struct kvm_io_bus    *buses[KVM_NR_BUSES];
     struct kvm_irq_routing_table *irq_routing;
-    struct hlist_head   irq_ack_notifier_list;
+    struct hlist_head    irq_ack_notifier_list;
 
-    /* Memory management */
-    struct kvm_page_track_notifier_head *track_notifier_head;
-    atomic64_t          arch_flags;
-
-    struct kvm_arch     arch;        /* architecture-specific state */
+    struct kvm_arch      arch;           /* architecture-specific state */
 };
 
 struct kvm_vcpu {
-    struct kvm         *kvm;
-    int                 cpu;         /* physical CPU this vCPU ran on last */
-    int                 vcpu_id;
-    int                 vcpu_idx;
+    struct kvm          *kvm;
+    int                  cpu;         /* physical CPU this vCPU ran on last */
+    int                  vcpu_id;     /* id given by userspace at creation */
+    int                  vcpu_idx;    /* index into kvm->vcpu_array */
 
-    int                 srcu_idx;
-    int                 mode;        /* IN_GUEST_MODE, etc. */
-    u64                 requests;    /* pending requests bitmask */
-    unsigned long       guest_debug; /* debug flags */
+    int                  ____srcu_idx; /* don't use directly — the leading
+                                           underscores are intentional */
+    int                  mode;        /* IN_GUEST_MODE, etc. */
+    u64                  requests;    /* pending requests bitmask */
+    unsigned long        guest_debug; /* debug flags */
 
-    int                 pre_pcpu;
-    struct list_head    blocked_vcpu_list;
+    struct mutex         mutex;
+    struct kvm_run       *run;        /* the mmap'd run structure */
 
-    struct mutex        mutex;
-    struct kvm_run     *run;         /* the mmap'd run structure */
+    struct rcuwait        wait;       /* for blocking on halt */
 
-    wait_queue_head_t   wq;          /* for blocking on halt */
-
-    struct kvm_vcpu_arch arch;       /* x86/arm64-specific state */
-    struct kvm_vcpu_stat stat;
+    struct kvm_vcpu_arch  arch;       /* x86/arm64-specific state */
+    struct kvm_vcpu_stat  stat;
 
     /* Dirty ring for tracking modified guest pages */
     struct kvm_dirty_ring dirty_ring;
@@ -170,53 +169,47 @@ struct kvm_vcpu {
 
 ## The vCPU run loop
 
+`kvm_arch_vcpu_ioctl_run()` — the direct handler for the `KVM_RUN` ioctl — mostly just validates state and hands off to `vcpu_run()`, which loops calling `vcpu_enter_guest()` once per guest entry/exit:
+
 ```c
-/* arch/x86/kvm/x86.c: kvm_arch_vcpu_ioctl_run() */
-int kvm_arch_vcpu_ioctl_run(struct kvm_vcpu *vcpu)
+/* arch/x86/kvm/x86.c: vcpu_enter_guest(), simplified */
+static int vcpu_enter_guest(struct kvm_vcpu *vcpu)
 {
-    struct kvm_run *kvm_run = vcpu->run;
+    /* Process any pending work before entering guest */
+    if (kvm_check_request(KVM_REQ_TLB_FLUSH, vcpu))
+        kvm_vcpu_flush_tlb_all(vcpu);
+    /* ... handle other requests ... */
 
-    while (1) {
-        /* Process any pending work before entering guest */
-        if (kvm_request_pending(vcpu)) {
-            if (kvm_check_request(KVM_REQ_TLB_FLUSH, vcpu))
-                kvm_vcpu_flush_tlb_guest(vcpu);
-            /* ... handle other requests ... */
-        }
+    /* Inject interrupts if pending */
+    if (kvm_cpu_has_injectable_intr(vcpu))
+        kvm_x86_call(inject_irq)(vcpu, false /* reinjected */);
 
-        /* Inject interrupts if pending */
-        if (vcpu->arch.interrupt.injected)
-            vmx_inject_irq(vcpu);
+    /* VM Entry */
+    exit_fastpath = kvm_x86_call(vcpu_run)(vcpu, run_flags);  /* VMLAUNCH/VMRESUME */
 
-        /* VM Entry */
-        kvm_x86_ops.run(vcpu);   /* calls VMLAUNCH or VMRESUME */
-
-        /* VM Exit: handle the reason */
-        r = kvm_x86_ops.handle_exit(vcpu, exit_fastpath);
-
-        if (r <= 0)
-            break;  /* exit to userspace */
-
-        /* Continue in-kernel: handle exits that don't need QEMU */
-    }
+    /* VM Exit: handle the reason */
+    r = kvm_x86_call(handle_exit)(vcpu, exit_fastpath);
 
     return r;
 }
 ```
+
+`kvm_x86_call(op)` is a macro wrapping a `static_call` into `struct kvm_x86_ops` — the vendor backend (VMX or SVM) plugs in via fields like `.vcpu_run`, `.handle_exit`, and `.inject_irq`. `vcpu_run()` repeats this per-entry work in a `for (;;)` loop until the exit reason needs userspace, at which point it returns up to `kvm_arch_vcpu_ioctl_run()`.
 
 ## Hypercalls: guest-to-host communication
 
 ```c
 /* Guest: issue a hypercall */
 /* On x86: vmcall (Intel) or vmmcall (AMD) */
-static inline long kvm_hypercall(unsigned int nr, unsigned long p1,
-                                  unsigned long p2, unsigned long p3,
-                                  unsigned long p4)
+/* arch/x86/include/asm/kvm_para.h defines one variant per argument count,
+ * kvm_hypercall0() through kvm_hypercall4() — there's no single variadic
+ * kvm_hypercall(). Zero-argument example: */
+static inline long kvm_hypercall0(unsigned int nr)
 {
     long ret;
     asm volatile("vmcall"
                  : "=a"(ret)
-                 : "a"(nr), "b"(p1), "c"(p2), "d"(p3), "S"(p4)
+                 : "a"(nr)
                  : "memory");
     return ret;
 }
@@ -240,12 +233,13 @@ KVM_HC_MAP_GPA_RANGE      /* memory attribute notification */
 ls /sys/kernel/debug/kvm/
 # 42-0/  42-1/  ...  (vm_id-vcpu_id directories)
 
+# Each stat gets its own file (see kvm_vcpu_stats_desc[] in arch/x86/kvm/x86.c) —
+# there's no single aggregate "exits" file, just a raw counter per file:
+ls /sys/kernel/debug/kvm/42-0/
+# exits  io_exits  mmio_exits  halt_exits  irq_window_exits  nmi_window_exits  ...
+
 cat /sys/kernel/debug/kvm/42-0/exits
-# Total: 12345678
-# mmio: 23456
-# io: 12345
-# halt: 100
-# irq_window: 5000
+# 12345678
 
 # perf KVM stats
 perf kvm stat record -a sleep 10
@@ -263,8 +257,8 @@ cat /sys/kernel/tracing/trace_pipe
 ### Kernel source
 
 - [include/linux/kvm_host.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/kvm_host.h) — `struct kvm` and `struct kvm_vcpu` definitions
-- [arch/x86/kvm/x86.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/x86.c) — `kvm_arch_vcpu_ioctl_run()`: the vCPU run loop (request handling, VM entry, exit dispatch)
-- [arch/x86/kvm/vmx/vmx.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/vmx/vmx.c) — Intel VT-x backend: VMLAUNCH/VMRESUME, `vmx_inject_irq()`, VMCS-based VM entry/exit
+- [arch/x86/kvm/x86.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/x86.c) — `kvm_arch_vcpu_ioctl_run()`, `vcpu_run()`, and `vcpu_enter_guest()`: the vCPU run loop (request handling, VM entry, exit dispatch)
+- [arch/x86/kvm/vmx/vmx.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/vmx/vmx.c) — Intel VT-x backend: VMLAUNCH/VMRESUME, `vmx_inject_irq(vcpu, bool reinjected)`, VMCS-based VM entry/exit
 - [virt/kvm/kvm_main.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/virt/kvm/kvm_main.c) — `/dev/kvm` core: `kvm_dev_ioctl()` handling `KVM_CREATE_VM`; `kvm_vm_ioctl()` handling `KVM_CREATE_VCPU` on the resulting VM fd
 - [include/uapi/linux/kvm.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/kvm.h) — `KVM_EXIT_*` exit reason constants and the `kvm_run` ABI
 - [include/uapi/linux/kvm_para.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/kvm_para.h) — `KVM_HC_*` hypercall numbers

--- a/docs/virtualization/kvm-arch.md
+++ b/docs/virtualization/kvm-arch.md
@@ -175,6 +175,11 @@ struct kvm_vcpu {
 /* arch/x86/kvm/x86.c: vcpu_enter_guest(), simplified */
 static int vcpu_enter_guest(struct kvm_vcpu *vcpu)
 {
+    fastpath_t exit_fastpath;
+    u64 run_flags = 0;   /* built up earlier from pending-exit, debug-register,
+                          * and debugctl state; omitted here */
+    int r;
+
     /* Process any pending work before entering guest */
     if (kvm_check_request(KVM_REQ_TLB_FLUSH, vcpu))
         kvm_vcpu_flush_tlb_all(vcpu);

--- a/docs/virtualization/kvm-arch.md
+++ b/docs/virtualization/kvm-arch.md
@@ -229,16 +229,16 @@ KVM_HC_MAP_GPA_RANGE      /* memory attribute notification */
 ## Observing KVM
 
 ```bash
-# KVM stats per VM (requires debugfs)
+# One directory per VM, named <creator-pid>-<vm-fd-name> (requires debugfs):
 ls /sys/kernel/debug/kvm/
-# 42-0/  42-1/  ...  (vm_id-vcpu_id directories)
+# 1234-3/   ...
 
-# Each stat gets its own file (see kvm_vcpu_stats_desc[] in arch/x86/kvm/x86.c) —
-# there's no single aggregate "exits" file, just a raw counter per file:
-ls /sys/kernel/debug/kvm/42-0/
+# Each vCPU gets its own subdirectory; each stat gets its own file inside it
+# (see kvm_vcpu_stats_desc[] in arch/x86/kvm/x86.c) — no aggregate "exits" file:
+ls /sys/kernel/debug/kvm/1234-3/vcpu0/
 # exits  io_exits  mmio_exits  halt_exits  irq_window_exits  nmi_window_exits  ...
 
-cat /sys/kernel/debug/kvm/42-0/exits
+cat /sys/kernel/debug/kvm/1234-3/vcpu0/exits
 # 12345678
 
 # perf KVM stats


### PR DESCRIPTION
Part of #740 (virtualization/ technical-accuracy audit). First of the seven flagged pages — small per-page PR per that issue's stated approach.

## In-scope fixes (all verified against current kernel.org source)

- **struct kvm**: wrong defining-file comment (`virt/kvm/kvm_main.c` → `include/linux/kvm_host.h`, matching this page's own Further Reading link); `KVM_ADDRESS_SPACE_NUM` → `KVM_MAX_NR_ADDRESS_SPACES`; the flat `vcpus[KVM_MAX_VCPUS]` array replaced with the real `struct xarray vcpu_array`; fabricated `arch_flags` removed; `track_notifier_head` was misplaced (it's part of the x86-specific `struct kvm_arch`, not the generic `struct kvm`, and isn't a pointer) — noted in the block comment instead of shown as a top-level field.
- **struct kvm_vcpu**: `srcu_idx` → `____srcu_idx`; `pre_pcpu`/`blocked_vcpu_list` (don't exist) removed; `wait_queue_head_t wq` → `struct rcuwait wait`.
- **vCPU run loop**: was attributed to `kvm_arch_vcpu_ioctl_run()`; the actual request-handling/entry/exit loop is `vcpu_run()` calling `vcpu_enter_guest()` (confirmed via call chain: `kvm_arch_vcpu_ioctl_run()` → `vcpu_run()`'s `for (;;)` loop → `vcpu_enter_guest()`). `KVM_REQ_TLB_FLUSH` was wrongly paired with `kvm_vcpu_flush_tlb_guest()` (that's actually `KVM_REQ_HV_TLB_FLUSH`'s handler) — real pairing is `kvm_vcpu_flush_tlb_all()`. `vmx_inject_irq()` was shown missing its `bool reinjected` argument. `kvm_x86_ops.run(vcpu)` doesn't exist — current source dispatches vendor ops through the `kvm_x86_call(op)` macro (`static_call(kvm_x86_##op)`), e.g. `kvm_x86_call(vcpu_run)(...)` / `kvm_x86_call(handle_exit)(...)` / `kvm_x86_call(inject_irq)(...)`.
- **Hypercalls**: `kvm_hypercall()` isn't real — the actual API is a family, `kvm_hypercall0()` through `kvm_hypercall4()`, one per argument count.
- **Observing KVM**: the debugfs example showed a single aggregate `exits` file with a formatted breakdown; real KVM debugfs gives each stat (`exits`, `io_exits`, `mmio_exits`, `halt_exits`, ...) its own file holding a raw counter, per `kvm_vcpu_stats_desc[]` in `arch/x86/kvm/x86.c`.

Further Reading's kernel-source bullets updated to match (added `vcpu_run()`/`vcpu_enter_guest()` alongside `kvm_arch_vcpu_ioctl_run()`; `vmx_inject_irq()`'s real signature).

## Follow-up commits from later review rounds

- The debugfs example's directory naming (`42-0/`, `42-1/`) and hierarchy (stat files directly under the VM dir) didn't match real source. Real hierarchy is `<pid>-<vm-fd-name>/vcpuN/<stat>`, confirmed against `kvm_create_vm_debugfs()`/`kvm_create_vcpu_debugfs()` in `virt/kvm/kvm_main.c`. Found while reviewing the sibling kvm-exits.md page (#781).
- The `vcpu_enter_guest()` snippet used `exit_fastpath`, `run_flags`, and `r` as if already declared. Declared them (`run_flags` as `u64`, matching its real declaration in `arch/x86/kvm/x86.c`). Same gap as #781.
- `struct kvm_vcpu`'s `cpu` field comment ("physical CPU this vCPU ran on last") was imprecise — real semantics (`vcpu_load()`/`vcpu_put()` in `kvm_main.c`) are "currently loaded on, -1 if not loaded," not a passive historical record.

## Review history

A dedicated adversarial re-review pass after the follow-up commits above, matching the standard applied to the sibling kvm-exits.md page (#781: 7 rounds, 2 consecutive clean before merge):

- **Round 1**: found and fixed the `cpu` field comment above.
- **Round 2**: fresh full read against source — VMCS diagram, `/dev/kvm` API ioctls and struct fields, hypercall numbers, Further Reading bullets, Related/External page descriptions. Nothing further found.
- **Round 3**: cross-checked every overlapping claim (`kvm_x86_call()` convention, `KVM_REQ_TLB_FLUSH` pairing, `inject_irq`'s `reinjected` arg, `vcpu_run()`'s `run_flags`) against the now-merged kvm-exits.md for drift. Consistent, no divergence.

Two consecutive clean rounds — same bar as #781.

## Verification

- Every changed claim (struct fields, function names/signatures, macro dispatch, debugfs layout) checked directly against current kernel.org source.
- Also spot-checked the untouched sections of this page (ioctl example, `KVM_EXIT_*`/`KVM_HC_*` constants, `struct kvm_regs`/`struct kvm_userspace_memory_region` fields) — all accurate, no further issues found.
- `mkdocs build --strict` passes clean.

## Remaining scope

6 more pages tracked in #740: `kvm-exits.md` (merged), `kvm-memory.md`, `live-migration.md`, `nested-virt.md`, `vfio.md`, `virtio.md`.
