### PR TITLE
virtualization: fix fabricated technical details in live-migration.md

### DIFF
--- a/docs/virtualization/live-migration.md
+++ b/docs/virtualization/live-migration.md
@@ -60,7 +60,7 @@ ioctl(vm_fd, KVM_GET_DIRTY_LOG, &dirty_log);
    KVM also clears all dirty bits and re-write-protects the pages. */
 ```
 
-`KVM_CLEAR_DIRTY_LOG` (added in kernel 5.4) clears dirty bits for a specific range of pages rather than the entire slot, reducing the number of EPT write-protection flushes during iterative pre-copy:
+`KVM_CLEAR_DIRTY_LOG` (added in kernel 5.0) clears dirty bits for a specific range of pages rather than the entire slot, reducing the number of EPT write-protection flushes during iterative pre-copy:
 
 ```c
 struct kvm_clear_dirty_log clear = {
@@ -114,7 +114,7 @@ Each round sends fewer pages — the guest's working set converges. QEMU tracks:
 
 Pre-copy ends when the estimated remaining transfer time drops below the target downtime (default 300 ms in QEMU's `migrate_set_parameter max-bandwidth`).
 
-**Auto-converge**: if the dirty rate stays high and convergence is not happening, QEMU throttles the vCPUs by injecting `usleep()` calls in the vCPU threads (controlled by the `throttle-trigger-threshold` and `cpu-throttle-increment` migration parameters, implemented in QEMU userspace) to slow the guest's write rate. This ensures migration completes at the cost of temporary guest performance degradation.
+**Auto-converge**: if the dirty rate stays high and convergence is not happening, `mig_throttle_guest_down()` (in `migration/ram.c`) calls `cpu_throttle_set()` to periodically stall the vCPU threads, ramping the throttle percentage up by `cpu-throttle-increment` each time the `throttle-trigger-threshold` ratio is exceeded, up to `max-cpu-throttle`. This ensures migration completes at the cost of temporary guest performance degradation.
 
 ### Phase 2: Stop-and-copy
 
@@ -166,14 +166,19 @@ ioctl(vcpu_fd, KVM_SET_LAPIC, &lapic);
 QEMU serializes device state using its VMState framework. Each device registers a `VMStateDescription`:
 
 ```c
-/* Example: hw/net/e1000.c (simplified) */
+/* hw/net/e1000.c, simplified — the real list has ~50 individual mac_reg[REG]
+ * entries (not one array macro) plus several .subsections; no RX-buffer
+ * content is migrated at all, only registers/config: */
 static const VMStateDescription vmstate_e1000 = {
     .name    = "e1000",
     .version_id = 2,
-    .fields  = (VMStateField[]) {
-        VMSTATE_UINT32_ARRAY(mac_reg, E1000State, MAC_REG_NUM),
+    .minimum_version_id = 1,
+    .fields  = (const VMStateField[]) {
+        VMSTATE_PCI_DEVICE(parent_obj, E1000State),
+        VMSTATE_UINT32(mac_reg[CTRL], E1000State),
+        VMSTATE_UINT32(mac_reg[STATUS], E1000State),
+        /* ... one VMSTATE_UINT32(mac_reg[REG], ...) per register ... */
         VMSTATE_UINT16_ARRAY(eeprom_data, E1000State, 64),
-        VMSTATE_BUFFER(rx_buf, E1000State),
         VMSTATE_END_OF_LIST()
     },
 };
@@ -195,7 +200,7 @@ ioctl(vhost_fd, VHOST_GET_VRING_BASE, &state);
 ioctl(vhost_fd, VHOST_SET_VRING_BASE, &state);
 ```
 
-For virtio devices backed by QEMU (not vhost), the virtqueue state is captured through the `struct virtio_device` VMState chain, which includes the last seen `avail_idx` and `used_idx`.
+For virtio devices backed by QEMU (not vhost), the virtqueue state is captured through QEMU's own `struct VirtQueue` (not the Linux kernel's `struct virtio_device`, which is a driver-side type in an entirely different codebase) via `vmstate_virtqueue` in `hw/virtio/virtio.c`, which includes `last_avail_idx` and `used_idx`.
 
 ## Post-copy migration
 
@@ -247,7 +252,7 @@ QEMU supports several transport channels:
 | multifd | Parallel TCP streams (`migrate_set_parameter multifd-channels N`); saturates high-bandwidth links |
 | Unix socket | Same-host testing |
 
-**multifd** (multiple file descriptors, added in QEMU 3.0) opens N parallel channels and assigns pages to channels in round-robin. With 8 channels on a 25 Gbps link, it can saturate bandwidth that a single TCP stream cannot due to per-stream throughput limits.
+**multifd** (multiple file descriptors) opens N parallel channels and assigns pages to channels in round-robin. Added as an experimental feature (`x-multifd-channels`) in QEMU 2.11, it stabilized — dropping the `x-` prefix, renamed to `multifd-channels` — in QEMU 4.0. With 8 channels on a 25 Gbps link, it can saturate bandwidth that a single TCP stream cannot due to per-stream throughput limits.
 
 ## Observing migration
 
@@ -267,8 +272,12 @@ QEMU supports several transport channels:
 echo 1 > /sys/kernel/tracing/events/kvm/kvm_dirty_ring_push/enable
 echo 1 > /sys/kernel/tracing/events/kvm/kvm_dirty_ring_reset/enable
 
-# Monitor EPT violation rate during migration (should spike then drop)
-watch -n1 'cat /sys/kernel/debug/kvm/*/exits | grep -A1 "EPT"'
+# Monitor per-vCPU page-fault rate during migration (should spike then
+# drop as dirty-tracking write-protection faults fire, then converge) —
+# no dedicated per-exit-type breakdown exists in a single debugfs file,
+# so watch the raw counter and use the perf command below for the
+# EPT_VIOLATION-specific view:
+watch -n1 'cat /sys/kernel/debug/kvm/*/vcpu0/pf_taken'
 
 # perf: watch for extra EPT violations from write-protection faults
 perf kvm stat report --event EPT_VIOLATION

--- a/docs/virtualization/live-migration.md
+++ b/docs/virtualization/live-migration.md
@@ -132,7 +132,7 @@ ioctl(vcpu_fd, KVM_SET_REGS, &regs);
 
 /* Segment registers, control registers, descriptor tables */
 struct kvm_sregs sregs;
-ioctl(vcpu_fd, KVM_GET_SREGS, &sregs);   /* cr0, cr3, cr4, cs, ss, gdtr, ... */
+ioctl(vcpu_fd, KVM_GET_SREGS, &sregs);   /* cr0, cr3, cr4, cs, ss, gdt, ... */
 ioctl(vcpu_fd, KVM_SET_SREGS, &sregs);
 
 /* Model-specific registers (MSRs) */

--- a/docs/virtualization/live-migration.md
+++ b/docs/virtualization/live-migration.md
@@ -112,7 +112,7 @@ Each round sends fewer pages — the guest's working set converges. QEMU tracks:
 - **Dirty rate**: pages dirtied per second by the guest.
 - **Bandwidth**: pages transferred per second to the destination.
 
-Pre-copy ends when the estimated remaining transfer time drops below the target downtime (default 300 ms in QEMU's `migrate_set_parameter max-bandwidth`).
+Pre-copy ends when the estimated remaining transfer time drops below the target downtime, set via the `downtime-limit` migration parameter (default 300 ms) — a separate knob from `max-bandwidth`, which caps transfer speed rather than target downtime.
 
 **Auto-converge**: if the dirty rate stays high and convergence is not happening, `mig_throttle_guest_down()` (in `migration/ram.c`) calls `cpu_throttle_set()` to periodically stall the vCPU threads, ramping the throttle percentage up by `cpu-throttle-increment` each time the `throttle-trigger-threshold` ratio is exceeded, up to `max-cpu-throttle`. This ensures migration completes at the cost of temporary guest performance degradation.
 

--- a/docs/virtualization/live-migration.md
+++ b/docs/virtualization/live-migration.md
@@ -321,9 +321,9 @@ QEMU migration is userspace code; per site policy these link to QEMU's own canon
 ### Related pages
 
 - [KVM Architecture](kvm-arch.md) — KVM ioctls, `struct kvm_run`, vCPU lifecycle
-- [KVM Exit Handling](kvm-exits.md) — EPT violations, dirty page tracking mechanics
+- [KVM Exit Handling](kvm-exits.md) — EPT violations and exit-reason dispatch
 - [Nested Virtualization](nested-virt.md) — `KVM_GET_NESTED_STATE` for migrating L1 hypervisors
-- [Memory Virtualization](kvm-memory.md) — EPT/NPT, MMU notifiers
+- [Memory Virtualization](kvm-memory.md) — EPT/NPT, dirty page tracking, the balloon driver
 
 ### LWN articles
 

--- a/docs/virtualization/live-migration.md
+++ b/docs/virtualization/live-migration.md
@@ -260,13 +260,23 @@ QEMU supports several transport channels:
 # QEMU monitor: start migration
 (qemu) migrate tcp:192.168.1.2:4444
 
-# Check migration status
+# Check migration status (real hmp_info_migrate output format)
 (qemu) info migrate
-# Migration status: active
-# total time: 4321 ms
-# ram: transferred 1234 MB, remaining 56 MB, total 4096 MB
-# dirty pages rate: 12300 pages/s
-# downtime limit: 300 ms
+# Status: 		active
+# Time (ms): 		total=4321
+# Remaining: 		56 MiB
+# RAM info:
+#   Throughput (Mbps): 	120.50
+#   Sizes: 		pagesize=4 KiB, total=4096 MiB
+#   Transfers: 		transferred=1234 MiB, remain=56 MiB
+#     Channels: 		precopy=1234 MiB, multifd=0 MiB, postcopy=0 MiB
+#     Page Types: 	normal=316000, zero=1500
+#   Page Rates (pps): 	transfer=45000, dirty=12300
+#   Others: 		dirty_syncs=8
+
+# The configured downtime target is a separate query:
+(qemu) info migrate_parameters
+# downtime-limit: 300 ms
 
 # On the source kernel: dirty log tracepoints
 echo 1 > /sys/kernel/tracing/events/kvm/kvm_dirty_ring_push/enable


### PR DESCRIPTION
Part of #740 (virtualization/ technical-accuracy audit). Fourth of the seven flagged pages.

## In-scope fixes from the round-5 review list (verified against current kernel.org and QEMU GitLab source)

- **`vmstate_e1000` example**: `MAC_REG_NUM` doesn't exist — real `hw/net/e1000.c` uses ~50 individual `VMSTATE_UINT32(mac_reg[REG], ...)` entries (one per named register), not a single array macro. `rx_buf` isn't a field of `E1000State` — no RX-buffer content is migrated at all, only registers/config state.
- **`struct virtio_device` was used as if it were QEMU's virtqueue-state type** — it's actually the Linux kernel's driver-side struct, in an entirely different codebase. Real QEMU type is `struct VirtQueue` (`hw/virtio/virtio.c`); its field is `last_avail_idx`, not `avail_idx` (`used_idx` was already correctly named).
- **multifd's real history**: checked `qapi/migration.json`'s parameter name across QEMU release tags directly — `x-multifd-channels` (experimental) at v2.11/v3.0/v3.1, renamed to `multifd-channels` (stable) at v4.0. The page's claim "added in QEMU 3.0" was wrong; the real story is: added experimental in **2.11**, stabilized in **4.0**.

## Additional issues found during verification, beyond the round-5 list

- **`KVM_CLEAR_DIRTY_LOG`'s claimed kernel version (5.4) was wrong** — confirmed absent from `include/uapi/linux/kvm.h` at v4.20, present at v5.0.
- The "monitor EPT violation rate" debugfs example put a per-vCPU stat directly under the VM directory instead of a `vcpuN/` subdirectory, and `grep`'d for "EPT" text inside what's actually a single raw-number file.
- The auto-converge section asserted vCPU throttling works via literal `usleep()` calls — a specific implementation detail I could not independently confirm. Reworded to state only what was verified.

## Review history

Seven more rounds after the initial fix, matching the standard applied to the sibling pages:

- **Round 2**: caught a real conflation — the "target downtime (default 300ms)" claim cited `max-bandwidth` as its source parameter. Checked `qapi/migration.json`: the 300ms default belongs to `downtime-limit`; `max-bandwidth` is an unrelated transfer-speed cap.
- **Round 3**: a `struct kvm_sregs` comment listed `gdtr` as a field name — the real C field is `gdt` (`struct kvm_dtable gdt`); `gdtr` is the x86 architectural register name, not the struct field.
- **Round 4** (the big one): the `(qemu) info migrate` sample output didn't match real `hmp_info_migrate` output *at all* — no "Migration status:"/"ram:"/"dirty pages rate:"/"downtime limit:" lines exist in current QEMU. Real format is "Status:", "Time (ms): total=...", "Remaining:", then a "RAM info:" block with Throughput/Sizes/Transfers/Channels/Page Types/Page Rates/Others sub-lines — checked directly against `migration/migration-hmp-cmds.c`. The downtime target isn't shown by `info migrate` at all; it's a separate `info migrate_parameters` query. Also confirmed `size_to_str()` uses IEC binary prefixes (MiB, not MB).
- **Round 5**: clean. Re-verified the dirty-ring enable-cap byte-size computation (`ring_size * sizeof(struct kvm_dirty_gfn)`) against `kvm_dirty_ring_alloc()`'s actual division — confirmed correct, not a bug.
- **Round 6**: found two more Related-pages overclaims — "KVM Exit Handling — EPT violations, dirty page tracking mechanics" (kvm-exits.md has zero mentions of dirty tracking) and "Memory Virtualization — EPT/NPT, MMU notifiers" (kvm-memory.md has no MMU-notifiers section at all). Fixed both to describe what those pages actually cover.
- **Round 7**: clean. Verified all 13 remaining kernel.org/GitLab/man7 citation links are live, and confirmed `vmstate_save_state()`/`vmstate_load_state()` are real function names in `migration/vmstate.c`.
- **Round 8**: clean. Independently fetched and quote-matched all three LWN citations against the live articles — all three direct quotes are exact.

Two consecutive clean rounds (7 and 8).

## Verification

- Every changed claim checked directly against current source: kernel.org for KVM/vhost/userfaultfd, and QEMU's canonical GitLab repo for device/migration code.
- Version claims were checked by testing file/symbol presence directly against tagged release refs rather than relying on memory.
- `mkdocs build --strict` passes clean.

## Remaining scope

3 more pages tracked in #740: `nested-virt.md`, `vfio.md`, `virtio.md`.
