### PR TITLE
virtualization: fix fabricated technical details in kvm-exits.md

### DIFF
--- a/docs/virtualization/kvm-exits.md
+++ b/docs/virtualization/kvm-exits.md
@@ -35,8 +35,9 @@ Before entering the guest on each iteration, `vcpu_enter_guest()` processes any 
 static int vcpu_enter_guest(struct kvm_vcpu *vcpu)
 {
     fastpath_t exit_fastpath;
-    u32 run_flags = 0;   /* built up earlier from pending debug-register /
-                           * debugctl state; omitted here */
+    u64 run_flags = 0;   /* KVM_RUN_FORCE_IMMEDIATE_EXIT, KVM_RUN_LOAD_GUEST_DR6,
+                           * KVM_RUN_LOAD_DEBUGCTL — built up from pending-exit,
+                           * debug-register, and debugctl state; omitted here */
 
     /* Process pending requests: TLB flushes, MMU reloads, etc. */
     if (kvm_check_request(KVM_REQ_MMU_SYNC, vcpu))
@@ -298,21 +299,32 @@ Interrupts to guest vCPUs do not arrive via normal hardware interrupt lines. KVM
  * kvm_vcpu_kick(vcpu) is a thin inline wrapper: __kvm_vcpu_kick(vcpu, false). */
 void __kvm_vcpu_kick(struct kvm_vcpu *vcpu, bool wait)
 {
+    int me, cpu;
+
     /* Wake it first: if it was blocking (e.g. in HLT), waking it is enough —
      * no IPI needed since it wasn't running on a pCPU. */
     if (kvm_vcpu_wake_up(vcpu))
         return;
 
-    /* Otherwise it's actually running: if that's still true, send an IPI
-     * to force a VM exit so it notices pending work (unless we're already
-     * running on the target's own pCPU, in which case a flag write suffices). */
-    if (kvm_arch_vcpu_should_kick(vcpu)) {
-        int cpu = READ_ONCE(vcpu->cpu);   /* -1 if not currently loaded */
+    me = get_cpu();
 
-        if (cpu != smp_processor_id() &&
-            (unsigned int)cpu < nr_cpu_ids && cpu_online(cpu))
+    /* Kicking your own vCPU from its own thread (e.g. a self-IPI-style
+     * event): just flip the mode flag it polls, no actual IPI needed. */
+    if (vcpu == __this_cpu_read(kvm_running_vcpu)) {
+        if (vcpu->mode == IN_GUEST_MODE)
+            WRITE_ONCE(vcpu->mode, EXITING_GUEST_MODE);
+        goto out;
+    }
+
+    /* Otherwise it's running on some other pCPU: send an IPI to force a
+     * VM exit so it notices pending work. */
+    if (kvm_arch_vcpu_should_kick(vcpu)) {
+        cpu = READ_ONCE(vcpu->cpu);   /* -1 if not currently loaded */
+        if (cpu != me && (unsigned int)cpu < nr_cpu_ids && cpu_online(cpu))
             smp_send_reschedule(cpu);
     }
+out:
+    put_cpu();
 }
 ```
 

--- a/docs/virtualization/kvm-exits.md
+++ b/docs/virtualization/kvm-exits.md
@@ -10,13 +10,15 @@ Every KVM vCPU runs in a tight loop inside `kvm_arch_vcpu_ioctl_run()` in `arch/
 kvm_arch_vcpu_ioctl_run()          arch/x86/kvm/x86.c
   └── vcpu_run()
         └── vcpu_enter_guest()
-              ├── kvm_x86_ops.prepare_guest_switch(vcpu)
+              ├── kvm_x86_call(prepare_switch_to_guest)(vcpu)
               ├── VMLAUNCH / VMRESUME  ← hardware runs guest here
               │       (guest executes at near-native speed)
               │
               │   [VM exit fires — hardware saves guest state to VMCS]
               │
-              └── kvm_x86_ops.handle_exit(vcpu, exit_fastpath)
+              ├── kvm_x86_call(handle_exit_irqoff)(vcpu)   (interrupts still off)
+              │
+              └── kvm_x86_call(handle_exit)(vcpu, exit_fastpath)
                     └── kvm_vmx_exit_handlers[exit_reason](vcpu)
                           returns 1 → resume guest
                           returns 0 → exit to userspace (QEMU)
@@ -33,34 +35,35 @@ Before entering the guest on each iteration, `vcpu_enter_guest()` processes any 
 static int vcpu_enter_guest(struct kvm_vcpu *vcpu)
 {
     /* Process pending requests: TLB flushes, MMU reloads, etc. */
-    if (kvm_request_pending(vcpu)) {
-        if (kvm_check_request(KVM_REQ_TLB_FLUSH_GUEST, vcpu))
-            kvm_vcpu_flush_tlb_guest(vcpu);
-        if (kvm_check_request(KVM_REQ_MMU_RELOAD, vcpu))
-            kvm_mmu_unload(vcpu);
-        /* ... other KVM_REQ_* flags ... */
-    }
+    if (kvm_check_request(KVM_REQ_MMU_SYNC, vcpu))
+        kvm_mmu_sync_roots(vcpu);
+    if (kvm_check_request(KVM_REQ_TLB_FLUSH, vcpu))
+        kvm_vcpu_flush_tlb_all(vcpu);
+    /* ... other KVM_REQ_* flags ... */
 
     /* Inject a pending interrupt (if any) before entering */
-    if (vcpu->arch.interrupt.injected)
-        kvm_x86_ops.inject_irq(vcpu);
+    if (kvm_cpu_has_injectable_intr(vcpu))
+        kvm_x86_call(inject_irq)(vcpu, false /* reinjected */);
 
     /* Disable preemption, switch to guest CR3, enter VMX non-root */
-    kvm_x86_ops.run(vcpu);  /* VMLAUNCH or VMRESUME */
+    exit_fastpath = kvm_x86_call(vcpu_run)(vcpu, run_flags);  /* VMLAUNCH or VMRESUME */
 
     /*
-     * We are back — VM exit occurred.
-     * vcpu->arch.exit_reason is now set from the VMCS.
+     * We are back — VM exit occurred. handle_exit_irqoff() does minimal
+     * work with interrupts still disabled (e.g. #NM handling); it doesn't
+     * return anything — exit_fastpath came from the vcpu_run() call above.
      */
-    exit_fastpath = kvm_x86_ops.handle_exit_irqoff(vcpu);
+    kvm_x86_call(handle_exit_irqoff)(vcpu);
 
-    return kvm_x86_ops.handle_exit(vcpu, exit_fastpath);
+    /* ... re-enable interrupts/preemption, account guest time, etc ... */
+
+    return kvm_x86_call(handle_exit)(vcpu, exit_fastpath);
 }
 ```
 
 ## Exit reason dispatch
 
-On Intel, the exit reason is stored in the VMCS `VM_EXIT_REASON` field. KVM VMX reads it into `vcpu->arch.exit_reason` and indexes into `kvm_vmx_exit_handlers[]`:
+On Intel, the exit reason is stored in the VMCS `VM_EXIT_REASON` field. `vmx_get_exit_reason(vcpu)` reads it (from a per-vCPU VMX field, not `vcpu->arch`) into a `union vmx_exit_reason`, and the low bits (`.basic`) index into `kvm_vmx_exit_handlers[]`:
 
 ```c
 /* arch/x86/kvm/vmx/vmx.c */
@@ -76,23 +79,36 @@ static int (*kvm_vmx_exit_handlers[])(struct kvm_vcpu *vcpu) = {
     [EXIT_REASON_HLT]               = kvm_emulate_halt,
     [EXIT_REASON_EPT_VIOLATION]     = handle_ept_violation,
     [EXIT_REASON_EPT_MISCONFIG]     = handle_ept_misconfig,
-    [EXIT_REASON_VMCALL]            = handle_vmcall,
+    [EXIT_REASON_VMCALL]            = kvm_emulate_hypercall,
     [EXIT_REASON_APIC_ACCESS]       = handle_apic_access,
-    /* ... ~40 total handlers ... */
+    /* ... ~50 total handlers ... */
 };
 
-static int vmx_handle_exit(struct kvm_vcpu *vcpu,
-                            enum exit_fastpath_completion exit_fastpath)
+static int __vmx_handle_exit(struct kvm_vcpu *vcpu,
+                              fastpath_t exit_fastpath)
 {
-    u32 exit_reason = vmx_get_exit_reason(vcpu);
+    union vmx_exit_reason exit_reason = vmx_get_exit_reason(vcpu);
 
-    if (unlikely(exit_reason >= ARRAY_SIZE(kvm_vmx_exit_handlers) ||
-                 !kvm_vmx_exit_handlers[exit_reason]))
+    /* If guest state is invalid (e.g. after a bad VM entry), emulate
+     * instead of dispatching through the table below: */
+    if (vmx->vt.emulation_required)
         return handle_invalid_guest_state(vcpu);
 
-    return kvm_vmx_exit_handlers[exit_reason](vcpu);
+    /* ... failed-entry and event-vectoring checks omitted ... */
+
+    if (exit_reason.basic >= kvm_vmx_max_exit_handlers ||
+        !kvm_vmx_exit_handlers[exit_reason.basic]) {
+        /* Unrecognized exit reason: dump state, exit to userspace */
+        dump_vmcs(vcpu);
+        kvm_prepare_unexpected_reason_exit(vcpu, exit_reason.full);
+        return 0;
+    }
+
+    return kvm_vmx_exit_handlers[exit_reason.basic](vcpu);
 }
 ```
+
+`__vmx_handle_exit()` does the actual dispatch; the `kvm_x86_ops.handle_exit` entry point is a thin `vmx_handle_exit()` wrapper around it that also checks for a detected bus lock (`KVM_EXIT_X86_BUS_LOCK`).
 
 AMD SVM follows the same pattern with `svm_exit_handlers[]` in `arch/x86/kvm/svm/svm.c`, indexed by the `EXITCODE` field in the VMCB.
 
@@ -115,11 +131,11 @@ static int handle_io(struct kvm_vcpu *vcpu)
     if (string)
         return kvm_emulate_instruction(vcpu, 0);
 
-    return kvm_emulate_pio(vcpu, in, size, port);
+    return kvm_fast_pio(vcpu, size, port, in);
 }
 ```
 
-`kvm_emulate_pio()` (in `arch/x86/kvm/x86.c`) first tries in-kernel device emulation via the `kvm_io_bus` dispatch table. If no in-kernel device owns the port, it fills `kvm_run` and returns `0`:
+`kvm_fast_pio()` (in `arch/x86/kvm/x86.c`) first tries in-kernel device emulation via the `kvm_io_bus` dispatch table. If no in-kernel device owns the port, it fills `kvm_run` and returns `0`:
 
 ```c
 /* struct kvm_run — userspace sees this on KVM_EXIT_IO */
@@ -141,7 +157,8 @@ struct kvm_run {
 When the guest accesses a guest physical address (GPA) that has no valid Extended Page Table (EPT) entry, or violates access permissions, hardware raises an EPT violation exit.
 
 ```c
-/* arch/x86/kvm/vmx/vmx.c */
+/* arch/x86/kvm/vmx/vmx.c — handle_ept_violation() with its
+ * __vmx_handle_ept_violation() helper folded in, simplified */
 static int handle_ept_violation(struct kvm_vcpu *vcpu)
 {
     unsigned long exit_qualification = vmx_get_exit_qual(vcpu);
@@ -174,15 +191,26 @@ static int handle_ept_violation(struct kvm_vcpu *vcpu)
 When the guest executes `HLT` and interrupts are disabled, there is nothing for the vCPU to do. KVM calls `kvm_vcpu_halt()` which calls `kvm_vcpu_block()`:
 
 ```c
-/* virt/kvm/kvm_main.c */
+/* virt/kvm/kvm_main.c, simplified */
 bool kvm_vcpu_block(struct kvm_vcpu *vcpu)
 {
-    /* vcpu->wait is a struct rcuwait, not a wait_queue_head_t */
-    rcuwait_wait_event(&vcpu->wait,
-                       kvm_arch_vcpu_runnable(vcpu) ||
-                       kvm_arch_vcpu_has_work(vcpu),
-                       TASK_INTERRUPTIBLE);
-    return kvm_arch_vcpu_runnable(vcpu);
+    struct rcuwait *wait = kvm_arch_vcpu_get_wait(vcpu);  /* &vcpu->wait, generically */
+    bool waited = false;
+
+    kvm_arch_vcpu_blocking(vcpu);
+    prepare_to_rcuwait(wait);
+
+    for (;;) {
+        set_current_state(TASK_INTERRUPTIBLE);
+        if (kvm_vcpu_check_block(vcpu) < 0)
+            break;          /* runnable again, or has other pending work */
+        waited = true;
+        schedule();
+    }
+
+    finish_rcuwait(wait);
+    kvm_arch_vcpu_unblocking(vcpu);
+    return waited;          /* did we actually sleep, or was there work already? */
 }
 ```
 
@@ -210,13 +238,18 @@ Guest executes:   mov [0xfee00000], eax   (write to local APIC MMIO)
   1. EPT violation exits — GPA 0xfee00000 has no EPT mapping
   2. handle_ept_violation() → kvm_mmu_page_fault()
   3. kvm_mmu_page_fault() detects MMIO: no struct page for this GPA
-  4. kvm_io_bus_write() tries in-kernel devices (e.g., KVM's APIC emulation)
-     ├── hit: handled in-kernel, resume guest (return 1)
-     └── miss: fall through to x86_emulate_instruction()
-
-  5. x86_emulate_instruction() decodes the faulting instruction
-     uses struct x86_emulate_ops to fetch instruction bytes from guest
-  6. Emulated result placed in kvm_run.mmio; ioctl returns to userspace
+  4. kvm_mmu_page_fault() calls x86_emulate_instruction() to decode and
+     execute the faulting instruction (uses struct x86_emulate_ops to
+     fetch instruction bytes from guest)
+  5. The emulator's write-emulated callback reaches vcpu_mmio_write(),
+     which dispatches the actual write:
+     ├── in-kernel local APIC — checked directly (vcpu->arch.apic->dev),
+     │   not via the generic kvm_io_bus
+     │     hit: handled in-kernel, resume guest (return 1)
+     └── miss → kvm_io_bus_write(KVM_MMIO_BUS, ...) — other in-kernel
+           devices (e.g. IOAPIC), matched by registered GPA range
+           ├── hit: handled in-kernel, resume guest (return 1)
+           └── miss: kvm_run.mmio filled; ioctl returns to userspace
 ```
 
 The MMIO fields in `struct kvm_run` (from `include/uapi/linux/kvm.h`):
@@ -239,32 +272,40 @@ For a guest **read**: QEMU fills `kvm_run.mmio.data` with the device register va
 
 For a guest **write**: QEMU reads `kvm_run.mmio.data` and forwards it to the device model.
 
-### KVM in-kernel MMIO devices
+### KVM in-kernel devices
 
 Several devices are emulated entirely in-kernel to avoid the QEMU round-trip:
 
-| Device | In-kernel emulation |
-|--------|---------------------|
-| Local APIC | `arch/x86/kvm/lapic.c` |
-| IOAPIC | `arch/x86/kvm/ioapic.c` |
-| PIT (8254 timer) | `arch/x86/kvm/i8254.c` |
+| Device | In-kernel emulation | Registration |
+|--------|---------------------|---------------|
+| Local APIC | `arch/x86/kvm/lapic.c` | Checked directly (`vcpu->arch.apic->dev`) ahead of the generic bus — not registered via `kvm_io_bus_register_dev()` |
+| IOAPIC | `arch/x86/kvm/ioapic.c` | `kvm_io_bus_register_dev(kvm, KVM_MMIO_BUS, ...)`, matched by GPA range |
+| PIT (8254 timer) | `arch/x86/kvm/i8254.c` | `kvm_io_bus_register_dev(kvm, KVM_PIO_BUS, ...)` — legacy port I/O (ports 0x40-0x43, 0x61), not MMIO |
 
-These register on the `kvm_io_bus` with `kvm_io_bus_register_dev()` and are matched by GPA range before any exit to userspace occurs.
+Only IOAPIC (and other genuine MMIO devices) go through the generic `kvm_io_bus` GPA-range lookup; the Local APIC is special-cased ahead of it, and the PIT is reached via the separate port-I/O bus, not MMIO at all.
 
 ## Interrupt injection
 
 Interrupts to guest vCPUs do not arrive via normal hardware interrupt lines. KVM manages virtual interrupt delivery:
 
 ```c
-/* Kick a vCPU to check for pending interrupts */
-void kvm_vcpu_kick(struct kvm_vcpu *vcpu)
+/* virt/kvm/kvm_main.c — __kvm_vcpu_kick(), simplified.
+ * kvm_vcpu_kick(vcpu) is a thin inline wrapper: __kvm_vcpu_kick(vcpu, false). */
+void __kvm_vcpu_kick(struct kvm_vcpu *vcpu, bool wait)
 {
-    /* If vCPU is running on another pCPU, send IPI to force exit */
-    if (kvm_arch_vcpu_should_kick(vcpu))
-        smp_send_reschedule(vcpu->cpu);
+    /* Wake it first: if it was blocking (e.g. in HLT), waking it is enough —
+     * no IPI needed since it wasn't running on a pCPU. */
+    if (kvm_vcpu_wake_up(vcpu))
+        return;
 
-    /* Wake the vCPU thread if it is blocking (e.g., in HLT) */
-    rcuwait_wake_up(&vcpu->wait);
+    /* Otherwise it's actually running: if that's still true, send an IPI
+     * to force a VM exit so it notices pending work (unless we're already
+     * running on the target's own pCPU, in which case a flag write suffices). */
+    if (kvm_arch_vcpu_should_kick(vcpu)) {
+        int cpu = READ_ONCE(vcpu->cpu);
+        if (cpu != smp_processor_id() && cpu_online(cpu))
+            smp_send_reschedule(cpu);
+    }
 }
 ```
 
@@ -291,17 +332,19 @@ Advanced interrupt features that reduce exits:
 VM exits are the primary source of KVM overhead. Minimizing exit frequency and exit handling latency is the main performance lever.
 
 ```bash
-# Per-VM, per-vCPU exit counters in debugfs
+# Per-VM directories in debugfs, one per VM: <creator-pid>-<vm-fd-name>
 ls /sys/kernel/debug/kvm/
-# <pid>-<vmid>/   directories, one per VM
+# 1234-3/   ...   (VM-level stat files live directly here)
 
-cat /sys/kernel/debug/kvm/1234-0/exits
-# total: 8473921
-# io_exits: 12304
-# mmio_exits: 340291
-# irq_window_exits: 5023
-# halt_exits: 29103
-# halt_wakeup: 29099
+# Each vCPU gets its own subdirectory, with one raw-counter file per stat
+# (see kvm_vcpu_stats_desc[] in arch/x86/kvm/x86.c) — no single aggregate file:
+ls /sys/kernel/debug/kvm/1234-3/vcpu0/
+# exits  io_exits  mmio_exits  irq_window_exits  halt_exits  halt_wakeup  ...
+
+cat /sys/kernel/debug/kvm/1234-3/vcpu0/exits
+# 8473921
+cat /sys/kernel/debug/kvm/1234-3/vcpu0/mmio_exits
+# 340291
 
 # perf KVM: aggregate exit statistics across all VMs
 perf kvm stat record -a sleep 10
@@ -339,7 +382,7 @@ Key performance guidelines:
 - [arch/x86/kvm/svm/svm.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/svm/svm.c) — `svm_exit_handlers[]`: AMD SVM's equivalent exit-reason table, indexed by the VMCB `EXITCODE` field
 - [arch/x86/kvm/mmu/mmu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/mmu/mmu.c) — `kvm_mmu_page_fault()`: distinguishes a missing EPT mapping, an MMIO region, and a permission fault
 - [arch/x86/kvm/cpuid.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/cpuid.c) — `kvm_emulate_cpuid()`: CPUID leaf lookup and feature-bit filtering
-- [arch/x86/kvm/emulate.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/emulate.c) — `x86_emulate_insn()`: the instruction emulator invoked for MMIO and string I/O
+- [arch/x86/kvm/emulate.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/emulate.c) — `x86_emulate_insn()`: the low-level decode-and-execute step invoked internally by `x86_emulate_instruction()` (in `x86.c`), the top-level entry point for MMIO and string I/O emulation; `vcpu_mmio_write()`/`vcpu_mmio_read()` (in `x86.c`) are the emulator callbacks that dispatch to the local APIC directly or fall back to `kvm_io_bus_write()`/`kvm_io_bus_read()`
 - [virt/kvm/kvm_main.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/virt/kvm/kvm_main.c) — `kvm_vcpu_block()`/`kvm_vcpu_kick()`: HLT-driven vCPU sleep and wake
 - [virt/kvm/irqchip.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/virt/kvm/irqchip.c) — `kvm_set_irq()` and the GSI routing table used to deliver device interrupts
 - [arch/x86/kvm/lapic.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/lapic.c) — in-kernel local APIC emulation

--- a/docs/virtualization/kvm-exits.md
+++ b/docs/virtualization/kvm-exits.md
@@ -21,7 +21,7 @@ kvm_arch_vcpu_ioctl_run()          arch/x86/kvm/x86.c
               └── kvm_x86_call(handle_exit)(vcpu, exit_fastpath)
                     └── kvm_vmx_exit_handlers[exit_reason](vcpu)
                           returns 1 → resume guest
-                          returns 0 → exit to userspace (QEMU)
+                          returns 0 → exit to userspace VMM
 ```
 
 The key contract: a handler returning `1` means KVM can re-enter the guest immediately. Returning `0` or a negative error means `KVM_RUN` ioctl returns to userspace, which inspects `struct kvm_run` to learn what happened.
@@ -34,6 +34,10 @@ Before entering the guest on each iteration, `vcpu_enter_guest()` processes any 
 /* arch/x86/kvm/x86.c (simplified) */
 static int vcpu_enter_guest(struct kvm_vcpu *vcpu)
 {
+    fastpath_t exit_fastpath;
+    u32 run_flags = 0;   /* built up earlier from pending debug-register /
+                           * debugctl state; omitted here */
+
     /* Process pending requests: TLB flushes, MMU reloads, etc. */
     if (kvm_check_request(KVM_REQ_MMU_SYNC, vcpu))
         kvm_mmu_sync_roots(vcpu);
@@ -87,6 +91,7 @@ static int (*kvm_vmx_exit_handlers[])(struct kvm_vcpu *vcpu) = {
 static int __vmx_handle_exit(struct kvm_vcpu *vcpu,
                               fastpath_t exit_fastpath)
 {
+    struct vcpu_vmx *vmx = to_vmx(vcpu);
     union vmx_exit_reason exit_reason = vmx_get_exit_reason(vcpu);
 
     /* If guest state is invalid (e.g. after a bad VM entry), emulate
@@ -108,7 +113,7 @@ static int __vmx_handle_exit(struct kvm_vcpu *vcpu,
 }
 ```
 
-`__vmx_handle_exit()` does the actual dispatch; the `kvm_x86_ops.handle_exit` entry point is a thin `vmx_handle_exit()` wrapper around it that also checks for a detected bus lock (`KVM_EXIT_X86_BUS_LOCK`).
+`__vmx_handle_exit()` does the actual dispatch; the entry point reached via `kvm_x86_call(handle_exit)` is a thin `vmx_handle_exit()` wrapper around it that also checks for a detected bus lock (`KVM_EXIT_X86_BUS_LOCK`).
 
 AMD SVM follows the same pattern with `svm_exit_handlers[]` in `arch/x86/kvm/svm/svm.c`, indexed by the `EXITCODE` field in the VMCB.
 
@@ -116,7 +121,7 @@ AMD SVM follows the same pattern with `svm_exit_handlers[]` in `arch/x86/kvm/svm
 
 ### EXIT_REASON_IO_INSTRUCTION — port I/O
 
-Port I/O instructions (`in`/`out`) exit unconditionally on VMX (unless the I/O bitmap says otherwise). The fast path handles simple cases in-kernel; the slow path exits to userspace.
+Port I/O instructions (`in`/`out`) exit by default; the per-VMCS I/O bitmap can be configured to let specific ports run without exiting at all. Of the ports that do exit, the fast path handles simple cases in-kernel; the slow path (string I/O) falls back to full instruction emulation.
 
 ```c
 /* arch/x86/kvm/vmx/vmx.c */
@@ -135,7 +140,7 @@ static int handle_io(struct kvm_vcpu *vcpu)
 }
 ```
 
-`kvm_fast_pio()` (in `arch/x86/kvm/x86.c`) first tries in-kernel device emulation via the `kvm_io_bus` dispatch table. If no in-kernel device owns the port, it fills `kvm_run` and returns `0`:
+`kvm_fast_pio()` (in `arch/x86/kvm/x86.c`) hands off to `kvm_fast_pio_in()`/`kvm_fast_pio_out()`, which go through the emulator's `emulator_pio_in()`/`emulator_pio_out()` path. That path tries in-kernel device emulation via the `kvm_io_bus` dispatch table first; if no in-kernel device owns the port, it fills `kvm_run` and returns `0`:
 
 ```c
 /* struct kvm_run — userspace sees this on KVM_EXIT_IO */
@@ -218,7 +223,7 @@ The vCPU thread sleeps until `kvm_vcpu_kick()` wakes it — typically because a 
 
 ### EXIT_REASON_MSR_READ / MSR_WRITE
 
-MSR accesses can be made cheap with the **MSR bitmap**: a 4KB bitmap in the VMCS where each bit controls whether a specific MSR causes a VM exit. Frequently-read MSRs like `IA32_TSC` or `IA32_SYSENTER_EIP` can be pass-through (no exit). For intercepted MSRs, KVM dispatches to `kvm_emulate_rdmsr()` or `kvm_emulate_wrmsr()` (in `arch/x86/kvm/x86.c`), which uses switch-based per-MSR dispatch inside `__kvm_get_msr()` / `__kvm_set_msr()`.
+MSR accesses can be made cheap with the **MSR bitmap**: a 4KB page (pointed to by the VMCS's `MSR_BITMAP` field, not embedded in the VMCS itself) where each bit controls whether a specific MSR causes a VM exit. Frequently-read MSRs like `IA32_TSC` or `IA32_SYSENTER_EIP` can be pass-through (no exit). For intercepted MSRs, KVM dispatches to `kvm_emulate_rdmsr()` or `kvm_emulate_wrmsr()` (in `arch/x86/kvm/x86.c`), which uses switch-based per-MSR dispatch inside `__kvm_get_msr()` / `__kvm_set_msr()`.
 
 ### EXIT_REASON_EXCEPTION_NMI
 
@@ -268,13 +273,13 @@ struct kvm_run {
 };
 ```
 
-For a guest **read**: QEMU fills `kvm_run.mmio.data` with the device register value, then re-enters KVM via `KVM_RUN`. KVM completes the emulated instruction by writing the data into the guest register.
+For a guest **read**: userspace (e.g. QEMU) fills `kvm_run.mmio.data` with the device register value, then re-enters KVM via `KVM_RUN`. KVM completes the emulated instruction by writing the data into the guest register.
 
-For a guest **write**: QEMU reads `kvm_run.mmio.data` and forwards it to the device model.
+For a guest **write**: userspace reads `kvm_run.mmio.data` and forwards it to its device model.
 
 ### KVM in-kernel devices
 
-Several devices are emulated entirely in-kernel to avoid the QEMU round-trip:
+Several devices are emulated entirely in-kernel to avoid the round-trip to userspace:
 
 | Device | In-kernel emulation | Registration |
 |--------|---------------------|---------------|
@@ -302,8 +307,10 @@ void __kvm_vcpu_kick(struct kvm_vcpu *vcpu, bool wait)
      * to force a VM exit so it notices pending work (unless we're already
      * running on the target's own pCPU, in which case a flag write suffices). */
     if (kvm_arch_vcpu_should_kick(vcpu)) {
-        int cpu = READ_ONCE(vcpu->cpu);
-        if (cpu != smp_processor_id() && cpu_online(cpu))
+        int cpu = READ_ONCE(vcpu->cpu);   /* -1 if not currently loaded */
+
+        if (cpu != smp_processor_id() &&
+            (unsigned int)cpu < nr_cpu_ids && cpu_online(cpu))
             smp_send_reschedule(cpu);
     }
 }
@@ -325,7 +332,7 @@ The routing table (`struct kvm_irq_routing_table`, allocated in `virt/kvm/irqchi
 Advanced interrupt features that reduce exits:
 
 - **APICv / AVIC**: virtualizes the local APIC in hardware (Intel APICv / AMD AVIC), eliminating most APIC MMIO exits and enabling posted interrupt delivery without a VM exit.
-- **Posted interrupts**: the CPU delivers virtual interrupts directly to the guest without a VM exit using the Posted Interrupt Descriptor (PID).
+- **Posted interrupts**: the CPU delivers virtual interrupts directly to the guest without a VM exit, tracked via a per-vCPU posted-interrupt descriptor (`struct pi_desc`).
 
 ## Performance: measuring exits
 

--- a/docs/virtualization/kvm-exits.md
+++ b/docs/virtualization/kvm-exits.md
@@ -95,8 +95,10 @@ static int __vmx_handle_exit(struct kvm_vcpu *vcpu,
     struct vcpu_vmx *vmx = to_vmx(vcpu);
     union vmx_exit_reason exit_reason = vmx_get_exit_reason(vcpu);
 
-    /* If guest state is invalid (e.g. after a bad VM entry), emulate
-     * instead of dispatching through the table below: */
+    /* If guest state can't run natively in VMX non-root mode (the
+     * common case: real-mode/16-bit code, e.g. BIOS, on hardware
+     * without "unrestricted guest" support), fully emulate instead of
+     * dispatching through the table below: */
     if (vmx->vt.emulation_required)
         return handle_invalid_guest_state(vcpu);
 


### PR DESCRIPTION
Part of #740 (virtualization/ technical-accuracy audit). Second of the seven flagged pages.

## In-scope fixes from the round-5 review list (all verified against current kernel.org source)

- **Exit-reason table**: `[EXIT_REASON_VMCALL] = handle_vmcall` doesn't exist — real: `kvm_emulate_hypercall`.
- **Port I/O**: `kvm_emulate_pio()` doesn't exist (also internally inconsistent — this page's own Further Reading already used the correct name) — real: `kvm_fast_pio()`, and its call had the wrong argument order (`(vcpu, in, size, port)` → real `(vcpu, size, port, in)`).
- **vCPU run loop diagram/code**: `kvm_x86_ops.prepare_guest_switch` → real field is `prepare_switch_to_guest`; `kvm_x86_ops.run`/`.inject_irq`/`.handle_exit` → current source dispatches through the `kvm_x86_call(op)` macro, not direct `.field()` calls (same fix as #780's kvm-arch.md, kept consistent across both pages).
- **`KVM_REQ_MMU_RELOAD`** doesn't exist anywhere in current source — replaced with the real request/handler pairs used in this exact spot of `vcpu_enter_guest()` (`KVM_REQ_MMU_SYNC` → `kvm_mmu_sync_roots()`).
- **`kvm_vcpu_block()`/`kvm_vcpu_kick()`**: both bodies were fabricated. Rewrote to match the real implementations.
- **`handle_invalid_guest_state()` was misattributed** as the fallback for an *unrecognized* exit reason. The real "unrecognized reason" path is the `unexpected_vmexit` label (`dump_vmcs()` + `kvm_prepare_unexpected_reason_exit()`), traced and added.
- **Local APIC does not register via `kvm_io_bus_register_dev()`** — confirmed false; it's checked directly (`vcpu->arch.apic->dev`) ahead of the generic bus. Also caught: the PIT was mischaracterized as an MMIO device in the same table — it actually registers on `KVM_PIO_BUS` (legacy port I/O), not `KVM_MMIO_BUS`. Rewrote the device table with a "Registration" column.

## Additional issues found during the initial verification pass, beyond the round-5 list

- `vcpu->arch.exit_reason` doesn't exist — read via `vmx_get_exit_reason(vcpu)` from a per-vCPU VMX field, not `vcpu->arch`.
- `exit_fastpath = kvm_x86_ops.handle_exit_irqoff(vcpu)` — wrong; `vmx_handle_exit_irqoff()` returns `void`. `exit_fastpath` actually comes from the earlier VM-entry call (`kvm_x86_call(vcpu_run)`).
- The MMIO-emulation diagram had the device-dispatch step positioned *before* instruction emulation; in real source it happens *inside* the emulator's write callback (`vcpu_mmio_write()`), after `x86_emulate_instruction()` is already underway. Reordered and corrected which device goes through which path.
- Further Reading cited `x86_emulate_insn()` as "the instruction emulator invoked for MMIO and string I/O" — wrong function, and inconsistent with this page's own body text, which correctly names `x86_emulate_instruction()`.
- The debugfs example showed a nonexistent aggregate `exits` file under a flattened path that doesn't match the real per-VM/per-vCPU directory hierarchy (`kvm_create_vm_debugfs()`/`kvm_create_vcpu_debugfs()` in `kvm_main.c`). Same bug existed in the sibling kvm-arch.md page from #780 — fixed there too.

## Review history

Four more rounds after the initial fix, each independently re-reading the full page against source rather than just the diff:

- **Round 2** (precision pass): stopped hardcoding QEMU into descriptions of the VMM-agnostic exit-to-userspace ABI; fixed self-contradictory "exit unconditionally... unless" phrasing on the I/O bitmap; declared `vmx`/`run_flags`/`exit_fastpath` in two snippets that used them as if already in scope; corrected the `kvm_fast_pio()` io_bus claim to name the real multi-hop call chain (`kvm_fast_pio_in/out` → `emulator_pio_in/out`); fixed "MSR bitmap in the VMCS" (it's a page pointed to by the VMCS's `MSR_BITMAP` field, not embedded); added the `nr_cpu_ids` bounds check `__kvm_vcpu_kick()`'s simplified body was missing before `cpu_online()`; fixed a leftover `kvm_x86_ops.handle_exit` reference to the `kvm_x86_call()` convention used everywhere else in the file; dropped the "PID" abbreviation for the posted-interrupt descriptor (collides with the process-id `pid` used elsewhere on the page).
- **Round 3**: caught two regressions from round 2's own fixes — `run_flags` declared `u32` (real: `u64`), and its comment describing it as debug/debugctl-state-only (missing `KVM_RUN_FORCE_IMMEDIATE_EXIT`); and a comment/code mismatch in `__kvm_vcpu_kick()` — the comment claimed a self-pCPU fast path ("a flag write suffices") that the shown code didn't actually implement (it just silently skipped the IPI). Added the real fast path (`vcpu == __this_cpu_read(kvm_running_vcpu)` → flip `vcpu->mode` directly, matching real source).
- **Round 4**: `emulation_required`'s trigger comment ("after a bad VM entry") was wrong. Traced `vmx_emulation_required()`: it's `emulate_invalid_guest_state && !vmx_guest_state_valid(vcpu)` — the common real-world trigger is real-mode/16-bit guest code (BIOS, option ROMs) on hardware without unrestricted-guest support, not a failed VM entry.
- **Rounds 5-7**: clean. Cross-checked against the sibling kvm-arch.md page (#780) and found the same undeclared-variable gap there too — fixed as a follow-up commit on that PR rather than here. Independently re-verified every remaining primitive used in the `kvm_vcpu_block()` rewrite (`KVM_EXIT_X86_BUS_LOCK`, `kvm_arch_vcpu_blocking()`/`unblocking()`, `prepare_to_rcuwait()`/`finish_rcuwait()`, `kvm_vcpu_check_block()`) against source. No further issues found across two consecutive rounds.

## Verification

- Every changed claim checked directly against current kernel.org source (`x86.c`, `vmx.c`, `svm.c`, `mmu.c`, `cpuid.c`, `lapic.c`, `ioapic.c`, `i8254.c`, `irqchip.c`, `kvm_main.c`, `kvm_host.h`, uapi headers).
- Also spot-checked several previously-unflagged claims (`struct kvm_run` io/mmio field layouts, `kvm_set_irq()`/`kvm_ioapic_set_irq()`/`kvm_apic_set_irq()` signatures, MSR bitmap pass-through claims, SVM's `EXITCODE` dispatch, `EXIT_REASON_EXCEPTION_NMI`/`kvm_handle_page_fault()`, `kvm_exit`/`kvm_mmio`/`kvm_pio` tracepoint names, the local-APIC MMIO base address) — all accurate.
- `mkdocs build --strict` passes clean.

## Remaining scope

5 more pages tracked in #740: `kvm-memory.md`, `live-migration.md`, `nested-virt.md`, `vfio.md`, `virtio.md`.
