### PR TITLE
Fix fabricated and outdated technical details in docs/kernel/early-boot.md

### DIFF
--- a/docs/kernel/early-boot.md
+++ b/docs/kernel/early-boot.md
@@ -25,35 +25,41 @@ start_kernel()
     boot_cpu_init()                        [3]
     page_address_init()                    [4]
     pr_notice(linux_banner)                [5]
-    early_security_init()                  [6]
-    setup_arch(&command_line)              [7]
+    setup_arch(&command_line)              [6]
+    mm_core_init_early()
+    jump_label_init()
+    static_call_init()
+    early_security_init()                  [7]
+    setup_boot_config()
     setup_command_line(command_line)       [8]
     setup_nr_cpu_ids()                     [9]
     setup_per_cpu_areas()                  [10]
     smp_prepare_boot_cpu()                 [11]
-    build_all_zonelists(NULL)              [12]
-    page_alloc_init()                      [13]
     parse_early_param()                    <- early_param() handlers run here
     ...
-    trap_init()                            [14]
-    mm_core_init()                         [15]
-    poking_init()                          [16]
-    ftrace_init()                          [17]
-    early_trace_init()                     [18]
-    sched_init()                           [19]
-    radix_tree_init()                      [20]
-    workqueue_init_early()                 [21]
-    rcu_init()                             [22]
-    init_IRQ()                             [23]
-    tick_init()                            [24]
-    timekeeping_init()                     [25]
-    time_init()                            [26]
-    kmem_cache_init()                      [27]
+    trap_init()                            [12]
+    mm_core_init()                         [13]
+    poking_init()                          [14]
+    ftrace_init()                          [15]
+    early_trace_init()                     [16]
+    sched_init()                           [17]
+    radix_tree_init()                      [18]
+    workqueue_init_early()                 [19]
+    rcu_init()                             [20]
+    init_IRQ()                             [21]
+    tick_init()                            [22]
+    timekeeping_init()                     [23]
+    time_init()                            [24]
+    kmem_cache_init_late()                 [25]
     ...
-    console_init()                         [28]
+    console_init()                         [26]
     ...
-    rest_init()                            [29]
+    rest_init()                            [27]
 ```
+
+`setup_arch()` genuinely runs before `early_security_init()` — swapped from an earlier version of this page. Between them, `start_kernel()` also calls `mm_core_init_early()` (an early memory-init split described under step [13] below), `jump_label_init()`, and `static_call_init()`; `setup_boot_config()` runs between `early_security_init()` and `setup_command_line()`. None of these get their own step number, same as the other unnumbered calls above.
+
+`build_all_zonelists(NULL)` and (the renamed) `page_alloc_init_cpuhp()` are no longer called directly from `start_kernel()` at all — both moved inside `mm_core_init()` (step [13]), alongside `kmem_cache_init()`.
 
 ### Key steps explained
 
@@ -77,11 +83,7 @@ Initializes the page address hash table used to convert `struct page *` to virtu
 
 The first human-readable log line: `Linux version 6.x.y (compiler) #N SMP ...`. This is the version string seen at the top of `dmesg`. At this point `printk` writes to an in-memory buffer; nothing appears on a console yet.
 
-**[6] `early_security_init()`**
-
-Initializes LSM (Linux Security Module) infrastructure that must be present before `setup_arch()`. Specifically, this allows LSMs that hook into architecture setup (e.g., integrity measurement) to register their early hooks. Introduced to support IMA/EVM initialization ordering.
-
-**[7] `setup_arch(&command_line)`** (`arch/x86/kernel/setup.c` or `arch/arm64/kernel/setup.c`)
+**[6] `setup_arch(&command_line)`** (`arch/x86/kernel/setup.c` or `arch/arm64/kernel/setup.c`)
 
 The largest and most architecture-specific call in `start_kernel()`. On x86-64 this includes:
 
@@ -93,6 +95,10 @@ The largest and most architecture-specific call in `start_kernel()`. On x86-64 t
 - Configuring the kernel's virtual address layout
 
 After `setup_arch()` returns, the kernel knows how much physical memory it has and where it is.
+
+**[7] `early_security_init()`** (`security/lsm_init.c`)
+
+Runs after `setup_arch()`, not before it. Walks the LSMs flagged "early" (`lsm_early_for_each_raw()`) and initializes each one via `lsm_init_single()` — this is what lets integrity-measurement and similar early-hooking LSMs register before most of the kernel is up. `security_init()`, which initializes the rest of the (non-early) LSMs, runs much later, well after `console_init()`.
 
 **[8] `setup_command_line(command_line)`**
 
@@ -110,75 +116,67 @@ Allocates memory for per-CPU data. The linker places per-CPU variables in a `.da
 
 Performs any SMP-specific initialization needed on the boot CPU before secondary CPUs start. On x86 this sets up the boot CPU's GS segment for per-CPU access.
 
-**[12] `build_all_zonelists(NULL)`** (`mm/page_alloc.c`)
-
-Constructs the NUMA zone fallback lists. Each node gets an ordered list of zones to try when its own zones are exhausted. The order is determined by NUMA distance (from `mm/numa.c`). This must happen before any NUMA-aware allocation.
-
-**[13] `page_alloc_init()`**
-
-Registers a CPU hotplug callback so the page allocator's per-CPU page frames (pcplists) are set up correctly when secondary CPUs come online.
-
-**[14] `trap_init()`** (`arch/x86/kernel/traps.c`)
+**[12] `trap_init()`** (`arch/x86/kernel/traps.c`)
 
 On x86, sets up the Interrupt Descriptor Table (IDT) with handlers for all CPU exceptions: divide error (#DE), page fault (#PF), general protection fault (#GP), double fault (#DF), etc. After this call, the CPU can handle exceptions properly. Before this, any fault is fatal.
 
-**[15] `mm_core_init()`** (`mm/mm_init.c`)
+**[13] `mm_core_init()`** (`mm/mm_init.c`)
 
-Initializes the core memory management infrastructure: `mem_init()` (converts memblock to the buddy allocator), `kmem_cache_init()` (bootstraps the slab allocator), page table caches, and more. After this, the general-purpose page allocator (`alloc_pages()`) is operational. Note: `kmem_cache_init_late()` is invoked later as a plain direct call from `start_kernel()` (not from within `mm_core_init()`, and not registered via any `core_initcall()`/initcall-level mechanism at all).
+Initializes the core memory management infrastructure: `mem_init()` (converts memblock to the buddy allocator), `kmem_cache_init()` (bootstraps the slab allocator), page table caches, and more. It's also where `build_all_zonelists(NULL)` (`mm/page_alloc.c` — constructs the NUMA zone fallback lists, in NUMA-distance order from `mm/numa.c`) and `page_alloc_init_cpuhp()` (registers the CPU hotplug callback that sets up each secondary CPU's per-CPU page frames/pcplists — renamed from the older `page_alloc_init()`) are called; neither is a standalone `start_kernel()` step any more. After `mm_core_init()`, the general-purpose page allocator (`alloc_pages()`) and `kmalloc()` are both operational. Note: `kmem_cache_init_late()` (step [25] below) is a separate, later, plain direct call from `start_kernel()` — not called from within `mm_core_init()`, and not registered via any `core_initcall()`/initcall-level mechanism.
 
-**[16] `poking_init()`**
+**[14] `poking_init()`**
 
 Initializes the text-poking infrastructure used by kprobes, ftrace, and live patching to safely modify kernel text at runtime. On x86 this sets up a temporary mapping mechanism to write to read-only kernel pages.
 
-**[17] `ftrace_init()`**
+**[15] `ftrace_init()`**
 
 Prepares the function tracer's internal data structures (the `ftrace_ops` list, the mcount call sites recorded in `__mcount_loc`). The tracer is not yet active but the infrastructure is ready.
 
-**[18] `early_trace_init()`**
+**[16] `early_trace_init()`**
 
 Initializes the tracing ring buffer and trace clock before most subsystems are up, so that trace events from early boot can be captured.
 
-**[19] `sched_init()`** (`kernel/sched/core.c`)
+**[17] `sched_init()`** (`kernel/sched/core.c`)
 
 Initializes the scheduler: allocates per-CPU runqueues (`struct rq`), sets up the CFS, RT, and deadline scheduling classes, and makes `init_task` runnable. After `sched_init()`, context switching is possible.
 
-**[20] `radix_tree_init()`**
+**[18] `radix_tree_init()`**
 
 Initializes the kmem_cache for radix tree nodes. The radix tree (now maple tree for VMAs, but radix tree still used elsewhere) is used by the page cache, the inode cache, and many other subsystems.
 
-**[21] `workqueue_init_early()`** (`kernel/workqueue.c`)
+**[19] `workqueue_init_early()`** (`kernel/workqueue.c`)
 
 Creates the early workqueue infrastructure. Full workqueue initialization (`workqueue_init()`) happens later via a core_initcall; this early call sets up the data structures so that `schedule_work()` can be queued even before worker threads exist.
 
-**[22] `rcu_init()`** (`kernel/rcu/tree.c`)
+**[20] `rcu_init()`** (`kernel/rcu/tree.c`)
 
 Initializes RCU (Read-Copy-Update). Sets up the RCU tree (rcu_node hierarchy), per-CPU state, and the rcu_tasks mechanism. After this, `rcu_read_lock()` / `rcu_read_unlock()` and `call_rcu()` are safe to use.
 
-**[23] `init_IRQ()`** (`arch/x86/kernel/irqinit.c`)
+**[21] `init_IRQ()`** (`arch/x86/kernel/irqinit.c`)
 
 Initializes the interrupt controller. On x86 this sets up the legacy 8259 PIC (or APIC if present), allocates IRQ descriptors, and prepares the interrupt handling framework. After this, `request_irq()` is possible.
 
-**[24] `tick_init()`** (`kernel/time/tick-common.c`)
+**[22] `tick_init()`** (`kernel/time/tick-common.c`)
 
 Initializes the tick framework (NO_HZ, HRTICK, broadcast clock event). Must precede timekeeping.
 
-**[25] `timekeeping_init()`** (`kernel/time/timekeeping.c`)
+**[23] `timekeeping_init()`** (`kernel/time/timekeeping.c`)
 
 Reads the hardware clock source and initializes `timekeeper`. After this, `ktime_get()` and `ktime_get_real_ts64()` work. This is the kernel's internal clock, not the wall clock.
 
-**[26] `time_init()`** (`arch/x86/kernel/time.c`)
+**[24] `time_init()`** (`arch/x86/kernel/time.c`)
 
 Architecture-specific time initialization. On x86 this calibrates the TSC against the PIT or HPET and sets up the clock event device for the timer interrupt.
 
-**[27] `kmem_cache_init()`** (`mm/slub.c` — SLAB has been removed; SLUB is the only allocator remaining)
+**[25] `kmem_cache_init_late()`** (`mm/slub.c` — SLAB has been removed; SLUB is the only allocator remaining)
 
-Bootstraps the slab allocator. This is a multi-stage process because the slab allocator needs to allocate memory for its own metadata, but it needs the slab allocator to do so. The bootstrap uses static arrays then migrates. After this call, `kmalloc()` works.
+Not the slab bootstrap — that's `kmem_cache_init()`, already done inside `mm_core_init()` (step [13]), and `kmalloc()` has worked since then. `kmem_cache_init_late()` runs much later, right before `console_init()`: it allocates the `slub_flushwq` workqueue SLUB uses to flush per-CPU partial-slab caches, and (when `CONFIG_SLAB_FREELIST_RANDOM` is enabled) seeds the per-boot freelist-randomization state via `prandom_init_once()`.
 
-**[28] `console_init()`** (`kernel/printk/printk.c`)
+**[26] `console_init()`** (`kernel/printk/printk.c`)
 
 Initializes the console subsystem and calls registered console drivers. After this call, `printk` output goes to the serial console or VGA — this is when the boot messages that were buffered in the log ring actually appear on screen.
 
-**[29] `rest_init()`** (`init/main.c`)
+**[27] `rest_init()`** (`init/main.c`)
 
 The last call in `start_kernel()`. Creates kernel threads and enters the idle loop (see below).
 
@@ -190,18 +188,26 @@ The last call in `start_kernel()`. Creates kernel threads and enters the idle lo
 /* init/main.c */
 static noinline void __ref __noreturn rest_init(void)
 {
+    struct kernel_clone_args init_args = {
+        .flags      = (CLONE_VM | CLONE_UNTRACED),
+        .fn         = kernel_init,
+        .fn_arg     = NULL,
+    };
     struct task_struct *tsk;
     int pid;
 
     rcu_scheduler_starting();
-
     /*
      * We need to spawn init first so that it obtains pid 1, however
      * the init task will end up wanting to create kthreads, which, if
      * we schedule it before we create kthreadd, will OOPS.
      */
-    pid = user_mode_thread(kernel_init, NULL, CLONE_FS);
-
+    pid = kernel_clone(&init_args);
+    /*
+     * Pin init on the boot CPU. Task migration is not properly working
+     * until sched_init_smp() has been run. It will set the allowed
+     * CPUs for init to the non isolated CPUs.
+     */
     rcu_read_lock();
     tsk = find_task_by_pid_ns(pid, &init_pid_ns);
     tsk->flags |= PF_NO_SETAFFINITY;
@@ -214,6 +220,13 @@ static noinline void __ref __noreturn rest_init(void)
     kthreadd_task = find_task_by_pid_ns(pid, &init_pid_ns);
     rcu_read_unlock();
 
+    /*
+     * Enable might_sleep() and smp_processor_id() checks.
+     * They cannot be enabled earlier because with CONFIG_PREEMPTION=y
+     * kernel_thread() would trigger might_sleep() splats. With
+     * CONFIG_PREEMPT_VOLUNTARY=y the init task might have scheduled
+     * already, but it's stuck on the kthreadd_done completion.
+     */
     system_state = SYSTEM_SCHEDULING;
 
     complete(&kthreadd_done);
@@ -228,7 +241,7 @@ static noinline void __ref __noreturn rest_init(void)
 }
 ```
 
-- **PID 1 (`kernel_init`)**: spawned via `user_mode_thread()` (not the generic `kernel_thread()` — PID 1 needs a real userspace return path), runs `do_initcalls()` to execute all registered initcalls, then mounts the root filesystem and execs `/sbin/init` (or whatever `init=` specifies on the command line).
+- **PID 1 (`kernel_init`)**: spawned via `kernel_clone()` with a `struct kernel_clone_args` requesting `CLONE_VM | CLONE_UNTRACED` (not the generic `kernel_thread()` — PID 1 needs a real userspace return path; an older version of this code called a dedicated `user_mode_thread()` helper for the same purpose, but `rest_init()` builds the `kernel_clone_args` directly now). Runs `do_initcalls()` to execute all registered initcalls, then mounts the root filesystem and execs `/sbin/init` (or whatever `init=` specifies on the command line).
 - **PID 2 (`kthreadd`)**: the kernel thread daemon, spawned via `kernel_thread()`. All subsequent kernel threads are created by `kthreadd` in response to `kernel_thread()` calls.
 - **CPU 0 idle**: after `rest_init()` finishes, CPU 0 enters `cpu_startup_entry()` and becomes the idle thread, running `do_idle()` in a loop. `rest_init()` itself never returns to `start_kernel()`.
 
@@ -256,20 +269,37 @@ Built-in kernel subsystems register initialization functions using initcall macr
 
 ### How it works
 
-Each macro expands through `__define_initcall(fn, id)`. On kernels without `CONFIG_HAVE_ARCH_PREL32_RELOCATIONS` (a minority today — most 64-bit architectures, including x86-64 and arm64, have it enabled), the expansion is close to the simple version this section used to show:
+Each macro (e.g. `core_initcall(fn)`) expands through a chain: `__define_initcall(fn, id)` → `___define_initcall(fn, id, .initcall##id)` → `__unique_initcall(fn, id, __sec, __iid)` → `____define_initcall(...)`, the layer that actually emits the section entry:
 
 ```c
-/* include/linux/init.h, CONFIG_HAVE_ARCH_PREL32_RELOCATIONS=n path */
+/* include/linux/init.h */
+#ifdef CONFIG_HAVE_ARCH_PREL32_RELOCATIONS
+#define ____define_initcall(fn, __stub, __name, __sec)		\
+	__define_initcall_stub(__stub, fn)			\
+	asm(".section	\"" __sec "\", \"a\"		\n"	\
+	    __stringify(__name) ":			\n"	\
+	    ".long	" __stringify(__stub) " - .	\n"	\
+	    ".previous					\n");	\
+	static_assert(__same_type(initcall_t, &fn));
+#else
 #define ____define_initcall(fn, __unused, __name, __sec)	\
-    static initcall_t __name __used			\
-        __attribute__((__section__(__sec))) = fn;
+	static initcall_t __name __used 			\
+		__attribute__((__section__(__sec))) = fn;
+#endif
 
-#define core_initcall(fn)       __define_initcall(fn, 1)
-#define device_initcall(fn)     __define_initcall(fn, 6)
-#define module_init(fn)         device_initcall(fn)
+#define __unique_initcall(fn, id, __sec, __iid)			\
+	____define_initcall(fn,					\
+		__initcall_stub(fn, __iid, id),			\
+		__initcall_name(initcall, __iid, id),		\
+		__initcall_section(__sec, __iid))
+
+#define ___define_initcall(fn, id, __sec)			\
+	__unique_initcall(fn, id, __sec, __initcall_id(fn))
+
+#define __define_initcall(fn, id) ___define_initcall(fn, id, .initcall##id)
 ```
 
-On the more common `CONFIG_HAVE_ARCH_PREL32_RELOCATIONS=y` path, each entry isn't a plain function pointer at all — it's a PC-relative 32-bit offset emitted via inline assembly, resolved back to a real address only when read (`initcall_from_entry()`, used below). This trades a small amount of decode overhead for a smaller `initcall*.init` section, since a 4-byte relative offset is half the size of a full pointer on 64-bit.
+Most 64-bit architectures (including x86-64 and arm64) build with `CONFIG_HAVE_ARCH_PREL32_RELOCATIONS=y` today. On that path, each initcall entry isn't a plain function pointer — `__define_initcall_stub()` emits a small wrapper function (`__stub`) that just calls `fn()`, and the `asm()` block stores a **PC-relative 32-bit offset** to that stub, resolved back to a real address only when read (`initcall_from_entry()`, used below). This trades a small amount of decode overhead for a smaller `initcall*.init` section, since a 4-byte relative offset is half the size of a full pointer on 64-bit. Without `CONFIG_HAVE_ARCH_PREL32_RELOCATIONS`, `____define_initcall()` falls back to the plain static function-pointer array this section used to show exclusively.
 
 The linker script (`arch/x86/kernel/vmlinux.lds.S`, via `include/asm-generic/vmlinux.lds.h`) collects all `.initcall*.init` sections in level order. `do_initcalls()` iterates this array and calls each function pointer:
 
@@ -279,22 +309,38 @@ static void __init do_initcall_level(int level, char *command_line)
 {
     initcall_entry_t *fn;
 
-    for (fn = initcall_levels[level]; fn < initcall_levels[level + 1]; fn++)
+    parse_args(initcall_level_names[level],
+               command_line, __start___param,
+               __stop___param - __start___param,
+               level, level,
+               NULL, ignore_unknown_bootoption);
+
+    do_trace_initcall_level(initcall_level_names[level]);
+    for (fn = initcall_levels[level]; fn < initcall_levels[level+1]; fn++)
         do_one_initcall(initcall_from_entry(fn));
 }
 
 static void __init do_initcalls(void)
 {
     int level;
-    size_t len = strlen(saved_command_line) + 1;
-    char *command_line = kzalloc(len, GFP_KERNEL);
+    size_t len = saved_command_line_len + 1;
+    char *command_line;
 
-    for (level = 0; level < ARRAY_SIZE(initcall_levels) - 1; level++)
+    command_line = kzalloc(len, GFP_KERNEL);
+    if (!command_line)
+        panic("%s: Failed to allocate %zu bytes\n", __func__, len);
+
+    for (level = 0; level < ARRAY_SIZE(initcall_levels) - 1; level++) {
+        /* Parser modifies command_line, restore it each time */
+        strcpy(command_line, saved_command_line);
         do_initcall_level(level, command_line);
+    }
 
     kfree(command_line);
 }
 ```
+
+Two things worth noting beyond the obvious level-by-level dispatch: `do_initcall_level()` re-runs `parse_args()` against each level's own module-parameter slice (so `module.param=value`-style boot arguments are matched against the right level, not just once globally at `parse_early_param()` time), and `do_initcalls()` re-copies `saved_command_line` into its scratch buffer before every level because `parse_args()` mutates the string it's given as it walks it — without the restore, only the first level would see the full, unmodified command line.
 
 The initcall return value matters: a non-zero return causes a `pr_warn` message but does not stop the boot process (unless `initcall_debug` is set to a stricter mode). An initcall that returns an error is simply logged and skipped.
 
@@ -308,13 +354,15 @@ Functions annotated with `__init` are placed in the `.init.text` ELF section. Af
 
 ```c
 /* init/main.c */
-static int __init kernel_init(void *unused)
+static int __ref kernel_init(void *unused)
 {
     ...
     free_initmem();
     ...
 }
 ```
+
+`kernel_init()` is annotated `__ref`, not `__init` — it can't be `__init` itself, because it's the function that calls `free_initmem()` to free the `.init.text`/`.init.data` sections. A function placed in `.init.text` that's still running when that section gets freed would be calling for its own page to be reclaimed out from under it. `__ref` tells modpost "yes, this function references `__init` code/data on purpose, don't warn about it."
 
 `free_initmem()` calls `free_reserved_area()` to return these pages to the buddy allocator. This is why the boot log contains a message like:
 
@@ -412,7 +460,8 @@ cat /sys/kernel/debug/tracing/trace | grep 'do_one_initcall'
 - [kernel/cpu.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/cpu.c) — `boot_cpu_init()`
 - [mm/mm_init.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/mm_init.c) — `mm_core_init()`
 - [mm/page_alloc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/page_alloc.c) — `build_all_zonelists()`
-- [mm/slub.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/slub.c) — `kmem_cache_init()`, the SLUB bootstrap
+- [mm/slub.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/slub.c) — `kmem_cache_init()`, the SLUB bootstrap, and `kmem_cache_init_late()`, the later `slub_flushwq`/freelist-randomization setup
+- [security/lsm_init.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/security/lsm_init.c) — `early_security_init()`: initializes the LSMs flagged "early"
 - [kernel/sched/core.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/sched/core.c) — `sched_init()`
 - [kernel/rcu/tree.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/rcu/tree.c) — `rcu_init()`
 - [kernel/workqueue.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/workqueue.c) — `workqueue_init_early()`


### PR DESCRIPTION
Verified every code block and technical claim in this page against current kernel source (git.kernel.org).

- \`rest_init()\`: PID 1 is now spawned via \`kernel_clone()\` with a \`struct kernel_clone_args\` (\`CLONE_VM | CLONE_UNTRACED\`), not the older \`user_mode_thread()\` helper.
- \`kernel_init()\` is annotated \`__ref\`, not \`__init\` — it can't live in \`.init.text\` since it's the function that frees that section via \`free_initmem()\`.
- \`start_kernel()\`'s call order corrected: \`setup_arch()\` runs before \`early_security_init()\`, not after.
- \`build_all_zonelists(NULL)\` and \`page_alloc_init()\` (renamed \`page_alloc_init_cpuhp()\`) are no longer standalone \`start_kernel()\` steps — both are called from inside \`mm_core_init()\`.
- The step previously labeled \`kmem_cache_init()\` late in the boot sequence is actually a different function, \`kmem_cache_init_late()\` — the real slab-allocator bootstrap (\`kmem_cache_init()\`) happens earlier, inside \`mm_core_init()\`.
- \`do_initcall_level()\`/\`do_initcalls()\` now show the real \`parse_args()\` call, \`do_trace_initcall_level()\`, \`saved_command_line_len\`, and the per-level command-line restore logic.
- Added the full \`__define_initcall\` macro chain (\`___define_initcall\` → \`__unique_initcall\` → \`____define_initcall\`) for the \`CONFIG_HAVE_ARCH_PREL32_RELOCATIONS=y\` path most 64-bit architectures build with today.
- Added \`early_security_init()\` and \`kmem_cache_init_late()\` to the Further Reading citations.

All source citations point to git.kernel.org. \`mkdocs build --strict\` passes.