### PR TITLE
virtualization: fix fabricated technical details in kvm-memory.md

### DIFF
--- a/docs/virtualization/kvm-memory.md
+++ b/docs/virtualization/kvm-memory.md
@@ -193,7 +193,7 @@ struct kvm_memory_slot {
 ```
 
 A slot can be:
-- **Normal RAM**: backed by `mmap(MAP_ANONYMOUS)` memory in QEMU
+- **Normal RAM**: backed by `mmap(MAP_ANONYMOUS)` memory in the VMM (e.g. QEMU)
 - **ROM**: read-only (bios, option ROM)
 - **MMIO**: no backing — triggers `KVM_EXIT_MMIO` on access
 

--- a/docs/virtualization/kvm-memory.md
+++ b/docs/virtualization/kvm-memory.md
@@ -140,9 +140,11 @@ struct kvm_mmu_page {
     atomic_t            write_flooding_count;
 
     /* Separate list (kvm->arch.possible_nx_huge_pages), independent of
-     * active_mmu_pages above: pages that, if zapped, would let KVM use a
-     * huge page here instead. Periodically zapped by a recovery thread
-     * (kvm_recover_nx_huge_pages()) to claw back the lost TLB coverage. */
+     * active_mmu_pages above: pages KVM split to 4K solely to mitigate the
+     * iTLB multihit erratum (an executable huge PTE would otherwise be
+     * split by hardware in a way that can hang certain CPUs). Periodically
+     * re-zapped by a recovery thread (kvm_recover_nx_huge_pages()) so KVM
+     * can retry the huge mapping and recoup the mitigation's TLB cost. */
     struct list_head    possible_nx_huge_page_link;
 };
 ```
@@ -357,7 +359,8 @@ void kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault
     if (is_error_noslot_pfn(fault->pfn))
         return;
     if (kvm_slot_dirty_track_enabled(slot))
-        return;   /* dirty tracking needs 4K-granularity writes */
+        return;   /* KVM dirty-logs at 4KiB granularity, so huge pages
+                     get split to 4K on first write when a slot is dirty-tracked */
 
     /* Largest level both the GPA alignment and the host page support: */
     fault->req_level = kvm_mmu_max_mapping_level(vcpu->kvm, fault,
@@ -374,8 +377,10 @@ void kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault
 ## Observing guest memory
 
 ```bash
-# Page faults handled per vCPU (there's no dedicated "ept_violations" file;
-# pf_taken is the closest real counter — see kvm_vcpu_stats_desc[] in x86.c)
+# There's no dedicated "ept_violations" file (see kvm_vcpu_stats_desc[] in
+# x86.c for the full real list). pf_taken is the nearest available proxy —
+# it counts every fault handled by kvm_mmu_page_fault(), which includes
+# EPT violations but isn't scoped to them exclusively:
 cat /sys/kernel/debug/kvm/*/vcpu0/pf_taken
 
 # Guest TLB flush requests (also per-vCPU, same directory level)

--- a/docs/virtualization/kvm-memory.md
+++ b/docs/virtualization/kvm-memory.md
@@ -34,9 +34,10 @@ For a 4-level guest walking a 4-level EPT, the hardware may touch up to 24 page 
 
 ```c
 /* Simplified — arch/x86/include/asm/kvm_host.h; several callback and
- * shadow-root fields (get_guest_pgd, inject_page_fault, gva_to_gpa,
- * sync_spte, mirror_root_hpa, cpu_role, pkru_mask, permissions[],
- * pml4_root, pml5_root, shadow/guest reserved-bits validators) omitted */
+ * shadow-root fields (get_guest_pgd, get_pdptr, inject_page_fault,
+ * gva_to_gpa, sync_spte, mirror_root_hpa, cpu_role, pkru_mask,
+ * permissions[], pml4_root, pml5_root, shadow/guest reserved-bits
+ * validators) omitted */
 struct kvm_mmu {
     /* Page fault handler: invoked on GPA fault */
     int (*page_fault)(struct kvm_vcpu *vcpu,

--- a/docs/virtualization/kvm-memory.md
+++ b/docs/virtualization/kvm-memory.md
@@ -33,25 +33,24 @@ For a 4-level guest walking a 4-level EPT, the hardware may touch up to 24 page 
 ### struct kvm_mmu
 
 ```c
-/* arch/x86/include/asm/kvm_host.h */
+/* Simplified — arch/x86/include/asm/kvm_host.h; several callback and
+ * shadow-root fields (get_guest_pgd, inject_page_fault, gva_to_gpa,
+ * sync_spte, mirror_root_hpa, cpu_role, pkru_mask, permissions[],
+ * pml4_root, pml5_root, shadow/guest reserved-bits validators) omitted */
 struct kvm_mmu {
     /* Page fault handler: invoked on GPA fault */
     int (*page_fault)(struct kvm_vcpu *vcpu,
                       struct kvm_page_fault *fault);
 
-    /* TLB flush */
-    void (*invlpg)(struct kvm_vcpu *vcpu, gva_t gva, hpa_t root_hpa);
-
     /* Root (top-level EPT/shadow PT physical address) */
     struct kvm_mmu_root_info root;   /* root.hpa, root.pgd */
     union kvm_mmu_page_role root_role;
 
-    /* GPA fault address from VMCS exit qualification */
-    gpa_t                gpa_available;
-
-    /* Shadow page table state */
-    struct kvm_mmu_page *pae_root;
     struct kvm_mmu_root_info prev_roots[KVM_MMU_NUM_PREV_ROOTS];
+
+    /* PAE root page table(s) — needed when shadowing a 32-bit/PAE guest
+     * paging mode (e.g. under NPT) with a 64-bit host MMU */
+    u64                  *pae_root;
 };
 ```
 
@@ -60,11 +59,12 @@ struct kvm_mmu {
 When a guest accesses memory with no EPT entry, the CPU triggers an EPT violation VM exit:
 
 ```c
-/* arch/x86/kvm/vmx/vmx.c */
+/* arch/x86/kvm/vmx/vmx.c — handle_ept_violation(), simplified */
 static int handle_ept_violation(struct kvm_vcpu *vcpu)
 {
     gpa_t gpa    = vmcs_read64(GUEST_PHYSICAL_ADDRESS);
     u64   exit_qual = vmcs_readl(EXIT_QUALIFICATION);
+    u64   error_code = 0;
 
     /*
      * exit_qual bits:
@@ -73,22 +73,43 @@ static int handle_ept_violation(struct kvm_vcpu *vcpu)
      *   bit 2: fetch fault
      *   bit 7: GPA in addr translation of GVA (not a direct access)
      */
+    if (exit_qual & EPT_VIOLATION_ACC_WRITE)
+        error_code |= PFERR_WRITE_MASK;
+    if (exit_qual & EPT_VIOLATION_ACC_INSTR)
+        error_code |= PFERR_FETCH_MASK;
+    /* (present/MBEC/GVA-translation/TDX-private bits omitted here) */
 
     /* Look up or create the HPA mapping */
     return kvm_mmu_page_fault(vcpu, gpa, error_code, NULL, 0);
 }
 
-/* arch/x86/kvm/mmu/mmu.c */
-static int kvm_mmu_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
-                               u64 error_code, ...)
+/* arch/x86/kvm/mmu/mmu.c — kvm_mmu_page_fault(), simplified (real signature
+ * takes 5 concrete params, not variadic; not static; also handles
+ * software-protected-VM attributes and write-protect faults, omitted here) */
+int noinline kvm_mmu_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
+                                 u64 error_code, void *insn, int insn_len)
 {
-    /* Try to resolve the fault by building EPT entries */
-    r = kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, error_code, false, &emulation_type);
-    if (r == RET_PF_INVALID) {
-        /* Emulate the access (e.g., MMIO to a device region) */
-        r = handle_mmio_page_fault(vcpu, cr2_or_gpa, is_present_gpte(error_code));
+    bool direct = vcpu->arch.mmu->root_role.direct;
+    int r, emulation_type = EMULTYPE_PF;
+
+    /* A reserved bit set in error_code is KVM's own MMIO hint */
+    if (error_code & PFERR_RSVD_MASK) {
+        r = handle_mmio_page_fault(vcpu, cr2_or_gpa, direct);
+        if (r == RET_PF_EMULATE)
+            goto emulate;
+    } else {
+        /* Try to resolve the fault by building EPT entries */
+        r = kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, error_code, false,
+                                  &emulation_type, NULL);
     }
-    return r;
+
+    if (r != RET_PF_EMULATE)
+        return r;
+
+emulate:
+    /* Emulate the access (e.g., MMIO to a device region) */
+    return x86_emulate_instruction(vcpu, cr2_or_gpa, emulation_type,
+                                   insn, insn_len);
 }
 ```
 
@@ -100,19 +121,28 @@ KVM tracks EPT/shadow pages via `struct kvm_mmu_page`. One struct per page table
 struct kvm_mmu_page {
     struct list_head    link;          /* in kvm->arch.active_mmu_pages */
     struct hlist_node   hash_link;     /* hash table by gfn */
-    struct list_head    lpage_disallowed_link;
 
     bool                unsync;        /* sptes may be out of date */
     u8                  mmu_valid_gen; /* generation counter */
+    bool                nx_huge_page_disallowed; /* can't use a huge page here
+                                                     due to the NX huge page
+                                                     mitigation */
 
     gfn_t               gfn;          /* guest frame number this page maps */
     union kvm_mmu_page_role role;      /* level, cr4_pae, access bits, ... */
 
     u64                *spt;          /* the actual page table page (4096 bytes) */
-    gfn_t              *shadowed_translation; /* gfn for each spte */
+    u64                *shadowed_translation; /* per-spte: shadowed GPA (upper
+                                                  bits) + access perms (lower) */
     struct kvm_rmap_head parent_ptes;  /* reverse map: who points here */
 
     atomic_t            write_flooding_count;
+
+    /* Separate list (kvm->arch.possible_nx_huge_pages), independent of
+     * active_mmu_pages above: pages that, if zapped, would let KVM use a
+     * huge page here instead. Periodically zapped by a recovery thread
+     * (kvm_recover_nx_huge_pages()) to claw back the lost TLB coverage. */
+    struct list_head    possible_nx_huge_page_link;
 };
 ```
 
@@ -237,27 +267,35 @@ Host (KVM)              Guest (virtio-balloon driver)
 The guest can also report memory statistics to the host:
 
 ```c
-/* drivers/virtio/virtio_balloon.c */
-static void update_balloon_stats(struct virtio_balloon *vb)
+/* drivers/virtio/virtio_balloon.c, simplified.
+ * update_stat() takes a running index, not just a tag — real callers do
+ * update_stat(vb, idx++, TAG, val). Real code splits this in two:
+ * update_balloon_vm_stats() first fills in vm-event-derived stats (swap
+ * in/out, major/minor faults, OOM kills, reclaim/scan counts, hugetlb
+ * stats — omitted here), returning the count; update_balloon_stats()
+ * below picks up from there and appends the sysinfo-derived stats. Both
+ * return the total entries filled, not void. */
+static unsigned int update_balloon_stats(struct virtio_balloon *vb)
 {
-    unsigned long events[NR_VM_EVENT_ITEMS];
     struct sysinfo i;
+    unsigned int idx;
+    unsigned long caches;
 
-    all_vm_events(events);
+    idx = update_balloon_vm_stats(vb);  /* SWAP_IN/OUT, MAJFLT, MINFLT, ... */
+
     si_meminfo(&i);
+    caches = global_node_page_state(NR_FILE_PAGES);
 
-    update_stat(vb, VIRTIO_BALLOON_S_SWAP_IN,
-                pages_to_bytes(events[PSWPIN]));
-    update_stat(vb, VIRTIO_BALLOON_S_SWAP_OUT,
-                pages_to_bytes(events[PSWPOUT]));
-    update_stat(vb, VIRTIO_BALLOON_S_MAJFLT, events[PGMAJFAULT]);
-    update_stat(vb, VIRTIO_BALLOON_S_MINFLT, events[PGFAULT]);
-    update_stat(vb, VIRTIO_BALLOON_S_MEMFREE,
-                pages_to_bytes(i.freeram));
-    update_stat(vb, VIRTIO_BALLOON_S_MEMTOT,
-                pages_to_bytes(i.totalram));
-    update_stat(vb, VIRTIO_BALLOON_S_AVAIL,
-                pages_to_bytes(si_mem_available()));
+    update_stat(vb, idx++, VIRTIO_BALLOON_S_MEMFREE,
+               pages_to_bytes(i.freeram));
+    update_stat(vb, idx++, VIRTIO_BALLOON_S_MEMTOT,
+               pages_to_bytes(i.totalram));
+    update_stat(vb, idx++, VIRTIO_BALLOON_S_AVAIL,
+               pages_to_bytes(si_mem_available()));
+    update_stat(vb, idx++, VIRTIO_BALLOON_S_CACHES,
+               pages_to_bytes(caches));
+
+    return idx;
 }
 ```
 
@@ -301,51 +339,57 @@ When EPT maps these, every 2MB of guest physical memory uses one EPT leaf entry 
 ### KVM large page handling
 
 ```c
-/* arch/x86/kvm/mmu/mmu.c */
-static int kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu,
-                                    struct kvm_page_fault *fault)
+/* arch/x86/kvm/mmu/mmu.c — kvm_mmu_hugepage_adjust(), simplified.
+ * Not static, and returns void, not int. The actual alignment / host-page-size
+ * check is a separate helper, kvm_mmu_max_mapping_level() (walks each memslot's
+ * per-gfn lpage_info plus the real host page size) — not reproduced here. */
+void kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
 {
     struct kvm_memory_slot *slot = fault->slot;
     kvm_pfn_t mask;
-    int level;
 
-    /*
-     * Walk from the maximum possible level (1GB) down to 4KB.
-     * Use the largest level where:
-     *   1. The GPA range is aligned
-     *   2. The HPA range is backed by a huge page
-     */
-    for (level = KVM_MAX_HUGEPAGE_LEVEL; level > PG_LEVEL_4K; level--) {
-        mask = KVM_PAGES_PER_HPAGE(level) - 1;
-        if (fault->addr & (mask << PAGE_SHIFT))
-            continue;  /* not aligned for this level */
-        if (!kvm_is_transparent_hugepage(fault->pfn & ~mask))
-            continue;  /* host page not huge */
-        fault->goal_level = level;
-        return 0;
-    }
-    return 0;
+    fault->huge_page_disallowed = fault->exec &&
+                                  fault->nx_huge_page_workaround_enabled;
+
+    if (fault->max_level == PG_LEVEL_4K)
+        return;
+    if (is_error_noslot_pfn(fault->pfn))
+        return;
+    if (kvm_slot_dirty_track_enabled(slot))
+        return;   /* dirty tracking needs 4K-granularity writes */
+
+    /* Largest level both the GPA alignment and the host page support: */
+    fault->req_level = kvm_mmu_max_mapping_level(vcpu->kvm, fault,
+                                                 fault->slot, fault->gfn);
+    if (fault->req_level == PG_LEVEL_4K || fault->huge_page_disallowed)
+        return;
+
+    fault->goal_level = fault->req_level;
+    mask = KVM_PAGES_PER_HPAGE(fault->goal_level) - 1;
+    fault->pfn &= ~mask;
 }
 ```
 
 ## Observing guest memory
 
 ```bash
-# EPT violations per vCPU (VM exits due to missing EPT entries)
-cat /sys/kernel/debug/kvm/*/ept_violations
+# Page faults handled per vCPU (there's no dedicated "ept_violations" file;
+# pf_taken is the closest real counter — see kvm_vcpu_stats_desc[] in x86.c)
+cat /sys/kernel/debug/kvm/*/vcpu0/pf_taken
 
-# Guest TLB flush requests
-cat /sys/kernel/debug/kvm/*/tlb_flush
+# Guest TLB flush requests (also per-vCPU, same directory level)
+cat /sys/kernel/debug/kvm/*/vcpu0/tlb_flush
 
-# Guest huge pages
+# Shadow pages KVM couldn't make huge, due to the NX-huge-page mitigation
+# (this one's a per-VM stat, directly under the VM directory)
 cat /sys/kernel/debug/kvm/*/nx_lpage_splits
 
 # Host sees guest RSS as the QEMU process
 cat /proc/$(pgrep qemu)/status | grep VmRSS
 
 # Check EPT is active
-grep ept /sys/module/kvm_intel/parameters/
-# ept:Y   (or N if disabled)
+cat /sys/module/kvm_intel/parameters/ept
+# Y   (or N if disabled)
 
 # Force EPT off for testing (requires shadow paging fallback)
 modprobe kvm_intel ept=0
@@ -359,10 +403,10 @@ Live migration must transfer guest memory to the destination. KVM's dirty loggin
 /* Enable dirty logging on a memory slot: */
 struct kvm_dirty_log {
     __u32 slot;
-    __u32 padding;
+    __u32 padding1;
     union {
         void __user *dirty_bitmap; /* userspace buffer for dirty bits */
-        __u64 padding;
+        __u64 padding2;
     };
 };
 
@@ -389,7 +433,7 @@ ioctl(vm_fd, KVM_GET_DIRTY_LOG, &dirty);
 
 The EPT hardware's dirty bit (EPT PTE bit 9) is cleared when KVM resets the bitmap. Next write access causes an EPT violation → KVM marks page dirty and re-enables the dirty bit.
 
-### KVM_DIRTY_LOG_PROTECT_2
+### KVM_CAP_MANUAL_DIRTY_LOG_PROTECT2
 
 A two-phase protocol for very large VMs that avoids races:
 
@@ -439,7 +483,7 @@ cat /sys/kernel/mm/ksm/pages_unshared   # not mergeable
 ### Related pages
 
 - [KVM Architecture](kvm-arch.md) — /dev/kvm API, vCPU run loop
-- [virtio](virtio.md) — paravirtual I/O, balloon transport
+- [virtio](virtio.md) — paravirtual I/O: virtqueues, virtio-net, virtio-blk
 - [VFIO](vfio.md) — direct device passthrough to VMs
 - [KVM Live Migration](live-migration.md) — how dirty-bitmap and dirty-ring tracking drive the pre-copy migration loop
 - [Memory Management: page tables](../mm/page-tables.md) — host-side page tables


### PR DESCRIPTION
Part of #740 (virtualization/ technical-accuracy audit). Third of the seven flagged pages — flagged as the most severe.

## In-scope fixes from the round-5 review list (all verified against current kernel.org source)

- **struct kvm_mmu**: fabricated `invlpg` and `gpa_available` fields removed; `pae_root`'s real type is `u64 *`, not `struct kvm_mmu_page *`.
- **struct kvm_mmu_page**: `lpage_disallowed_link` doesn't exist — real: `possible_nx_huge_page_link`, a separate list from `active_mmu_pages` (a page can be on both simultaneously, not one or the other); `shadowed_translation` is `u64 *`, not `gfn_t *`.
- **`kvm_mmu_hugepage_adjust()` and `update_balloon_stats()` were both fabricated** — wrong signatures and invented logic, including a `kvm_is_transparent_hugepage()` that doesn't exist anywhere. Both rewritten to match the real control flow.
- **Nonexistent debugfs stat `ept_violations`** — no such file exists; closest real counter is `pf_taken`.
- **Heading `KVM_DIRTY_LOG_PROTECT_2`** → real capability name `KVM_CAP_MANUAL_DIRTY_LOG_PROTECT2`.
- **`struct kvm_dirty_log` reused the field name `padding` twice** (wouldn't compile) → real names `padding1`/`padding2`.

## Additional issues found during the initial verification pass, beyond the round-5 list

- `handle_ept_violation()`'s `error_code` was referenced in the `kvm_mmu_page_fault()` call but never computed anywhere in the shown function — added the real WRITE/FETCH bit derivation from `exit_qual` (the bit-meaning comments were already accurate; just the actual computation was missing).
- `kvm_mmu_page_fault()`'s shown signature (`static`, variadic `...`) doesn't match reality (not `static`, 5 concrete params) and its internal logic order was backwards — real code checks `PFERR_RSVD_MASK` (KVM's own MMIO hint) *first* to decide whether to try `handle_mmio_page_fault()`, not after a failed normal walk. Also, `handle_mmio_page_fault()`'s real third argument is `direct` (from `root_role.direct`), not `is_present_gpte(error_code)` as shown.
- The debugfs example put a per-vCPU stat (`tlb_flush`) directly under the VM directory instead of a `vcpuN/` subdirectory — same hierarchy bug already fixed in the sibling `kvm-arch.md` (#780) and `kvm-exits.md` (#781) pages.
- `grep ept /sys/module/kvm_intel/parameters/` doesn't work on a directory — real usage is `cat .../parameters/ept`.
- Related pages claimed `virtio.md` covers "balloon transport" — it doesn't. Checked `virtio.md`'s actual sections and its own Related Pages section, which points *back* to this page for balloon coverage. Fixed the description.

## Review history

Four more rounds after the initial fix, matching the standard applied to the sibling kvm-arch.md/kvm-exits.md pages (#780/#781):

- **Round 2**: caught an incomplete disclaimer — the "Simplified" comment on `struct kvm_mmu` listing which real fields were omitted was itself missing one (`get_pdptr`).
- **Round 3**: same QEMU-hardcoding pattern already fixed in kvm-exits.md — one bullet describing the KVM-level memory-slot-type concept hardcoded "in QEMU" where it should say "in the VMM (e.g. QEMU)". (The several other QEMU mentions on this page are legitimately QEMU-specific — real `qemu-system-x86_64` command-line walkthroughs, not KVM-ABI descriptions — so those were left alone.)
- **Round 4**: clean. Verified the EPT page walk diagram, dirty-logging ioctl/flag constants (`KVM_MEM_LOG_DIRTY_PAGES`, `KVM_GET_DIRTY_LOG`, `KVM_CLEAR_DIRTY_LOG`), and `si_mem_available()`/`global_node_page_state()` usage in the balloon-stats rewrite — all accurate.
- **Round 5**: clean. Independently re-verified `handle_mmio_page_fault()`'s and `kvm_mmu_do_page_fault()`'s exact signatures against source, confirming both match the round-1 `kvm_mmu_page_fault()` rewrite character-for-character. Cross-checked the EPT-violation error_code derivation against the same snippet in the sibling kvm-exits.md page for drift — none found.

Two consecutive clean rounds (4 and 5).

## Verification

- Every changed claim checked directly against current kernel.org source (`kvm_host.h` — both generic and x86-specific, `mmu.c`, `mmu_internal.h`, `vmx.c`, `virtio_balloon.c`, `kvm_dirty_ring.h`, uapi headers).
- Also spot-checked several previously-unflagged claims: `struct kvm_memory_slot` (fully accurate, no changes needed), `struct kvm_dirty_ring`/`struct kvm_dirty_gfn` field layouts, the EPT-violation exit-qualification bit meanings (all 4 confirmed accurate), the EPT dirty-bit position (bit 9, confirmed via `VMX_EPT_DIRTY_BIT`), the `nx_lpage_splits` VM-level stat, and the `ept` module parameter path.
- `mkdocs build --strict` passes clean.

## Remaining scope

4 more pages tracked in #740: `live-migration.md`, `nested-virt.md`, `vfio.md`, `virtio.md`.
