### PR TITLE
Fix fabricated technical details in docs/debugging/syzkaller.md

### DIFF
--- a/docs/debugging/syzkaller.md
+++ b/docs/debugging/syzkaller.md
@@ -97,7 +97,6 @@ CONFIG_DEBUG_INFO=y
 CONFIG_KASAN=y
 CONFIG_KASAN_INLINE=y
 CONFIG_UBSAN=y
-CONFIG_UBSAN_SANITIZE_ALL=y
 CONFIG_FAULT_INJECTION=y
 CONFIG_FAULT_INJECTION_DEBUG_FS=y
 CONFIG_FAILSLAB=y
@@ -184,7 +183,7 @@ gcc -o repro repro.c && sudo ./repro
 # https://syzkaller.appspot.com/upstream
 
 # Each bug report includes:
-# - Title: e.g., "KASAN: use-after-free in sock_destroy"
+# - Title: e.g., "KASAN: use-after-free in sk_destruct"
 # - Kernel version and commit
 # - C reproducer
 # - syzlang reproducer
@@ -211,7 +210,7 @@ git bisect run ./scripts/faddr2line vmlinux <addr>
 # Analyze a core dump with crash:
 crash vmlinux core.dump
 crash> bt      # backtrace of crashed process
-crash> dis -l sock_destroy  # disassemble with source lines
+crash> dis -l sk_destruct  # disassemble with source lines
 ```
 
 ## Further reading


### PR DESCRIPTION
## Changes

- **Fabricated function name**: `sock_destroy` is not a real, disassemblable kernel function — no symbol by that name exists. The closest real thing is the `SOCK_DESTROY` netlink command and its per-protocol `.destroy` diag callback (`net/core/sock_diag.c`), not a function you could pass to `crash> dis -l` or see in a KASAN report title. Replaced both occurrences (the syzbot bug-title example and the `crash` disassembly example) with `sk_destruct`, which the page already cites correctly and accurately elsewhere (`net/core/sock.c`).
- **Stale Kconfig option**: `CONFIG_UBSAN_SANITIZE_ALL` no longer exists in the kernel's UBSAN Kconfig. Current UBSAN uses granular per-check options (`UBSAN_BOUNDS`, `UBSAN_BOOL`, `UBSAN_ENUM`, etc.), most of which already default to on when `CONFIG_UBSAN=y` is set — matching syzkaller's own current setup documentation, which recommends only `CONFIG_UBSAN=y`.

## Verified correct, left unchanged

- kcov ioctl interface (`KCOV_INIT_TRACE`, `KCOV_ENABLE`, `KCOV_DISABLE`, `KCOV_TRACE_PC`) and `__sanitizer_cov_trace_pc()`'s coverage-buffer layout — exact match against `include/uapi/linux/kcov.h` and `kernel/kcov.c`.
- `scripts/faddr2line` usage syntax — exact match against the script's own usage string.
- The `syzkaller.cfg` JSON example — every field name and value matches syzkaller's own official setup documentation for this exact scenario (Ubuntu host, QEMU VM, x86-64 kernel).
- All "Related pages" links resolve to real files in this repo.