### PR TITLE
Fix fabricated and outdated technical details in docs/syscalls/syscall-define.md

### DIFF
--- a/docs/syscalls/syscall-define.md
+++ b/docs/syscalls/syscall-define.md
@@ -54,7 +54,9 @@ static long __do_sys_write(unsigned int fd, const char __user *buf, size_t count
     /* implementation here */
 }
 
-/* SYSCALL_METADATA() creates tracepoint data and audit hooks */
+/* SYSCALL_METADATA() emits the struct syscall_metadata + trace events
+ * ftrace's syscall tracepoints use — it's tracing-only, not audit; the
+ * audit hooks are wired in separately (see Syscall Auditing) */
 ```
 
 ### Full example: sys_write
@@ -69,19 +71,18 @@ SYSCALL_DEFINE3(write, unsigned int, fd, const char __user *, buf,
 
 ssize_t ksys_write(unsigned int fd, const char __user *buf, size_t count)
 {
-    struct fd f = fdget_pos(fd);  /* get file from fd table */
+    CLASS(fd_pos, f)(fd);  /* cleanup-guard: auto fdput_pos() on return */
     ssize_t ret = -EBADF;
 
-    if (f.file) {
-        loff_t pos, *ppos = file_ppos(f.file);
+    if (!fd_empty(f)) {
+        loff_t pos, *ppos = file_ppos(fd_file(f));
         if (ppos) {
             pos = *ppos;
             ppos = &pos;
         }
-        ret = vfs_write(f.file, buf, count, ppos);
+        ret = vfs_write(fd_file(f), buf, count, ppos);
         if (ret >= 0 && ppos)
-            f.file->f_pos = pos;
-        fdput_pos(f);
+            fd_file(f)->f_pos = pos;
     }
 
     return ret;
@@ -89,6 +90,8 @@ ssize_t ksys_write(unsigned int fd, const char __user *buf, size_t count)
 ```
 
 Note the `ksys_write()` wrapper: it allows calling the syscall logic from within the kernel (e.g., in `init` code) without going through the syscall entry path. This pattern is used for syscalls that the kernel itself needs to call internally.
+
+`CLASS(fd_pos, f)(fd)` replaced the older `struct fd f = fdget_pos(fd); ... fdput_pos(f);` pattern: it's a scope-based cleanup guard (`DEFINE_CLASS`-generated) that calls `fdput_pos()` automatically when `f` goes out of scope, so every return path releases the reference without an explicit call. `fd_empty(f)`/`fd_file(f)` are the accessors for the guarded fd, replacing direct `f.file` access.
 
 ## The syscall table
 
@@ -117,11 +120,12 @@ Which is included in the syscall table array:
 
 ```c
 /* arch/x86/entry/syscall_64.c */
-asmlinkage const sys_call_ptr_t sys_call_table[] = {
+const sys_call_ptr_t sys_call_table[] = {
 #include <asm/syscalls_64.h>
 };
-const int sys_call_table_size = sizeof(sys_call_table);
 ```
+
+`sys_call_table[]` is no longer how dispatch actually happens — real dispatch (`do_syscall_64()` in the same file) goes through `x64_sys_call()`, a `switch` statement built from the same `<asm/syscalls_64.h>` include (`case nr: return __x64_##sym(regs);`). This replaced an indexed call through the function-pointer array specifically to avoid an *indirect* call: as [the commit that made the change](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1e3ad78334a69b36e107232e337f9d693dcc9df2) explains, a `switch` lets the compiler emit conditional branches instead, and a misprediction there only speculatively runs the *wrong syscall* — a bounded, harmless outcome — rather than an indirect call mispredicting to attacker-influenced code. The array itself is kept only because `kernel/trace/trace_syscalls.c` still wants each syscall's address.
 
 ### Architecture-independent: include/uapi/asm-generic/unistd.h
 
@@ -157,46 +161,55 @@ For new features, the kernel adds new syscalls rather than extend old ones in in
 The modern approach passes arguments in a struct, allowing future extension without new syscalls:
 
 ```c
-/* struct-based syscall: clone3 */
+/* struct-based syscall: clone3 (kernel/fork.c) */
 SYSCALL_DEFINE2(clone3, struct clone_args __user *, uargs, size_t, size)
 {
-    struct clone_args kargs;
+    int err;
+    struct kernel_clone_args kargs;   /* NOT struct clone_args — see below */
     pid_t set_tid[MAX_PID_NS_LEVEL];
 
-    if (size < CLONE_ARGS_SIZE_VER0)
+    kargs.set_tid = set_tid;
+
+    err = copy_clone_args_from_user(&kargs, uargs, size);
+    if (err)
+        return err;
+
+    if (!clone3_args_valid(&kargs))
         return -EINVAL;
-    if (size > PAGE_SIZE)
-        return -E2BIG;
 
-    /* Copy only what caller provided; zero-initialize the rest */
-    if (copy_struct_from_user(&kargs, sizeof(kargs), uargs, size))
-        return -EFAULT;
-
-    /* ... validate and use kargs ... */
+    return kernel_clone(&kargs);
 }
 ```
 
-`copy_struct_from_user` handles the versioning:
+Two distinct structs are involved, easy to conflate because both are visible here:
 
-- If `size < sizeof(kargs)`: copies what's there, zeros the rest (old userspace)
-- If `size > sizeof(kargs)`: checks that extension bytes are zero (new userspace, old kernel)
+- `struct clone_args` (`include/uapi/linux/sched.h`) is the fixed, versioned, userspace-shaped layout `uargs` points to — the ABI contract, all `__aligned_u64` fields.
+- `struct kernel_clone_args` (`include/linux/sched/task.h`) is the kernel's internal representation `kargs` — a superset used everywhere clone happens (`fork()`, `vfork()`, kernel threads, `io_uring` workers, not just `clone3()`), with kernel-only fields like `fn`/`fn_arg` that have no userspace equivalent.
+
+`copy_clone_args_from_user()` (also in `kernel/fork.c`) is what bridges them: it calls `copy_struct_from_user(&args, sizeof(args), uargs, usize)` into a local `struct clone_args`, handling the versioning —
+
+- If `usize < sizeof(args)`: copies what's there, zeros the rest (old userspace, new kernel)
+- If `usize > sizeof(args)`: checks that the extension bytes are zero (new userspace, old kernel)
+
+— then copies the validated fields across into the `struct kernel_clone_args` the rest of the clone path uses.
 
 ## 32-bit compat syscalls
 
-64-bit kernels support 32-bit userspace binaries. Compat syscalls handle argument size differences:
+64-bit kernels support 32-bit userspace binaries. Where argument layout or size actually differs between ABIs, `COMPAT_SYSCALL_DEFINEx()` defines a separate compat entry point. But that's only needed when it's needed — `mmap2` is a useful counter-example: it doesn't need a compat variant at all, because its arguments are already the same width and meaning on every ABI:
 
 ```c
-/* For types that differ between 32/64-bit: */
-#ifdef CONFIG_COMPAT
-COMPAT_SYSCALL_DEFINE6(mmap2, ...)
+/* mm/mmap.c — this is a NATIVE syscall, not COMPAT_SYSCALL_DEFINE: */
+SYSCALL_DEFINE6(mmap_pgoff, unsigned long, addr, unsigned long, len,
+                unsigned long, prot, unsigned long, flags,
+                unsigned long, fd, unsigned long, pgoff)
 {
-    /* 32-bit mmap uses 4KB page units for offset, not bytes */
-    /* 32-bit uses u32 fd, offset; 64-bit uses long */
+    return ksys_mmap_pgoff(addr, len, prot, flags, fd, pgoff);
 }
-#endif
 ```
 
-32-bit processes use `ia32_sys_call_table` (separate from `sys_call_table`).
+`mmap2` (i386 syscall 192) is wired directly to `sys_mmap_pgoff` in `arch/x86/entry/syscalls/syscall_32.tbl`, with no separate compat entry point at all — unlike legacy `mmap` (i386 syscall 90), which does have one (`compat_sys_ia32_mmap`). `mmap2` takes the offset in page units already (`pgoff`, not bytes), so it needs no ABI-specific translation of its own. The 64-bit `mmap` syscall (a *different* entry point, `SYSCALL_DEFINE6(mmap, ...)` in `arch/x86/kernel/sys_x86_64.c`) does the byte-to-page-unit conversion its own ABI requires — right-shifting the byte offset by `PAGE_SHIFT` — before calling into the same shared internal helper, `ksys_mmap_pgoff()`, that `sys_mmap_pgoff` also calls.
+
+There's no separate `ia32_sys_call_table` symbol — `arch/x86/entry/syscall_32.c` mirrors `syscall_64.c`'s pattern exactly: a vestigial `sys_call_table[]` array (only built for pure 32-bit kernels, kept for tracing) alongside the real dispatcher, `ia32_sys_call()`, another `switch` statement built from `<asm/syscalls_32.h>`.
 
 ## Syscall tracing and audit
 
@@ -229,31 +242,33 @@ ausearch -k access
 Some syscalls go through a "slow path" that handles signals, scheduling, restart:
 
 ```c
-/* syscall_exit_to_user_mode_work: checks on return to userspace */
-static void exit_to_user_mode_loop(struct pt_regs *regs,
-                                    u32 cached_flags)
+/* kernel/entry/common.c (simplified — the real loop is split into an
+ * outer exit_to_user_mode_loop() and this inline helper, and covers
+ * more work items than shown: uprobes, livepatch, arch-specific work) */
+static unsigned long __exit_to_user_mode_loop(struct pt_regs *regs,
+                                               unsigned long ti_work)
 {
-    while (true) {
+    while (ti_work & EXIT_TO_USER_MODE_WORK_LOOP) {
         local_irq_enable();
 
-        if (cached_flags & _TIF_NEED_RESCHED)
-            schedule();                  /* preemption point */
+        if (ti_work & (_TIF_NEED_RESCHED | _TIF_NEED_RESCHED_LAZY))
+            schedule();                        /* preemption point */
 
-        if (cached_flags & _TIF_SIGPENDING)
-            arch_do_signal_or_restart(regs);  /* deliver signal */
+        if (ti_work & (_TIF_SIGPENDING | _TIF_NOTIFY_SIGNAL))
+            arch_do_signal_or_restart(regs);    /* deliver signal */
 
-        if (cached_flags & _TIF_NOTIFY_RESUME)
-            resume_user_mode_work(regs); /* seccomp, ptrace notify */
+        if (ti_work & _TIF_NOTIFY_RESUME)
+            resume_user_mode_work(regs);        /* seccomp, ptrace notify */
 
-        /* Check again for new work */
-        cached_flags = read_thread_flags();
-        if (!(cached_flags & EXIT_TO_USER_MODE_WORK))
-            break;
+        local_irq_disable();
+        ti_work = read_thread_flags();          /* re-check for new work */
     }
+
+    return ti_work;
 }
 ```
 
-This is why syscalls are preemption and signal delivery points — the kernel checks `TIF_*` flags on every syscall return.
+This is why syscalls are preemption and signal delivery points — the kernel checks thread-info work flags on every syscall return. The real flag set also includes `_TIF_UPROBE` (pending uprobe callback) and `_TIF_PATCH_PENDING` (livepatch transition), each with their own handler in the loop.
 
 ## Further reading
 
@@ -263,8 +278,15 @@ This is why syscalls are preemption and signal delivery points — the kernel ch
 - [arch/x86/include/asm/syscall_wrapper.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/include/asm/syscall_wrapper.h) — x86's override of `__SYSCALL_DEFINEx()`: decodes `pt_regs` into the `__x64_sys_*()`/`__ia32_sys_*()` stubs
 - [fs/read_write.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/read_write.c) — `SYSCALL_DEFINE3(write, ...)` and `ksys_write()`, the worked example on this page
 - [kernel/fork.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/fork.c) — `SYSCALL_DEFINE2(clone3, ...)` and `copy_clone_args_from_user()`: the struct-based, extensible syscall pattern
+- [include/uapi/linux/sched.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/sched.h) — `struct clone_args`, the versioned userspace ABI struct `clone3()` copies from
+- [include/linux/sched/task.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/sched/task.h) — `struct kernel_clone_args`, the internal struct shared by every clone path (`fork()`, `vfork()`, kernel threads), not just `clone3()`
+- [mm/mmap.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) — `SYSCALL_DEFINE6(mmap_pgoff, ...)`, the native (non-compat) syscall `mmap2` is wired to directly
+- [arch/x86/entry/syscalls/syscall_32.tbl](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/syscalls/syscall_32.tbl) — the i386 syscall table showing `mmap2` → `sys_mmap_pgoff` with no compat entry point, versus legacy `mmap` → `sys_old_mmap`/`compat_sys_ia32_mmap`
 - [arch/x86/entry/syscalls/syscall_64.tbl](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/syscalls/syscall_64.tbl) — the syscall number → entry point table that `sys_call_table` is generated from
-- [kernel/entry/common.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/entry/common.c) — `exit_to_user_mode_loop()`: the slow-path signal/reschedule checks on syscall return
+- [arch/x86/entry/syscall_64.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/syscall_64.c) — `do_syscall_64()` and `x64_sys_call()`: the real `switch`-based dispatch that replaced indexing `sys_call_table[]` directly
+- [arch/x86/entry/syscall_32.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/syscall_32.c) — the 32-bit/IA32-compat mirror of `syscall_64.c`: `ia32_sys_call()`, the same `switch`-based dispatch pattern
+- [commit 1e3ad78334a6](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1e3ad78334a69b36e107232e337f9d693dcc9df2) — "x86/syscall: Don't force use of indirect calls for system calls", the change and its stated Spectre-mitigation rationale
+- [kernel/entry/common.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/entry/common.c) — `exit_to_user_mode_loop()`/`__exit_to_user_mode_loop()`: the slow-path signal/reschedule/uprobe/livepatch checks on syscall return
 
 ### Man pages
 


### PR DESCRIPTION
Part of #741.

Fixes to the illustrative code in `docs/syscalls/syscall-define.md`, verified against current kernel source at [git.kernel.org](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/):

- **`ksys_write()`**: replaced the outdated `struct fd f = fdget_pos(fd); ... fdput_pos(f);` pattern with the current `CLASS(fd_pos, f)(fd)` cleanup-guard pattern, per [`fs/read_write.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/read_write.c).
- **`mmap2`**: was shown as `COMPAT_SYSCALL_DEFINE6(mmap2, ...)`, which doesn't exist. `mmap2` is a **native** `SYSCALL_DEFINE6(mmap_pgoff, ...)` in [`mm/mmap.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mmap.c) — it's wired directly in the i386 syscall table with no compat entry point at all, unlike legacy `mmap`.
- **`clone3`**: the syscall body used `struct clone_args` for its local `kargs` variable; the real type is `struct kernel_clone_args`. Clarified the two distinct structs — the fixed, versioned userspace ABI struct (`include/uapi/linux/sched.h`) vs. the internal struct used by every clone path (`include/linux/sched/task.h`) — and how `copy_clone_args_from_user()` bridges them.
- Corrected a claim that `SYSCALL_METADATA()` creates audit hooks; it only creates ftrace tracepoint data ([`include/linux/syscalls.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/syscalls.h)) — audit is wired in separately.
- The syscall-table dispatch example was stale: `sys_call_table[]` is no longer used for dispatch (kept only for tracing); real dispatch goes through a `switch`-based `x64_sys_call()`/`ia32_sys_call()` ([`arch/x86/entry/syscall_64.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/syscall_64.c), [`syscall_32.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/entry/syscall_32.c)) — a change made specifically to avoid indirect calls, per [the commit that made it](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1e3ad78334a69b36e107232e337f9d693dcc9df2). Also removed a fabricated `ia32_sys_call_table` symbol that doesn't exist.
- The slow-path `exit_to_user_mode_loop()` example used a stale signature and an incomplete/wrong set of TIF flags; updated to match the current split between `exit_to_user_mode_loop()` and `__exit_to_user_mode_loop()` in [`kernel/entry/common.c`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/entry/common.c).

`mkdocs build --strict` passes.