### PR TITLE
Fix crashkernel=auto claim in docs/kernel/war-stories.md

### DIFF
--- a/docs/kernel/war-stories.md
+++ b/docs/kernel/war-stories.md
@@ -203,7 +203,7 @@ echo c > /proc/sysrq-trigger
 # (system will panic and attempt to capture vmcore)
 ```
 
-Modern distributions expose automatic sizing via `crashkernel=auto`, which the kernel computes based on system RAM. However, "auto" values are conservative minimums and may still be insufficient for systems with many loaded modules or complex memory topologies.
+`crashkernel=auto` is not a value the mainline kernel's own command-line parser understands — `kernel/crash_reserve.c` has no special case for the string "auto"; it expects a concrete size. The auto-sizing some distributions expose is done by their own userspace tooling (e.g. dracut/kdump installer scripts), which computes a size from installed RAM and writes a concrete `crashkernel=N` value into the bootloader config. Whatever size a given distribution's tooling picks, it is still a fixed reservation from the last time it ran — it does not adapt automatically if RAM is later added, which is exactly the failure mode in this case.
 
 ### Lesson
 


### PR DESCRIPTION
Part of the docs/kernel/ accuracy audit (#744).

Case 3's fix section claimed distributions expose automatic `crashkernel=` sizing via `crashkernel=auto`, computed by the kernel. Verified against `kernel/crash_reserve.c` and `Documentation/admin-guide/kernel-parameters.txt`: the mainline kernel's command-line parser has no special case for the string "auto" and expects a concrete size — `crashkernel=auto` is not a value the kernel itself understands.

Corrected the mechanism: automatic sizing is done by distribution-level userspace tooling, which computes a size from installed RAM and writes a concrete `crashkernel=N` value into the bootloader configuration, not something the kernel computes at boot. This also makes the case's underlying point sharper — the reservation is fixed at whatever value the tooling last computed, so it doesn't adapt if RAM is added later, which is exactly the failure mode described.

The rest of the page (initcall level macros and net_dev_init's registration, the `__init`/`free_initmem()` mechanism and `init_section_contains()`, `pr_notice()`/`KERN_NOTICE` and `CONFIG_CONSOLE_LOGLEVEL_DEFAULT`'s default of 7, `unknown_bootoption()`/`print_unknown_bootoptions()`, the `do_init_module()` code block, and the kmemleak/"Bad page state" message formats) was independently verified against current kernel source and found accurate.