### PR TITLE
Add blank lines before bullet lists for consistent Markdown formatting

### DIFF
--- a/docs/arch/arm64/README.md
+++ b/docs/arch/arm64/README.md
@@ -5,6 +5,7 @@
 ## Why ARM64?
 
 ARM64 (AArch64) is the dominant architecture for:
+
 - Mobile (Android, iOS)
 - Embedded and IoT (Raspberry Pi, NXP, TI)
 - Servers (AWS Graviton, Ampere Altra)

--- a/docs/arch/arm64/exception-model.md
+++ b/docs/arch/arm64/exception-model.md
@@ -17,6 +17,7 @@ EL0: User space (applications)
 ```
 
 Key properties:
+
 - **EL0**: unprivileged, can only access user-accessible system registers
 - **EL1**: kernel mode, full access to kernel address space and EL1 system registers
 - **EL2**: hypervisor mode, can trap and emulate EL1 operations

--- a/docs/arch/arm64/memory-model.md
+++ b/docs/arch/arm64/memory-model.md
@@ -65,6 +65,7 @@ ISB
 ```
 
 Use ISB after:
+
 - Writing to system registers that affect instruction execution (e.g., SCTLR_EL1)
 - Self-modifying code
 - Changing the instruction cache attributes

--- a/docs/arch/x86/boot.md
+++ b/docs/arch/x86/boot.md
@@ -27,6 +27,7 @@ Modern x86-64 systems boot via one of two firmware interfaces:
 On power-on, the x86-64 CPU resets to real mode and executes its first instruction at the **reset vector**: physical address `0xFFFFFFF0` (mapped to ROM). This is the top 16 bytes of the 4GB address space.
 
 The BIOS firmware runs **POST** (Power-On Self Test):
+
 - Initializes and tests RAM
 - Enumerates PCI devices
 - Detects the memory map (passed to the OS via INT 0x15/E820)
@@ -129,6 +130,7 @@ The resulting e820 table describes which physical memory ranges are usable RAM, 
 ### Video mode setup and other detection
 
 The setup code also:
+
 - Detects available video modes and sets the console resolution
 - Queries APM BIOS, EDD (Enhanced Disk Drive) information
 - Reads CPUID to detect CPU capabilities
@@ -217,6 +219,7 @@ lret    /* pops cs:eip from stack, cs selects 64-bit descriptor */
 ### startup_64 (`arch/x86/boot/compressed/head_64.S`)
 
 `startup_64` is the first 64-bit code. At this point:
+
 - The CPU is in 64-bit long mode
 - Only a minimal identity-mapped page table exists
 - The compressed kernel blob is still in memory, not yet decompressed

--- a/docs/arch/x86/exceptions.md
+++ b/docs/arch/x86/exceptions.md
@@ -109,6 +109,7 @@ Hardware actions (automatic, before any software):
 ```
 
 For ring-0 → ring-0 exceptions (kernel taking a fault):
+
 - No stack switch (stays on current kernel stack)
 - On x86-64, SS/RSP are **always** pushed even for same-privilege exceptions (unlike 32-bit x86)
 - Still pushes SS/RSP/RFLAGS/CS/RIP and error code (if applicable)
@@ -435,6 +436,7 @@ DEFINE_IDTENTRY_NMI(exc_nmi)
 ```
 
 NMIs are used for:
+
 - Hardware errors (MCE, watchdog)
 - Perf PMU overflow interrupts (PEBS/LBR)
 - kdump NMI shootdown (crash on one CPU, NMI all others)

--- a/docs/arch/x86/spectre-meltdown.md
+++ b/docs/arch/x86/spectre-meltdown.md
@@ -293,6 +293,7 @@ cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass
 MDS is a family of vulnerabilities that allow leaking data from CPU internal buffers (line fill buffer, store buffer, load ports) to an attacker on the same physical CPU core.
 
 Variants:
+
 - **MFBDS** (CVE-2018-12130): Microarchitectural Fill Buffer Data Sampling (ZombieLoad)
 - **MLPDS** (CVE-2018-12127): Microarchitectural Load Port Data Sampling
 - **MSBDS** (CVE-2018-12126): Microarchitectural Store Buffer Data Sampling (Fallout)
@@ -348,6 +349,7 @@ The mitigations impose measurable overhead, concentrated in syscall-heavy and co
 | Spectre v4 | SSBD | 2–8% when enabled per-thread; negligible when off |
 
 Workload-specific impact:
+
 - **Database servers (PostgreSQL, MySQL)**: high syscall rate → KPTI and IBPB have the most impact
 - **Web servers (nginx, Apache)**: moderate syscall rate; retpoline overhead visible
 - **HPC / batch compute**: mostly user-space computation; mitigations largely invisible

--- a/docs/arch/x86/syscall-entry.md
+++ b/docs/arch/x86/syscall-entry.md
@@ -296,6 +296,7 @@ cat /proc/self/maps | grep vdso
 ### vDSO source
 
 The vDSO is compiled as a special shared library:
+
 - `arch/x86/vdso/` — x86-64 vDSO source
 - `arch/x86/vdso/vdso64.lds.S` — linker script
 - `arch/x86/vdso/vclock_gettime.c` — `clock_gettime` implementation

--- a/docs/arch/x86/war-stories.md
+++ b/docs/arch/x86/war-stories.md
@@ -197,6 +197,7 @@ On **AMD** processors the `#GP` is delivered before the CPU reaches that exploit
 ### Discovery and impact
 
 Here is the twist that makes this a good war story: **Linux had already fixed this exact bug in 2006.** Linux hit the non-canonical-`SYSRET` hole on early Intel EM64T CPUs and closed it in **2.6.16.5** (CVE-2006-0744) — the fault-on-the-user-stack-with-wrong-GS problem, described there in almost the same words. Six years later, Rafal Wojtczuk found that everyone who *hadn't* copied Linux's fix was still exposed, and disclosed it as CVE-2012-0217 (June 2012). Because `SYSRET` is subtle enough that each kernel got it wrong independently, it hit a broad set of systems — all **running on Intel CPUs**:
+
 - Xen PV guests on Intel hosts (the Xen `SYSRET` path) — a guest → hypervisor escape
 - FreeBSD, NetBSD, Oracle Solaris / illumos, and Microsoft Windows (7 / Server 2008 R2)
 - **Linux was *not* affected in 2012** — it had been fixed since 2006
@@ -330,6 +331,7 @@ JIT compilers are a special case in the mitigation story. The compiler-based mit
 PCID (Process-Context Identifiers) was introduced in Intel Sandy Bridge (2011) and allows the TLB to cache entries tagged with a process identifier, avoiding full TLB flushes on context switches. The KPTI PCID optimization (Linux 4.15) uses PCID to reduce the overhead of the dual-PGD CR3 switches required for Meltdown mitigation.
 
 The `INVPCID` instruction (Invalidate Process-Context Identifier) allows selective TLB invalidation by PCID. It is required for the full KPTI+PCID optimization because:
+
 - Without INVPCID, flushing a specific PCID requires loading CR3 with the no-flush bit cleared, which is a broader operation
 - With INVPCID, you can invalidate exactly the entries you need
 

--- a/docs/block/bio-request.md
+++ b/docs/block/bio-request.md
@@ -145,6 +145,7 @@ After merging:
 ```
 
 Merging is constrained by hardware limits:
+
 - `queue->limits.max_sectors` — maximum request size
 - `queue->limits.max_segments` — maximum scatter-gather segments
 - `queue->limits.max_segment_size` — maximum bytes per segment

--- a/docs/block/blk-mq.md
+++ b/docs/block/blk-mq.md
@@ -7,6 +7,7 @@
 Traditional block layer had a single request queue per device, protected by a global lock. This was fine for HDDs (which are sequential anyway) but became a bottleneck for NVMe SSDs that can handle millions of IOPS across multiple hardware queues.
 
 blk-mq (introduced in Linux 3.13) uses:
+
 - **Multiple software queues** (one per CPU or CPU group) to eliminate lock contention
 - **Multiple hardware queues** (mapped to NVMe queues, SCSI host adapters, etc.)
 - **Per-CPU tag allocation** for request objects

--- a/docs/block/block-overview.md
+++ b/docs/block/block-overview.md
@@ -145,6 +145,7 @@ This is analogous to TCP's Nagle algorithm: batching small operations into large
 The `elevator_queue` in `request_queue` is optional. The I/O scheduler sits between bio submission and hardware dispatch, reordering and merging requests. For HDDs this was essential — an elevator scheduler could turn random writes into sequential I/O, doubling throughput by reducing seek time.
 
 NVMe changes the calculus:
+
 - No seek latency: request order is irrelevant to performance.
 - Hardware does its own internal scheduling across NAND dies.
 - Adding a software scheduler introduces latency (requests wait in the scheduler queue) with zero benefit.

--- a/docs/block/dm-verity.md
+++ b/docs/block/dm-verity.md
@@ -7,6 +7,7 @@
 dm-verity provides **transparent integrity checking** of a block device using a Merkle (hash) tree. Every read is verified against pre-computed hashes. If data is tampered with, the kernel returns an error or panics.
 
 Used by:
+
 - **Android**: verifying the read-only system partition
 - **ChromeOS**: verified boot for rootfs
 - **Linux distributions**: immutable root filesystem with integrity

--- a/docs/block/io-schedulers.md
+++ b/docs/block/io-schedulers.md
@@ -35,6 +35,7 @@ echo none > /sys/block/nvme0n1/queue/scheduler  # for NVMe
 ### none
 
 No scheduling. Requests are dispatched in submission order. Optimal for:
+
 - NVMe SSDs with hardware queues (no seek latency, no benefit from reordering)
 - Very low-latency workloads where scheduler overhead matters
 
@@ -88,6 +89,7 @@ cat /sys/block/sda/queue/iosched/fifo_batch  # default 16
 BFQ assigns each process or group a **budget** of sectors to serve. When the budget is exhausted, the scheduler moves to the next process. Budget is dynamically sized based on workload characteristics.
 
 Key properties:
+
 - Interactive processes get boosted priority (short bursts are rewarded)
 - cgroups integration: `/sys/block/sda/queue/iosched/` exposes per-group weights
 - `CONFIG_BFQ_GROUP_IOSCHED` enables cgroup-based I/O isolation
@@ -111,6 +113,7 @@ ionice -c 3 rsync source/ dest/         # idle class
 **For multi-queue, low-latency devices (NVMe, SSDs).** Introduced in Linux 4.12 by Omar Sandoval — [`00e043936e9a`](https://git.kernel.org/linus/00e043936e9a1c274c29366c7ecd9e17c79418e6), [LWN](https://lwn.net/Articles/720675/). Uses per-operation-type queues (read, write, discard) with token-based latency targeting.
 
 Rather than reordering, kyber:
+
 - Limits in-flight requests per category to hit target latencies
 - Doesn't do merging (relies on hardware)
 - Very low overhead

--- a/docs/bpf/README.md
+++ b/docs/bpf/README.md
@@ -67,6 +67,7 @@ Scheduler          → sched_ext (BPF-defined schedulers, 6.12+)
 ```
 
 **Key kernel files:**
+
 - `kernel/bpf/verifier.c` — safety checker
 - `kernel/bpf/core.c` — interpreter and JIT glue
 - `kernel/bpf/syscall.c` — bpf() syscall implementation

--- a/docs/bpf/bpf-maps.md
+++ b/docs/bpf/bpf-maps.md
@@ -59,6 +59,7 @@ if (count) {
 ```
 
 Update flags:
+
 - `BPF_ANY` — create or update
 - `BPF_NOEXIST` — create only (fail if key exists)
 - `BPF_EXIST` — update only (fail if key doesn't exist)
@@ -164,6 +165,7 @@ static int handle_event(void *ctx, void *data, size_t size)
 ```
 
 Why ringbuf over perf_event output:
+
 - Single shared ring across all CPUs (no per-CPU waste)
 - Events are ordered within the ring
 - No copy — userspace reads directly from the ring memory

--- a/docs/bpf/bpf-overview.md
+++ b/docs/bpf/bpf-overview.md
@@ -158,6 +158,7 @@ struct bpf_insn {
 ```
 
 Register conventions:
+
 - `r0` — return value from helper calls and program exit
 - `r1`–`r5` — function arguments (r1 = context pointer on entry)
 - `r6`–`r9` — callee-saved registers
@@ -263,6 +264,7 @@ int xdp_drop_icmp(struct xdp_md *ctx)
 ```
 
 XDP return codes:
+
 - `XDP_ABORTED` — bug/error, drops packet + fires tracepoint
 - `XDP_DROP` — drop immediately (before skb allocation)
 - `XDP_PASS` — pass to normal networking stack
@@ -288,6 +290,7 @@ refcount==0:               → bpf_prog_free()
 ```
 
 BPF links (`BPF_LINK_CREATE`) are preferred over legacy attach methods because:
+
 - Closing the link_fd automatically detaches (no dangling programs)
 - Links survive the original loader process exiting (if pinned)
 - Atomic program replacement via `BPF_LINK_UPDATE`

--- a/docs/bpf/bpf-ringbuf.md
+++ b/docs/bpf/bpf-ringbuf.md
@@ -24,6 +24,7 @@ int trace_write(struct trace_event_raw_sys_enter *ctx) {
 ```
 
 Problems with `PERF_EVENT_ARRAY`:
+
 - **Per-CPU**: separate buffer per CPU, requires per-CPU polling in userspace
 - **Memory waste**: each CPU gets a full buffer even if mostly idle
 - **No variable-size records**: must pre-declare event size
@@ -55,6 +56,7 @@ Ring buffer memory layout:
 ```
 
 Key properties:
+
 - **Single buffer**: no per-CPU waste; all CPUs share one ring
 - **Spinlock-free**: compare-and-swap for producer position reservation
 - **Two-phase commit**: reserve space, fill it, then submit or discard

--- a/docs/bpf/bpf-verifier.md
+++ b/docs/bpf/bpf-verifier.md
@@ -209,6 +209,7 @@ BPF program is too large. Processed 1000001 insn
 ```
 
 Strategies to reduce complexity:
+
 - Use `__always_inline` to inline helper functions (reduces call sites)
 - Split into tail calls (each program has its own limit)
 - Use `bpf_loop()` instead of unrolled loops
@@ -247,12 +248,14 @@ Sample verifier output for a type error:
 ## Privileged vs unprivileged BPF
 
 Unprivileged BPF (`CAP_BPF` not set) is heavily restricted:
+
 - Only `BPF_PROG_TYPE_SOCKET_FILTER` and `BPF_PROG_TYPE_CGROUP_SKB`
 - No pointer arithmetic beyond map value access
 - JIT hardening: constant blinding (prevents JIT spraying attacks)
 - Verifier enforces stricter rules
 
 Privileged BPF requires:
+
 - `CAP_BPF` (since 5.8, split from `CAP_SYS_ADMIN`)
 - `CAP_PERFMON` for tracing programs
 - `CAP_NET_ADMIN` for XDP and TC programs

--- a/docs/bpf/btf-core.md
+++ b/docs/bpf/btf-core.md
@@ -51,6 +51,7 @@ struct btf_member {
 ```
 
 The kernel loads BTF via `BTF_LOAD` bpf() command and uses it:
+
 - For the verifier: to understand pointed-to struct layouts
 - For CO-RE relocation: to patch field offsets at program load time
 - For bpftool/libbpf: to pretty-print map values and program contexts

--- a/docs/cgroups/README.md
+++ b/docs/cgroups/README.md
@@ -5,12 +5,14 @@
 ## What cgroups and namespaces do
 
 **Cgroups (control groups)** limit *how much* resource a group of processes can use:
+
 - CPU time (cpu.weight, cpu.max)
 - Memory (memory.max, memory.swap.max)
 - I/O bandwidth (io.weight, io.max)
 - Process count (pids.max)
 
 **Namespaces** control *what* processes can see:
+
 - Which processes are visible (PID namespace)
 - Which filesystem view they have (mount namespace)
 - Which network interfaces and addresses they have (network namespace)

--- a/docs/cgroups/cgroup-bpf.md
+++ b/docs/cgroups/cgroup-bpf.md
@@ -229,6 +229,7 @@ int __cgroup_bpf_check_dev_permission(short dev_type, u32 major, u32 minor,
 ```
 
 These are invoked via macros from:
+
 - `net/ipv4/ip_output.c`, `net/ipv6/ip6_output.c` → `BPF_CGROUP_RUN_PROG_INET_EGRESS`
 - `net/ipv4/ip_input.c` (`ip_rcv`) → `BPF_CGROUP_RUN_PROG_INET_INGRESS`
 - `net/socket.c` (`__sock_create`) → `BPF_CGROUP_RUN_PROG_INET_SOCK`

--- a/docs/cgroups/cgroup-v2.md
+++ b/docs/cgroups/cgroup-v2.md
@@ -268,6 +268,7 @@ int cgroup_filter(struct __sk_buff *skb)
 ```
 
 Supported BPF attach types on cgroups:
+
 - `BPF_CGROUP_INET_INGRESS` / `BPF_CGROUP_INET_EGRESS`
 - `BPF_CGROUP_INET_SOCK_CREATE` / `BPF_CGROUP_SOCK_OPS`
 - `BPF_CGROUP_DEVICE` — device access control

--- a/docs/cgroups/io-cgroup.md
+++ b/docs/cgroups/io-cgroup.md
@@ -5,6 +5,7 @@
 ## Overview
 
 The cgroup v2 `io` controller manages block I/O resources for processes. It provides:
+
 - **io.max**: hard rate limits (bytes/sec, IOPS)
 - **io.weight**: proportional share scheduling (WFQ)
 - **io.latency**: latency SLA enforcement (evict excess I/O to protect latency) [(commit)](https://git.kernel.org/linus/d70675121546c35feaceebf7ed9caed8716640f3) [(LWN)](https://lwn.net/Articles/758963/)

--- a/docs/cgroups/namespaces.md
+++ b/docs/cgroups/namespaces.md
@@ -181,6 +181,7 @@ mount --make-unbindable /mnt
 ## Network namespace
 
 Each network namespace has its own:
+
 - Network interfaces (except loopback is separate per-ns)
 - IP routing table
 - Netfilter rules (iptables)
@@ -296,6 +297,7 @@ The key property: a process can be UID 0 (root) inside a user namespace but have
 ### Capability scope
 
 Capabilities in a user namespace only grant privilege over resources owned by that namespace and its descendants. Root in a user namespace cannot:
+
 - Load kernel modules
 - Modify kernel parameters outside the namespace
 - Read files owned by other users on the host

--- a/docs/cgroups/systemd-cgroups.md
+++ b/docs/cgroups/systemd-cgroups.md
@@ -38,6 +38,7 @@ Unlike services, systemd does not start or stop processes in a scope — it only
 Hierarchical grouping containers for services and scopes. A slice does not hold processes directly; it holds child slices, services, and scopes. Its cgroup provides a resource envelope shared by all children.
 
 The default slices are:
+
 - `system.slice` — all system services
 - `user.slice` — all user sessions
 - `machine.slice` — VMs and containers managed by `systemd-machined`
@@ -147,6 +148,7 @@ Delegate=cpu memory pids
 ```
 
 This is used by:
+
 - **containerd** / **Docker** — create per-container sub-cgroups under `containerd.service/`
 - **Kubernetes kubelet** — creates per-pod cgroups under `kubelet.service/` or a dedicated slice
 - **User systemd instances** — `user@1000.service` is delegated so the per-user systemd can manage `user.slice/user-1000.slice/`

--- a/docs/crypto/war-stories.md
+++ b/docs/crypto/war-stories.md
@@ -234,6 +234,7 @@ dmesg | grep -E "random:|crng"
 ```
 
 The VM was:
+
 - Running under KVM without virtio-rng device configured
 - CPU feature masking prevented RDRAND from being visible to the guest
 - `systemd-random-seed.service` was loading the seed file too late in the boot sequence
@@ -350,6 +351,7 @@ static int proc_keys_show(struct seq_file *m, void *v)
 
 The default permissions for user-created keys give `view` permission to the world
 (`other` bits include `0x01 = view`). A key with `perm = 0x1f3f0000` has:
+
 - possessor: `0x1f` = view|read|write|search|link (setattr bit 0x20 is NOT set)
 - user: `0x3f` = all permissions (view|read|write|search|link|setattr)
 - group: `0x00` = no permissions

--- a/docs/debugging/dynamic-debug-lockdep.md
+++ b/docs/debugging/dynamic-debug-lockdep.md
@@ -74,6 +74,7 @@ Each lock in the splat is annotated with `{+.+.}-{3:3}`:
 ```
 
 Common annotations:
+
 - `{+.+.}` — mutex taken in process context with IRQs enabled
 - `{-.-.}` — spinlock taken with IRQs disabled
 - `{++++}` — rwsem taken in all four contexts (e.g., i_data_sem)
@@ -343,6 +344,7 @@ lock_stat version 0.4
 ```
 
 Key columns:
+
 - **con-bounces** — lock was contended and the CPU changed hands between acquire and release
 - **contentions** — total number of times a task had to wait for this lock
 - **waittime-min/max/total** — time spent waiting (microseconds)

--- a/docs/debugging/kasan-kfence.md
+++ b/docs/debugging/kasan-kfence.md
@@ -284,6 +284,7 @@ CPU: 0 PID: 1 Comm: swapper Not tainted 6.8.0 #1
 ```
 
 Key fields:
+
 - **kfence-#42** — the KFENCE slot number
 - **0xffff888080a3c000-0xffff888080a3c006** — the object address range (7 bytes)
 - **1B left of kfence-#42** — the overrun distance

--- a/docs/debugging/kcsan.md
+++ b/docs/debugging/kcsan.md
@@ -70,6 +70,7 @@ CPU: 1 PID: 5678 Comm: worker Tainted: G    B W
 ```
 
 Key fields:
+
 - **read/write**: which operation triggered the watchpoint
 - **address**: the racing memory location
 - **value changed**: shows the write that caused the race

--- a/docs/debugging/oops-analysis.md
+++ b/docs/debugging/oops-analysis.md
@@ -17,10 +17,12 @@ A **kernel oops** is a non-fatal kernel error — the kernel detected an inconsi
 ```
 
 Breaking down the first line:
+
 - `BUG: kernel NULL pointer dereference` — the fault type
 - `address: 0x18` — the virtual address that caused the fault (0x18 = offset 24 in a struct)
 
 The error code `0000`:
+
 - Bit 0 = 0: page not present (vs protection fault)
 - Bit 1 = 0: read (vs write)
 - Bit 2 = 0: kernel mode (vs user mode)
@@ -70,6 +72,7 @@ K — live patched
 ```
 
 Key registers for diagnosis:
+
 - `RIP` — where the crash happened
 - `CR2` — the faulting address (for page faults)
 - `RAX = 0` — often the NULL pointer that was dereferenced

--- a/docs/debugging/war-stories.md
+++ b/docs/debugging/war-stories.md
@@ -48,6 +48,7 @@ Freed by task 12:
 ```
 
 Reading the report:
+
 - The **Read of size 4** is accessing `skb->len` (a `__u32` at offset `0x68` in `struct sk_buff`)
 - The free stack shows `mydrv_rx_completion+0x198`; the access stack shows `mydrv_rx_completion+0x1a8` — the access is 16 bytes later in the same function, confirming a use-after-free in the same call frame
 

--- a/docs/drivers/platform-driver.md
+++ b/docs/drivers/platform-driver.md
@@ -5,6 +5,7 @@
 ## What platform devices are
 
 Platform devices are devices that are not discoverable by hardware (unlike PCI or USB). The `platform_device` / `platform_driver` abstraction is part of the Linux driver model that shipped with Linux 2.6.0; a good overview is Jonathan Corbet's 2011 LWN article [(LWN)](https://lwn.net/Articles/448499/). Devices are instantiated via:
+
 - **Device tree** (ARM, RISC-V, embedded)
 - **ACPI** (x86, modern ARM servers)
 - **Board files** (old ARM, legacy)

--- a/docs/filesystems/ext4.md
+++ b/docs/filesystems/ext4.md
@@ -125,6 +125,7 @@ struct ext4_extent_header {
 ```
 
 Benefits over old indirect maps:
+
 - A single extent covers contiguous blocks (e.g., 128MB in one entry)
 - Sequential reads are contiguous on disk → fast
 - Reduces inode tree depth for large files
@@ -221,6 +222,7 @@ ext4_writepages()
 ```
 
 Benefits:
+
 - Small writes that are quickly deleted never need block allocation
 - Large sequential writes get contiguous blocks (better for extent efficiency)
 - Reduces journal pressure (allocations batched)

--- a/docs/filesystems/xfs.md
+++ b/docs/filesystems/xfs.md
@@ -5,6 +5,7 @@
 ## Why XFS?
 
 XFS was originally developed at SGI for IRIX in 1993, then ported to Linux by Steve Lord and the SGI team; it was merged into the mainline kernel in Linux 2.5.36 (2002). It excels at:
+
 - **Large files and filesystems**: up to 8 EiB volumes, 8 EiB files
 - **High concurrency**: per-allocation-group locking, minimal global contention
 - **Metadata performance**: B-tree indexes for extents, inodes, and free space
@@ -183,6 +184,7 @@ write() → page cache → dirty pages
 ```
 
 Benefits:
+
 - Consecutive writes can be merged into large extents
 - Allocation happens when more context is available (full file size known)
 - Fewer, larger extents → less fragmentation

--- a/docs/interrupts/irq-affinity.md
+++ b/docs/interrupts/irq-affinity.md
@@ -5,6 +5,7 @@
 ## Why IRQ affinity matters
 
 By default, the kernel distributes interrupts across CPUs automatically (`irqbalance` daemon). For latency-sensitive or high-throughput workloads, manual affinity control lets you:
+
 - Dedicate CPUs to specific network queues (one queue per CPU)
 - Isolate real-time tasks from interrupt storms
 - Colocate IRQ handling with the NUMA node that owns the memory

--- a/docs/interrupts/irq-desc.md
+++ b/docs/interrupts/irq-desc.md
@@ -40,6 +40,7 @@ struct irq_desc {
 ```
 
 Key fields:
+
 - `handle_irq`: the **flow handler** — decides how to run the action chain (edge-triggered, level-triggered, per-CPU, etc.)
 - `action`: linked list of `irqaction` structs, one per registered handler
 - `depth`: incremented by `disable_irq()`, decremented by `enable_irq()` — only 0 means actually enabled
@@ -141,6 +142,7 @@ The flow handler (`handle_irq` in `irq_desc`) determines how interrupt delivery 
 | `handle_simple_irq` | No mask/ack, just run actions |
 
 The difference between edge and level matters:
+
 - **Edge**: interrupt fires once when signal transitions. If missed, it won't fire again.
 - **Level**: interrupt fires as long as signal is asserted. Must be masked during handling.
 

--- a/docs/interrupts/msi-msix.md
+++ b/docs/interrupts/msi-msix.md
@@ -5,6 +5,7 @@
 ## Why MSI-X?
 
 Legacy PCI interrupts (INTx, INTA-INTD) have fundamental limitations:
+
 - **Shared**: multiple devices share one IRQ line → spurious interrupts, no isolation
 - **Level-triggered**: interrupt line held until acknowledged → cannot miss (line stays asserted until cleared); edge-triggered interrupts can be missed if the transition occurs while masked
 - **Limited**: only 4 lines per PCI bus

--- a/docs/interrupts/tasklets.md
+++ b/docs/interrupts/tasklets.md
@@ -104,6 +104,7 @@ This is the key advantage over raw softirqs, where the same handler can run on m
 ## Tasklets are deprecated for new code
 
 Since Linux 5.14 (2021), tasklets are explicitly deprecated for new code [(LWN)](https://lwn.net/Articles/830964/). The reasons:
+
 - Softirq context means no sleeping, limited functionality
 - Serialization is too coarse for modern hardware
 - Workqueues provide similar functionality with more flexibility

--- a/docs/interrupts/threaded-irq.md
+++ b/docs/interrupts/threaded-irq.md
@@ -5,6 +5,7 @@
 ## The problem with hardirq handlers
 
 Hardware interrupt handlers (hardirq) run with interrupts disabled on the current CPU. This means:
+
 - They cannot sleep
 - They cannot acquire sleeping locks (mutex, semaphore)
 - They block other interrupts on the same CPU

--- a/docs/io-uring/README.md
+++ b/docs/io-uring/README.md
@@ -9,6 +9,7 @@ This documentation explains how io_uring works — not just the API, but the des
 ### Prerequisites
 
 This documentation assumes familiarity with:
+
 - **C programming** — io_uring's API and the kernel implementation are both in C
 - **File descriptors and syscalls** — how `read()`, `write()`, `accept()` work at the OS level
 - **Basic async concepts** — event loops, non-blocking I/O, callbacks

--- a/docs/io-uring/io-uring-arch.md
+++ b/docs/io-uring/io-uring-arch.md
@@ -5,6 +5,7 @@
 ## The problem io_uring solves
 
 Traditional I/O interfaces:
+
 - `read()`/`write()`: one syscall per operation, blocking
 - `aio_read()` (POSIX AIO): thread-pool based, complex API, poor performance
 - `epoll` + non-blocking: two syscalls per operation (one to check, one to act), no batching
@@ -165,6 +166,7 @@ struct io_uring_cqe {
 ```
 
 `res` semantics mirror the corresponding blocking syscall:
+
 - `IORING_OP_READ`: bytes read, or -errno
 - `IORING_OP_WRITE`: bytes written, or -errno
 - `IORING_OP_ACCEPT`: new fd, or -errno

--- a/docs/io-uring/life-of-request.md
+++ b/docs/io-uring/life-of-request.md
@@ -929,6 +929,7 @@ for (int i = 0; i < 1000; i++)
 #### Real-world implications
 
 Any application that submits bursts of requests and reaps lazily must either:
+
 - Size the CQ ring large enough via `IORING_SETUP_CQSIZE` in `io_uring_params`, or
 - Interleave reaping with submission, or
 - Rely on `IORING_FEAT_NODROP` (available since kernel 5.5), which buffers overflowed CQEs internally.

--- a/docs/io/README.md
+++ b/docs/io/README.md
@@ -9,6 +9,7 @@ This documentation explains how Linux handles I/O — not just the system call A
 ### Prerequisites
 
 This documentation assumes familiarity with:
+
 - **C programming** — The kernel is written in C; syscall behavior is best understood at the C level
 - **Basic OS concepts** — Processes, kernel vs. userspace, system calls, file descriptors
 - **File descriptors** — What they are, how `open()` / `close()` / `dup()` work, and that they reference kernel-side `struct file` objects

--- a/docs/io/async-io.md
+++ b/docs/io/async-io.md
@@ -5,6 +5,7 @@
 ## The problem with synchronous I/O
 
 Synchronous `read()`/`write()` block the calling thread until data is transferred. For high-throughput servers this means either:
+
 - Many threads (each blocking on I/O) — high memory cost, context switch overhead
 - Non-blocking I/O with `epoll` — works for sockets, but **epoll does not work for regular files** (they are always "ready")
 
@@ -46,6 +47,7 @@ aio_suspend(list, 1, NULL);
 ```
 
 **The problem**: glibc implements POSIX AIO using a thread pool. Each `aio_read()` submits work to a worker thread that calls `pread()` synchronously. This adds:
+
 - Thread creation/teardown overhead
 - Memory per thread (stack)
 - Context switches to the worker thread and back

--- a/docs/io/fsync-fdatasync.md
+++ b/docs/io/fsync-fdatasync.md
@@ -258,11 +258,13 @@ The latency is dominated by the time to drain the write cache and for the journa
 > *If the file is not in a special file, it is not required to update metadata such as st_atime or st_mtime.*
 
 The metadata `fdatasync()` can skip:
+
 - `atime` (last access time) — never affects data retrieval
 - `mtime` (last modification time) — does not affect data location
 - `ctime` (last status change time) — inode change timestamp
 
 The metadata `fdatasync()` **must** flush:
+
 - File size (`i_size`) — if the file grew, the new size is needed to locate the new data
 - Block pointers — any newly allocated data blocks must be findable
 - Indirect/extent tree changes — required to locate data
@@ -480,6 +482,7 @@ The large ratio for random 4KB writes is because each write round-trips to the d
 Consider a database writing a data page and then a journal record describing that write. If the storage device reorders these two writes — journal record lands first, crash occurs, data page never arrives — recovery replays a journal entry that points to stale data. The file is now corrupt.
 
 Write barriers solve this: a barrier ensures all writes issued before it are persistent before any write issued after it begins. On NVMe:
+
 - **FUA (Force Unit Access)**: a flag on a specific write command that bypasses the volatile write cache for that command only.
 - **FLUSH command** (`REQ_OP_FLUSH`): drains the entire volatile write cache; all previous writes are persistent before this command returns.
 
@@ -796,6 +799,7 @@ fio --name=odsync --rw=randwrite --bs=4k --size=1G \
 ```
 
 Key fio output fields for fsync benchmarking:
+
 - `lat (usec)`: per-operation latency including the fsync
 - `iops`: operations per second
 - `clat percentiles`: 99th/99.9th percentile latency reveals outliers

--- a/docs/io/io-bandwidth.md
+++ b/docs/io/io-bandwidth.md
@@ -123,6 +123,7 @@ dd if=/dev/nvme0n1 of=/dev/null bs=1M count=10240 iflag=direct
 ```
 
 **CPU-limited bandwidth symptoms:**
+
 - `iostat %util` < 100% but bandwidth plateau at ~3–4 GB/s
 - One CPU core at 100% (`mpstat` shows high `%irq` or `%soft`)
 - Throughput increases linearly with the number of parallel jobs (up to CPU saturation)
@@ -220,6 +221,7 @@ fio --name=fs --rw=read --bs=1M --direct=1 --iodepth=32 \
 ```
 
 Typical filesystem overhead for sequential I/O with `O_DIRECT`:
+
 - **ext4, XFS**: 3–8% overhead (extent lookup, inode lock)
 - **Btrfs**: 5–15% overhead (tree operations, checksums)
 - **tmpfs**: 0% (memory-backed, no device I/O)

--- a/docs/io/life-of-a-write.md
+++ b/docs/io/life-of-a-write.md
@@ -892,6 +892,7 @@ NVMe controllers are required to honour the Flush command — all preceding writ
 Most HDDs and many SSDs have a DRAM write cache. When the kernel issues a write, the device acknowledges it as soon as the data lands in this cache — before writing it to the platters or NAND. If power fails between the acknowledgement and the actual physical write, data is lost.
 
 This means that even after `fsync()` returns successfully, data can be lost on drives with volatile write caches unless:
+
 - The drive's write cache is disabled (`hdparm -W 0 /dev/sda`), or
 - The drive supports and honours FUA / Flush commands.
 

--- a/docs/io/mmap-io.md
+++ b/docs/io/mmap-io.md
@@ -904,6 +904,7 @@ void db_close(db_env_t *env)
 ```
 
 Key design points from LMDB:
+
 - The mapping is `MAP_SHARED` — writes are visible to all reader processes immediately.
 - Readers need no locks for read-only access because the B-tree is updated via copy-on-write at the database level (MVCC pages, not OS COW).
 - `msync(MS_SYNC)` is called only when committing a transaction, not on every write.

--- a/docs/io/pread-pwrite.md
+++ b/docs/io/pread-pwrite.md
@@ -611,6 +611,7 @@ The main advantage of `io_uring` over `preadv2` is not the per-call flags (those
 | `io_uring` | no | yes | yes | High-concurrency, batch submission |
 
 For a database using multiple threads to issue random reads:
+
 - `read()` + `lseek()`: requires external mutex around each seek+read pair.
 - `pread()`: safe without any mutex; each thread passes its own offset.
 - `preadv()`: safe and avoids an extra `memcpy` when the page header and body go to different structures.

--- a/docs/iommu/README.md
+++ b/docs/iommu/README.md
@@ -16,6 +16,7 @@ With IOMMU:
 ```
 
 Beyond security, the IOMMU enables:
+
 - **IOVA remapping**: devices with < 64-bit address buses can DMA to high memory
 - **Scatter-gather flattening**: discontiguous physical pages appear contiguous to the device
 - **Device passthrough (VFIO)**: safely assign physical devices to VMs

--- a/docs/iommu/dma-api.md
+++ b/docs/iommu/dma-api.md
@@ -5,6 +5,7 @@
 ## Why a DMA API?
 
 DMA programming is architecture-dependent:
+
 - x86 with IOMMU: allocate IOVA, program device with IOVA
 - x86 without IOMMU: device uses physical addresses directly
 - ARM with non-coherent cache: must flush/invalidate cache around DMA
@@ -56,6 +57,7 @@ dma_free_coherent(dev, size, cpu_addr, dma_handle);
 ```
 
 **How it works under the hood:**
+
 - x86 with cache-coherent bus: `dma_alloc_coherent` → `alloc_pages` + IOMMU mapping
 - ARM non-coherent: `dma_alloc_coherent` → `alloc_pages` + mark as uncached (`pgprot_noncached`)
 - No IOMMU: `dma_alloc_coherent` → `alloc_pages` restricted to DMA zone (< 4GB if 32-bit mask)
@@ -95,6 +97,7 @@ dma_unmap_single(dev, dma_handle, size, DMA_TO_DEVICE);
 ```
 
 **What happens at map/unmap:**
+
 - With IOMMU: allocate IOVA, create IOMMU mapping
 - Without IOMMU, coherent cache: mapping is a no-op (physical == device address)
 - Without IOMMU, non-coherent cache: `map` flushes CPU cache; `unmap` invalidates CPU cache

--- a/docs/iommu/vfio-internals.md
+++ b/docs/iommu/vfio-internals.md
@@ -7,6 +7,7 @@
 VFIO (Virtual Function I/O) is the kernel framework for safely exposing physical devices to userspace processes or virtual machines. It uses the IOMMU to enforce memory access isolation while giving the userspace driver (or hypervisor) direct access to device MMIO, interrupts, and DMA.
 
 The three primary use cases are:
+
 - **VM device passthrough**: QEMU/KVM passes a physical NIC, GPU, or NVMe to a guest.
 - **Userspace drivers**: DPDK binds NICs to VFIO for kernel-bypass packet processing.
 - **Mediated devices**: A physical GPU or NIC is split into virtual instances assigned to separate VMs.
@@ -110,6 +111,7 @@ The `pin_user_pages_remote()` call (introduced in kernel 5.6 to replace `get_use
 ### The DMA map rb-tree
 
 All active DMA mappings are tracked in a red-black tree, keyed and searched for overlap by IOVA (`vfio_find_dma()`) — not a radix tree or the kernel's interval-tree API. This allows the kernel to:
+
 - Detect and reject overlapping `MAP_DMA` requests.
 - Enumerate all mappings for cleanup when a group is removed.
 - Implement `VFIO_IOMMU_UNMAP_DMA` by looking up and removing entries.

--- a/docs/ipc/eventfd-signalfd.md
+++ b/docs/ipc/eventfd-signalfd.md
@@ -5,6 +5,7 @@
 ## eventfd: a counter you can poll
 
 `eventfd` creates a file descriptor backed by a kernel counter. It's used for:
+
 - Event notification between threads or processes
 - Waking up `epoll`/`select`/`poll` from another context
 - Counting occurrences (semaphore-like, but pollable)

--- a/docs/ipc/mqueue.md
+++ b/docs/ipc/mqueue.md
@@ -5,6 +5,7 @@
 ## Overview
 
 POSIX message queues (`mq_open`, `mq_send`, `mq_receive`) provide a message-passing IPC mechanism with:
+
 - **Priority ordering**: messages are dequeued highest-priority first
 - **Blocking and non-blocking**: readers block until a message arrives
 - **Async notification**: `mq_notify` delivers a signal or starts a thread when a message arrives

--- a/docs/ipc/pipes.md
+++ b/docs/ipc/pipes.md
@@ -14,6 +14,7 @@ write(pipefd[1], data)  →  pipe buffer  →  read(pipefd[0], buf)
 ```
 
 Properties:
+
 - **Unidirectional**: data flows write→read only
 - **Byte stream**: no message boundaries
 - **Blocking**: write blocks if full, read blocks if empty
@@ -218,6 +219,7 @@ int fd = open("/tmp/myfifo", O_RDONLY);
 ```
 
 Opening rules:
+
 - Read-only open blocks until a writer opens (unless `O_NONBLOCK`)
 - Write-only open blocks until a reader opens (unless `O_NONBLOCK`, returns `ENXIO`)
 - Read-write open never blocks

--- a/docs/ipc/shared-memory.md
+++ b/docs/ipc/shared-memory.md
@@ -209,6 +209,7 @@ void consumer(int efd) {
 ```
 
 eventfd is used extensively in:
+
 - QEMU/KVM virtio notifications
 - io_uring completion notification
 - libuv/libevent event loop backends
@@ -236,6 +237,7 @@ send_fd_over_socket(socket_fd, fd);
 ```
 
 `memfd_create` is used by:
+
 - Graphics/Wayland: sharing framebuffers between client and compositor
 - dbus-broker: passing large messages without DBUS limits
 - D-Bus: replacing shared memory segments

--- a/docs/ipc/signals.md
+++ b/docs/ipc/signals.md
@@ -144,6 +144,7 @@ static void my_handler(int sig, siginfo_t *info, void *ctx)
 ```
 
 Important flags:
+
 - `SA_SIGINFO` — use `sa_sigaction` (3-arg handler) instead of `sa_handler`
 - `SA_RESTART` — auto-restart interrupted syscalls (`EINTR` hidden from app)
 - `SA_NODEFER` — don't block the signal during its own handler (reentrant)
@@ -199,6 +200,7 @@ struct sigpending {
 ## Real-time signals
 
 Real-time signals (SIGRTMIN..SIGRTMAX) differ from standard signals:
+
 - **Queued**: multiple sends before delivery are all delivered (FIFO order)
 - **Value**: can carry an integer or pointer (via sigqueue + `si_value`)
 - **Priority**: lower signal number = higher priority within real-time range

--- a/docs/ipc/unix-sockets.md
+++ b/docs/ipc/unix-sockets.md
@@ -51,6 +51,7 @@ listen(srv, SOMAXCONN);
 ```
 
 Properties:
+
 - Permissions are enforced by the file's mode bits (`chmod 0660 /run/myservice.sock`)
 - The socket file persists after the server exits — must be removed with `unlink()` before rebinding
 - Controlled by the filesystem namespace: containers with separate mount namespaces cannot see each other's socket files
@@ -70,6 +71,7 @@ bind(srv, (struct sockaddr *)&addr, addrlen);
 ```
 
 Properties:
+
 - Automatically cleaned up when the last file descriptor referencing it is closed — no `unlink()` needed
 - Name is arbitrary bytes, not a C string; can contain null bytes beyond the first
 - Visible only within the same network namespace (`ip netns` or container namespaces provide isolation)

--- a/docs/kernel/boot-params.md
+++ b/docs/kernel/boot-params.md
@@ -39,6 +39,7 @@ Parameters registered with `early_param()` are processed here.
 Called from `start_kernel()` after `setup_arch()` and the per-CPU areas are set up. This phase handles the bulk of kernel parameters registered with `__setup()`.
 
 Anything not matched by `__setup()` or `early_param()` is treated as either:
+
 - A module parameter for a built-in module (`module.param=value` form)
 - An environment variable to pass to the init process
 - An unknown parameter (logged via `pr_notice()`, not a warning)

--- a/docs/linux-evolution.md
+++ b/docs/linux-evolution.md
@@ -44,6 +44,7 @@ Linus Torvalds, a 21-year-old student at University of Helsinki, [posted to `com
 > *"I'm doing a (free) operating system (just a hobby, won't be big and professional like gnu) for 386(486) AT clones."*
 
 He was frustrated that MINIX (Andrew Tanenbaum's teaching OS) couldn't be freely modified. Linux 0.01 had:
+
 - Basic process management
 - Simple memory management (buddy allocator)
 - Minimal filesystem support
@@ -52,6 +53,7 @@ He was frustrated that MINIX (Andrew Tanenbaum's teaching OS) couldn't be freely
 ### The GPL Decision (1992)
 
 Originally under a restrictive license, Torvalds switched to [GPL](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html) in February 1992. This was pivotal - it meant:
+
 - Anyone could contribute
 - Improvements had to be shared back
 - Companies couldn't make proprietary forks
@@ -59,6 +61,7 @@ Originally under a restrictive license, Torvalds switched to [GPL](https://www.g
 ### The Tanenbaum Debate (January 1992)
 
 Andrew Tanenbaum [declared "Linux is obsolete"](https://www.oreilly.com/openbook/opensources/book/appa.html), arguing:
+
 - Monolithic kernels were outdated
 - Microkernels were the future
 - Linux was too tied to `i386`
@@ -68,6 +71,7 @@ Torvalds defended the pragmatic choice: monolithic was simpler, faster, and actu
 ### v1.0 (March 1994)
 
 After 3 years of development, [Linux 1.0](https://cdn.kernel.org/pub/linux/kernel/v1.0/) was released. It supported:
+
 - Networking (`TCP/IP`)
 - Loadable kernel modules
 - Multiple filesystems
@@ -82,6 +86,7 @@ After 3 years of development, [Linux 1.0](https://cdn.kernel.org/pub/linux/kerne
 **The need**: Multi-processor systems were becoming affordable.
 
 **The challenge**: The original kernel assumed single CPU. Adding SMP required:
+
 - Spinlocks for synchronization
 - Per-CPU data structures
 - Big Kernel Lock (`BKL`) as initial solution
@@ -91,6 +96,7 @@ The `BKL` was a single global lock - simple but limited scalability. It took yea
 ### Enterprise Interest Begins
 
 By late 1990s, companies noticed Linux:
+
 - **1998**: [Oracle shipped Oracle8 for Linux](https://www.theregister.com/1998/10/09/oracle_aims_oracle8_for_linux/)
 - **1999**: [HP formed Linux organization](https://www.linux.co.cr/oem-support/review/1999/0301.html), offered 24x7 support
 - **2000**: [IBM invested $1 billion in Linux](https://www.linux.co.cr/oem-support/review/2000/1212.html), Dell shipping Linux servers
@@ -111,6 +117,7 @@ By late 1990s, companies noticed Linux:
 ### v2.4: Production Ready (2001)
 
 The kernel that convinced enterprises:
+
 - Journaling filesystems (`ext3`, ReiserFS)
 - LVM (Logical Volume Manager)
 - USB support
@@ -121,6 +128,7 @@ The kernel that convinced enterprises:
 ### The SCO Lawsuit (2003-2007)
 
 [SCO Group sued IBM](https://en.wikipedia.org/wiki/SCO_Group,_Inc._v._International_Business_Machines_Corp.) claiming Linux contained stolen Unix code. The lawsuit:
+
 - Created fear, uncertainty, doubt (FUD)
 - Led to better documentation of code origins
 - Eventually collapsed (SCO lost, [settled 2021](https://en.wikipedia.org/wiki/SCO%E2%80%93Linux_disputes#Settlement))
@@ -132,6 +140,7 @@ Result: Stronger processes for tracking code provenance, [Developer Certificate 
 ### v2.6: The Scalability Kernel (2003)
 
 Major rewrite with:
+
 - **`O(1)` scheduler**: Constant-time scheduling regardless of process count (later replaced by CFS in v2.6.23, 2007)
 - **Preemptible kernel**: Better responsiveness
 - **NPTL**: Native POSIX Thread Library (vastly improved threading)
@@ -142,6 +151,7 @@ This kernel could scale from embedded to enterprise.
 ### Git Created (2005)
 
 Kernel development outgrew BitKeeper (proprietary). Torvalds [announced the need for a replacement](https://lore.kernel.org/all/Pine.LNX.4.58.0504060800280.2215@ppc970.osdl.org/) and wrote Git in weeks. Impact:
+
 - Distributed development model
 - Anyone can have full history
 - Branching/merging became trivial
@@ -154,6 +164,7 @@ Kernel development outgrew BitKeeper (proprietary). Torvalds [announced the need
 ### Android Announced (November 2007)
 
 [Google's mobile OS](https://www.openhandsetalliance.com/press_110507.html), built on Linux kernel. Required:
+
 - **Binder IPC**: Fast inter-process communication
 - **Ashmem**: Anonymous shared memory for apps
 - **Wakelocks**: Power management for mobile
@@ -164,6 +175,7 @@ Some Android patches took years to upstream, others remain Android-specific.
 ### Containers Foundation (2006-2008)
 
 Cloud computing needed lightweight virtualization:
+
 - **Namespaces** (2006): Isolate process views of system
 - **[Cgroups](https://lwn.net/Articles/236038/)** (v2.6.24, 2008): Resource limits per process group
 
@@ -172,6 +184,7 @@ These became the foundation for Docker (2013) and modern container orchestration
 ### v2.6.28-v2.6.39: Rapid Evolution
 
 The 2.6.x series lasted until 2011, with rapid feature additions:
+
 - [KVM virtualization](https://lwn.net/Articles/205580/) (v2.6.20, 2007)
 - `ext4` filesystem (2008)
 - `btrfs` development begins
@@ -188,6 +201,7 @@ Not a major technical change - Torvalds [changed versioning](https://lwn.net/Art
 ### Supercomputer Dominance
 
 Linux share of [TOP500 supercomputers](https://www.top500.org/statistics/details/osfam/1):
+
 - 2000: ~30%
 - 2005: ~75%
 - 2010: ~90%
@@ -202,6 +216,7 @@ Not kernel, but significant: [systemd](https://systemd.io/) replaced SysVinit ac
 ### Real-time Improvements (`PREEMPT_RT`)
 
 Gradual merging of real-time patches:
+
 - Threaded interrupt handlers
 - Priority inheritance for mutexes
 - High-resolution timers
@@ -215,6 +230,7 @@ Enabling Linux in industrial and automotive applications.
 ### Meltdown/Spectre (2018)
 
 [CPU vulnerabilities](https://meltdownattack.com/) requiring kernel-level mitigations:
+
 - **[KPTI](https://lore.kernel.org/all/20171204150606.306546484@linutronix.de/T/)**: Kernel page table isolation (Meltdown)
 - **Retpoline**: Speculative execution mitigation
 - **`IBRS`/`IBPB`**: Indirect branch controls
@@ -224,6 +240,7 @@ Performance impact: 5-30% for some workloads. Led to hardware/software co-design
 ### Extended BPF (eBPF)
 
 [Extended BPF (eBPF)](https://lore.kernel.org/netdev/1395404418-25376-9-git-send-email-dborkman@redhat.com/) transformed from packet filtering to:
+
 - Tracing and profiling
 - Security enforcement
 - Network acceleration
@@ -236,6 +253,7 @@ Safe, JIT-compiled programs running in kernel space with verifier guarantees.
 **Commit**: [8aebac82933f](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8aebac82933ff1a7c8eede18cab11e1115e2062b) (v6.1)
 
 First high-level language besides C in Linux kernel. [Pull request for v6.1](https://lore.kernel.org/lkml/CAK7LNAQ2xBLG_aSDm64SSYRBOBKwhJnZ6UDg8ycAezATVToFLg@mail.gmail.com/t/) accepted. Motivation:
+
 - Memory safety guarantees
 - Prevent entire classes of bugs
 - Modern language features
@@ -286,6 +304,7 @@ CPU architectures are only part of the story — buses, network hardware, and bo
 ### The Maintainer Model
 
 Linux uses a hierarchical [maintainer model](https://docs.kernel.org/process/maintainer-netdev.html):
+
 - ~1,700 active maintainers
 - Subsystem maintainers review patches
 - Lieutenants collect subsystem work

--- a/docs/locking/atomics.md
+++ b/docs/locking/atomics.md
@@ -101,6 +101,7 @@ atomic_long_cmpxchg(&v, old, new);
 ## READ_ONCE and WRITE_ONCE
 
 Two CPUs accessing a variable simultaneously is undefined behavior in C. `READ_ONCE` and `WRITE_ONCE` prevent the compiler from:
+
 - Tearing the access (splitting a word-sized read/write into multiple)
 - Merging or reordering accesses
 - Caching the value in a register across function calls

--- a/docs/locking/completions.md
+++ b/docs/locking/completions.md
@@ -69,6 +69,7 @@ if (try_wait_for_completion(&c)) {
 ## struct wait_queue_head_t
 
 `wait_queue_head_t` is the lower-level primitive that `completion` builds on. It supports:
+
 - Multiple waiters on the same event
 - Custom wake conditions
 - Exclusive vs non-exclusive wakeup

--- a/docs/locking/futex.md
+++ b/docs/locking/futex.md
@@ -15,6 +15,7 @@ futex(2) entered Linux 2.6.0 (December 2003) — see [`man 2 futex`](https://www
 A **futex** (fast userspace mutex) is the kernel mechanism that allows userspace locking primitives (pthreads mutex, condition variables, semaphores) to be efficient. The key insight: in the common uncontended case, locking and unlocking should happen entirely in userspace with no kernel involvement. The kernel is only called when there's actual contention.
 
 The futex syscall (`futex(2)`) provides two core operations:
+
 - `FUTEX_WAIT`: sleep if the futex word has a given value
 - `FUTEX_WAKE`: wake one or more waiters
 
@@ -150,6 +151,7 @@ int futex_wait(u32 __user *uaddr, u32 val, ...)
 ```
 
 The crucial step is checking the value **under the hash bucket lock** (step 3). This prevents a race where:
+
 - Userspace sees the lock is contended and calls FUTEX_WAIT
 - The lock holder unlocks and calls FUTEX_WAKE before we've queued
 - We'd sleep forever without the lock check

--- a/docs/locking/lock-debugging.md
+++ b/docs/locking/lock-debugging.md
@@ -5,6 +5,7 @@
 ## Identifying the problem
 
 Lock contention manifests as CPUs burning time waiting rather than doing useful work. Symptoms:
+
 - High CPU utilization but low throughput
 - `perf top` shows `_raw_spin_lock` or `mutex_lock` near the top
 - `sar -u` shows high `%sys` with low actual work rate
@@ -33,6 +34,7 @@ class name    con-bounces  contentions  waittime-min  waittime-max  waittime-tot
 ```
 
 Key columns:
+
 - **contentions**: number of times a caller had to wait (lock was already held)
 - **waittime-max**: worst-case wait time (µs) — your tail latency
 - **holdtime-total**: total time the lock was held — high means long critical sections

--- a/docs/locking/lockdep.md
+++ b/docs/locking/lockdep.md
@@ -77,6 +77,7 @@ the existing dependency chain (in reverse order) is:
 ```
 
 Key fields:
+
 - The lock type annotation `{+.+.}` shows where it's used: `+` = used with IRQs enabled, `-` = used with IRQs disabled, `.` = not used in that context
 - The dependency chain shows the exact call path that created the dependency
 
@@ -162,6 +163,7 @@ cat /proc/lock_stat
 ```
 
 Columns:
+
 - `contentions`: times the lock was already held when taken
 - `waittime-*`: how long callers waited (microseconds)
 - `acquisitions`: total lock acquisitions

--- a/docs/locking/mutex.md
+++ b/docs/locking/mutex.md
@@ -164,6 +164,7 @@ Use spinlock when:
 Before `struct mutex` existed, the standard sleeping lock in the kernel was `struct semaphore`. A semaphore has a count — `down()` decrements it and sleeps if the count reaches zero; `up()` increments it and wakes a waiter.
 
 The problem with using a counting semaphore as a mutex: because `up()` can be called by *any* task (not just the one that called `down()`), the kernel couldn't enforce ownership. This ruled out:
+
 - Detecting recursive locking (which could deadlock)
 - Priority inheritance (who holds the lock? unknown)
 - Debugging tools that check "is the lock held when the task exits?"
@@ -178,6 +179,7 @@ The BKL (`lock_kernel()` / `unlock_kernel()`) was a single global recursive spin
 The BKL had unusual properties: it was released automatically on `schedule()` (so the holder could sleep without deadlocking other holders) and it was recursive. These properties made it easy to adopt but hard to remove, because removing it required proving that the protected code was safe without it.
 
 Subsystem by subsystem, developers replaced BKL sections with proper per-subsystem mutexes and spinlocks. The process took over a decade:
+
 - VFS: converted ~2004–2007 (big_kernel_lock → i_mutex, etc.)
 - TTY layer: converted ~2009
 - Remaining network drivers, sound: converted ~2011–2013

--- a/docs/locking/percpu.md
+++ b/docs/locking/percpu.md
@@ -7,6 +7,7 @@
 Many kernel subsystems maintain per-CPU counters or state — a count of context switches, cache statistics, a runqueue pointer. The obvious approach is a global variable with a lock. But the per-CPU approach is better: give each CPU its own copy.
 
 Benefits:
+
 - **No synchronization needed for CPU-local access**: reading/writing your own CPU's copy requires no locks
 - **No cache line bouncing**: each CPU touches only its own data, no false sharing
 - **Naturally scalable**: performance doesn't degrade as CPU count increases
@@ -54,6 +55,7 @@ this_cpu_write(my_counter, 0);
 ```
 
 The difference between `get_cpu_var` and `this_cpu_*`:
+
 - `get_cpu_var` disables preemption — safe even if code can be preempted
 - `this_cpu_*` does NOT disable preemption — caller must guarantee they won't migrate (e.g., already in a preemption-disabled section, or in a per-CPU context)
 

--- a/docs/locking/rcu.md
+++ b/docs/locking/rcu.md
@@ -33,6 +33,7 @@ The critical property: **readers pay almost nothing**. On non-preemptible kernel
 A **grace period** is the time the writer waits after publishing the new pointer before freeing the old one. A grace period ends when every CPU has passed through a **quiescent state** — a point where no RCU read-side critical section can be in progress.
 
 Quiescent states include:
+
 - Context switch (the CPU was preempted)
 - Idle (the CPU has no work)
 - User mode execution

--- a/docs/locking/spinlock.md
+++ b/docs/locking/spinlock.md
@@ -152,6 +152,7 @@ raw_spin_trylock(&raw_lock);       /* returns 1 on success */
 ## Debugging: lockdep catches misuse
 
 With `CONFIG_DEBUG_SPINLOCK` and `CONFIG_LOCKDEP`, the kernel detects:
+
 - Double-locking (taking a lock you already hold)
 - Lock ordering violations (potential deadlocks between lock classes)
 - Sleeping while holding a spinlock

--- a/docs/mm/README.md
+++ b/docs/mm/README.md
@@ -9,6 +9,7 @@ This documentation explains how Linux manages memory - not just the theory, but 
 ### Prerequisites
 
 This documentation assumes familiarity with:
+
 - **C programming** - The kernel is written in C
 - **Pointers and memory addresses** - Virtual vs physical addressing
 - **Basic OS concepts** - Processes, kernel vs userspace

--- a/docs/mm/brk-vs-mmap.md
+++ b/docs/mm/brk-vs-mmap.md
@@ -45,6 +45,7 @@ syscall(SYS_brk, current_brk + 4096);             // Extend by 4KB
 ```
 
 **Characteristics:**
+
 - Single contiguous region
 - Grows upward
 - Cannot release memory in the middle
@@ -82,6 +83,7 @@ void *p = mmap(NULL, size,
 See [`do_mmap()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) for the kernel implementation.
 
 **Characteristics:**
+
 - Arbitrary location in address space
 - Each mapping independent
 - Can release (`munmap`) individually
@@ -130,22 +132,26 @@ See [glibc malloc tunables](https://www.gnu.org/software/libc/manual/html_node/M
 ### Small allocations → brk (heap)
 
 **Pros:**
+
 - Lower syscall overhead (glibc extends heap in large chunks, serves many mallocs per brk call)
 - Good locality (allocations are adjacent)
 - Fast allocation from free lists
 
 **Cons:**
+
 - Memory fragmentation over time
 - Harder to return memory to OS (requires free space at top of heap)
 
 ### Large allocations → mmap
 
 **Pros:**
+
 - Memory returned to OS immediately on free (`munmap()`)
 - No heap fragmentation from large blocks
 - Predictable cleanup
 
 **Cons:**
+
 - Per-allocation syscall overhead
 - TLB pressure (each mapping needs entries)
 - Potential address space fragmentation
@@ -277,6 +283,7 @@ These two system calls come from different eras and were designed for different 
 For over a decade, `brk()` was the **only** way for applications to acquire heap memory. Every `malloc()` implementation used it.
 
 The call is now considered a historical artifact:
+
 - Marked **LEGACY** in Single UNIX Specification v2
 - **Removed** from POSIX.1-2001
 - Linux keeps it for compatibility, but modern allocators use it less
@@ -286,6 +293,7 @@ The call is now considered a historical artifact:
 `mmap()` was designed for a completely different purpose: **memory-mapped files**.
 
 Timeline:
+
 - **1983 (4.2BSD)**: API designed and documented, but not implemented
 - **~1988 (SunOS 4.0)**: First working implementation by Sun Microsystems
 - **4.3BSD-Reno**: BSD implementation (based on Mach VM, after Sun refused to share their code)

--- a/docs/mm/compaction.md
+++ b/docs/mm/compaction.md
@@ -38,6 +38,7 @@ After running for days/weeks, a system may have plenty of free memory but no con
 ### Before Compaction
 
 Prior to compaction, high-order allocation failures were common:
+
 - THP couldn't allocate 2MB pages
 - DMA buffers failed
 - Network jumbo frames unavailable
@@ -112,6 +113,7 @@ ps aux | grep kcompactd
 ```
 
 Woken when:
+
 - Watermarks indicate fragmentation
 - High-order allocations are failing
 - Explicitly triggered
@@ -237,6 +239,7 @@ Processes blocked waiting for compaction.
 **Symptoms**: Latency spikes, high `compact_stall` count
 
 **Solutions**:
+
 - Enable proactive compaction
 - Tune `compaction_proactiveness`
 - Reduce high-order allocations
@@ -248,10 +251,12 @@ Can't create contiguous regions.
 **Symptoms**: High `compact_fail`, THP allocation failures
 
 **Causes**:
+
 - Too many unmovable pages
 - Severe fragmentation
 
 **Solutions**:
+
 - Reduce kernel memory usage
 - Increase movable zone size
 - Consider memory hotplug for isolation
@@ -263,6 +268,7 @@ Background compaction consuming CPU.
 **Debug**: `top`, `perf top`
 
 **Solutions**:
+
 - Reduce `compaction_proactiveness`
 - Accept more direct compaction instead
 

--- a/docs/mm/contiguous-memory.md
+++ b/docs/mm/contiguous-memory.md
@@ -81,6 +81,7 @@ The buddy allocator maintains separate free lists per migrate type ([mm/page_all
 ```
 
 This helps because:
+
 - Movable pages can be migrated to create contiguous free space
 - Reclaimable pages can be freed under pressure
 - Unmovable pages are grouped together, limiting fragmentation spread

--- a/docs/mm/cow.md
+++ b/docs/mm/cow.md
@@ -259,6 +259,7 @@ From the fix commit message:
 **Author**: John Hubbard (NVIDIA)
 
 Post-Dirty COW, the kernel needed a clean distinction between:
+
 - **get_user_pages()**: Short-term references (will be released quickly)
 - **pin_user_pages()**: Long-term pins for DMA (new FOLL_PIN flag)
 

--- a/docs/mm/cxl-memory-tiering.md
+++ b/docs/mm/cxl-memory-tiering.md
@@ -98,6 +98,7 @@ memory_tier2 (slowest) → node 2  (CXL/PMEM)
 ```
 
 The demotion paths would be:
+
 - node 1 (HBM) → node 0 (DRAM)
 - node 0 (DRAM) → node 2 (CXL)
 - node 2 (CXL) → nowhere (terminal)

--- a/docs/mm/fork.md
+++ b/docs/mm/fork.md
@@ -699,6 +699,7 @@ The fix removed the `FOLL_WRITE` flag manipulation that created the race window.
 #### Why it went undetected
 
 The bug was subtle:
+
 - Required precise timing between two threads
 - Only affected private mappings of read-only files
 - Normal testing wouldn't trigger the race
@@ -822,6 +823,7 @@ The fix ensures TLB flushes happen before releasing both source and destination 
 #### The pattern
 
 `userfaultfd` allows userspace to handle page faults. This is extremely useful for:
+
 - Live migration of VMs
 - Garbage collectors
 - Custom memory management

--- a/docs/mm/glossary.md
+++ b/docs/mm/glossary.md
@@ -66,6 +66,7 @@ When free memory exists but isn't usable because it's broken into small, non-con
 
 ### GFP Flags (Get Free Pages)
 Flags passed to allocation functions specifying behavior:
+
 - `GFP_KERNEL`: Normal allocation, can sleep
 - `GFP_ATOMIC`: Can't sleep (used in interrupts)
 - `__GFP_ZERO`: Zero the memory before returning
@@ -247,11 +248,13 @@ Resize a vmalloc allocation. Can shrink in-place (freeing pages) or grow (may ne
 Division of physical memory by hardware constraints. Zones vary by architecture:
 
 **x86-64:**
+
 - **`ZONE_DMA`**: First 16MB (legacy 16-bit DMA)
 - **`ZONE_DMA32`**: 16MB - 4GB (32-bit DMA devices)
 - **`ZONE_NORMAL`**: Above 4GB (regular allocations)
 
 **32-bit x86:**
+
 - **`ZONE_DMA`**: First 16MB
 - **`ZONE_NORMAL`**: 16MB - ~896MB (directly mapped)
 - **`ZONE_HIGHMEM`**: Above ~896MB (not directly mapped, requires kmap)

--- a/docs/mm/hugepages-1gb.md
+++ b/docs/mm/hugepages-1gb.md
@@ -163,11 +163,8 @@ numastat -m | grep -i huge
 **Workloads that benefit:**
 
 - **In-memory databases** — Oracle Database, SAP HANA, and similar systems with buffer pools larger than ~100GB. The buffer pool is accessed randomly; every cache hit becomes a TLB miss at 2MB granularity when the working set exceeds TLB capacity.
-
 - **ML training with large model weights** — Large language model training loads multi-gigabyte weight tensors that are repeatedly accessed. With 1GB pages, the entire weight tensor for a transformer layer can fit in a handful of TLB entries.
-
 - **HPC with dense matrices** — Scientific codes doing dense linear algebra (DGEMM, FFTs) on large matrices see measurable speedups from 1GB pages when matrix dimensions push working sets into the hundreds of gigabytes.
-
 - **DPDK and high-speed packet processing** — DPDK has long recommended 1GB pages for its memory pools. A single TLB entry covers the entire packet buffer pool, and the zero TLB miss rate on packet descriptor lookups is measurable in throughput.
 
 **Rule of thumb:** consider 1GB pages when:

--- a/docs/mm/ksm.md
+++ b/docs/mm/ksm.md
@@ -47,6 +47,7 @@ With KSM: Shared pages reduce to ~8GB (varies by workload)
 ### Beyond VMs
 
 KSM also helps:
+
 - Containers with shared base images
 - Multiple instances of the same application
 - Fork-heavy workloads
@@ -76,10 +77,12 @@ ksmd loop:
 KSM uses two red-black trees:
 
 **Stable tree**: Contains merged (shared) pages
+
 - Pages already deduplicated
 - Searched first for matches
 
 **Unstable tree**: Contains candidate pages
+
 - Pages seen once, waiting for a match
 - Rebuilt each scan cycle
 
@@ -287,6 +290,7 @@ ksmd consuming too much CPU.
 **Symptoms**: High CPU in `ksmd` process
 
 **Solutions**:
+
 - Reduce `pages_to_scan`
 - Increase `sleep_millisecs`
 - Disable if savings are minimal
@@ -298,6 +302,7 @@ Few pages being merged.
 **Debug**: Check `pages_shared` vs `pages_unshared`
 
 **Causes**:
+
 - Workloads with unique data
 - Scan rate too slow
 - Memory not marked `MADV_MERGEABLE`

--- a/docs/mm/life-of-malloc.md
+++ b/docs/mm/life-of-malloc.md
@@ -533,6 +533,7 @@ Fixed in glibc 2.39. The vulnerability was introduced in glibc 2.37 by commit `5
 #### Mitigations
 
 Modern glibc includes:
+
 - **Safe-linking**: Pointer mangling in fastbins/tcache
 - **Chunk size validation**: Detect corrupted size fields
 - **Top chunk integrity checks**: Prevent wilderness corruption
@@ -561,6 +562,7 @@ void vulnerable() {
 #### Real-world implications
 
 Local privilege escalation on many Linux distributions. The vulnerability affected:
+
 - Linux (CVE-2017-1000364)
 - FreeBSD, OpenBSD, NetBSD, Solaris
 - Programs using large stack allocations
@@ -598,6 +600,7 @@ From [Red Hat's advisory](https://access.redhat.com/articles/17995):
 #### The fix
 
 Multiple commits fixed the SELinux policy and strengthened `mmap_min_addr` enforcement:
+
 - [9c0d9010](https://git.kernel.org/linus/9c0d9010)
 - [8cf948e7](https://git.kernel.org/linus/8cf948e7)
 
@@ -654,6 +657,7 @@ ASLR (Address Space Layout Randomization) randomizes mmap but historically left 
 If `brk()` always returns the same address, heap exploitation becomes easier - attackers know where heap data lives.
 
 Early ASLR implementations randomized:
+
 - Stack location ✓
 - mmap base ✓
 - brk/heap location - **partially or not at all**

--- a/docs/mm/life-of-page.md
+++ b/docs/mm/life-of-page.md
@@ -137,6 +137,7 @@ flowchart LR
 ```
 
 The [`_mapcount`](https://lwn.net/Articles/974223/) tracks page table mappings specifically (see [`include/linux/mm.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/mm.h)):
+
 - `-1`: Not mapped in any page table
 - `0`: Mapped in exactly one page table
 - `N`: Mapped in N+1 page tables (shared)
@@ -361,6 +362,7 @@ flowchart LR
 ```
 
 The page stays in swap cache until:
+
 - All processes have private copies (after COW)
 - Or the swap slot is needed
 
@@ -523,6 +525,7 @@ The `struct page` has grown and changed significantly over the years:
 **Author**: Matthew Wilcox (Oracle)
 
 Throughout the lifecycle above, you see `folio` instead of `page` in modern code:
+
 - **Stage 1**: `vma_alloc_zeroed_movable_folio()` allocates a folio
 - **Stage 4**: `shrink_folio_list()` processes folios during reclaim
 - **Why it matters**: A folio explicitly represents one or more contiguous pages as a unit, eliminating ambiguity about whether a function receives a head page, tail page, or single page
@@ -625,6 +628,7 @@ Pages must be properly added to and removed from LRU lists. Bugs in this code ca
 #### The bug class
 
 Common patterns:
+
 - Adding a page to LRU twice
 - Removing a page not on LRU
 - Racing between LRU add/remove and page free
@@ -636,6 +640,7 @@ From a [Red Hat bug report](https://access.redhat.com/solutions/5773601):
 #### Why it's hard
 
 LRU operations happen from multiple contexts:
+
 - Page allocation (add to LRU)
 - Page reclaim (remove from LRU)
 - Page migration (move between LRUs)
@@ -665,12 +670,14 @@ When reclaiming a page, the kernel must:
 3. Only then free the page
 
 If rmap is corrupted or incomplete:
+
 - PTEs point to freed pages → **use-after-free**
 - Pages can't be reclaimed → **memory leak**
 
 #### Historical example
 
 Early rmap implementations had scalability issues. A page mapped by 1000 processes required walking 1000 entries. This led to:
+
 - Long reclaim latencies
 - Lock contention
 - Livelock under pressure
@@ -696,6 +703,7 @@ From a kernel fix for `mm/hwpoison`:
 > *"After trying to drain pages from pagevec/pageset, the reference count of the page was not reduced if the page was still not on the LRU list."*
 
 Hwpoison must handle pages in various states:
+
 - On LRU, can be isolated normally
 - In pagevec (batched, not yet on LRU)
 - Being migrated
@@ -714,6 +722,7 @@ The fix adds `put_page()` to drop the page reference from `__get_any_page()` whe
 #### Why this matters
 
 Hardware errors are rare but when they occur:
+
 - Page must be isolated immediately
 - Processes mapping the page need `SIGBUS`
 - Page must never be reallocated

--- a/docs/mm/life-of-read.md
+++ b/docs/mm/life-of-read.md
@@ -459,11 +459,13 @@ read(fd, aligned_buffer, size);
 ```
 
 **When to use direct I/O**:
+
 - Database engines (they have their own caching)
 - Very large sequential reads (cache would be wasteful)
 - When you need predictable I/O timing
 
 **Requirements**:
+
 - Buffer must be aligned (typically 512 bytes or 4KB)
 - Offset and size often must be aligned too
 
@@ -635,6 +637,7 @@ If Thread B truncates the file while Thread A is faulting in a page, Thread A mi
 #### Real-world implications
 
 Applications using mmap'd files (databases, VMs, etc.) could see:
+
 - Stale data after truncation
 - Blank pages
 - Crashes on invalid access
@@ -693,6 +696,7 @@ For tmpfs/shmem, there's no backing store to recover from - the data is simply l
 #### Real-world implications
 
 Hardware errors in RAM used for page cache could cause:
+
 - Database corruption
 - Lost user data
 - Inconsistent filesystem state
@@ -700,6 +704,7 @@ Hardware errors in RAM used for page cache could cause:
 #### Mitigation
 
 The patches ensure:
+
 - Poisoned pages are immediately evicted from cache
 - Subsequent reads go to disk (if file-backed)
 - Errors are properly propagated to userspace
@@ -766,6 +771,7 @@ pread(fd_dio, buf, 4, 0);  // Might see old data!
 #### Real-world implications
 
 Databases often use:
+
 - Direct I/O for data files (predictable latency)
 - Buffered I/O for logs (better small-write performance)
 

--- a/docs/mm/memblock.md
+++ b/docs/mm/memblock.md
@@ -210,7 +210,6 @@ The kernel's early DT scanning code (`early_init_dt_scan_memory()` in [`drivers/
 On ACPI systems, the firmware provides memory maps through different mechanisms:
 
 - **x86**: The BIOS/UEFI provides an **e820 memory map** -- a table of address ranges with types (usable, reserved, ACPI reclaimable, etc.). The function `e820__memblock_setup()` in [`arch/x86/kernel/e820.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/e820.c) translates e820 entries into `memblock_add()` and `memblock_reserve()` calls.
-
 - **ARM64 with ACPI**: Uses EFI memory map entries, processed by `efi_init()`.
 
 ### The Pattern

--- a/docs/mm/memcg-oom.md
+++ b/docs/mm/memcg-oom.md
@@ -195,6 +195,7 @@ A complete cgroup OOM log has these sections:
 ```
 
 Key differences from a global OOM log:
+
 - Section 3 shows `Memory cgroup stats for <path>:` with named byte counters, not the zone-based `Mem-Info:` dump
 - Section 4 lists only processes in the cgroup
 - Section 5 shows `constraint=CONSTRAINT_MEMCG` and `Memory cgroup out of memory:`

--- a/docs/mm/memcg.md
+++ b/docs/mm/memcg.md
@@ -165,6 +165,7 @@ echo 100M > /sys/fs/cgroup/mygroup/memory.reclaim
 ```
 
 Useful for:
+
 - Pre-warming before load spike
 - Reducing memory before migration
 - Testing reclaim behavior
@@ -335,6 +336,7 @@ Container hit its `memory.max` limit.
 **Debug**: Check `memory.events` for `oom` count.
 
 **Solutions**:
+
 - Increase limit
 - Optimize application memory usage
 - Add swap and `memory.swap.max`
@@ -346,6 +348,7 @@ Memory being reclaimed during startup.
 **Debug**: Check `memory.pressure`
 
 **Solutions**:
+
 - Increase `memory.high`
 - Pre-warm with `memory.reclaim`
 - Check if limit is too low

--- a/docs/mm/memory-hotplug.md
+++ b/docs/mm/memory-hotplug.md
@@ -496,6 +496,7 @@ cat /sys/devices/system/memory/memoryN/valid_zones
 ```
 
 **Remedies**:
+
 - If possible, online the block as `ZONE_MOVABLE` instead (requires re-onlining)
 - Set `auto_online_blocks=online_movable` before the next hotplug event
 - Try the offline repeatedly — memory compaction runs between attempts and may free the range

--- a/docs/mm/numa.md
+++ b/docs/mm/numa.md
@@ -171,11 +171,13 @@ cat /proc/sys/kernel/numa_balancing_scan_period_max_ms  # Max time between scans
 ### Trade-offs
 
 **Benefits**:
+
 - No application changes needed
 - Adapts to changing access patterns
 - Helps poorly-placed workloads
 
 **Costs**:
+
 - CPU overhead from fault handling
 - Migration overhead
 - Can fight with explicit policies
@@ -273,6 +275,7 @@ Allocations forced to remote nodes due to local exhaustion.
 **Symptoms**: High `numa_miss` in `/proc/vmstat`
 
 **Solutions**:
+
 - Balance workload memory across nodes
 - Use `MPOL_INTERLEAVE` for large allocations
 - Reserve memory on each node
@@ -284,6 +287,7 @@ Excessive migration and fault handling.
 **Symptoms**: High CPU in `task_numa_fault`, many page migrations
 
 **Solutions**:
+
 - Disable if workload has stable access patterns: `echo 0 > /proc/sys/kernel/numa_balancing`
 - Tune scan rates
 - Use explicit memory policies
@@ -295,6 +299,7 @@ One node exhausted while others have free memory.
 **Debug**: Check `/sys/devices/system/node/node*/meminfo`
 
 **Solutions**:
+
 - Use `MPOL_INTERLEAVE` for large allocations
 - Improve workload distribution
 

--- a/docs/mm/oom.md
+++ b/docs/mm/oom.md
@@ -409,6 +409,7 @@ dmesg | grep -i "out of memory"
 ```
 
 The log shows:
+
 - Which process was killed
 - Memory usage breakdown (vm, rss, file, shmem)
 - User ID
@@ -908,6 +909,7 @@ The patch tracked process history in a tree structure:
 > *"The fork bomb killer will perform a depth-first traversal of the process history tree... At the end, the process with the highest score is examined; if there are at least ten processes in the history below the high scorer, it is deemed to be a fork bomb."*
 
 When detected:
+
 - All tasks in the fork bomb are killed
 - New `fork()` in that session returns `-ENOMEM` for 30 seconds
 

--- a/docs/mm/overcommit.md
+++ b/docs/mm/overcommit.md
@@ -40,6 +40,7 @@ if (pid == 0) {
 Without overcommit, `fork()` would need 8GB total (4GB parent + 4GB child) even though the child immediately calls `exec()` and discards its copy.
 
 With copy-on-write and overcommit:
+
 - Child shares parent's pages (no copy yet)
 - `exec()` replaces address space before any copy happens
 - Actual memory needed: ~4GB (not 8GB)
@@ -248,6 +249,7 @@ The inevitable consequence of optimistic allocation: sometimes the bet fails. Ri
 > *"Thanks go out to Claus Fischer for some serious inspiration and for goading me into coding this file."*
 
 The OOM killer was controversial from day one. But the alternatives are worse:
+
 - **(a)** Return `ENOMEM` and have programs crash anyway
 - **(b)** Never overcommit and waste enormous amounts of memory
 - **(c)** Kill something and let the system recover
@@ -274,6 +276,7 @@ echo -1000 > /proc/<pid>/oom_score_adj
 ```
 
 **For containers:**
+
 - Use memory cgroups to limit and isolate
 - Let container runtime handle OOM
 

--- a/docs/mm/overview.md
+++ b/docs/mm/overview.md
@@ -59,6 +59,7 @@ How Linux memory allocators relate to each other:
 ```
 
 **Key insight**: All allocators ultimately get pages from the buddy allocator. The difference is how they present memory to callers:
+
 - **kmalloc/SLUB**: Physically contiguous, fast, small allocations
 - **vmalloc**: Virtually contiguous, can satisfy large requests from fragmented memory
 
@@ -116,6 +117,7 @@ When they free those 2 pages, you merge them back with their "buddy":
 ### The Problem
 
 The page allocator works in page-sized chunks (`4KB`). But kernel objects are often tiny:
+
 - An inode? ~600 bytes
 - A dentry? ~200 bytes
 - A socket buffer? ~200 bytes
@@ -143,6 +145,7 @@ Each object type gets its own cache. Allocating is fast (grab from cache), freei
 *Note: SLAB predates good LKML archives. The Bonwick paper is the canonical design reference.*
 
 **SLUB (v2.6.22, 2007)**: Simpler redesign by Christoph Lameter.
+
 - **Commit**: [81819f0fc828](https://git.kernel.org/linus/81819f0fc828)
 - Removed complex queuing
 - Lower memory overhead
@@ -193,6 +196,7 @@ Page tables must be set up. TLB (translation cache) entries are consumed. It's s
 **The problem**: vunmap needed to flush TLB entries. On multi-core systems, this meant an IPI (interrupt) to *every* CPU. Under a global lock. As core counts grew from 4 to 64+, this became quadratic slowdown.
 
 **The fix**: Nick Piggin rewrote vmalloc from scratch:
+
 - **Commit**: [db64fe02258f](https://git.kernel.org/linus/db64fe02258f)
 - Lazy TLB flushing: Don't flush immediately, batch multiple unmaps
 - RBTree for address lookup: `O(log n)` instead of `O(n)` list scan
@@ -205,6 +209,7 @@ Page tables must be set up. TLB (translation cache) entries are consumed. It's s
 **The problem**: With huge vmalloc buffers (BPF programs, modules), each `4KB` page needed a TLB entry. TLB is limited. Lots of TLB misses.
 
 **The fix**: Use huge pages (`2MB`) when possible:
+
 - **Commit**: [121e6f3258fe](https://git.kernel.org/linus/121e6f3258fe) | [LKML](https://lore.kernel.org/linux-mm/1616036421.amjz2efujj.astroid@bobo.none/)
 - Fewer TLB entries needed
 - Trade-off: More internal fragmentation
@@ -214,6 +219,7 @@ Page tables must be set up. TLB (translation cache) entries are consumed. It's s
 **The problem**: You have a vmalloc buffer and want to resize it. Previously, you'd have to allocate new, copy, free old.
 
 **The fix**: `vrealloc()` - resize in place when possible:
+
 - **Commit**: [3ddc2fefe6f3](https://git.kernel.org/linus/3ddc2fefe6f3)
 - Motivated by Rust's allocator needs (`Vec` resizing)
 - See [vrealloc](vrealloc.md) for the full story and bugs found

--- a/docs/mm/page-allocator.md
+++ b/docs/mm/page-allocator.md
@@ -290,6 +290,7 @@ cat /proc/pagetypeinfo
 Large contiguous allocations (order > 3) can fail due to fragmentation even with free memory.
 
 **Solutions**:
+
 - Use `__GFP_RETRY_MAYFAIL` to try harder
 - Use vmalloc instead (virtual contiguity)
 - Enable compaction (`/proc/sys/vm/compact_memory`)

--- a/docs/mm/page-cache.md
+++ b/docs/mm/page-cache.md
@@ -311,11 +311,13 @@ int fd = open("file", O_RDWR | O_DIRECT);
 ```
 
 **Use cases**:
+
 - Databases with their own caching
 - Avoiding double-caching
 - Predictable latency
 
 **Trade-offs**:
+
 - No readahead benefits
 - No write buffering
 - Application must handle caching
@@ -329,6 +331,7 @@ Working set larger than available RAM.
 **Symptoms**: High `pgpgin`/`pgpgout`, slow I/O
 
 **Solutions**:
+
 - Add RAM
 - Reduce working set
 - Use O_DIRECT for some workloads
@@ -340,6 +343,7 @@ Too many dirty pages causing write stalls.
 **Symptoms**: Processes blocked in `balance_dirty_pages`
 
 **Solutions**:
+
 - Lower `dirty_ratio`
 - Faster storage
 - Reduce write rate
@@ -349,6 +353,7 @@ Too many dirty pages causing write stalls.
 Sequential readahead hurts random workloads.
 
 **Solutions**:
+
 - Use `posix_fadvise(POSIX_FADV_RANDOM)`
 - Reduce `read_ahead_kb`
 - Use `madvise(MADV_RANDOM)` for mmap

--- a/docs/mm/page-tables.md
+++ b/docs/mm/page-tables.md
@@ -192,11 +192,13 @@ if (pmd_large(*pmd)) {
 ```
 
 Benefits:
+
 - Fewer TLB entries needed
 - Reduced page table memory
 - Fewer page faults
 
 Trade-offs:
+
 - Internal fragmentation
 - Allocation challenges
 
@@ -275,6 +277,7 @@ Sparse address spaces waste page table memory.
 Can't allocate huge pages due to fragmentation.
 
 **Solutions**:
+
 - Reserve at boot: `hugepages=N`
 - Enable THP: `/sys/kernel/mm/transparent_hugepage/enabled`
 - Compact memory: `echo 1 > /proc/sys/vm/compact_memory`

--- a/docs/mm/page-walk.md
+++ b/docs/mm/page-walk.md
@@ -5,6 +5,7 @@
 ## Why walk page tables?
 
 The kernel needs to inspect or modify page table entries programmatically in many contexts:
+
 - **KVM**: scan guest memory to find dirty pages
 - **Migration**: find all PTEs mapping a page before moving it
 - **Debugging**: `ptdump` dumps page tables to `/sys/kernel/debug/kernel_page_tables`

--- a/docs/mm/proc-meminfo.md
+++ b/docs/mm/proc-meminfo.md
@@ -237,6 +237,7 @@ MemTotal ≈ MemFree
 ```
 
 The gap comes from:
+
 - Kernel allocations not individually tracked in meminfo (percpu memory, vmalloc backing pages, kernel page tables)
 - Race conditions — `meminfo_proc_show()` reads counters without a single lock
 - CMA pages in MemFree that are restricted-use
@@ -249,6 +250,7 @@ The gap comes from:
 Watch **MemAvailable**. If it approaches zero, the system is under memory pressure. Do not watch MemFree — it is normally near zero on a healthy system.
 
 Secondary signals:
+
 - SwapFree dropping (swap being consumed)
 - Active(anon) growing
 - `/proc/pressure/memory` showing elevated `some` or `full` (v4.20+)
@@ -263,10 +265,12 @@ Compare `Active(file) + Inactive(file)` with disk I/O rates (from `iostat`):
 ### How to spot a memory leak
 
 **Userspace leak**:
+
 - `AnonPages` and `Committed_AS` growing over time
 - Per-process: watch `/proc/<pid>/status` VmRSS or `/proc/<pid>/smaps_rollup`
 
 **Kernel leak**:
+
 - `SUnreclaim` growing = slab leak (check `slabtop`)
 - `VmallocUsed` growing = vmalloc leak (note: this field was zeroed in v4.4 ([commit a5ad88ce8c7f](https://git.kernel.org/linus/a5ad88ce8c7f)) and restored in v5.3 ([commit 97105f0ab7b8](https://git.kernel.org/linus/97105f0ab7b8)); on kernels 4.4-5.2, check `/proc/vmallocinfo` instead)
 - `KernelStack` growing with stable process count = thread leak

--- a/docs/mm/reading-oom-log.md
+++ b/docs/mm/reading-oom-log.md
@@ -147,6 +147,7 @@ score = RSS + swap entries + page table pages
 | Adjustment | `oom_score_adj * totalpages / 1000` |
 
 Special cases:
+
 - `oom_score_adj = -1000`: process is immune (never selected)
 - `oom_score_adj = 1000`: adds `totalpages` to score (guaranteed victim)
 - Kernel threads and init (PID 1) are never killed

--- a/docs/mm/reclaim.md
+++ b/docs/mm/reclaim.md
@@ -137,6 +137,7 @@ The kernel tracks page usage with LRU (Least Recently Used) lists. Pages move be
 ```
 
 Four lists per node (two types x two states):
+
 - `LRU_INACTIVE_ANON` - Inactive anonymous pages
 - `LRU_ACTIVE_ANON` - Active anonymous pages
 - `LRU_INACTIVE_FILE` - Inactive file-backed pages
@@ -154,6 +155,7 @@ Generation 0 (oldest) ──> Generation 1 ──> ... ──> Generation N (you
 ```
 
 **Benefits**:
+
 - Better detection of hot vs cold pages
 - Reduced CPU overhead from page table scanning
 - Improved performance under memory pressure
@@ -355,6 +357,7 @@ Processes blocked in direct reclaim, causing latency spikes.
 **Debug**: Check `allocstall_*` in `/proc/vmstat`
 
 **Solutions**:
+
 - Increase `vm.min_free_kbytes`
 - Add swap if missing
 - Reduce memory pressure
@@ -366,6 +369,7 @@ kswapd consuming excessive CPU.
 **Debug**: `top` or `perf top`
 
 **Causes**:
+
 - Too little free memory
 - Workload constantly dirtying pages
 - Swap thrashing

--- a/docs/mm/slab-internals.md
+++ b/docs/mm/slab-internals.md
@@ -5,6 +5,7 @@
 ## Why a slab allocator?
 
 `kmalloc` could just call the page allocator for every allocation, but that's wasteful:
+
 - Page allocator minimum granularity: 4096 bytes
 - Typical kernel allocation: 32–512 bytes
 - Objects of the same type are created and freed repeatedly

--- a/docs/mm/swap.md
+++ b/docs/mm/swap.md
@@ -388,6 +388,7 @@ Constant swapping makes system unusable.
 **Symptoms**: High `si`/`so` in vmstat, system unresponsive
 
 **Solutions**:
+
 - Add RAM
 - Reduce workload
 - Lower swappiness
@@ -400,6 +401,7 @@ No swap space available.
 **Symptoms**: OOM kills despite "free" memory
 
 **Solutions**:
+
 - Add more swap
 - Enable zswap/zram
 - Investigate memory usage
@@ -409,6 +411,7 @@ No swap space available.
 Excessive swap writes wearing SSD.
 
 **Solutions**:
+
 - Use zswap (reduces writes 2-5x)
 - Reduce swappiness
 - Add RAM

--- a/docs/mm/swapping.md
+++ b/docs/mm/swapping.md
@@ -324,6 +324,7 @@ flowchart LR
 ```
 
 After I/O completes successfully:
+
 - Page is removed from swap cache
 - Physical page is freed
 - Only the swap slot remains with the data
@@ -600,11 +601,13 @@ flowchart LR
 ```
 
 **Signs of thrashing**:
+
 - High swap I/O (`vmstat` si/so columns)
 - High CPU time in kernel (`top` shows high sy/wa)
 - Application responsiveness drops drastically
 
 **Solutions**:
+
 - Add more RAM
 - Reduce memory usage
 - Use zswap or zram for compression
@@ -863,6 +866,7 @@ If `do_swap_page()` retrieves the page from swap cache, it returns stale data - 
 #### Mitigations
 
 Zswap has undergone multiple locking improvements to address these races. The interactions between:
+
 - Zswap entry lifecycle
 - Swap cache operations
 - Page writeback
@@ -906,6 +910,7 @@ Swap files introduce additional complexity compared to swap partitions because t
 #### The bug
 
 With swap files, `swap_writepage()` must go through the filesystem. This can race with:
+
 - Filesystem operations on the same device
 - Filesystem metadata updates
 - Journal commits

--- a/docs/mm/thp.md
+++ b/docs/mm/thp.md
@@ -166,6 +166,7 @@ cat /sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none
 ### Databases
 
 Databases often benefit from THP but can suffer from:
+
 - Latency spikes during compaction
 - Memory bloat (2MB granularity)
 
@@ -276,6 +277,7 @@ THP defragmentation can cause allocation stalls.
 **Symptoms**: Random latency spikes in latency-sensitive applications
 
 **Solutions**:
+
 - Use `defrag=defer` or `defrag=madvise`
 - Set `enabled=madvise` and control per-region
 - Disable THP for latency-critical apps
@@ -289,6 +291,7 @@ Small allocations rounded up to 2MB.
 **Debug**: Compare `AnonHugePages` vs `Anonymous` in `/proc/meminfo`
 
 **Solutions**:
+
 - Use `madvise` mode
 - Tune application allocation patterns
 
@@ -299,6 +302,7 @@ khugepaged consuming too much CPU.
 **Debug**: `top` or `perf top`
 
 **Solutions**:
+
 - Increase `scan_sleep_millisecs`
 - Reduce `pages_to_scan`
 
@@ -333,6 +337,7 @@ The khugepaged daemon scans memory looking for 512 contiguous 4KB pages to colla
 #### The bug class
 
 Multiple bugs have been found in khugepaged collapse:
+
 - Race with concurrent page faults
 - Race with munmap
 - Race with madvise(MADV_DONTNEED)

--- a/docs/mm/tuning-containers.md
+++ b/docs/mm/tuning-containers.md
@@ -62,7 +62,6 @@ Why have both? Because `memory.high` creates back-pressure. Instead of running a
 These knobs work in the opposite direction. Instead of limiting how much memory a cgroup can use, they guarantee how much it gets to keep during system-wide memory pressure.
 
 - **`memory.low`**: Best-effort protection. Memory below this threshold won't be reclaimed unless there is no other reclaimable memory anywhere in the system. Think of it as "please don't take this memory unless you absolutely have to."
-
 - **`memory.min`**: Hard protection. Memory below this threshold is never reclaimed, period. Even under extreme pressure, the kernel will OOM-kill other things rather than reclaim this cgroup's protected memory.
 
 ```bash

--- a/docs/mm/userfaultfd.md
+++ b/docs/mm/userfaultfd.md
@@ -7,6 +7,7 @@
 Normally, page faults are handled by the kernel: a missing page triggers an anonymous allocation, swap-in, or file read. But some applications need to **intercept** page faults — to provide pages from their own storage or to implement copy-on-write in userspace.
 
 Use cases:
+
 - **QEMU live migration**: receive guest RAM pages on-the-fly as the guest accesses them
 - **CRIU** (Checkpoint/Restore In Userspace): restore process memory lazily
 - **Hypervisors**: implement demand-paging for guest memory from userspace

--- a/docs/mm/vdso.md
+++ b/docs/mm/vdso.md
@@ -5,6 +5,7 @@
 ## The problem
 
 Every system call requires a mode switch: user → kernel → user. For `gettimeofday()`, this means:
+
 - Save registers, change privilege level (CPL 0)
 - Look up time in the kernel
 - Restore registers, return to userspace
@@ -43,6 +44,7 @@ __vdso_getcpu()           /* getcpu() — current CPU/NUMA node   — fast */
 ## The vdso_data shared page
 
 The kernel maintains a **vvar** (vDSO variable) page that is:
+
 - Mapped read-only into every process
 - Written by the kernel (holding current time)
 - Read by the vDSO functions (no syscall)

--- a/docs/mm/virtual-physical-resident.md
+++ b/docs/mm/virtual-physical-resident.md
@@ -15,6 +15,7 @@ The answer lies in understanding three different ways of measuring memory.
 **What it is:** The total address space a process has mapped.
 
 **What it includes:**
+
 - Code (text segment)
 - Data (heap, stack, globals)
 - Shared libraries
@@ -39,6 +40,7 @@ In this example, `bash` has 500MB of virtual address space but only ~12MB reside
 **What it is:** Actual RAM chips in your system.
 
 **What uses it:**
+
 - Kernel code and data structures
 - Process pages that are resident (`RSS`)
 - Page cache (file data cached in memory, including block buffers)
@@ -59,10 +61,12 @@ Here, 10GB is "used" by cache but available if needed.
 **What it is:** The portion of virtual memory currently in physical RAM.
 
 **What it includes:**
+
 - Private pages actually in RAM
 - Shared pages (libraries, shared memory)
 
 **What it excludes:**
+
 - Swapped out pages
 - Pages never touched (demand paging)
 - Memory-mapped files not currently loaded
@@ -219,6 +223,7 @@ Memory metrics evolved as systems became more complex and the question "how much
 ### Early Unix: Simple Metrics
 
 In early Unix systems, memory accounting was straightforward:
+
 - **Virtual size**: How much address space is mapped
 - **Resident size**: How much is in physical RAM
 
@@ -271,6 +276,7 @@ RssShmem:     3456 kB
 ### Modern Challenges
 
 Today's complexity continues to grow:
+
 - **`cgroups`**: Memory limits across process groups
 - **`KSM`**: Identical pages merged across processes
 - **Transparent Huge Pages**: 2MB/1GB pages complicate accounting

--- a/docs/mm/vmalloc.md
+++ b/docs/mm/vmalloc.md
@@ -55,6 +55,7 @@ The Hellwig rework is [documented on LWN](https://lwn.net/Articles/7473/).
 **What changed**: vmalloc can now use `PMD`-sized huge pages for large allocations.
 
 **How it works**:
+
 - If allocation >= `PMD` size, try huge pages first
 - Fall back to small pages if huge allocation fails
 - `VM_NOHUGE` flag to force small pages (needed for module allocations with strict rwx)
@@ -73,11 +74,13 @@ See [vrealloc](vrealloc.md) for detailed history.
 ## When to Use vmalloc
 
 **Use vmalloc when:**
+
 - Allocation is large (multiple pages)
 - Physical contiguity not required
 - Memory won't be used for DMA
 
 **Don't use vmalloc when:**
+
 - Small allocations (use kmalloc - less overhead)
 - Need physical contiguity (use kmalloc or alloc_pages)
 - DMA operations (need physical addresses)
@@ -193,6 +196,7 @@ Each vmalloc region has a guard page (unmapped) at the end. Buffer overflows hit
 ### Why lazy TLB flushing?
 
 TLB flushes are expensive:
+
 - IPI (Inter-Processor Interrupt) to all CPUs
 - Each CPU must flush its TLB
 - All done under lock
@@ -233,6 +237,7 @@ cat /proc/vmallocinfo
 ```
 
 Key fields:
+
 - **Address range**: Virtual address start-end
 - **Size**: In bytes
 - **Caller**: Function that allocated (useful for debugging leaks)

--- a/docs/mm/vrealloc.md
+++ b/docs/mm/vrealloc.md
@@ -48,6 +48,7 @@ The existing `kvrealloc()` had inconsistent behavior compared to `krealloc()`:
 **Author**: Kees Cook
 
 Introduced `vm_struct::requested_size` to track actual requested size separately from allocated area. This enabled:
+
 - Correct KASAN poisoning boundaries
 - Growing within existing allocation
 - Foundation for shrink optimization
@@ -81,6 +82,7 @@ Introduced `vm_struct::requested_size` to track actual requested size separately
 **Problem identified**: `vrealloc()` shrinking only updated metadata but kept all pages mapped. Shrinking `256KB` to `16KB` still consumed `256KB` of physical memory.
 
 **The fix**:
+
 - Unmap pages beyond new size via `vunmap_range()`
 - Free pages via `__free_page()`
 - Update memcg accounting
@@ -93,6 +95,7 @@ Introduced `vm_struct::requested_size` to track actual requested size separately
 ### Shrinking
 
 When shrinking (size < current):
+
 - Preserves data up to new size
 - Frees unused pages (since e64f42036ef4)
 - Returns same pointer (no copy)
@@ -100,6 +103,7 @@ When shrinking (size < current):
 ### Growing
 
 When growing (size > current):
+
 - May reuse existing allocation if space allows (since a0309faf1cb0)
 - Otherwise: allocate new, copy, free old
 - Returns potentially new pointer
@@ -117,6 +121,7 @@ The first page is used for memcg accounting via `mod_memcg_page_state()`. The me
 ### Why no minimum threshold for shrink
 
 Early iterations considered requiring >= 4 pages to free before actually freeing. This was removed:
+
 - Callers should control behavior, not arbitrary kernel policy
 - Any freed memory has value
 - Magic thresholds are hard to justify in review

--- a/docs/mm/war-stories-regressions.md
+++ b/docs/mm/war-stories-regressions.md
@@ -320,10 +320,12 @@ sysctl vm.page_cluster=5  # prefetch 32 pages
 ```
 
 Setting `vm.page_cluster=0` disables swap readahead entirely, reading exactly the page that faulted. This is appropriate for:
+
 - Systems with NVMe swap where random I/O latency is low
 - Workloads with random swap access patterns (many small independent processes)
 
 Higher values (3-5) are appropriate for:
+
 - Rotational disk swap where sequential I/O is much faster than random I/O
 - Single large processes being restored from swap
 

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -5,6 +5,7 @@
 ## What kernel modules are
 
 A kernel module is an ELF shared object loaded into the kernel at runtime. Modules:
+
 - Share the kernel's address space and run at ring 0 (full privilege)
 - Can export and use symbols from other modules or the core kernel
 - Are loaded by `insmod`/`modprobe` and removed by `rmmod`

--- a/docs/modules/module-params.md
+++ b/docs/modules/module-params.md
@@ -25,6 +25,7 @@ MODULE_PARM_DESC(enable_feature, "Enable experimental feature");
 ```
 
 The third argument is the `sysfs` permission:
+
 - `0644` — owner read-write, group/other read-only → visible and changeable
 - `0444` — read-only for everyone
 - `0` — not exposed in sysfs (load-time only)
@@ -211,6 +212,7 @@ Addresses are hidden from unprivileged readers. `/proc/kallsyms` calls
 than the real addresses shown above — hence the `sudo`.
 
 Symbol types:
+
 - `T`/`t` — code (.text) — uppercase=global, lowercase=local
 - `D`/`d` — data (.data)
 - `R`/`r` — read-only data (.rodata)

--- a/docs/modules/module-signing.md
+++ b/docs/modules/module-signing.md
@@ -5,6 +5,7 @@
 ## Why module signing?
 
 Without module signing, anyone with root access can insert arbitrary kernel code via `insmod`. Module signing prevents loading unauthorized modules in security-sensitive environments:
+
 - **Secure Boot**: UEFI firmware verifies the boot chain; modules must also be verified
 - **Locked-down kernel**: `lockdown=integrity` mode prevents unsigned modules
 - **Compliance**: PCI-DSS, FIPS 140-3 requirements

--- a/docs/net/af-xdp.md
+++ b/docs/net/af-xdp.md
@@ -95,6 +95,7 @@ bind(xsk_fd, (struct sockaddr *)&sxdp, sizeof(sxdp));
 ## Zero-copy mode
 
 In **zero-copy** mode (`XDP_ZEROCOPY`), the NIC DMA-writes packets directly into the UMEM frames. No data copying occurs between NIC, kernel, and userspace. Requires:
+
 - Driver support (i40e, mlx5, ixgbe, etc.)
 - UMEM frames pinned in memory
 

--- a/docs/net/connect.md
+++ b/docs/net/connect.md
@@ -110,6 +110,7 @@ int tcp_connect(struct sock *sk)
 ```
 
 SYN options set in the SYN packet:
+
 - **MSS** (Maximum Segment Size): tells the server the max segment we'll accept
 - **WSCALE**: window scaling factor for large windows
 - **SACK_PERM**: we support Selective ACK

--- a/docs/net/epoll.md
+++ b/docs/net/epoll.md
@@ -5,6 +5,7 @@
 ## The problem with poll/select
 
 `select()` and `poll()` require passing the entire set of monitored file descriptors on every call. For N fds:
+
 - Userspace → kernel copy: O(N)
 - Kernel scans all fds for readiness: O(N)
 - Kernel → userspace copy of ready fds: O(N)

--- a/docs/net/ip-routing.md
+++ b/docs/net/ip-routing.md
@@ -143,6 +143,7 @@ ip rule show
 ```
 
 Rules can match on:
+
 - Source address (`from`)
 - Destination address (`to`)
 - Incoming interface (`iif`)

--- a/docs/net/ktls.md
+++ b/docs/net/ktls.md
@@ -11,6 +11,7 @@ Application → plaintext → OpenSSL encrypt → ciphertext → write() syscall
 ```
 
 This means:
+
 - Every TLS record copy: user buffer → kernel socket buffer
 - `sendfile()` doesn't work: data must pass through userspace for encryption
 - TLS offload to NIC requires kernel involvement anyway
@@ -22,6 +23,7 @@ Application → plaintext → write()/sendfile() → kernel TLS encrypt → NIC
 ```
 
 Benefits:
+
 - `sendfile()` works for TLS: zero-copy file → TLS → NIC
 - NIC TLS offload: kernel can push crypto to hardware
 - Lower CPU usage for TLS-heavy workloads (nginx, envoy)

--- a/docs/net/life-of-packet-tx.md
+++ b/docs/net/life-of-packet-tx.md
@@ -65,6 +65,7 @@ Data is held in `sk->sk_write_queue` until TCP decides to send it.
 ## Phase 2: TCP write: tcp_write_xmit()
 
 TCP decides *when* to send based on:
+
 - Congestion window (`tp->snd_cwnd`)
 - Receive window advertised by peer (`tp->snd_wnd`)
 - Nagle algorithm (delay small packets)
@@ -232,6 +233,7 @@ int dev_queue_xmit(struct sk_buff *skb)
 ```
 
 The qdisc can:
+
 - Drop packets (rate limiting via TBF, policing)
 - Reorder packets (FQ scheduling)
 - Delay packets (netem for testing)

--- a/docs/net/net-namespaces.md
+++ b/docs/net/net-namespaces.md
@@ -5,6 +5,7 @@
 ## What network namespaces provide
 
 Each **network namespace** has its own:
+
 - Network interfaces (lo, eth0, etc.)
 - IP addresses and routing tables
 - iptables/nftables rules

--- a/docs/net/netfilter.md
+++ b/docs/net/netfilter.md
@@ -59,6 +59,7 @@ struct nf_hook_ops {
 ```
 
 Hook verdicts:
+
 - `NF_ACCEPT` — continue processing
 - `NF_DROP` — drop the packet
 - `NF_STOLEN` — hook took ownership (no further processing)
@@ -131,6 +132,7 @@ nft add rule inet myfilter input ip saddr @allowed_ips accept
 ## Connection tracking (conntrack)
 
 **Conntrack** is the stateful packet inspection layer. It tracks every connection through the kernel, enabling:
+
 - Stateful firewall rules (`-m state --state ESTABLISHED,RELATED`)
 - NAT (both DNAT and SNAT need to rewrite both directions)
 - Connection-aware applications (via NFQUEUE or nf_conntrack events)

--- a/docs/net/netlink.md
+++ b/docs/net/netlink.md
@@ -52,6 +52,7 @@ struct nlmsghdr {
 ```
 
 Common flags:
+
 - `NLM_F_REQUEST`: this is a request to the kernel
 - `NLM_F_ACK`: request an acknowledgement
 - `NLM_F_DUMP`: dump all objects of this type

--- a/docs/net/network-stack-overview.md
+++ b/docs/net/network-stack-overview.md
@@ -139,6 +139,7 @@ The best way to understand the stack is to follow a packet:
 - [Life of a Packet (transmit)](life-of-packet-tx.md) — Application to wire
 
 Or start with the key structures:
+
 - [sk_buff](sk-buff.md) — The packet structure used everywhere
 - [Socket Layer Overview](socket-layer.md) — The socket/sock/proto hierarchy
 - [Network Device and NAPI](napi.md) — The receive hardware interface

--- a/docs/net/packet-socket.md
+++ b/docs/net/packet-socket.md
@@ -7,6 +7,7 @@
 `AF_PACKET` sockets give userspace direct access to the network device's frame layer (Layer 2). Applications receive raw Ethernet frames (including headers) before the kernel's network stack processes them.
 
 Used by:
+
 - `tcpdump` and `Wireshark` — packet capture
 - `arping`, `arpwatch` — ARP utilities
 - Network boot agents (DHCP, PXE)

--- a/docs/net/sk-buff.md
+++ b/docs/net/sk-buff.md
@@ -226,6 +226,7 @@ Early sk_buff implementations stored packet data in a single contiguous `kmalloc
 A NIC with scatter-gather can DMA-write a received packet into non-contiguous physical pages — the payload goes into page cache pages, the header goes into a small slab allocation. Copying everything into one contiguous buffer would waste memory and CPU cycles. The kernel needed a representation that could hold both.
 
 The solution was the linear + fragment model:
+
 - The **linear portion** (`head`…`tail`) holds packet headers — small, always contiguous, fast to access.
 - The **paged fragments** (`skb_shinfo(skb)->frags[]`) hold payload — large, may be non-contiguous pages that came directly from DMA.
 

--- a/docs/net/tc-qdisc.md
+++ b/docs/net/tc-qdisc.md
@@ -76,6 +76,7 @@ tc qdisc show dev eth0
 ```
 
 Parameters:
+
 - `target`: acceptable minimum standing queue delay (default 5ms)
 - `interval`: control loop interval for CoDel (default 100ms)
 - `flows`: number of hash buckets for fair queueing (default 1024)
@@ -174,6 +175,7 @@ tc filter add dev eth0 ingress bpf obj tc_ingress.o sec tc direct-action
 ```
 
 TC-BPF verdicts:
+
 - `TC_ACT_OK` (= 0): pass to next stage
 - `TC_ACT_SHOT` (= 2): drop
 - `TC_ACT_REDIRECT` (= 7): redirect to another interface

--- a/docs/net/tcp-congestion.md
+++ b/docs/net/tcp-congestion.md
@@ -14,6 +14,7 @@ cwnd: sender's estimate of network capacity (congestion control)
 ```
 
 The congestion controller runs on the sender and responds to:
+
 - **ACK received**: increase cwnd (network has capacity)
 - **Loss detected**: decrease cwnd (congestion)
 - **ECN (Explicit Congestion Notification)**: decrease cwnd before loss
@@ -147,6 +148,7 @@ CUBIC window function:
 ```
 
 The cubic shape means CUBIC:
+
 - Grows quickly far below Wmax (catching up after loss)
 - Slows near Wmax (probing carefully)
 - Overshoots if Wmax was limited by receiver
@@ -197,6 +199,7 @@ static void bictcp_cong_avoid(struct sock *sk, u32 ack, u32 acked)
 ### HyStart++: safe slow start exit
 
 CUBIC uses HyStart to exit slow start before actual loss:
+
 - **Delay increase**: exit when RTT increases by more than a threshold (ACK train delay)
 - **ACK train end**: exit when ACK spacing shows the pipe is full
 

--- a/docs/sched/cfs.md
+++ b/docs/sched/cfs.md
@@ -25,11 +25,13 @@ The scheduler always picks the task with the **smallest vruntime**. Combined wit
 Three tasks: A (nice -5, weight 3121), B (nice 0, weight 1024), C (nice +5, weight 335).
 
 Total weight = 4480. Ideal CPU shares:
+
 - A: 3121/4480 = 69.7%
 - B: 1024/4480 = 22.9%
 - C:  335/4480 =  7.5%
 
 CFS achieves this by making vruntime advance at different rates:
+
 - A's vruntime grows at `1024/3121` of real time (~0.33x)
 - B's vruntime grows at `1024/1024` of real time (1.0x)
 - C's vruntime grows at `1024/335` of real time (~3.1x)

--- a/docs/sched/context-switch.md
+++ b/docs/sched/context-switch.md
@@ -40,6 +40,7 @@ static void resched_curr(struct rq *rq)
 ```
 
 Common triggers:
+
 - **Timer tick** (`task_tick_fair()`): current task has run too long
 - **Wakeup** (`wakeup_preempt()`): a higher-priority task became runnable
 - **Explicit yield** (`sched_yield()`): task voluntarily gives up the CPU

--- a/docs/sched/cpu-affinity.md
+++ b/docs/sched/cpu-affinity.md
@@ -7,6 +7,7 @@
 CPU affinity lets a task (or an admin) restrict which CPUs a specific task may run on. Unlike cpuset — which applies to an entire cgroup — affinity is **per-task**.
 
 Common uses:
+
 - **Cache locality**: Pin a task to CPUs sharing an L3 cache
 - **Interrupt binding**: Keep a task on the same CPU as the NIC interrupt it processes
 - **Benchmarking**: Eliminate CPU-to-CPU variation by pinning to one core
@@ -103,6 +104,7 @@ taskset -p $PID            # effective: only 4-7 (cpuset intersection)
 ```
 
 The kernel stores both masks separately:
+
 - `user_cpus_ptr`: what the user asked for
 - `cpus_mask`: the intersection with cpuset (what's actually enforced)
 

--- a/docs/sched/cpu-bandwidth.md
+++ b/docs/sched/cpu-bandwidth.md
@@ -7,6 +7,7 @@
 CPU weight (shares) controls the *proportion* of CPU a group gets when the system is busy. Bandwidth control caps the *absolute* amount — a group set to 50% will be throttled to 50% even if the other 99% of CPU is idle.
 
 This matters for:
+
 - **Predictable latency**: Ensure a group never monopolizes the CPU
 - **Multi-tenant isolation**: Prevent one tenant from starving others
 - **Resource accounting**: Know exactly how much CPU a container is using
@@ -212,6 +213,7 @@ echo "200000 100000" > /sys/fs/cgroup/mygroup/cpu.max
 ## Bandwidth slice tuning
 
 The default 5ms slice is a trade-off between:
+
 - **Too small** (< 1ms): High lock contention on `cfs_b->lock`
 - **Too large** (> 10ms): CPU gets 10ms of budget it may never use; throttle response is slow
 

--- a/docs/sched/cpuset.md
+++ b/docs/sched/cpuset.md
@@ -11,6 +11,7 @@
 - **cpuset**: Which CPUs are even eligible — tasks never run on excluded CPUs
 
 This matters for:
+
 - **NUMA locality**: Pin tasks to CPUs close to their memory
 - **Core isolation**: Reserve specific cores for latency-sensitive workloads
 - **Hardware partitioning**: Assign CPUs to dedicated containers
@@ -129,6 +130,7 @@ echo "isolated" > /sys/fs/cgroup/mygroup/cpuset.cpus.partition
 ```
 
 Partition states:
+
 - `member` (default): Normal cpuset, shares parent's scheduling domain
 - `root`: Carves out CPUs into a dedicated scheduling domain
 - `isolated`: Like root, but also disables load balancing within the partition

--- a/docs/sched/deadline.md
+++ b/docs/sched/deadline.md
@@ -147,6 +147,7 @@ static enum hrtimer_restart dl_task_timer(struct hrtimer *timer)
 ```
 
 `replenish_dl_entity()` sets:
+
 - `dl_se->runtime = dl_se->dl_runtime` (full budget restored)
 - `dl_se->deadline += dl_se->dl_period` (absolute deadline advanced)
 

--- a/docs/sched/eevdf.md
+++ b/docs/sched/eevdf.md
@@ -17,6 +17,7 @@ EEVDF is based on the 1995 technical report ["Earliest Eligible Virtual Deadline
 It was implemented for Linux by Peter Zijlstra (Intel) and merged in kernel 6.6 (October 2023). **Patch series**: [lore.kernel.org, May 2023](https://lore.kernel.org/lkml/20230531115839.089944915@infradead.org/)
 
 **Commits**:
+
 - [`147f3efaa241`](https://git.kernel.org/linus/147f3efaa24182a21706bca15eab2f3f4630b5fe) — `sched/fair: Implement an EEVDF-like scheduling algorithm`
 - [`5e963f2bd465`](https://git.kernel.org/linus/5e963f2bd4654a202a8a05aa3a86cb0300b10e6c) — `sched/fair: Commit to EEVDF` (makes EEVDF unconditional in `pick_next_entity`)
 

--- a/docs/sched/load-balancing.md
+++ b/docs/sched/load-balancing.md
@@ -5,6 +5,7 @@
 ## Why load balancing is hard
 
 Load balancing must trade off:
+
 - **Throughput**: spread tasks evenly to use all CPUs
 - **Cache affinity**: a task recently on CPU A has hot cache — migrating it to B is expensive
 - **NUMA locality**: migrating across NUMA nodes is more expensive than across cores

--- a/docs/sched/rt-tuning.md
+++ b/docs/sched/rt-tuning.md
@@ -5,6 +5,7 @@
 ## What "real-time" means on Linux
 
 A real-time system guarantees a **worst-case response time** — not just average latency. Linux with PREEMPT_RT can achieve:
+
 - `cyclictest` worst-case latency: **10-100µs** (vs 1-100ms without RT) — see [PREEMPT_RT latency benchmarks](https://wiki.linuxfoundation.org/realtime/documentation/howto/tools/cyclictest/start)
 - Suitable for: audio processing, industrial control, motor drives, trading systems
 

--- a/docs/sched/sched-domains.md
+++ b/docs/sched/sched-domains.md
@@ -9,6 +9,7 @@ The Linux scheduler doesn't just balance load between individual CPUs — it use
 Each level in the tree is a `sched_domain` spanning a set of CPUs. When load balancing runs, it works domain by domain, from narrowest (SMT) to widest (NUMA), respecting topology boundaries.
 
 This matters because:
+
 - Moving a task between SMT siblings is cheap (shared L1/L2 cache)
 - Moving between NUMA sockets is expensive (remote memory access)
 - The scheduler should balance aggressively at the cheap levels and conservatively at the expensive ones
@@ -124,6 +125,7 @@ static int build_sched_domains(const struct cpumask *cpu_map,
 ```
 
 This is called via `rebuild_sched_domains()`, which is triggered by:
+
 - `sched_domain_sysctl` changes
 - CPU hotplug events
 - cpuset partition root changes

--- a/docs/sched/sched-tick.md
+++ b/docs/sched/sched-tick.md
@@ -5,6 +5,7 @@
 ## The periodic tick
 
 The kernel runs a periodic timer interrupt (the "tick") at a rate of `HZ` times per second. The tick drives:
+
 - Updating `jiffies` (coarse-grained time)
 - Updating process CPU time accounting
 - Checking if the current task should be preempted (`scheduler_tick`)
@@ -231,6 +232,7 @@ static bool can_stop_full_tick(int cpu, struct tick_sched *ts)
 ```
 
 NOHZ full CPUs receive a tick "kick" from CPU 0 when:
+
 - Another task is added to the run queue
 - RCU needs a quiescent state
 - Timers expire
@@ -260,6 +262,7 @@ DEFINE_PER_CPU(struct tick_device, tick_cpu_device);
 ```
 
 On x86:
+
 - BSP (boot CPU): uses TSC or HPET for the tick
 - Other CPUs: use the local APIC timer
 - All CPUs: can switch to one-shot mode (for NOHZ)

--- a/docs/sched/sched-tracing.md
+++ b/docs/sched/sched-tracing.md
@@ -110,6 +110,7 @@ perf sched script | head -20
 ### perf sched latency
 
 High "Maximum delay" for a task means it was occasionally stuck waiting for the CPU for a long time. Common causes:
+
 - CPU temporarily saturated
 - Lock contention in the scheduler (rare)
 - NUMA migration overhead
@@ -221,6 +222,7 @@ myapp-1234 [002] 12345.678901: sched_switch: prev_comm=myapp prev_pid=1234
 ```
 
 Interpretation:
+
 - `myapp` (pid 1234) on CPU 2 switched to sleep (`prev_state=S`)
 - `kworker/2:1` (pid 5678) is now running on CPU 2
 - Both at priority 120 (nice 0)

--- a/docs/sched/schedstat.md
+++ b/docs/sched/schedstat.md
@@ -179,6 +179,7 @@ done | sort -rn | head -20
 ```
 
 High `wait_time` relative to `cpu_time` means a task is often runnable but waiting for a CPU. Possible causes:
+
 - System is overloaded (more runnable tasks than CPUs)
 - Task has low priority (nice value or cgroup weight)
 - CPU affinity is too restrictive

--- a/docs/sched/scheduler-classes.md
+++ b/docs/sched/scheduler-classes.md
@@ -19,6 +19,7 @@ When Ingo Molnár replaced the O(1) scheduler with CFS, he also introduced `stru
 **CFS announcement**: [LKML, April 13 2007](https://lkml.org/lkml/2007/4/13/180) — Ingo Molnár, "[Announce] [patch] Modular Scheduler Core and Completely Fair Scheduler [CFS]"
 
 **CFS merge commits** (July 9, 2007, Ingo Molnár):
+
 - [`bf0f6f24a1ec`](https://git.kernel.org/linus/bf0f6f24a1ece8988b243aefe84ee613099a9245) — `sched: cfs core, kernel/sched_fair.c`
 - [`dd41f596cda0`](https://git.kernel.org/linus/dd41f596cda0d7d6e4a8b139ffdfabcefdd46528) — `sched: cfs core code` (wires `struct sched_class` into the core scheduler)
 
@@ -204,6 +205,7 @@ This is where CFS and EEVDF live. See [CFS](cfs.md) and [EEVDF](eevdf.md) for de
 The idle class runs the per-CPU idle thread (`swapper/N`). It's selected only when no other class has a runnable task.
 
 The idle thread calls `cpu_idle_loop()`, which invokes the CPU's idle instruction (`hlt` on x86, `wfi` on ARM). It also handles:
+
 - CPU frequency scaling callbacks
 - RCU quiescent state reporting
 - Polling for new work before sleeping

--- a/docs/sched/scheduler-evolution.md
+++ b/docs/sched/scheduler-evolution.md
@@ -7,6 +7,7 @@
 The kernel must answer one question thousands of times per second: **which task should run next?**
 
 The answer must be:
+
 - **Fair** — no task should starve
 - **Fast** — picking a task must be cheap
 - **Responsive** — interactive tasks need low latency
@@ -200,6 +201,7 @@ This distinction matters for latency. A task that wakes up after sleeping has a 
 ### Eligibility and virtual deadlines
 
 Each task has:
+
 - `vruntime` — virtual time consumed (same as CFS)
 - `deadline` — virtual time by which it must run
 - `slice` — requested time slice

--- a/docs/security/audit.md
+++ b/docs/security/audit.md
@@ -5,6 +5,7 @@
 ## What the audit subsystem does
 
 The Linux audit subsystem provides mandatory, tamper-resistant logging of security-relevant events:
+
 - Syscall execution (who called `open()`, `execve()`, `setuid()`?)
 - File access (who read `/etc/shadow`?)
 - Authentication events (PAM, sudo)

--- a/docs/security/capabilities.md
+++ b/docs/security/capabilities.md
@@ -86,6 +86,7 @@ struct cred {
 ```
 
 Rules:
+
 - **Effective**: used in access checks (`capable()`)
 - **Permitted**: superset of effective; can re-add dropped effective caps
 - **Inheritable**: can be passed across exec if the file also has it
@@ -157,6 +158,7 @@ setcap cap_dac_read_search=+eip /usr/sbin/rsync  # backup without root
 ```
 
 The `e`, `i`, `p` flags:
+
 - `e` = effective
 - `i` = inheritable
 - `p` = permitted

--- a/docs/security/credentials.md
+++ b/docs/security/credentials.md
@@ -103,6 +103,7 @@ int cap_bprm_creds_from_file(struct linux_binprm *bprm, const struct file *file)
 ## User namespaces
 
 A **user namespace** creates a private mapping between UIDs/GIDs in the namespace and the host system. This allows:
+
 - Unprivileged container creation
 - "root" inside a container without host root
 - Capability isolation: root inside namespace ≠ root outside

--- a/docs/security/fscrypt.md
+++ b/docs/security/fscrypt.md
@@ -5,6 +5,7 @@
 ## Overview
 
 fscrypt provides **per-directory** transparent encryption at the VFS layer. Unlike dm-crypt (full disk), fscrypt encrypts individual files and directories, allowing:
+
 - Multiple users to have separate encrypted directories with different keys
 - Selective encryption (not all files need to be encrypted)
 - Fast key revocation (remove key → files become inaccessible)
@@ -36,6 +37,7 @@ Master key (256-bit, type: ext4/logon)
 ```
 
 Each encrypted directory has a **policy** that records:
+
 - Which master key to use (by key descriptor or key identifier)
 - Which encryption mode (AES-256-XTS for contents, AES-256-CTS for filenames)
 - Key derivation version (v1 trusted keyring, v2 HKDF)

--- a/docs/security/kernel-hardening.md
+++ b/docs/security/kernel-hardening.md
@@ -43,6 +43,7 @@ Boot time:
 ```
 
 **Bypass**: KASLR is defeated by:
+
 - Kernel pointer leaks via `/proc`, uninitialized reads, or info-disclosure bugs
 - `CONFIG_RANDOMIZE_BASE=n` in non-default configs
 

--- a/docs/security/landlock.md
+++ b/docs/security/landlock.md
@@ -7,6 +7,7 @@
 Landlock (merged in Linux 5.13 by Mickaël Salaün — [`17ae69aba89d`](https://git.kernel.org/linus/17ae69aba89dbfa2139b7f8024b757ab3cc42f59), [LWN](https://lwn.net/Articles/859908/)) is a Linux Security Module that allows **unprivileged processes** to restrict their own access to the filesystem (since 5.13) and TCP network ports (since Linux 6.7, ABI v4). Unlike seccomp which filters syscalls, Landlock controls resource access at a semantic level.
 
 Key properties:
+
 - **No root required**: any process can create a Landlock sandbox for itself
 - **Irreversible**: once rules are enforced, they cannot be loosened
 - **Inherited**: child processes inherit the restrictions

--- a/docs/security/lsm.md
+++ b/docs/security/lsm.md
@@ -7,6 +7,7 @@
 The Linux Security Module framework (introduced in Linux 2.6.0, December 2003) provides a set of hooks throughout the kernel where security modules can enforce additional access controls beyond standard DAC. Designed by Crispin Cowan (WireX) with NSA, SGI, and others — presented at USENIX Security 2002: ["Linux Security Modules: General Security Support for the Linux Kernel"](https://www.usenix.org/conference/11th-usenix-security-symposium/linux-security-modules-general-security-support-linux). Kernel docs: [security/lsm.html](https://www.kernel.org/doc/html/latest/security/lsm.html).
 
 LSM hooks are called at security-critical points:
+
 - File open/read/write/execute
 - Network socket creation and connections
 - Process creation and credential changes

--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -5,6 +5,7 @@
 ## What seccomp does
 
 seccomp (secure computing mode) installs a BPF program that runs on every syscall entry. The filter can:
+
 - Allow the syscall to proceed
 - Return an error to the caller (without kernel processing)
 - Kill the process
@@ -191,6 +192,7 @@ docker run --security-opt seccomp=/path/to/profile.json ubuntu bash
 ```
 
 The default Docker profile blocks (among others):
+
 - `acct` — process accounting
 - `add_key` — kernel keyring
 - `bpf` — BPF programs
@@ -205,6 +207,7 @@ The default Docker profile blocks (among others):
 ## SECCOMP_RET_USER_NOTIF: supervisor pattern
 
 Since Linux 5.0, a filter can defer decisions to a supervisor process. This enables:
+
 - Userspace policy enforcement
 - Container escape prevention (container manager approves mounts)
 - Debugging (supervisor logs allowed syscalls)

--- a/docs/syscalls/adding-syscall.md
+++ b/docs/syscalls/adding-syscall.md
@@ -5,11 +5,13 @@
 ## When to add a new syscall
 
 A new syscall is the right approach when:
+
 - Exposing a new kernel capability to userspace
 - The operation requires privilege or atomic semantics unavailable in userspace
 - It needs access to kernel-internal state
 
 Avoid adding syscalls for things that can be done via:
+
 - `ioctl` on an existing device/file (for device-specific operations)
 - `sysfs`/`procfs` (for configuration and observation)
 - Netlink (for networking-related configuration)
@@ -90,6 +92,7 @@ struct hello_args {
 ```
 
 Key rules for UAPI structs:
+
 - Use `__u8`, `__u16`, `__u32`, `__u64` (not `int`, `long`, etc.)
 - Add explicit padding (`__u32 pad`) for alignment — never rely on implicit struct holes
 - Use `__u64` for pointer-sized fields (enables compat with 32-bit userspace)

--- a/docs/syscalls/syscall-define.md
+++ b/docs/syscalls/syscall-define.md
@@ -141,11 +141,13 @@ __SYSCALL(__NR_io_destroy, sys_io_destroy)
 Once a syscall is merged, its number and argument semantics are **never changed**. This is a hard kernel rule: user-space must not break.
 
 Specific guarantees:
+
 - Syscall numbers don't change
 - Existing arguments are never reinterpreted
 - Structs passed by pointer only grow (new fields at the end, with zero meaning "not set")
 
 For new features, the kernel adds new syscalls rather than extend old ones in incompatible ways:
+
 - `clone()` → `clone3()` (struct-based, extensible)
 - `open()` → `openat()` → `openat2()` (added `how` struct)
 - `read()` → `pread64()`, `readv()`, `preadv()`, `preadv2()`
@@ -175,6 +177,7 @@ SYSCALL_DEFINE2(clone3, struct clone_args __user *, uargs, size_t, size)
 ```
 
 `copy_struct_from_user` handles the versioning:
+
 - If `size < sizeof(kargs)`: copies what's there, zeros the rest (old userspace)
 - If `size > sizeof(kargs)`: checks that extension bytes are zero (new userspace, old kernel)
 

--- a/docs/syscalls/syscall-entry.md
+++ b/docs/syscalls/syscall-entry.md
@@ -169,6 +169,7 @@ put_user(x, user_ptr)   /* *user_ptr = x */
 ```
 
 Why mandatory copies?
+
 - User pointers might be NULL or invalid
 - Kernel and user address spaces are separate (KPTI)
 - Userspace can change the pointed-to memory after the check (TOCTOU)
@@ -233,6 +234,7 @@ do_hres(const struct vdso_data *vd, clockid_t clk,
 ```
 
 Syscalls fast-pathed through the vDSO (no ring switch):
+
 - `clock_gettime(CLOCK_REALTIME/MONOTONIC/...)`
 - `gettimeofday()`
 - `clock_getres()`

--- a/docs/time/hrtimers.md
+++ b/docs/time/hrtimers.md
@@ -138,6 +138,7 @@ static void hrtimer_switch_to_hres(void)
 ```
 
 After switching:
+
 - The scheduler tick is implemented via an hrtimer (no longer a fixed-rate interrupt)
 - Timer resolution is limited only by hardware latency (~100ns typical)
 - `NOHZ` (tickless idle) can skip ticks entirely when CPU is idle

--- a/docs/time/ntp.md
+++ b/docs/time/ntp.md
@@ -167,6 +167,7 @@ A time synchronization daemon:
 4. Adjusts `constant` (the PLL time constant) based on the poll interval — longer poll intervals use a larger time constant for stability.
 
 `chrony` differs from `ntpd` in several ways:
+
 - Uses `ADJ_SETOFFSET` to make fast step corrections when the offset is large (e.g., on first start), rather than slewing slowly.
 - Supports hardware timestamping via `SO_TIMESTAMPING` for sub-microsecond accuracy with a PPS or PTP source.
 - Tracks multiple reference sources and weights them by jitter and distance.

--- a/docs/time/posix-timers.md
+++ b/docs/time/posix-timers.md
@@ -258,6 +258,7 @@ if (count > 1)
 ```
 
 Overruns happen when:
+
 - Handler takes longer than the period
 - System is loaded; scheduling latency > period
 - Thread was blocked (sleeping, waiting for I/O)

--- a/docs/time/war-stories.md
+++ b/docs/time/war-stories.md
@@ -11,6 +11,7 @@ The consequence: a task scheduled on socket 0 could read `CLOCK_MONOTONIC` via t
 The kernel's fix is the **clocksource watchdog** (`kernel/time/clocksource.c`, `clocksource_watchdog()`). A periodic timer compares TSC readings against a reference clocksource (HPET or ACPI PM timer). If the TSC and the reference diverge by more than a threshold, the TSC is marked `CLOCK_SOURCE_UNSTABLE` and the kernel downgrades to the next-best clocksource (typically HPET, with a rating of 250 vs TSC's fixed rating of 300).
 
 Modern Intel and AMD CPUs expose the **Invariant TSC** feature: `CPUID` leaf `0x80000007`, EDX bit 8 (`TSC_INVARIANT`). An invariant TSC:
+
 - Runs at a constant rate regardless of CPU frequency scaling (P-states) and power states (C-states up to C1).
 - Is synchronized across all cores in the package.
 - Is synchronized across all sockets on Intel platforms using RESET synchronization.
@@ -50,6 +51,7 @@ The result: Reddit, Mozilla, LinkedIn, Qantas, and hundreds of other Linux-based
 Root cause: the leap second handling hrtimers were never notified of the clock step via `clock_was_set()`, so `CLOCK_REALTIME`/`TIMER_ABSTIME` timers fired immediately in a continuous loop. The kernel was subsequently patched with backports that corrected `hrtimer` behavior during leap second insertion.
 
 **Workarounds used at the time:**
+
 - Set the system clock slightly ahead before midnight so the leap second was absorbed as a normal tick, avoiding the confused state entirely.
 - Use `ntpd`'s `leapsmear` option (chrony, NTPD 4.2.6+) to spread the one-second adjustment over a longer window (12–24 hours) so no single second has a discontinuity — preventing the sharp discontinuity that triggered the spin. Many NTP server operators and cloud providers now smear by default. The kernel does not implement smearing natively; it is done by the time daemon.
 - Apply the kernel fix: backported patches that corrected `hrtimer` behavior during leap second insertion were available for affected kernel versions.

--- a/docs/tracing/kprobes-tracepoints.md
+++ b/docs/tracing/kprobes-tracepoints.md
@@ -147,6 +147,7 @@ static struct kretprobe my_kretprobe = {
 ## Static tracepoints: TRACE_EVENT
 
 Static tracepoints are annotation points compiled into the kernel at specific places. They have:
+
 - Zero overhead when disabled (a single no-op test)
 - Rich structured data (not just register dumps)
 - Stable ABI (unlike kprobes which depend on function names)

--- a/docs/vfs/README.md
+++ b/docs/vfs/README.md
@@ -7,6 +7,7 @@
 The Virtual Filesystem Switch (VFS) is an abstraction layer that allows the kernel to support many different filesystems (ext4, btrfs, tmpfs, procfs, NFS...) through a common interface. When your program calls `read()`, it goes through VFS, which dispatches to the appropriate filesystem implementation.
 
 VFS makes the following possible:
+
 - A single `open()`, `read()`, `write()` API works for ext4, NFS, /proc, /sys, pipes, and sockets
 - Files can be accessed across mounted filesystems transparently
 - Filesystems can be developed as kernel modules

--- a/docs/vfs/file-ops.md
+++ b/docs/vfs/file-ops.md
@@ -102,6 +102,7 @@ vfs_write() → file->f_op->write_iter()
 ```
 
 Data is only guaranteed on disk after:
+
 - `fsync(fd)` or `fdatasync(fd)` — explicit flush [(man page)](https://man7.org/linux/man-pages/man2/fsync.2.html)
 - The writeback daemon flushes (typically after 30 seconds or when memory pressure is high; controlled by `dirty_expire_centisecs`)
 - The filesystem's `sync_fs()` is called
@@ -165,6 +166,7 @@ __close_fd() → filp_close()
 ```
 
 `flush()` vs `release()`:
+
 - `flush()`: called on every `close()` — some filesystems use this for error checking (NFS flushing dirty data)
 - `release()`: called only when the last reference to the `struct file` is dropped (e.g., after all `dup()`'d fds are closed)
 

--- a/docs/vfs/inotify.md
+++ b/docs/vfs/inotify.md
@@ -115,6 +115,7 @@ echo 524288 | sudo tee /proc/sys/fs/inotify/max_user_watches
 ## fanotify: filesystem-wide event notification
 
 `fanotify` was introduced in Linux 2.6.36 by Eric Paris at Red Hat [(commit)](https://git.kernel.org/linus/ff0b16a9850e8a240ad59e10b0a1291a8fcf7cbc) and fully enabled in Linux 2.6.37. It is a superset of inotify with additional capabilities:
+
 - Watch entire mount points, not just individual files/dirs
 - Receive the file descriptor of the changed file (open for reading)
 - **Permission events**: intercept access and deny it (used by AV scanners)

--- a/docs/vfs/life-of-write.md
+++ b/docs/vfs/life-of-write.md
@@ -177,6 +177,7 @@ void wb_workfn(struct bdi_writeback *wb)
 ```
 
 Writeback is triggered by:
+
 - **Time**: after `dirty_expire_centisecs` (default 3000 = 30 seconds)
 - **Memory pressure**: when dirty pages exceed `dirty_ratio` (default 20% of RAM)
 - **fsync()**: explicit flush by the application

--- a/docs/vfs/vfs-objects.md
+++ b/docs/vfs/vfs-objects.md
@@ -126,6 +126,7 @@ struct dentry {
 ```
 
 Key distinction:
+
 - **Positive dentry**: `d_inode != NULL` — the name exists in the filesystem
 - **Negative dentry**: `d_inode == NULL` — the name was looked up but doesn't exist (cached to avoid repeated failed lookups)
 

--- a/docs/vfs/xattr.md
+++ b/docs/vfs/xattr.md
@@ -54,6 +54,7 @@ getfattr -d report.pdf
 ```
 
 Restrictions:
+
 - Not supported on symlinks or device files (to prevent privilege escalation via root-owned devices)
 - Subject to filesystem quota if enabled
 
@@ -75,6 +76,7 @@ Setting `security.*` requires `CAP_SYS_ADMIN` or LSM-specific permissions.
 ### `trusted` namespace
 
 Requires `CAP_SYS_ADMIN`. Used by:
+
 - **OverlayFS**: `trusted.overlay.opaque`, `trusted.overlay.whiteout` for directory/file hiding
 - **Container runtimes**: Store container metadata on image layers
 - **Quota systems**: Some implementations store quota data in `trusted.*`

--- a/docs/virtualization/kvm-arch.md
+++ b/docs/virtualization/kvm-arch.md
@@ -5,6 +5,7 @@
 ## Intel VT-x: hardware virtualization basics
 
 Intel VT-x adds two new CPU operating modes:
+
 - **VMX root mode**: where the hypervisor (KVM) runs — full privilege
 - **VMX non-root mode**: where the guest OS runs — hardware-restricted
 

--- a/docs/virtualization/kvm-memory.md
+++ b/docs/virtualization/kvm-memory.md
@@ -195,6 +195,7 @@ struct kvm_memory_slot {
 ```
 
 A slot can be:
+
 - **Normal RAM**: backed by `mmap(MAP_ANONYMOUS)` memory in the VMM (e.g. QEMU)
 - **ROM**: read-only (bios, option ROM)
 - **MMIO**: no backing — triggers `KVM_EXIT_MMIO` on access

--- a/docs/virtualization/live-migration.md
+++ b/docs/virtualization/live-migration.md
@@ -109,6 +109,7 @@ QEMU on the source enables dirty logging, then repeatedly:
 3. Sends the newly-dirtied pages.
 
 Each round sends fewer pages — the guest's working set converges. QEMU tracks:
+
 - **Dirty rate**: pages dirtied per second by the guest.
 - **Bandwidth**: pages transferred per second to the destination.
 

--- a/docs/virtualization/vfio.md
+++ b/docs/virtualization/vfio.md
@@ -17,6 +17,7 @@ With VFIO passthrough:
 ```
 
 **Requirements**:
+
 - IOMMU hardware (Intel VT-d or AMD-Vi)
 - Device must be in its own IOMMU group (or group isolation satisfied)
 - `intel_iommu=on` or `amd_iommu=on` boot parameter


### PR DESCRIPTION
MkDocs incorrectly renders the list as part of the preceding paragraph without intended bullet list spacing if there are no blank lines between paragraphs and bullet lists. This MR adds blank lines to ensure the Markdown is rendered correctly. 

Example:

| Before | After |
| --- | --- |
| <img width="670" height="190" alt="image" src="https://github.com/user-attachments/assets/8cf5f914-03d3-4e29-8f3f-ffdf65c486a3" /> | <img width="670" height="230" alt="image" src="https://github.com/user-attachments/assets/dad9421e-64e0-40ca-9247-52f754386f8f" /> |

